### PR TITLE
Error: use of deleted function ‘std::unique_ptr' when compiling with cython

### DIFF
--- a/src/Simd/SimdDetection.hpp
+++ b/src/Simd/SimdDetection.hpp
@@ -427,7 +427,7 @@ namespace Simd
                     ::SimdRelease(hids[i].handle);
             }
         };
-        typedef std::unique_ptr<Level> LevelPtr;
+        typedef std::shared_ptr<Level> LevelPtr;
         typedef std::vector<LevelPtr> LevelPtrs;
 
         std::vector<Data> _data;


### PR DESCRIPTION
Fixed issue #139
By replacing unique_ptr by shared_ptr