### PR TITLE
Fix syntax error for macro on VS.

### DIFF
--- a/src/Simd/SimdAvx512bwResizerArea.cpp
+++ b/src/Simd/SimdAvx512bwResizerArea.cpp
@@ -214,8 +214,8 @@ namespace Simd
             {
                 ptrdiff_t srcTail = size2N - size4F, dstTail = srcTail / 2;
                 __mmask64 srcMask = TailMask64(srcTail);
-                __m512i s0 = _mm512_permutexvar_epi64(K64_PERMUTE_FOR_UNPACK, Load<false, true>(src0 + i, srcMask));
-                __m512i s1 = _mm512_permutexvar_epi64(K64_PERMUTE_FOR_UNPACK, Load<false, true>(src1 + i, srcMask));
+                __m512i s0 = _mm512_permutexvar_epi64(K64_PERMUTE_FOR_UNPACK, (Load<false, true>(src0 + i, srcMask)));
+                __m512i s1 = _mm512_permutexvar_epi64(K64_PERMUTE_FOR_UNPACK, (Load<false, true>(src1 + i, srcMask)));
                 s0 = _mm512_maddubs_epi16(ShuffleColor<N>(s0), K8_01);
                 s1 = _mm512_maddubs_epi16(ShuffleColor<N>(s1), K8_01);
                 Update<update, false, true>(dst + 0, _mm512_madd_epi16(_mm512_unpacklo_epi16(s0, s1), _val), TailMask16(dstTail - 0));


### PR DESCRIPTION
I have used Visual Studio 2017 solution but I changed WIndows SDK version from 8.1 to 10.9 (it should not matter but just wanted to note) and I got a syntax error in the following 2 lines: 217 and 218 in `Simd\src\Simd\SimdAvx512bwResizerArea.cpp`

```
__m512i s0 = _mm512_permutexvar_epi64(K64_PERMUTE_FOR_UNPACK, Load<false, true>(src0 + i, srcMask));
__m512i s1 = _mm512_permutexvar_epi64(K64_PERMUTE_FOR_UNPACK, Load<false, true>(src1 + i, srcMask));
```
because the macro according to VS does this expansion in this situation:
![image](https://user-images.githubusercontent.com/13377190/174344212-5b8bca95-e90b-4b5f-b1eb-5bba39b69c75.png)

so I fixed it by adding an extra pair or parentheses and now it builds fine.
