### PR TITLE
Patches for compiler warnings + 1 error in MSVC2022 (Unicode, All warnings turned on)

### DIFF
--- a/src/Simd/SimdAmxBf16SynetMergedConvolution16bDepthwise3x3.cpp
+++ b/src/Simd/SimdAmxBf16SynetMergedConvolution16bDepthwise3x3.cpp
@@ -388,10 +388,10 @@ namespace Simd
                 LoadSrc<T, H, 1>(src0, src1, src2, src3, src4, src5, 0, mask0, tailS, mask2, s);
                 for (size_t dx = 0, offs = sX; dx < dstW; dx += 1, offs += sX)
                 {
-                    if (H > 0) d[0] = _mm512_setzero_ps();
-                    if (H > 1) d[1] = _mm512_setzero_ps();
-                    if (H > 2) d[2] = _mm512_setzero_ps();
-                    if (H > 3) d[3] = _mm512_setzero_ps();
+                    if constexpr (H > 0) d[0] = _mm512_setzero_ps();
+                    if constexpr (H > 1) d[1] = _mm512_setzero_ps();
+                    if constexpr (H > 2) d[2] = _mm512_setzero_ps();
+                    if constexpr (H > 3) d[3] = _mm512_setzero_ps();
                     switch (dx % 3)
                     {
                     case 0:

--- a/src/Simd/SimdAmxBf16SynetMergedConvolution8iInput.cpp
+++ b/src/Simd/SimdAmxBf16SynetMergedConvolution8iInput.cpp
@@ -461,6 +461,7 @@ namespace Simd
             case SimdConvolutionActivationMish: SetInput<SimdConvolutionActivationMish>(p, input); break;
             case SimdConvolutionActivationSwish: SetInput<SimdConvolutionActivationSwish>(p, input); break;
             case SimdConvolutionActivationGelu: SetInput<SimdConvolutionActivationGelu>(p, input); break;
+			case SimdConvolutionActivationHardSigmoid: SetInput<SimdConvolutionActivationHardSigmoid>(p, input); break;
             }
         }
     }

--- a/src/Simd/SimdAmxBf16SynetMergedConvolution8iOutput.cpp
+++ b/src/Simd/SimdAmxBf16SynetMergedConvolution8iOutput.cpp
@@ -427,6 +427,7 @@ namespace Simd
             case SimdConvolutionActivationMish: SetOutput<SimdConvolutionActivationMish>(p, output); break;
             case SimdConvolutionActivationSwish: SetOutput<SimdConvolutionActivationSwish>(p, output); break;
             case SimdConvolutionActivationGelu: SetOutput<SimdConvolutionActivationGelu>(p, output); break;
+			case SimdConvolutionActivationHardSigmoid: SetOutput<SimdConvolutionActivationHardSigmoid>(p, output); break;
             }
         }
     }

--- a/src/Simd/SimdAvx2Gemm32f.cpp
+++ b/src/Simd/SimdAvx2Gemm32f.cpp
@@ -845,6 +845,14 @@ namespace Simd
             Gemm32fNNcb::Main kernelMM, kernelMT;
             Gemm32fNNcb::Tail kernelTM, kernelTT;
             size_t microM, microN;
+
+			microM = 4;
+			microN = 8;
+			kernelMM = Avx2::GemmKernel4x8nn;
+			kernelMT = Avx2::GemmKernel4x8nn;
+			kernelTM = Avx2::GetGemmTail(M%microM, microN);
+			kernelTT = Avx2::GetGemmTail(M%microM, microN);
+
 #ifdef SIMD_X64_ENABLE
             if (type == GemmKernelF3 || (type == GemmKernelAny && (M == 4 || M == 8 || M == 16 || N == 24 || N == 48 || N == 96) && N > 16))
             {
@@ -878,13 +886,6 @@ namespace Simd
                 kernelTT = Avx2::GetGemmTail(M%microM, microN);
                 type = GemmKernelF1;
             }
-#else
-            microM = 4;
-            microN = 8;
-            kernelMM = Avx2::GemmKernel4x8nn;
-            kernelMT = Avx2::GemmKernel4x8nn;
-            kernelTM = Avx2::GetGemmTail(M%microM, microN);
-            kernelTT = Avx2::GetGemmTail(M%microM, microN);
 #endif
             return Gemm32fNNcb(M, N, K, microM, microN, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3(), 
                 kernelMM, kernelMT, kernelTM, kernelTT, Avx2::GemmPackA, Avx2::GemmPackB, Avx2::GemmScaleC, NULL, compatibility);

--- a/src/Simd/SimdAvx512bwTexture.cpp
+++ b/src/Simd/SimdAvx512bwTexture.cpp
@@ -175,7 +175,7 @@ namespace Simd
         template <bool align> void TextureGetDifferenceSum(const uint8_t * src, size_t srcStride, size_t width, size_t height,
             const uint8_t * lo, size_t loStride, const uint8_t * hi, size_t hiStride, int64_t * sum)
         {
-            assert(sum != NULL);
+            assert(sum != nullptr);
             if (align)
                 assert(Aligned(src) && Aligned(srcStride) && Aligned(lo) && Aligned(loStride) && Aligned(hi) && Aligned(hiStride));
 

--- a/src/Simd/SimdAvx512bwWinograd3.cpp
+++ b/src/Simd/SimdAvx512bwWinograd3.cpp
@@ -322,7 +322,7 @@ namespace Simd
                 PadType rowPad = dstH2 < dstH ? PadTail1 : PadNone;
                 size_t tailRow = dstH2 < dstH ? dstH - 1 : dstH - 2;
                 bool specialRowTail = dstH2 < dstH || (pad && dstH2);
-                bool specialColTail = pad ? dstW32 : (dstW32 < dstW);
+                bool specialColTail = pad ? static_cast<bool>(dstW32) : (dstW32 < dstW);
 
                 __mmask16 tails[5], noses[5];
                 for (size_t c = 0; c < 2; ++c)

--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -1398,6 +1398,9 @@ namespace Simd
                     _context->yuv420pToBgra(_context->img_comp[0].data, _context->img_comp[0].w2, _context->img_comp[1].data, _context->img_comp[1].w2,
                         _context->img_comp[2].data, _context->img_comp[2].w2, _context->img_x, _context->img_y, _image.data, _image.stride, 0xFF, SimdYuvTrect871);
                     return true;
+				default:
+					assert(false && "Unsupported pixel format for YUV 420 conversion.");
+					return false;
                 }
             }
             if (IsYuv444(*_context))
@@ -1414,18 +1417,29 @@ namespace Simd
                     _context->yuv444pToBgra(_context->img_comp[0].data, _context->img_comp[0].w2, _context->img_comp[1].data, _context->img_comp[1].w2,
                         _context->img_comp[2].data, _context->img_comp[2].w2, _context->img_x, _context->img_y, _image.data, _image.stride, 0xFF, SimdYuvTrect871);
                     return true;
+				default:
+					assert(false && "Unsupported pixel format for YUV 444 conversion.");
+					return false;
                 }
             }
             if (JpegToRgba(_context))
             {
                 size_t stride = 4 * _context->img_x;
-                if (_param.format == SimdPixelFormatRgba32)
+				switch (_param.format)
+				{
+				case SimdPixelFormatRgba32:
                     Base::Copy(_context->out.data, stride, _context->img_x, _context->img_y, 4, _image.data, _image.stride);
-                else if (_param.format == SimdPixelFormatGray8 || _param.format == SimdPixelFormatBgr24 ||
-                    _param.format == SimdPixelFormatBgra32 || _param.format == SimdPixelFormatRgb24)
+					return true;
+				case SimdPixelFormatGray8:
+				case SimdPixelFormatBgr24:
+				case SimdPixelFormatBgra32:
+				case SimdPixelFormatRgb24:
                     _context->rgbaToAny(_context->out.data, _context->img_x, _context->img_y, stride, _image.data, _image.stride);
-                else
-                    return false;
+					return true;
+				default:
+					assert(false && "Unsupported pixel format for JPEG conversion.");
+					return false;
+				}
                 return true;
             }
             return false;

--- a/src/Simd/SimdBaseImageLoadPng.cpp
+++ b/src/Simd/SimdBaseImageLoadPng.cpp
@@ -60,7 +60,7 @@ namespace Simd
                     sizes[0] = 0;
                     for (i = 1; i < 16; ++i)
                         if (sizes[i] > (1 << i))
-                            return CorruptPngError("bad sizes");
+                            return static_cast<bool>(CorruptPngError("bad sizes"));
                     code = 0;
                     for (i = 1; i < 16; ++i)
                     {
@@ -69,7 +69,7 @@ namespace Simd
                         firstSymbol[i] = (uint16_t)k;
                         code = (code + sizes[i]);
                         if (sizes[i] && code - 1 >= (1 << i))
-                            return CorruptPngError("bad codelengths");
+                            return static_cast<bool>(CorruptPngError("bad codelengths"));
                         maxCode[i] = code << (16 - i);
                         code <<= 1;
                         k += sizes[i];
@@ -1104,13 +1104,13 @@ namespace Simd
 
             _buffer.Resize(width * height * output_bytes);
             if (_buffer.Empty())
-                return PngLoadError("outofmem", "Out of memory");
+                return static_cast<bool>(PngLoadError("outofmem", "Out of memory"));
 
             img_width_bytes = (_channels * width * _depth + 7) >> 3;
             img_len = (img_width_bytes + 1) * height;
 
             if (size < img_len)
-                return CorruptPngError("not enough pixels");
+                return static_cast<bool>(CorruptPngError("not enough pixels"));
 
             for (j = 0; j < height; ++j)
             {
@@ -1119,12 +1119,12 @@ namespace Simd
                 int filter = *data++;
 
                 if (filter > 4)
-                    return CorruptPngError("invalid filter");
+                    return static_cast<bool>(CorruptPngError("invalid filter"));
 
                 if (_depth < 8)
                 {
                     if (img_width_bytes > width)
-                        return CorruptPngError("invalid width");
+                        return static_cast<bool>(CorruptPngError("invalid width"));
                     cur += width * _outN - img_width_bytes; // store output to the rightmost img_len bytes, so we can decode in place
                     filter_bytes = 1;
                     width_ = img_width_bytes;

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -7361,7 +7361,7 @@ extern "C"
 
         \fn void* SimdSynetPermuteInit(const size_t * shape, const size_t* order, size_t count, SimdTensorDataType type);
 
-        \short Initilizes permute algorithm.
+        \short Initializes permute algorithm.
 
         \param [in] shape - a pointer to shape of input tensor.
         \param [in] order - a pointer to order of dimensions in output tensor.

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -757,7 +757,7 @@ extern "C"
 
         \return string with version of %Simd Library (major version number, minor version number, release number, number of SVN's commits).
     */
-    SIMD_API const char * SimdVersion();
+    SIMD_API const char * SimdVersion(void);
 
     /*! @ingroup info
 
@@ -831,7 +831,7 @@ extern "C"
 
         \return string with internal performance statistics of %Simd Library.
     */
-    SIMD_API const char * SimdPerformanceStatistic();
+    SIMD_API const char * SimdPerformanceStatistic(void);
 
     /*! @ingroup memory
 
@@ -881,7 +881,7 @@ extern "C"
 
         \return a required alignment.
     */
-    SIMD_API size_t SimdAlignment();
+    SIMD_API size_t SimdAlignment(void);
 
     /*! @ingroup memory
 
@@ -903,7 +903,7 @@ extern "C"
 
         \return current thread number.
     */
-    SIMD_API size_t SimdGetThreadNumber();
+    SIMD_API size_t SimdGetThreadNumber(void);
 
     /*! @ingroup thread
 
@@ -921,7 +921,7 @@ extern "C"
 
         \short Clears MMX registers (runs EMMS instruction). It is x86 specific functionality. 
     */
-    SIMD_API void SimdEmpty();
+    SIMD_API void SimdEmpty(void);
 
     /*! @ingroup cpu_flags
 
@@ -931,7 +931,7 @@ extern "C"
 
         \return current 'fast' mode.
     */
-    SIMD_API SimdBool SimdGetFastMode();
+    SIMD_API SimdBool SimdGetFastMode(void);
 
     /*! @ingroup cpu_flags
 
@@ -949,7 +949,7 @@ extern "C"
 
         \short Set configuration of AMX registers to maximat size. It is x86 specific functionality. Affect only on CPU with AMX support.
     */
-    SIMD_API void SimdSetAmxFull();
+    SIMD_API void SimdSetAmxFull(void);
 
     /*! @ingroup hash
 

--- a/src/Simd/SimdSse41Gemm32fNN.cpp
+++ b/src/Simd/SimdSse41Gemm32fNN.cpp
@@ -622,6 +622,14 @@ namespace Simd
             Gemm32fNNcb::Main kernelMM, kernelMT;
             Gemm32fNNcb::Tail kernelTM, kernelTT;
             size_t microM, microN;
+
+			microM = 4;
+			microN = 4;
+			kernelMM = Sse41::GemmKernel4x4nn;
+			kernelMT = Sse41::GemmKernel4x4nn;
+			kernelTM = Sse41::GetGemmTail(M%microM, microN);
+			kernelTT = Sse41::GetGemmTail(M%microM, microN);
+
 #ifdef SIMD_X64_ENABLE
             if (type == GemmKernelF3 || (type == GemmKernelAny && (M == 4 || M == 8 || M == 16) && N > 8))
             {
@@ -655,13 +663,6 @@ namespace Simd
                 kernelTT = Sse41::GetGemmTail(M%microM, microN);
                 type = GemmKernelF1;
             }
-#else
-            microM = 4;
-            microN = 4;
-            kernelMM = Sse41::GemmKernel4x4nn;
-            kernelMT = Sse41::GemmKernel4x4nn;
-            kernelTM = Sse41::GetGemmTail(M%microM, microN);
-            kernelTT = Sse41::GetGemmTail(M%microM, microN);
 #endif
             return Gemm32fNNcb(M, N, K, microM, microN, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3(),  
                 kernelMM, kernelMT, kernelTM, kernelTT, NULL, Sse41::GemmPackB, Sse41::GemmScaleC, NULL, compatibility);

--- a/src/Test/TestCheckC.c
+++ b/src/Test/TestCheckC.c
@@ -29,6 +29,6 @@
 
 #include "Simd/SimdLib.h"
 
-void test()
+void test(void)
 {
 }

--- a/src/Test/TestFile.cpp
+++ b/src/Test/TestFile.cpp
@@ -49,7 +49,7 @@ namespace Test
     bool DirectoryExists(const String & path)
     {
 #if defined(_WIN32)
-        DWORD fileAttribute = GetFileAttributes(path.c_str());
+        DWORD fileAttribute = GetFileAttributesA(path.c_str());
         return ((fileAttribute != INVALID_FILE_ATTRIBUTES) &&
             (fileAttribute & FILE_ATTRIBUTE_DIRECTORY) != 0);
 #elif defined(__linux__)

--- a/src/Test/TestVideo.h
+++ b/src/Test/TestVideo.h
@@ -36,7 +36,9 @@ namespace Test
 
         struct Filter
         {
-            virtual bool Process(const Frame & input, Frame & output) = 0;
+			virtual ~Filter() = default;
+
+			virtual bool Process(const Frame & input, Frame & output) = 0;
         };
 
         Video(bool window = true);


### PR DESCRIPTION
As it says on the tin.

Each commit stands on its own and can be cherrypicked independently -- iff you want some but not all of this.

The MSVC2022 warning/error reports are part of each commit's message; mostly trivial stuff, but do note commit SHA-1: b607c282cb4fff80ded676957cb1128c3aaf16e5, which followed after MSVC started yakking about the sigmoid enum value not being implemented (*oops?*).

Also note commit SHA-1: 9d383d00d15fcf6ff27cf77b15eadf8b1e6ce5ba which turns the run-time `if` statements in the template to compile-time `if constexpr` ones, so the compiler can safely agree with us that there's no out-of-bounds write access happening in the code.

HTH & Thank you for this lib!