### PR TITLE
Add SVE2 BackgroundIncrementCount optimization

### DIFF
--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -21,6 +21,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -16,6 +16,9 @@
     <Filter Include="Sve2\Math">
       <UniqueIdentifier>{20effda6-54db-458e-893a-7d219e5ec991}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sve2\Motion">
+      <UniqueIdentifier>{c7b7a0a0-3931-46d4-b726-c78f5257c775}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdSve2.h">
@@ -23,6 +26,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp">
+      <Filter>Sve2\Motion</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp">
       <Filter>Sve2\System</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -801,6 +801,11 @@ SIMD_API void SimdBackgroundIncrementCount(const uint8_t * value, size_t valueSt
         Sse41::BackgroundIncrementCount(value, valueStride, width, height, loValue, loValueStride, hiValue, hiValueStride, loCount, loCountStride, hiCount, hiCountStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BackgroundIncrementCount(value, valueStride, width, height, loValue, loValueStride, hiValue, hiValueStride, loCount, loCountStride, hiCount, hiCountStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BackgroundIncrementCount(value, valueStride, width, height, loValue, loValueStride, hiValue, hiValueStride, loCount, loCountStride, hiCount, hiCountStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -31,6 +31,10 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        void BackgroundIncrementCount(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
+            uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride);
+
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Background.cpp
+++ b/src/Simd/SimdSve2Background.cpp
@@ -1,0 +1,72 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void BackgroundIncrementCount(const uint8_t* value, const uint8_t* loValue, const uint8_t* hiValue,
+            uint8_t* loCount, uint8_t* hiCount, const svuint8_t& _1, const svbool_t& mask)
+        {
+            svuint8_t _value = svld1_u8(mask, value);
+            svuint8_t _loValue = svld1_u8(mask, loValue);
+            svuint8_t _hiValue = svld1_u8(mask, hiValue);
+            svuint8_t _loCount = svld1_u8(mask, loCount);
+            svuint8_t _hiCount = svld1_u8(mask, hiCount);
+
+            svbool_t incLo = svcmplt_u8(mask, _value, _loValue);
+            svbool_t incHi = svcmpgt_u8(mask, _value, _hiValue);
+
+            svst1_u8(mask, loCount, svqadd_u8(_loCount, svand_u8_z(incLo, _1, _1)));
+            svst1_u8(mask, hiCount, svqadd_u8(_hiCount, svand_u8_z(incHi, _1, _1)));
+        }
+
+        void BackgroundIncrementCount(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
+            uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            svuint8_t _1 = svdup_n_u8(1);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    BackgroundIncrementCount(value + col, loValue + col, hiValue + col, loCount + col, hiCount + col, _1, body);
+                if (widthA < width)
+                    BackgroundIncrementCount(value + col, loValue + col, hiValue + col, loCount + col, hiCount + col, _1, tail);
+                value += valueStride;
+                loValue += loValueStride;
+                hiValue += hiValueStride;
+                loCount += loCountStride;
+                hiCount += hiCountStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -534,6 +534,11 @@ namespace Test
             result = result && BackgroundIncrementCountAutoTest(FUNC2(Simd::Neon::BackgroundIncrementCount), FUNC2(SimdBackgroundIncrementCount));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BackgroundIncrementCountAutoTest(FUNC2(Simd::Sve2::BackgroundIncrementCount), FUNC2(SimdBackgroundIncrementCount));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Simd::Sve2::BackgroundIncrementCount` with predicated SVE2 byte operations.
- Route `SimdBackgroundIncrementCount` to the SVE2 implementation when available.
- Extend background auto-tests and VS2022 SVE2 project metadata for the new source file.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BackgroundIncrementCount -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I"/workspace/src" -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only "/workspace/src/Simd/SimdSve2Background.cpp"`
- `aarch64-linux-gnu-g++ -std=c++17 -I"/workspace/src" -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only "/workspace/src/Simd/SimdLib.cpp"`
- `aarch64-linux-gnu-g++ -std=c++17 -I"/workspace/src" -march=armv9-a+sve2 -msve-vector-bits=scalable -c "/workspace/src/Simd/SimdSve2Background.cpp" -o "/tmp/SimdSve2Background.o"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc4d25ff-fe7f-4b61-af7e-5128f13b10f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc4d25ff-fe7f-4b61-af7e-5128f13b10f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

