### PR TITLE
Add View::Copy and Frame::Copy returning by value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /prj/txt/FullVersion.txt
 /src/Simd/SimdVersion.h
+.idea/
+cmake-build-*/

--- a/src/Simd/SimdFrame.hpp
+++ b/src/Simd/SimdFrame.hpp
@@ -201,6 +201,21 @@ namespace Simd
         Frame * Clone(Frame & buffer) const;
 
         /*!
+            Gets a copy of current frame by value.
+
+            \return a new Frame structure containing a copy of the frame.
+        */
+        Frame Copy() const;
+
+        /*!
+            Gets a copy of region of current frame bounded by the rectangle with specified coordinates, by value.
+
+            \param [in] rect - a rectangle which bounds the region.
+            \return a new Frame structure containing a copy of the region.
+        */
+        Frame Copy(const Rectangle<ptrdiff_t>& rect) const;
+
+        /*!
             Creates reference to other Frame structure.
 
             \note This function does not create a copy of the frame! It only creates a reference to the same frame.
@@ -678,6 +693,18 @@ namespace Simd
                                         flipped, timestamp, yuvType);
         Copy(*this, *clone);
         return clone;
+    }
+
+    template <template<class> class A> SIMD_INLINE Frame<A> Frame<A>::Copy() const
+    {
+        Frame<A> copy(width, height, format, flipped, timestamp, yuvType);
+        Simd::Copy(*this, copy);
+        return copy;
+    }
+
+    template <template<class> class A> SIMD_INLINE Frame<A> Frame<A>::Copy(const Rectangle<ptrdiff_t>& rect) const
+    {
+        return Region(rect).Copy();
     }
 
     template <template<class> class A> SIMD_INLINE Frame<A> & Frame<A>::operator = (const Frame<A> & frame)

--- a/src/Simd/SimdView.hpp
+++ b/src/Simd/SimdView.hpp
@@ -267,6 +267,21 @@ namespace Simd
         View * Clone(View & buffer) const;
 
         /*!
+            Gets a copy of current image view by value.
+
+            \return a new View structure containing a copy of the image.
+        */
+        View Copy() const;
+
+        /*!
+            Gets a copy of region of current image view bounded by the rectangle with specified coordinates, by value.
+
+            \param [in] rect - a rectangle which bounds the region.
+            \return a new View structure containing a copy of the region.
+        */
+        View Copy(const Rectangle<ptrdiff_t>& rect) const;
+
+        /*!
             Creates view which references to other View structure.
 
             \note This function does not create a copy of image view! It only creates a reference to the same image.
@@ -938,6 +953,20 @@ namespace Simd
         for (size_t row = 0; row < height; ++row)
             memcpy(view->data + view->stride*row, data + stride*row, size);
         return view;
+    }
+
+    template <template<class> class A> SIMD_INLINE View<A> View<A>::Copy() const
+    {
+        View<A> view(width, height, format);
+        size_t size = width*PixelSize();
+        for (size_t row = 0; row < height; ++row)
+            memcpy(view.data + view.stride*row, data + stride*row, size);
+        return view;
+    }
+
+    template <template<class> class A> SIMD_INLINE View<A> View<A>::Copy(const Rectangle<ptrdiff_t>& rect) const
+    {
+        return Region(rect).Copy();
     }
 
     /*! \cond */


### PR DESCRIPTION
## Summary

Add `Copy()` overloads to `View` and `Frame` that return a new object by value, alongside the existing `Clone()` methods which return raw pointers the caller must `delete`.

## Details

`View::Clone()` and `Frame::Clone()` return `View*` / `Frame*`, leaving ownership to the caller. This patch adds value-returning counterparts:

- `View<A> View<A>::Copy() const`
- `View<A> View<A>::Copy(const Rectangle<ptrdiff_t>& rect) const`
- `Frame<A> Frame<A>::Copy() const`
- `Frame<A> Frame<A>::Copy(const Rectangle<ptrdiff_t>& rect) const`

Implementation mirrors the existing `Clone()`: `View::Copy()` does row-wise `memcpy` into a freshly constructed `View`; `Frame::Copy()` constructs a new `Frame` and delegates to the global `Simd::Copy(src, dst)`. The region overloads forward to `Region(rect).Copy()`.

No changes to existing API.