### PR TITLE
Add SVE2 BackgroundAdjustRangeMasked optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -56,6 +56,7 @@
  <li>SVE2 optimizations of function ConditionalSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
+ <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
 </ul>
 
 <h4>Documentation</h4>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -870,6 +870,12 @@ SIMD_API void SimdBackgroundAdjustRangeMasked(uint8_t * loCount, size_t loCountS
         hiCount, hiCountStride,hiValue, hiValueStride, threshold, mask, maskStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BackgroundAdjustRangeMasked(loCount, loCountStride, width, height, loValue, loValueStride,
+            hiCount, hiCountStride, hiValue, hiValueStride, threshold, mask, maskStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BackgroundAdjustRangeMasked(loCount, loCountStride, width, height, loValue, loValueStride,

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -35,6 +35,10 @@ namespace Simd
             const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
             uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride);
 
+        void BackgroundAdjustRangeMasked(uint8_t* loCount, size_t loCountStride, size_t width, size_t height,
+            uint8_t* loValue, size_t loValueStride, uint8_t* hiCount, size_t hiCountStride,
+            uint8_t* hiValue, size_t hiValueStride, uint8_t threshold, const uint8_t* mask, size_t maskStride);
+
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Background.cpp
+++ b/src/Simd/SimdSve2Background.cpp
@@ -67,6 +67,62 @@ namespace Simd
                 hiCount += hiCountStride;
             }
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint8_t AdjustLo(const svuint8_t& count, const svuint8_t& value, const svbool_t& mask, const svuint8_t& threshold, const svuint8_t& _1)
+        {
+            svbool_t dec = svcmpgt_u8(mask, count, threshold);
+            svbool_t inc = svcmplt_u8(mask, count, threshold);
+            return svqsub_u8(svqadd_u8(value, svand_u8_z(inc, _1, _1)), svand_u8_z(dec, _1, _1));
+        }
+
+        SIMD_INLINE svuint8_t AdjustHi(const svuint8_t& count, const svuint8_t& value, const svbool_t& mask, const svuint8_t& threshold, const svuint8_t& _1)
+        {
+            svbool_t inc = svcmpgt_u8(mask, count, threshold);
+            svbool_t dec = svcmplt_u8(mask, count, threshold);
+            return svqsub_u8(svqadd_u8(value, svand_u8_z(inc, _1, _1)), svand_u8_z(dec, _1, _1));
+        }
+
+        SIMD_INLINE void BackgroundAdjustRangeMasked(uint8_t* loCount, uint8_t* loValue, uint8_t* hiCount, uint8_t* hiValue,
+            const uint8_t* mask, const svuint8_t& threshold, const svuint8_t& _1, const svuint8_t& _0, const svbool_t& tail)
+        {
+            svuint8_t _mask = svld1_u8(tail, mask);
+            svbool_t adjust = svcmpne_u8(tail, _mask, _0);
+            svuint8_t _loCount = svld1_u8(tail, loCount);
+            svuint8_t _loValue = svld1_u8(tail, loValue);
+            svuint8_t _hiCount = svld1_u8(tail, hiCount);
+            svuint8_t _hiValue = svld1_u8(tail, hiValue);
+
+            svst1_u8(tail, loValue, AdjustLo(_loCount, _loValue, adjust, threshold, _1));
+            svst1_u8(tail, hiValue, AdjustHi(_hiCount, _hiValue, adjust, threshold, _1));
+            svst1_u8(tail, loCount, _0);
+            svst1_u8(tail, hiCount, _0);
+        }
+
+        void BackgroundAdjustRangeMasked(uint8_t* loCount, size_t loCountStride, size_t width, size_t height,
+            uint8_t* loValue, size_t loValueStride, uint8_t* hiCount, size_t hiCountStride,
+            uint8_t* hiValue, size_t hiValueStride, uint8_t threshold, const uint8_t* mask, size_t maskStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            svuint8_t _threshold = svdup_n_u8(threshold), _1 = svdup_n_u8(1), _0 = svdup_n_u8(0);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    BackgroundAdjustRangeMasked(loCount + col, loValue + col, hiCount + col, hiValue + col, mask + col, _threshold, _1, _0, body);
+                if (widthA < width)
+                    BackgroundAdjustRangeMasked(loCount + col, loValue + col, hiCount + col, hiValue + col, mask + col, _threshold, _1, _0, tail);
+                loValue += loValueStride;
+                hiValue += hiValueStride;
+                loCount += loCountStride;
+                hiCount += hiCountStride;
+                mask += maskStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -598,6 +598,11 @@ namespace Test
             result = result && BackgroundAdjustRangeMaskedAutoTest(FUNC4(Simd::Neon::BackgroundAdjustRangeMasked), FUNC4(SimdBackgroundAdjustRangeMasked));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BackgroundAdjustRangeMaskedAutoTest(FUNC4(Simd::Sve2::BackgroundAdjustRangeMasked), FUNC4(SimdBackgroundAdjustRangeMasked));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation for `SimdBackgroundAdjustRangeMasked`.
- Wire SVE2 dispatch and direct SVE2 coverage into `BackgroundAdjustRangeMaskedAutoTest`.
- Document the new SVE2 optimization in 2026 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BackgroundAdjustRangeMasked -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -fsyntax-only src/Simd/SimdSve2Background.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a96dcbe-39f2-4df8-9ef8-427a48cafc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a96dcbe-39f2-4df8-9ef8-427a48cafc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

