### PR TITLE
Add images abs difference

### DIFF
--- a/src/Simd/SimdAvx2.h
+++ b/src/Simd/SimdAvx2.h
@@ -31,6 +31,9 @@ namespace Simd
 #ifdef SIMD_AVX2_ENABLE    
     namespace Avx2
     {
+		void AbsDifference(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+			size_t width, size_t height);
+
         void AbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride,
             size_t width, size_t height, uint64_t * sum);
 

--- a/src/Simd/SimdAvx2AbsDifference.cpp
+++ b/src/Simd/SimdAvx2AbsDifference.cpp
@@ -1,0 +1,74 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2017 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdLoad.h"
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdExtract.h"
+#include "Simd/SimdSet.h"
+#include "Simd/SimdStore.h"
+
+namespace Simd
+{
+#ifdef SIMD_AVX2_ENABLE    
+	namespace Avx2
+	{
+		template <bool align> void AbsDifference(
+			const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+			size_t width, size_t height)
+		{
+			assert(width >= A);
+			if (align)
+				assert(Aligned(a) && Aligned(aStride) && Aligned(b) && Aligned(bStride) && Aligned(c) && Aligned(cStride));
+
+			size_t bodyWidth = AlignLo(width, A);
+			for (size_t row = 0; row < height; ++row)
+			{
+				for (size_t col = 0; col < bodyWidth; col += A)
+				{
+					const __m256i a_ = Load<align>((__m256i*)(a + col));
+					const __m256i b_ = Load<align>((__m256i*)(b + col));
+					Store<align>((__m256i*)(c + col), _mm256_sub_epi8(_mm256_max_epu8(a_, b_), _mm256_min_epu8(a_, b_)));
+				}
+				if (width - bodyWidth)
+				{
+					const __m256i a_ = Load<false>((__m256i*)(a + width - A));
+					const __m256i b_ = Load<false>((__m256i*)(b + width - A));
+					Store<false>((__m256i*)(c + width - A), _mm256_sub_epi8(_mm256_max_epu8(a_, b_), _mm256_min_epu8(a_, b_)));
+				}
+				a += aStride;
+				b += bStride;
+				c += bStride;
+			}
+		}
+
+		void AbsDifference(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+			size_t width, size_t height)
+		{
+			if (Aligned(a) && Aligned(aStride) && Aligned(b) && Aligned(bStride))
+				AbsDifference<true>(a, aStride, b, bStride, c, cStride, width, height);
+			else
+				AbsDifference<false>(a, aStride, b, bStride, c, cStride, width, height);
+		}
+	}
+#endif// SIMD_AVX2_ENABLE
+}

--- a/src/Simd/SimdBase.h
+++ b/src/Simd/SimdBase.h
@@ -37,6 +37,9 @@ namespace Simd
 
         uint32_t Crc32c(const void * src, size_t size);
 
+		void AbsDifference(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+			size_t width, size_t height);
+
         void AbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride,
             size_t width, size_t height, uint64_t * sum);
 

--- a/src/Simd/SimdBaseAbsDifference.cpp
+++ b/src/Simd/SimdBaseAbsDifference.cpp
@@ -1,0 +1,46 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2017 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMath.h"
+
+namespace Simd
+{
+	namespace Base
+	{
+		void AbsDifference(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+			size_t width, size_t height)
+		{
+			for (size_t row = 0; row < height; ++row)
+			{
+				int rowSum = 0;
+				for (size_t col = 0; col < width; ++col)
+				{
+					c[col] = AbsDifferenceU8(a[col], b[col]);
+				}
+				a += aStride;
+				b += bStride;
+				c += cStride;
+			}
+		}
+	}
+}

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -214,6 +214,17 @@ SIMD_API uint32_t SimdCrc32c(const void * src, size_t size)
         return Base::Crc32c(src, size);
 }
 
+SIMD_API void SimdAbsDifference(const uint8_t *a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t *c, size_t cStride,
+	size_t width, size_t height)
+{
+#ifdef SIMD_AVX2_ENABLE
+	if (Avx2::Enable && width >= Avx2::A)
+		Avx2::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
+	else
+#endif
+	Base::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
+}
+
 SIMD_API void SimdAbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8_t * b, size_t bStride,
                                    size_t width, size_t height, uint64_t * sum)
 {

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -401,6 +401,28 @@ extern "C"
     */
     SIMD_API uint32_t SimdCrc32c(const void * src, size_t size);
 
+	/*! @ingroup correlation
+
+		\fn void SimdAbsDifference(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t *c, size_t cStride, size_t width, size_t height, uint64_t * sum);
+
+		\short Gets absolute difference of two gray 8-bit images, pyxel by pixel.
+
+		The three images must have the same width and height.
+
+		\note This function has a C++ wrapper Simd::AbsDifference(const View<A> & a, const View<A> & b, const View<A> & c).
+
+		\param [in] a - a pointer to pixels data of first image.
+		\param [in] aStride - a row size of first image.
+		\param [in] b - a pointer to pixels data of second image.
+		\param [in] bStride - a row size of second image.
+		\param [out] c - a pointer to pixels data of destination image.
+		\param [in]cStride - a row size of destination image.
+		\param [in] width - an image width.
+		\param [in] height - an image height.
+	*/
+	SIMD_API void SimdAbsDifference(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t *c, size_t cStride,
+		size_t width, size_t height);
+
     /*! @ingroup correlation
 
         \fn void SimdAbsDifferenceSum(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, size_t width, size_t height, uint64_t * sum);

--- a/src/Simd/SimdLib.hpp
+++ b/src/Simd/SimdLib.hpp
@@ -33,6 +33,27 @@
 /*! \namespace Simd */
 namespace Simd
 {
+	/*! @ingroup correlation
+
+		\fn void AbsDifference(const View<A>& a, const View<A>& b, const View<A>& c)
+
+		\short Gets absolute difference of two gray 8-bit images, pyxel by pixel.
+
+		Both images must have the same width and height.
+
+		\note This function is a C++ wrapper for function ::SimdAbsDifference.
+
+		\param [in] a - a first image.
+		\param [in] b - a second image.
+		\param [out] c - a destination image.
+	*/
+	template<template<class> class A> SIMD_INLINE void AbsDifference(const View<A>& a, const View<A>& b, View<A>& c)
+	{
+		assert(Compatible(a, b) && Compatible(b, c) && a.format == View<A>::Gray8);
+
+		SimdAbsDifference(a.data, a.stride, b.data, b.stride, c.data, c.stride, a.width, a.height);
+	}
+
     /*! @ingroup correlation
 
         \fn void AbsDifferenceSum(const View<A>& a, const View<A>& b, uint64_t & sum)

--- a/src/Test/Test.cpp
+++ b/src/Test/Test.cpp
@@ -72,6 +72,8 @@ namespace Test
     bool name##AddToList(){ g_groups.push_back(Group(#name, name##AutoTest, name##DataTest, name##SpecialTest)); return true; } \
     bool name##AtList = name##AddToList();
 
+    TEST_ADD_GROUP_AD0(AbsDifference);
+
     TEST_ADD_GROUP_AD0(AbsDifferenceSum);
     TEST_ADD_GROUP_AD0(AbsDifferenceSumMasked);
     TEST_ADD_GROUP_AD0(AbsDifferenceSums3x3);

--- a/src/Test/TestAbsDifference.cpp
+++ b/src/Test/TestAbsDifference.cpp
@@ -1,0 +1,175 @@
+/*
+* Tests for Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2018 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Test/TestUtils.h"
+#include "Test/TestPerformance.h"
+#include "Test/TestData.h"
+
+namespace Test
+{
+	namespace
+	{
+		struct Func1
+		{
+			typedef void(*FuncPtr)(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+				size_t width, size_t height);
+
+			FuncPtr func;
+			String description;
+
+			Func1(const FuncPtr & f, const String & d) : func(f), description(d) {}
+
+			void Call(const View & a, const View & b, View & c) const
+			{
+				TEST_PERFORMANCE_TEST(description);
+				func(a.data, a.stride, b.data, b.stride, c.data, c.stride, a.width, a.height);
+			}
+		};
+	}
+
+#define FUNC1(function) \
+    Func1(function, std::string(#function))
+
+	bool AbsDifferenceAutoTest(int width, int height, const Func1 & f1, const Func1 & f2, int count)
+	{
+		bool result = true;
+
+		TEST_LOG_SS(Info, "Test " << f1.description << " & " << f2.description << " [" << width << ", " << height << "].");
+
+		View a(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+		FillRandom(a);
+
+		View b(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+		FillRandom(b);
+
+		View c1(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+		View c2(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+
+		TEST_EXECUTE_AT_LEAST_MIN_TIME(f1.Call(a, b, c1));
+
+		TEST_EXECUTE_AT_LEAST_MIN_TIME(f2.Call(a, b, c2));
+
+		result = Compare(c1, c2, 0, true, count);
+
+		return result;
+	}
+
+	bool AbsDifferenceAutoTest(const Func1 & f1, const Func1 & f2, int count)
+	{
+		bool result = true;
+
+		result = result && AbsDifferenceAutoTest(W, H, f1, f2, count);
+		result = result && AbsDifferenceAutoTest(W + O, H - O, f1, f2, count);
+
+		return result;
+	}
+
+	bool AbsDifferenceAutoTest()
+	{
+		bool result = true;
+
+		result = result && AbsDifferenceAutoTest(FUNC1(Simd::Base::AbsDifference), FUNC1(SimdAbsDifference), 1);
+		/*
+		#ifdef SIMD_SSE2_ENABLE
+				if (Simd::Sse2::Enable && W >= Simd::Sse2::A)
+					result = result && AbsDifferenceAutoTest(FUNC1(Simd::Sse2::AbsDifference), FUNC1(SimdAbsDifference), 1);
+		#endif
+		*/
+#ifdef SIMD_AVX2_ENABLE
+		if (Simd::Avx2::Enable && W >= Simd::Avx2::A)
+			result = result && AbsDifferenceAutoTest(FUNC1(Simd::Avx2::AbsDifference), FUNC1(SimdAbsDifference), 1);
+#endif 
+		/*
+		#ifdef SIMD_AVX512BW_ENABLE
+				if (Simd::Avx512bw::Enable)
+					result = result && AbsDifferenceAutoTest(FUNC1(Simd::Avx512bw::AbsDifference), FUNC1(SimdAbsDifference), 1);
+		#endif
+
+		#ifdef SIMD_VMX_ENABLE
+				if (Simd::Vmx::Enable && W >= Simd::Vmx::A)
+					result = result && AbsDifferenceAutoTest(FUNC1(Simd::Vmx::AbsDifference), FUNC1(SimdAbsDifference), 1);
+		#endif
+
+		#ifdef SIMD_NEON_ENABLE
+				if (Simd::Neon::Enable && W >= Simd::Neon::A)
+					result = result && AbsDifferenceAutoTest(FUNC1(Simd::Neon::AbsDifference), FUNC1(SimdAbsDifference), 1);
+		#endif
+		*/
+		return result;
+	}
+
+	//-----------------------------------------------------------------------
+
+	bool AbsDifferenceDataTest(bool create, int width, int height, const Func1 & f, int count)
+	{
+		bool result = true;
+
+		Data data(f.description);
+
+		TEST_LOG_SS(Info, (create ? "Create" : "Verify") << " test " << f.description << " [" << width << ", " << height << "].");
+
+		View a(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+		View b(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+
+		View c1(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+		View c2(width, height, View::Gray8, NULL, TEST_ALIGN(width));
+
+		if (create)
+		{
+			FillRandom(a);
+			FillRandom(b);
+
+			TEST_SAVE(a);
+			TEST_SAVE(b);
+
+			f.Call(a, b, c1);
+
+			TEST_SAVE(c1);
+		}
+		else
+		{
+			TEST_LOAD(a);
+			TEST_LOAD(b);
+
+			TEST_LOAD(c1);
+
+			f.Call(a, b, c2);
+
+			TEST_SAVE(c2);
+
+			result = result && Compare(c1, c2, 0, true, count);
+		}
+
+		return result;
+	}
+
+	bool AbsDifferenceDataTest(bool create)
+	{
+		bool result = true;
+
+		result = result && AbsDifferenceDataTest(create, DW, DH, FUNC1(SimdAbsDifference), 1);
+
+		return result;
+	}
+
+}


### PR DESCRIPTION
I found the library recently, and it works very well, really like it.  
I searched for a function similar to OpenCV [absdiff](https://docs.opencv.org/4.1.0/d2/de8/group__core__array.html#ga6fef31bc8c4071cbc114a758a2b79c14), but I did not find one. So I try adding it on my own. It only works for AVX2 (and a base implementation), but I did not want to go further without knowing if it is a good contribution or not, and if the structure I am using is correct.  