### PR TITLE
Add SVE2 BackgroundShiftRange optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -58,6 +58,7 @@
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
+ <li>SVE2 optimizations of function BackgroundShiftRange.</li>
 </ul>
 
 <h4>Documentation</h4>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -911,6 +911,11 @@ SIMD_API void SimdBackgroundShiftRange(const uint8_t * value, size_t valueStride
         Sse41::BackgroundShiftRange(value, valueStride, width, height, lo, loStride, hi, hiStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BackgroundShiftRange(value, valueStride, width, height, lo, loStride, hi, hiStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BackgroundShiftRange(value, valueStride, width, height, lo, loStride, hi, hiStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -43,6 +43,9 @@ namespace Simd
             uint8_t* loValue, size_t loValueStride, uint8_t* hiCount, size_t hiCountStride,
             uint8_t* hiValue, size_t hiValueStride, uint8_t threshold);
 
+        void BackgroundShiftRange(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
+
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Background.cpp
+++ b/src/Simd/SimdSve2Background.cpp
@@ -164,6 +164,41 @@ namespace Simd
                 mask += maskStride;
             }
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void BackgroundShiftRange(const uint8_t* value, uint8_t* lo, uint8_t* hi, const svbool_t& mask)
+        {
+            svuint8_t _value = svld1_u8(mask, value);
+            svuint8_t _lo = svld1_u8(mask, lo);
+            svuint8_t _hi = svld1_u8(mask, hi);
+
+            svuint8_t add = svqsub_u8(_value, _hi);
+            svuint8_t sub = svqsub_u8(_lo, _value);
+
+            svst1_u8(mask, lo, svqsub_u8(svqadd_u8(_lo, add), sub));
+            svst1_u8(mask, hi, svqsub_u8(svqadd_u8(_hi, add), sub));
+        }
+
+        void BackgroundShiftRange(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    BackgroundShiftRange(value + col, lo + col, hi + col, body);
+                if (widthA < width)
+                    BackgroundShiftRange(value + col, lo + col, hi + col, tail);
+                value += valueStride;
+                lo += loStride;
+                hi += hiStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -638,6 +638,11 @@ namespace Test
             result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Neon::BackgroundShiftRange), FUNC1(SimdBackgroundShiftRange));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve2::BackgroundShiftRange), FUNC1(SimdBackgroundShiftRange));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdBackgroundShiftRange`.
- Route the public API and auto-test coverage through the SVE2 path.
- Update 2026 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BackgroundShiftRange -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdSve2Background.cpp`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-448330cd-b28c-4c3a-8b10-00ccaedf1b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-448330cd-b28c-4c3a-8b10-00ccaedf1b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

