### PR TITLE
Fix integer overflow in JPEG dimension sanity check

### DIFF
--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -899,7 +899,7 @@ namespace Simd
             }
             if (scan) 
                 return 1;
-            if (z->img_x* z->img_y * z->img_n > INT_MAX) 
+            if ((uint64_t)z->img_x * z->img_y * z->img_n > INT_MAX)
                 return JpegLoadError("too large", "Image too large to decode");
             int h_max = 1, v_max = 1;
             for (int i = 0; i < z->img_n; ++i) 


### PR DESCRIPTION
### Bug

`JpegProcessFrameHeader` in `src/Simd/SimdBaseImageLoadJpeg.cpp:902` guards against oversized JPEGs with:

```cpp
if (z->img_x* z->img_y * z->img_n > INT_MAX)
    return JpegLoadError("too large", "Image too large to decode");
```

`img_x` and `img_y` are `uint32_t` and `img_n` is `int`, so the product is computed in 32-bit unsigned arithmetic and wraps around modulo 2^32 before being compared with `INT_MAX`. Because `img_x` and `img_y` are read with `GetBe16u()` they each fit in 16 bits, and the worst-case product `65535 * 65535 * 4 ≈ 2^34` exceeds the 32-bit range, so the check can be bypassed with carefully chosen dimensions.

For example, with `img_x = img_y = 46341` (each within the 16-bit range) and `img_n = 4`:

* True product: `46341 * 46341 * 4 = 8,589,953,124`
* Truncated to `uint32_t`: `18,532`
* `18532 > INT_MAX` is false → the check passes.

### Reproducer

A small standalone snippet that mirrors the expression demonstrates the wrap:

```cpp
#include <cstdio>
#include <cstdint>
#include <climits>
int main() {
    uint32_t img_x = 46341, img_y = 46341;
    int img_n = 4;
    printf("buggy:   %d\n", (img_x * img_y * img_n > INT_MAX));        // 0
    printf("correct: %d\n", ((uint64_t)img_x * img_y * img_n > INT_MAX)); // 1
}
```

Once a crafted SOF marker slips past the check, downstream allocations in the same translation unit use the unchecked dimensions. In particular `JpegToRgba` does:

```cpp
z->out.Resize(n * z->img_x * z->img_y + 1);   // line 1141
...
uint8_t* out = z->out.data + n * z->img_x * j; // line 1146
```

The first expression is still 32-bit arithmetic, so the allocation request also wraps (to ~18 kB for the example above) while the subsequent decode loop walks the full `img_x * img_y` pixels and writes far beyond the allocated buffer.

### Fix

Promote the multiplication to `uint64_t` so the comparison reflects the actual product. This keeps the original intent of the check (refuse images whose pixel count exceeds `INT_MAX`) and closes the wrap-around path that fed the later overflow. The change is local to the callee that performed the check and does not touch any caller.

### Build evidence

`cmake` + `make Simd` builds cleanly on macOS / clang 17 after the change.