### PR TITLE
Add a function to load a cascade from memory

### DIFF
--- a/src/Simd/SimdBase.h
+++ b/src/Simd/SimdBase.h
@@ -173,6 +173,8 @@ namespace Simd
         void DeinterleaveBgra(const uint8_t * bgra, size_t bgraStride, size_t width, size_t height,
             uint8_t * b, size_t bStride, uint8_t * g, size_t gStride, uint8_t * r, size_t rStride, uint8_t * a, size_t aStride);
 
+        void * DetectionLoadStringXml(char * xml, const char * path = NULL);
+
         void * DetectionLoadA(const char * path);
 
         void DetectionInfo(const void * data, size_t * width, size_t * height, SimdDetectionInfoFlags * flags);

--- a/src/Simd/SimdBase.h
+++ b/src/Simd/SimdBase.h
@@ -38,8 +38,8 @@ namespace Simd
 
         uint32_t Crc32c(const void * src, size_t size);
 
-		void AbsDifference(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
-			size_t width, size_t height);
+        void AbsDifference(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride, uint8_t *c, size_t cStride,
+            size_t width, size_t height);
 
         void AbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8_t *b, size_t bStride,
             size_t width, size_t height, uint64_t * sum);
@@ -523,7 +523,7 @@ namespace Simd
         void ValueSum(const uint8_t * src, size_t stride, size_t width, size_t height, uint64_t * sum);
 
         void SquareSum(const uint8_t * src, size_t stride, size_t width, size_t height, uint64_t * sum);
-		
+
         void ValueSquareSum(const uint8_t * src, size_t stride, size_t width, size_t height, uint64_t * valueSum, uint64_t * squareSum);
 
         void CorrelationSum(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, size_t width, size_t height, uint64_t * sum);

--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -1,7 +1,8 @@
 /*
 * Simd Library (http://ermig1979.github.io/Simd).
 *
-* Copyright (c) 2011-2019 Yermalayeu Ihar.
+* Copyright (c) 2011-2019 Yermalayeu Ihar.,
+*               2019-2019 Facundo Galan.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -32,8 +33,8 @@
 
 #define SIMD_EX(message) \
 { \
-	std::stringstream __ss; \
-	__ss << message; \
+    std::stringstream __ss; \
+    __ss << message; \
     std::cerr << __ss.str().c_str() << std::endl; \
     throw std::runtime_error(__ss.str().c_str()); \
 }
@@ -148,23 +149,25 @@ namespace Simd
             const char * rect = "rect";
         }
 
-        void * DetectionLoadA(const char * path)
+        void * DetectionLoadStringXml(char * xml, const char * path)
         {
             static const float THRESHOLD_EPS = 1e-5f;
 
             Data * data = NULL;
             try
             {
-                Xml::File file;
-                if (!file.Open(path))
-                    SIMD_EX("Can't load XML file '" << path << "'!");
-
                 Xml::Document doc;
-                doc.Parse<0>(file.Data());
+                doc.Parse<0>(xml);
 
                 Xml::Node * root = doc.FirstNode();
-                if (root == NULL)
-                    SIMD_EX("Invalid format of XML file '" << path << "'!");
+                if (root == NULL) {
+                    if (path == NULL) {
+                        SIMD_EX("Invalid format of XML string!");
+                    }
+                    else {
+                        SIMD_EX("Invalid format of XML file '" << path << "'!");
+                    }
+                }
 
                 Xml::Node * cascade = root->FirstNode(Names::cascade);
                 if (cascade == NULL)
@@ -314,6 +317,15 @@ namespace Simd
             }
 
             return data;
+        }
+
+        void * DetectionLoadA(const char * path)
+        {
+            Xml::File file;
+            if (!file.Open(path))
+                SIMD_EX("Can't load XML file '" << path << "'!");
+
+            return DetectionLoadStringXml(file.Data(), path);
         }
 
         void DetectionInfo(const void * _data, size_t * width, size_t * height, SimdDetectionInfoFlags * flags)

--- a/src/Simd/SimdDetection.hpp
+++ b/src/Simd/SimdDetection.hpp
@@ -1,7 +1,8 @@
 /*
 * Simd Library (http://ermig1979.github.io/Simd).
 *
-* Copyright (c) 2011-2018 Yermalayeu Ihar.
+* Copyright (c) 2011-2018 Yermalayeu Ihar.,
+*               2019-2019 Facundo Galan.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -207,6 +208,35 @@ namespace Simd
         {
             for (size_t i = 0; i < _data.size(); ++i)
                 ::SimdRelease(_data[i].handle);
+        }
+
+        /*!
+            Loads from file classifier cascade. Supports OpenCV HAAR and LBP cascades type.
+            You can call this function more than once if you want to use several object detectors at the same time.
+
+            \note Tree based cascades and old cascade formats are not supported!
+
+            \param [in] xml - a path to cascade.
+            \param [in] tag - an user defined tag. This tag will be inserted in output Object structure.
+            \return a result of this operation.
+        */
+        bool LoadStringXml(const std::string & xml, Tag tag = UNDEFINED_OBJECT_TAG)
+        {
+            // Copy the received string to a non const char pointer.
+            char * xmlTmp = new char[xml.size() + 1];
+            std::copy(xml.begin(), xml.end(), xmlTmp);
+            xmlTmp[xml.size()] = '\0';
+
+            Handle handle = ::SimdDetectionLoadStringXml(xmlTmp);
+            if (handle)
+            {
+                Data data;
+                data.handle = handle;
+                data.tag = tag;
+                ::SimdDetectionInfo(handle, (size_t*)&data.size.x, (size_t*)&data.size.y, &data.flags);
+                _data.push_back(data);
+            }
+            return handle != NULL;
         }
 
         /*!

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1607,6 +1607,11 @@ SIMD_API void SimdDeinterleaveBgra(const uint8_t * bgra, size_t bgraStride, size
         Base::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
 }
 
+SIMD_API void * SimdDetectionLoadStringXml(char * xml)
+{
+    return Base::DetectionLoadStringXml(xml);
+}
+
 SIMD_API void * SimdDetectionLoadA(const char * path)
 {
     return Base::DetectionLoadA(path);

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -232,14 +232,14 @@ SIMD_API uint32_t SimdCrc32c(const void * src, size_t size)
 }
 
 SIMD_API void SimdAbsDifference(const uint8_t *a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t *c, size_t cStride,
-	size_t width, size_t height)
+    size_t width, size_t height)
 {
 #ifdef SIMD_AVX2_ENABLE
-	if (Avx2::Enable && width >= Avx2::A)
-		Avx2::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
-	else
+    if (Avx2::Enable && width >= Avx2::A)
+        Avx2::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
+    else
 #endif
-	Base::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
+    Base::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
 }
 
 SIMD_API void SimdAbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8_t * b, size_t bStride,

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -676,26 +676,26 @@ extern "C"
     */
     SIMD_API uint32_t SimdCrc32c(const void * src, size_t size);
 
-	/*! @ingroup correlation
+    /*! @ingroup correlation
 
-		\fn void SimdAbsDifference(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t * c, size_t cStride, size_t width, size_t height);
+        \fn void SimdAbsDifference(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t * c, size_t cStride, size_t width, size_t height);
 
-		\short Gets absolute difference of two gray 8-bit images, pyxel by pixel.
+        \short Gets absolute difference of two gray 8-bit images, pyxel by pixel.
 
-		The three images must have the same width and height.
+        The three images must have the same width and height.
 
-		\note This function has a C++ wrapper Simd::AbsDifference(const View<A> & a, const View<A> & b, View<A> & c).
+        \note This function has a C++ wrapper Simd::AbsDifference(const View<A> & a, const View<A> & b, View<A> & c).
 
-		\param [in] a - a pointer to pixels data of first image.
-		\param [in] aStride - a row size of first image.
-		\param [in] b - a pointer to pixels data of second image.
-		\param [in] bStride - a row size of second image.
-		\param [out] c - a pointer to pixels data of destination image.
-		\param [in] cStride - a row size of destination image.
-		\param [in] width - an image width.
-		\param [in] height - an image height.
-	*/
-	SIMD_API void SimdAbsDifference(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t * c, size_t cStride, size_t width, size_t height);
+        \param [in] a - a pointer to pixels data of first image.
+        \param [in] aStride - a row size of first image.
+        \param [in] b - a pointer to pixels data of second image.
+        \param [in] bStride - a row size of second image.
+        \param [out] c - a pointer to pixels data of destination image.
+        \param [in] cStride - a row size of destination image.
+        \param [in] width - an image width.
+        \param [in] height - an image height.
+    */
+    SIMD_API void SimdAbsDifference(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, uint8_t * c, size_t cStride, size_t width, size_t height);
 
     /*! @ingroup correlation
 
@@ -5370,10 +5370,10 @@ extern "C"
         \param [in] height - an image height.
         \param [out] sum - the result sum.
     */
-	
+    
     SIMD_API void SimdSquareSum(const uint8_t * src, size_t stride, size_t width, size_t height, uint64_t * sum);
-	
-	    /*! @ingroup other_statistic
+    
+        /*! @ingroup other_statistic
 
         \fn void SimdValueSquareSum(const uint8_t * src, size_t stride, size_t width, size_t height, uint64_t * valueSum, uint64_t * squareSum);
 
@@ -5386,10 +5386,10 @@ extern "C"
         \param [in] width - an image width.
         \param [in] height - an image height.
         \param [out] valueSum - the result value sum.
-		\param [out] squareSum - the result square sum.
+        \param [out] squareSum - the result square sum.
     */
     SIMD_API void SimdValueSquareSum(const uint8_t * src, size_t stride, size_t width, size_t height, uint64_t * valueSum, uint64_t * squareSum);
-	
+    
     /*! @ingroup other_statistic
 
         \fn void SimdCorrelationSum(const uint8_t * a, size_t aStride, const uint8_t * b, size_t bStride, size_t width, size_t height, uint64_t * sum);

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -2001,6 +2001,23 @@ extern "C"
 
     /*! @ingroup object_detection
 
+        \fn void * SimdDetectionLoadStringXml(char * xml);
+
+        \short Loads a classifier cascade from a string.
+
+        This function supports OpenCV HAAR and LBP cascades type.
+        Tree based cascades and old cascade formats are not supported.
+
+        \note This function is used for implementation of Simd::Detection.
+
+        \param [in,out] xml - A string with the xml of a classifier cascade.
+        \return a pointer to loaded cascade. On error it returns NULL.
+                This pointer is used in functions ::SimdDetectionInfo and ::SimdDetectionInit, and must be released with using of function ::SimdRelease.
+    */
+    SIMD_API void * SimdDetectionLoadStringXml(char * xml);
+
+    /*! @ingroup object_detection
+
         \fn void SimdDetectionInfo(const void * data, size_t * width, size_t * height, SimdDetectionInfoFlags * flags);
 
         \short Gets information about the classifier cascade.

--- a/src/Simd/SimdLib.hpp
+++ b/src/Simd/SimdLib.hpp
@@ -68,26 +68,26 @@ namespace Simd
         os << std::endl;
     }
 
-	/*! @ingroup correlation
+    /*! @ingroup correlation
 
-		\fn void AbsDifference(const View<A> & a, const View<A> & b, View<A> & c)
+        \fn void AbsDifference(const View<A> & a, const View<A> & b, View<A> & c)
 
-		\short Gets absolute difference of two gray 8-bit images, pyxel by pixel.
+        \short Gets absolute difference of two gray 8-bit images, pyxel by pixel.
 
-		Both images must have the same width and height.
+        Both images must have the same width and height.
 
-		\note This function is a C++ wrapper for function ::SimdAbsDifference.
+        \note This function is a C++ wrapper for function ::SimdAbsDifference.
 
-		\param [in] a - a first image.
-		\param [in] b - a second image.
-		\param [out] c - a destination image.
-	*/
-	template<template<class> class A> SIMD_INLINE void AbsDifference(const View<A> & a, const View<A> & b, View<A> & c)
-	{
-		assert(Compatible(a, b) && Compatible(b, c) && a.format == View<A>::Gray8);
+        \param [in] a - a first image.
+        \param [in] b - a second image.
+        \param [out] c - a destination image.
+    */
+    template<template<class> class A> SIMD_INLINE void AbsDifference(const View<A> & a, const View<A> & b, View<A> & c)
+    {
+        assert(Compatible(a, b) && Compatible(b, c) && a.format == View<A>::Gray8);
 
-		SimdAbsDifference(a.data, a.stride, b.data, b.stride, c.data, c.stride, a.width, a.height);
-	}
+        SimdAbsDifference(a.data, a.stride, b.data, b.stride, c.data, c.stride, a.width, a.height);
+    }
 
     /*! @ingroup correlation
 
@@ -3465,8 +3465,8 @@ namespace Simd
 
         SimdSquareSum(src.data, src.stride, src.width, src.height, &sum);
     }
-	
-	    /*! @ingroup other_statistic
+    
+        /*! @ingroup other_statistic
 
         \fn void ValueSquareSum(const View<A>& src, uint64_t & valueSum, uint64_t & squareSum)
 
@@ -3476,7 +3476,7 @@ namespace Simd
 
         \param [in] src - an input image.
         \param [out] valueSum - a result value sum.
-		\param [out] squareSum - a result square sum.
+        \param [out] squareSum - a result square sum.
     */
     template<template<class> class A> SIMD_INLINE void ValueSquareSum(const View<A>& src, uint64_t & valueSum, uint64_t & squareSum)
     {


### PR DESCRIPTION
The problem I encountered was that I had an xml string with the waterfall, not a file. To load it, I had to write it to a file and then reload it with the detection module.  
In this PR I add a new function * LoadStringXml * (the chosen name might not be the best), which allows you to load a cascade from an xml cascade already loaded in a string.  

I also found some wrong indentation in a previous PR I made, so I fix them here as well.