### PR TITLE
Fix compile error at GCC11

### DIFF
--- a/src/Simd/SimdGemm.h
+++ b/src/Simd/SimdGemm.h
@@ -24,7 +24,7 @@
 #ifndef __SimdGemm_h__
 #define __SimdGemm_h__
 
-#if defined(__GNUC__) && (__GNUC__ == 10) && (__GNUC_MINOR__ >= 1) && (__GNUC_MINOR__ <= 2)
+#if defined(__GNUC__) && ((__GNUC__ > 10) || ((__GNUC__ == 10) && (__GNUC_MINOR__ >= 1) && (__GNUC_MINOR__ <= 2)))
 #define SIMD_FUTURE_DISABLE
 #endif
 


### PR DESCRIPTION
The original SIMD_FUTURE_DISABLE implementation doesn't cover the higher version of GCC, so modify it
