### PR TITLE
use gray converters for 8-bit bmp in SetConverters

### DIFF
--- a/src/Simd/SimdAvx2ImageLoad.cpp
+++ b/src/Simd/SimdAvx2ImageLoad.cpp
@@ -131,6 +131,18 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            if (_bpp == 8)
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Avx2::GrayToBgr; break;
+                case SimdPixelFormatRgb24: _toAny = Avx2::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Avx2::GrayToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Avx2::GrayToBgra; break;
+                default: break;
+                }
+                return;
+            }
             switch (_param.format)
             {
             case SimdPixelFormatGray8: _toAny = (_bpp == 32 ? Avx2::BgraToGray : (_bpp == 24 ? Avx2::BgrToGray : NULL)); break;

--- a/src/Simd/SimdAvx512bwImageLoad.cpp
+++ b/src/Simd/SimdAvx512bwImageLoad.cpp
@@ -127,6 +127,18 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            if (_bpp == 8)
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Avx512bw::GrayToBgr; break;
+                case SimdPixelFormatRgb24: _toAny = Avx512bw::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Avx512bw::GrayToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Avx512bw::GrayToBgra; break;
+                default: break;
+                }
+                return;
+            }
             switch (_param.format)
             {
             case SimdPixelFormatGray8: _toAny = (_bpp == 32 ? Avx512bw::BgraToGray : (_bpp == 24 ? Avx512bw::BgrToGray : NULL)); break;

--- a/src/Simd/SimdBaseImageLoadBmp.cpp
+++ b/src/Simd/SimdBaseImageLoadBmp.cpp
@@ -197,6 +197,18 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            if (_bpp == 8)
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Base::GrayToBgr; break;
+                case SimdPixelFormatRgb24: _toAny = Base::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Base::GrayToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Base::GrayToBgra; break;
+                default: break;
+                }
+                return;
+            }
             switch (_param.format)
             {
             case SimdPixelFormatGray8: _toAny = (_bpp == 32 ? Base::BgraToGray : (_bpp == 24 ? Base::BgrToGray : NULL)); break;

--- a/src/Simd/SimdNeonImageLoad.cpp
+++ b/src/Simd/SimdNeonImageLoad.cpp
@@ -127,6 +127,18 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            if (_bpp == 8)
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Neon::GrayToBgr; break;
+                case SimdPixelFormatRgb24: _toAny = Neon::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Neon::GrayToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Neon::GrayToBgra; break;
+                default: break;
+                }
+                return;
+            }
             switch (_param.format)
             {
             case SimdPixelFormatGray8: _toAny = (_bpp == 32 ? Neon::BgraToGray : (_bpp == 24 ? Neon::BgrToGray : NULL)); break;

--- a/src/Simd/SimdSse41ImageLoad.cpp
+++ b/src/Simd/SimdSse41ImageLoad.cpp
@@ -132,6 +132,18 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            if (_bpp == 8)
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Sse41::GrayToBgr; break;
+                case SimdPixelFormatRgb24: _toAny = Sse41::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Sse41::GrayToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Sse41::GrayToBgra; break;
+                default: break;
+                }
+                return;
+            }
             switch (_param.format)
             {
             case SimdPixelFormatGray8: _toAny = (_bpp == 32 ? Sse41::BgraToGray : (_bpp == 24 ? Sse41::BgrToGray : NULL)); break;


### PR DESCRIPTION
Turned this up feeding non-default output formats to the image loaders. An 8-bit BMP gives a 1-byte-per-pixel source row (`_size = _width`), but `SetConverters` drops through to `BgrToRgb` / `BgrToBgra` / `RgbToBgra` for color targets, all of which read 3 bytes per pixel and walk off the end of the row. Send `_bpp == 8` to the gray converters, matching the PXM loader.