### PR TITLE
fix OOB write in png ReadTransparency for palette tRNS

### DIFF
--- a/src/Simd/SimdBaseImageLoadPng.cpp
+++ b/src/Simd/SimdBaseImageLoadPng.cpp
@@ -994,7 +994,7 @@ namespace Simd
                 return false;
             if (_paletteChannels)
             {
-                if (_palette.size == 0 || chunk.size > _palette.size || !_stream.CanRead(chunk.size))
+                if (_palette.size == 0 || chunk.size > _palette.size / 4 || !_stream.CanRead(chunk.size))
                     return false;
                 _paletteChannels = 4;
                 for (size_t i = 0; i < chunk.size; ++i)


### PR DESCRIPTION
ReadPalette sizes `_palette` to length*4 bytes (length = PLTE entry count). ReadTransparency then bounds the tRNS chunk by `_palette.size` while writing `_palette.data[i*4+3]` for `i < chunk.size`, so a chunk up to 4x the entry count overruns the buffer with attacker bytes. With 2 entries an 8-byte buffer accepts an 8-byte tRNS and the loop writes index 11. stb_image checks the chunk against the entry count, so bound by `_palette.size / 4`.