### PR TITLE
fix uint32 wrap in JpegToRgba output buffer sizing

### DIFF
--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -1138,7 +1138,10 @@ namespace Simd
                 else                               
                     r->resample = JpegResampleRowGeneric;
             }
-            z->out.Resize(n * z->img_x * z->img_y + 1);
+            uint64_t outSize = (uint64_t)n * z->img_x * z->img_y + 1;
+            if (outSize > INT_MAX)
+                return JpegLoadError("too large", "Image too large to decode");
+            z->out.Resize((size_t)outSize);
             if (z->out.Empty()) 
                 return JpegLoadError("outofmem", "Out of memory");
             for (unsigned int j = 0; j < z->img_y; ++j) 


### PR DESCRIPTION
JpegToRgba allocates `n * img_x * img_y + 1` in uint32 with n=4 hardcoded, while the SOF sanity check at line 902 only bounds `img_x * img_y * img_n`. For a grayscale JPEG (img_n=1) with img_x=img_y=32774 the check passes (1,074,138,756 ≤ INT_MAX) but the allocation wraps to ~1.5 MB and the subsequent per-row loop writes ~4.3 GB past `z->out.data`. The AVX2 path at line 1989 already uses `jpeg__malloc_mad3` for the same allocation; this brings the Base path to parity by promoting the multiplication to uint64 and rejecting overflow.