### PR TITLE
fix OOB write in JPEG DHT parsing when sizes sum > 256

### DIFF
--- a/src/Simd/SimdAvx2ImageLoadJpeg.cpp
+++ b/src/Simd/SimdAvx2ImageLoadJpeg.cpp
@@ -319,7 +319,12 @@ namespace Simd
         static int jpeg__build_huffman(jpeg__huffman* h, int* count)
         {
             int i, j, k = 0;
+            int total = 0;
             unsigned int code;
+            for (i = 0; i < 16; ++i)
+                total += count[i];
+            if (total > 256)
+                return JpegLoadError("bad DHT count", "Corrupt JPEG");
             // build size list for each symbol (from JPEG spec)
             for (i = 0; i < 16; ++i)
                 for (j = 0; j < count[i]; ++j)

--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -52,6 +52,11 @@ namespace Simd
         int JpegHuffman::Build(const int* count)
         {
             int i, j, k = 0;
+            int total = 0;
+            for (i = 0; i < 16; ++i)
+                total += count[i];
+            if (total > 256)
+                return JpegLoadError("bad DHT count", "Corrupt JPEG");
             for (i = 0; i < 16; ++i)
                 for (j = 0; j < count[i]; ++j)
                     size[k++] = (uint8_t)(i + 1);


### PR DESCRIPTION
A crafted DHT marker can hand `JpegHuffman::Build` a `count[]` whose 16 entries sum well past 256 (max 16*255 = 4080). The first inner loop then writes `size[k++]` past the 257-byte `size` member of `JpegHuffman`, and the follow-up `for (i=0; i<n; ++i) v[i] = stream->Get8u();` in the `0xC4` handler overruns `values[256]` with attacker-controlled bytes. Reject `total > 256` up front in both the Base and AVX2 stb-derived decoders.