### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,20 @@ In order to use [Simd::Neural](http://ermig1979.github.io/Simd/help/namespace_si
 In order to use [Simd::Motion](http://ermig1979.github.io/Simd/help/namespace_simd_1_1_motion.html) you must include:
 
     #include "Simd/SimdMotion.hpp"
-	
+
+Package Managers
+================
+
+You can download and install simd using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install simd
+
+The simd port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Interaction with OpenCV
 =======================
 


### PR DESCRIPTION
`simd` is available as a port in vcpkg, a C++ library manager that simplifies installation for `simd `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build simd, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/simd/portfile.cmake). We try to keep the library maintained as close as possible to the original library.