### PR TITLE
MSVC 2019 fix

### DIFF
--- a/prj/vs2019/Alg.vcxproj
+++ b/prj/vs2019/Alg.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Prop.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1622C4EF-06A4-4DAA-9631-5D71B32858A2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectName>Alg</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\Simd\Simd*.h" />
+    <ClInclude Include="..\..\src\Simd\Simd*.hpp" />
+    <ClCompile Include="..\..\src\Simd\SimdBase*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSse1*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSse2*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSse3*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSsse3*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSse41*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSse42*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx1*.cpp">
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx2*.cpp">
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx512f*.cpp">
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx512bw*.cpp">
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdVmx*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdVsx*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeon*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdMsa*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/prj/vs2019/Prop.props
+++ b/prj/vs2019/Prop.props
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="Configuration">
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>
+    <UseDebugLibraries Condition="'$(Configuration)'=='Release'">false</UseDebugLibraries>
+    <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)\..\..\bin\$(PlatformToolset)\$(PlatformName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)\..\..\obj\$(PlatformToolset)\$(PlatformName)\$(Configuration)\$(ProjectName)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)'=='Debug'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)'=='Release'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <FloatingPointModel>Fast</FloatingPointModel>
+    </ClCompile>
+    <ClCompile Condition="'$(Configuration)'=='Debug'">
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <ClCompile Condition="'$(Configuration)'=='Release'">
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>
+      <EnableCOMDATFolding Condition="'$(Configuration)'=='Release'">true</EnableCOMDATFolding>
+      <OptimizeReferences Condition="'$(Configuration)'=='Release'">true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+    <BuildLog>
+      <Path>$(SolutionDir)\..\..\obj\$(PlatformToolset)\$(PlatformName)\$(Configuration)\$(ProjectName)\Build.log</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+</Project>

--- a/prj/vs2019/Simd.sln
+++ b/prj/vs2019/Simd.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Test", "Test.vcxproj", "{423128F2-9D4E-408D-9123-49CE57A32B0A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Simd", "Simd.vcxproj", "{C809D7A3-6C52-4E36-8582-00CED929317D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Alg", "Alg.vcxproj", "{1622C4EF-06A4-4DAA-9631-5D71B32858A2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Debug|Win32.Build.0 = Debug|Win32
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Debug|x64.ActiveCfg = Debug|x64
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Debug|x64.Build.0 = Debug|x64
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Release|Win32.ActiveCfg = Release|Win32
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Release|Win32.Build.0 = Release|Win32
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Release|x64.ActiveCfg = Release|x64
+		{423128F2-9D4E-408D-9123-49CE57A32B0A}.Release|x64.Build.0 = Release|x64
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Debug|Win32.Build.0 = Debug|Win32
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Debug|x64.ActiveCfg = Debug|x64
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Debug|x64.Build.0 = Debug|x64
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Release|Win32.ActiveCfg = Release|Win32
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Release|Win32.Build.0 = Release|Win32
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Release|x64.ActiveCfg = Release|x64
+		{C809D7A3-6C52-4E36-8582-00CED929317D}.Release|x64.Build.0 = Release|x64
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Debug|Win32.ActiveCfg = Debug|Win32
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Debug|Win32.Build.0 = Debug|Win32
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Debug|x64.ActiveCfg = Debug|x64
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Debug|x64.Build.0 = Debug|x64
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Release|Win32.ActiveCfg = Release|Win32
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Release|Win32.Build.0 = Release|Win32
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Release|x64.ActiveCfg = Release|x64
+		{1622C4EF-06A4-4DAA-9631-5D71B32858A2}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/prj/vs2019/Simd.vcxproj
+++ b/prj/vs2019/Simd.vcxproj
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Prop.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C809D7A3-6C52-4E36-8582-00CED929317D}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectName>Simd</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <PreBuildEvent>
+      <Command>"$(ProjectDir)..\cmd\GetVersion.cmd" "$(ProjectDir)..\.."</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\Simd\Simd*.hpp" />
+    <ClInclude Include="..\..\src\Simd\SimdLib.h" />
+    <ClCompile Include="..\..\src\Simd\SimdLib.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Alg.vcxproj">
+      <Project>{1622c4ef-06a4-4daa-9631-5d71b32858a2}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/prj/vs2019/Test.vcxproj
+++ b/prj/vs2019/Test.vcxproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Prop.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="Ocv.props" Condition="exists('Ocv.props')" Label="Ocv" />
+  </ImportGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{423128F2-9D4E-408D-9123-49CE57A32B0A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Test</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\Test\Test*.h" />
+    <ClCompile Include="..\..\src\Test\Test*.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Platform)'=='x64'">NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Simd.vcxproj">
+      <Project>{c809d7a3-6c52-4e36-8582-00ced929317d}</Project>
+    </ProjectReference>
+    <ProjectReference Include="Alg.vcxproj">
+      <Project>{1622c4ef-06a4-4daa-9631-5d71b32858a2}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/Simd/SimdCompare.h
+++ b/src/Simd/SimdCompare.h
@@ -160,7 +160,7 @@ namespace Simd
             return _mm_andnot_si128(_mm_cmpeq_epi16(a, b), K_INV_ZERO);
         }
 
-        SIMD_INLINE __m128i GreaterOrEqual16i(__m128i a, __m128i b)
+        SIMD_INLINE __m128i GreaterOrEqual16i_m128(__m128i a, __m128i b)
         {
             return _mm_andnot_si128(_mm_cmplt_epi16(a, b), K_INV_ZERO);
         }
@@ -189,7 +189,7 @@ namespace Simd
 
         template<> SIMD_INLINE __m128i Compare16i<SimdCompareGreaterOrEqual>(__m128i a, __m128i b)
         {
-            return GreaterOrEqual16i(a, b);
+            return GreaterOrEqual16i_m128(a, b);
         }
 
         template<> SIMD_INLINE __m128i Compare16i<SimdCompareLesser>(__m128i a, __m128i b)
@@ -269,7 +269,7 @@ namespace Simd
             return _mm256_andnot_si256(_mm256_cmpeq_epi16(a, b), K_INV_ZERO);
         }
 
-        SIMD_INLINE __m256i GreaterOrEqual16i(__m256i a, __m256i b)
+        SIMD_INLINE __m256i GreaterOrEqual16i_m256(__m256i a, __m256i b)
         {
             return _mm256_andnot_si256(_mm256_cmpgt_epi16(b, a), K_INV_ZERO);
         }
@@ -298,7 +298,7 @@ namespace Simd
 
         template<> SIMD_INLINE __m256i Compare16i<SimdCompareGreaterOrEqual>(__m256i a, __m256i b)
         {
-            return GreaterOrEqual16i(a, b);
+            return GreaterOrEqual16i_m256(a, b);
         }
 
         template<> SIMD_INLINE __m256i Compare16i<SimdCompareLesser>(__m256i a, __m256i b)

--- a/src/Simd/SimdMath.h
+++ b/src/Simd/SimdMath.h
@@ -878,7 +878,7 @@ namespace Simd
 
         SIMD_INLINE __m512 Rcp14(const __m512 & a)
         {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER<1922
             return _mm512_maskz_rcp14_ps(_MM_K0_REG, a);
 #else
             return _mm512_rcp14_ps(a);
@@ -887,7 +887,7 @@ namespace Simd
 
         SIMD_INLINE __m512 Rsqrt14(const __m512 & a)
         {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER<1922
             return _mm512_maskz_rsqrt14_ps(_MM_K0_REG, a);
 #else
             return _mm512_rsqrt14_ps(a);


### PR DESCRIPTION
Hi. I needed to compile Simd on Visual studio 2019 and I have got some problems.

1. There are no sln and project file for VS2019. So, I copy it from VS2017w and update.
2. It doesn't compile: unknown _MM_K0_REG identifier, so I change if def.
3. There was a test error on ConditionalCount16i >= 
Here screen: https://ibb.co/HHysQnb
I have done some test and I think that it is a VS2019 compiler bug. It is related to function overload and optimization, because it exist only in Release version (x64, not tested on x32) and after renaming two functions (GreaterOrEqual16i to GreaterOrEqual16i_m256 and GreaterOrEqual16i_m128) the tests was passed. So, I made a commit with such changes. 