### PR TITLE
*fix bug: The `-help` option of `Test` was processed incorrectly

### DIFF
--- a/src/Test/Test.cpp
+++ b/src/Test/Test.cpp
@@ -426,7 +426,7 @@ namespace Test
             for (int i = 1; i < argc; ++i)
             {
                 String arg = argv[i];
-                if (arg.substr(0, 2) == "-help" || arg.substr(0, 2) == "-?")
+                if (arg.substr(0, 5) == "-help" || arg.substr(0, 2) == "-?")
                 {
                     help = true;
                     break;


### PR DESCRIPTION
The `-help` option did not work at all because of an erroneous substring extraction.