### PR TITLE
Fix multithreaded test harness teardown races

### DIFF
--- a/src/Test/Test.cpp
+++ b/src/Test/Test.cpp
@@ -562,6 +562,11 @@ namespace Test
         volatile double _progress;
 #if defined(__linux__)
         static __thread jmp_buf s_threadData;
+        static __thread bool s_threadDataValid;
+        static std::mutex s_signalMutex;
+        static size_t s_signalUseCount;
+        static Ints s_signalTypes;
+        static std::vector<sighandler_t> s_signalHandlers;
 #endif
     public:
         static volatile bool s_stopped;
@@ -646,27 +651,23 @@ namespace Test
                 return false;
             }
 #elif defined(__linux__)
-            Ints types;
-            std::vector<sighandler_t> prevs;
-            for (int i = 0; i <= SIGSYS; ++i)
-            {
-                if (i == SIGCHLD)
-                    continue;
-                sighandler_t prev = signal(i, (sighandler_t)PrintErrorMessage);
-                if (prev == SIG_IGN)
-                    signal(i, prev);
-                else
-                {
-                    types.push_back(i);
-                    prevs.push_back(prev);
-                }
-            }
+            SignalScope signalScope;
             int rc = setjmp(s_threadData);
+            s_threadDataValid = rc == 0;
             bool result = false;
             if (rc == 0)
-                result = group.autoTest(options);
-            for (size_t i = 0; i < prevs.size(); ++i)
-                signal(types[i], prevs[i]);
+            {
+                try
+                {
+                    result = group.autoTest(options);
+                }
+                catch (...)
+                {
+                    s_threadDataValid = false;
+                    throw;
+                }
+            }
+            s_threadDataValid = false;
             return result;
 #else
             return group.autoTest(options);
@@ -692,8 +693,53 @@ namespace Test
 #endif
 
 #if defined(__linux__)
+        class SignalScope
+        {
+        public:
+            SignalScope()
+            {
+                std::lock_guard<std::mutex> lock(s_signalMutex);
+                if (s_signalUseCount++ == 0)
+                {
+                    s_signalTypes.clear();
+                    s_signalHandlers.clear();
+                    for (int i = 0; i <= SIGSYS; ++i)
+                    {
+                        if (i == SIGCHLD)
+                            continue;
+                        sighandler_t prev = signal(i, (sighandler_t)PrintErrorMessage);
+                        if (prev == SIG_IGN)
+                            signal(i, prev);
+                        else
+                        {
+                            s_signalTypes.push_back(i);
+                            s_signalHandlers.push_back(prev);
+                        }
+                    }
+                }
+            }
+
+            ~SignalScope()
+            {
+                std::lock_guard<std::mutex> lock(s_signalMutex);
+                if (--s_signalUseCount == 0)
+                {
+                    for (size_t i = 0; i < s_signalHandlers.size(); ++i)
+                        signal(s_signalTypes[i], s_signalHandlers[i]);
+                    s_signalTypes.clear();
+                    s_signalHandlers.clear();
+                }
+            }
+        };
+
         static void PrintErrorMessage(int code)
         {
+            if (!s_threadDataValid)
+            {
+                signal(code, SIG_DFL);
+                raise(code);
+                return;
+            }
             String desc;
             switch (code)
             {
@@ -712,6 +758,11 @@ namespace Test
     volatile bool Task::s_stopped = false;
 #if defined(__linux__)
     __thread jmp_buf Task::s_threadData;
+    __thread bool Task::s_threadDataValid = false;
+    std::mutex Task::s_signalMutex;
+    size_t Task::s_signalUseCount = 0;
+    Ints Task::s_signalTypes;
+    std::vector<sighandler_t> Task::s_signalHandlers;
 #endif
     typedef std::shared_ptr<Task> TaskPtr;
     typedef std::vector<TaskPtr> TaskPtrs;

--- a/src/Test/TestLog.cpp
+++ b/src/Test/TestLog.cpp
@@ -46,27 +46,32 @@ namespace Test
 
     void Log::SetLogFile(String name)
     {
+        std::lock_guard<std::mutex> lock(_mutex);
         CreatePathIfNotExist(name, true);
         _file.open(name);
     }
 
     void Log::SetLevel(Level level)
     {
+        std::lock_guard<std::mutex> lock(_mutex);
         _level = level;
     }
 
     void Log::SetEnableThreadId(bool enable)
     {
+        std::lock_guard<std::mutex> lock(_mutex);
         _enableThreadId = enable;
     }
 
     void Log::SetEnablePrefix(bool enable)
     {
+        std::lock_guard<std::mutex> lock(_mutex);
         _enablePrefix = enable;
     }
 
     void Log::Write(Level level, const String & message)
     {
+        std::lock_guard<std::mutex> lock(_mutex);
         std::stringstream ss;
         std::thread::id id = std::this_thread::get_id();
         if (_enableThreadId)
@@ -93,7 +98,6 @@ namespace Test
         }
         else
         {
-            std::lock_guard<std::mutex> lock(_mutex);
             if (_level == Error)
             {
                 String & last = _lastSkippedMessages[id];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Serialize `Test::Log` state mutations and output so skipped messages, thread names, and file/stdout writes are safe under threaded tests.
- Replace per-worker Linux signal handler install/restore with a shared ref-counted scope and a thread-local valid-jump guard.

## Testing
- `cmake ./prj/cmake -B build-debug-ci -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AVX512BF16=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build-debug-ci --parallel$(nproc)`
- `LD_LIBRARY_PATH="/workspace/build-debug-ci:$LD_LIBRARY_PATH" ./Test "-r=.." -m=a -tt=4 "-ot=log_Debug_sobel_verify.txt" -ts=1 -mt=1 -w=640 -h=480 -c=256 -fi=Sobel`
- `LD_LIBRARY_PATH="/workspace/build-debug-ci:$LD_LIBRARY_PATH" ./Test "-r=.." -m=a -tt=$(nproc) "-ot=log_Debug_broad_verify.txt" -ts=5 -mt=1 -w=640 -h=480 -c=256 -fe=SynetConvolution8i -fe=SynetQuantizedConvolution`
- Warning: the exact unfiltered CI command exits early on this VM with `SIGILL` in `SynetConvolution8iForwardAutoTest`, so local validation used the broad filtered run above to reach the reported post-success teardown path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d84d5df-d3bd-4be8-96bb-8d9eae79dceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d84d5df-d3bd-4be8-96bb-8d9eae79dceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

