### PR TITLE
Remove invalid command line arg when building with clang

### DIFF
--- a/prj/cmake/CMakeLists.txt
+++ b/prj/cmake/CMakeLists.txt
@@ -115,7 +115,11 @@ endif()
     set_source_files_properties(${SIMD_SSE42_SRC} PROPERTIES COMPILE_FLAGS "${COMMON_CXX_FLAGS} -msse4.2")
 
     file(GLOB_RECURSE SIMD_AVX1_SRC ${TRUNK_DIR}/src/Simd/SimdAvx1*.cpp)
-    set_source_files_properties(${SIMD_AVX1_SRC} PROPERTIES COMPILE_FLAGS "${COMMON_CXX_FLAGS} -mavx -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store")
+    if ((CMAKE_CXX_COMPILER MATCHES "clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+        set_source_files_properties(${SIMD_AVX1_SRC} PROPERTIES COMPILE_FLAGS "${COMMON_CXX_FLAGS} -mavx")
+    else()
+        set_source_files_properties(${SIMD_AVX1_SRC} PROPERTIES COMPILE_FLAGS "${COMMON_CXX_FLAGS} -mavx -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store")
+    endif()
 
     file(GLOB_RECURSE SIMD_AVX2_SRC ${TRUNK_DIR}/src/Simd/SimdAvx2*.cpp)
     if ((CMAKE_CXX_COMPILER MATCHES "clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))


### PR DESCRIPTION
Based on https://clang.llvm.org/docs/ClangCommandLineReference.html#x86
this flag does not exist for Clang.

I read up a bit more on https://stackoverflow.com/a/52628753/4052492 and
it looks like clang defaults to not splitting unaligned load when given
-mavx: https://godbolt.org/z/n6Tx949hc

This is also similar to the check for clang when setting the flags for AVX2 (right below).