### PR TITLE
Add SVE2 BackgroundAdjustRange optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -56,6 +56,7 @@
  <li>SVE2 optimizations of function ConditionalSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
+ <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
 </ul>
 
 <h4>Documentation</h4>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -837,6 +837,12 @@ SIMD_API void SimdBackgroundAdjustRange(uint8_t * loCount, size_t loCountStride,
         hiCount, hiCountStride, hiValue, hiValueStride, threshold);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BackgroundAdjustRange(loCount, loCountStride, width, height, loValue, loValueStride,
+            hiCount, hiCountStride, hiValue, hiValueStride, threshold);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BackgroundAdjustRange(loCount, loCountStride, width, height, loValue, loValueStride,

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -35,6 +35,10 @@ namespace Simd
             const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
             uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride);
 
+        void BackgroundAdjustRange(uint8_t* loCount, size_t loCountStride, size_t width, size_t height,
+            uint8_t* loValue, size_t loValueStride, uint8_t* hiCount, size_t hiCountStride,
+            uint8_t* hiValue, size_t hiValueStride, uint8_t threshold);
+
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Background.cpp
+++ b/src/Simd/SimdSve2Background.cpp
@@ -67,6 +67,61 @@ namespace Simd
                 hiCount += hiCountStride;
             }
         }
+
+        SIMD_INLINE svuint8_t AdjustLo(const svbool_t& mask, const svuint8_t& count, const svuint8_t& value,
+            const svuint8_t& threshold, const svuint8_t& _1)
+        {
+            svuint8_t dec = svand_u8_z(svcmpgt_u8(mask, count, threshold), _1, _1);
+            svuint8_t inc = svand_u8_z(svcmplt_u8(mask, count, threshold), _1, _1);
+            return svqsub_u8(svqadd_u8(value, inc), dec);
+        }
+
+        SIMD_INLINE svuint8_t AdjustHi(const svbool_t& mask, const svuint8_t& count, const svuint8_t& value,
+            const svuint8_t& threshold, const svuint8_t& _1)
+        {
+            svuint8_t inc = svand_u8_z(svcmpgt_u8(mask, count, threshold), _1, _1);
+            svuint8_t dec = svand_u8_z(svcmplt_u8(mask, count, threshold), _1, _1);
+            return svqsub_u8(svqadd_u8(value, inc), dec);
+        }
+
+        SIMD_INLINE void BackgroundAdjustRange(uint8_t* loCount, uint8_t* loValue, uint8_t* hiCount, uint8_t* hiValue,
+            const svuint8_t& threshold, const svuint8_t& _1, const svuint8_t& _0, const svbool_t& mask)
+        {
+            svuint8_t _loCount = svld1_u8(mask, loCount);
+            svuint8_t _loValue = svld1_u8(mask, loValue);
+            svuint8_t _hiCount = svld1_u8(mask, hiCount);
+            svuint8_t _hiValue = svld1_u8(mask, hiValue);
+
+            svst1_u8(mask, loValue, AdjustLo(mask, _loCount, _loValue, threshold, _1));
+            svst1_u8(mask, hiValue, AdjustHi(mask, _hiCount, _hiValue, threshold, _1));
+            svst1_u8(mask, loCount, _0);
+            svst1_u8(mask, hiCount, _0);
+        }
+
+        void BackgroundAdjustRange(uint8_t* loCount, size_t loCountStride, size_t width, size_t height,
+            uint8_t* loValue, size_t loValueStride, uint8_t* hiCount, size_t hiCountStride,
+            uint8_t* hiValue, size_t hiValueStride, uint8_t threshold)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            svuint8_t _threshold = svdup_n_u8(threshold);
+            svuint8_t _1 = svdup_n_u8(1);
+            svuint8_t _0 = svdup_n_u8(0);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    BackgroundAdjustRange(loCount + col, loValue + col, hiCount + col, hiValue + col, _threshold, _1, _0, body);
+                if (widthA < width)
+                    BackgroundAdjustRange(loCount + col, loValue + col, hiCount + col, hiValue + col, _threshold, _1, _0, tail);
+                loValue += loValueStride;
+                hiValue += hiValueStride;
+                loCount += loCountStride;
+                hiCount += hiCountStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -568,6 +568,11 @@ namespace Test
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && BackgroundAdjustRangeAutoTest(FUNC3(Simd::Neon::BackgroundAdjustRange), FUNC3(SimdBackgroundAdjustRange));
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BackgroundAdjustRangeAutoTest(FUNC3(Simd::Sve2::BackgroundAdjustRange), FUNC3(SimdBackgroundAdjustRange));
+#endif
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBackgroundAdjustRange`.
- Add SVE2 coverage in the background adjust range auto test.
- Document the new SVE2 optimization in 2026 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BackgroundAdjustRange -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -I src -c src/Simd/SimdSve2Background.cpp -o /tmp/SimdSve2Background.o`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -I src -c src/Test/TestBackground.cpp -o /tmp/TestBackground.o`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e03a804-9761-4057-9ac6-1683c9937548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e03a804-9761-4057-9ac6-1683c9937548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

