### PR TITLE
Add SVE2 Reorder16bit optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -46,6 +46,7 @@
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>
  <li>SVE2 optimizations of function RgbaToGray.</li>
+ <li>SVE2 optimizations of function Reorder16bit.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="Sve2\Motion">
       <UniqueIdentifier>{c7b7a0a0-3931-46d4-b726-c78f5257c775}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sve2\Transform">
+      <UniqueIdentifier>{1e141a04-6825-47f3-adbe-0a26c1e8ff5a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdSve2.h">
@@ -43,6 +46,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp">
       <Filter>Sve2\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
+      <Filter>Sve2\Transform</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4377,6 +4377,11 @@ SIMD_API void SimdReorder16bit(const uint8_t * src, size_t size, uint8_t * dst)
         Sse41::Reorder16bit(src, size, dst);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Reorder16bit(src, size, dst);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && size >= Neon::A)
         Neon::Reorder16bit(src, size, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -68,6 +68,8 @@ namespace Simd
 
         void CorrelationSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum);
 
+        void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
+
         void RgbaToGray(const uint8_t* rgba, size_t width, size_t height, size_t rgbaStride, uint8_t* gray, size_t grayStride);
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Reorder.cpp
+++ b/src/Simd/SimdSve2Reorder.cpp
@@ -1,0 +1,53 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdReorder.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void Reorder16bit(const uint16_t * src, const svbool_t & mask, uint16_t * dst)
+        {
+            svst1_u16(mask, dst, svrevb_u16_x(mask, svld1_u16(mask, src)));
+        }
+
+        void Reorder16bit(const uint8_t * src, size_t size, uint8_t * dst)
+        {
+            assert(size % 2 == 0);
+
+            size_t A = svlen(svuint16_t()), size16 = size / 2, sizeA = AlignLo(size16, A);
+            const uint16_t * s = (const uint16_t*)src;
+            uint16_t * d = (uint16_t*)dst;
+            const svbool_t body = svptrue_b16();
+            size_t i = 0;
+            for (; i < sizeA; i += A)
+                Reorder16bit(s + i, body, d + i);
+            if (i < size16)
+                Reorder16bit(s + i, svwhilelt_b16(i, size16), d + i);
+        }
+    }
+#endif
+}

--- a/src/Test/TestReorder.cpp
+++ b/src/Test/TestReorder.cpp
@@ -103,6 +103,11 @@ namespace Test
             result = result && ReorderAutoTest(FUNC(Simd::Avx512bw::Reorder16bit), FUNC(SimdReorder16bit), 2);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ReorderAutoTest(FUNC(Simd::Sve2::Reorder16bit), FUNC(SimdReorder16bit), 2);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ReorderAutoTest(FUNC(Simd::Neon::Reorder16bit), FUNC(SimdReorder16bit), 2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdReorder16bit`.
- Cover the SVE2 implementation in `Reorder16bitAutoTest`.
- Add Visual Studio SVE2 project entries and 7.2.163 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=Reorder16bit -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -I build -fsyntax-only src/Simd/SimdSve2Reorder.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df1a2192-8f66-4817-8f31-a0f091a8480a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df1a2192-8f66-4817-8f31-a0f091a8480a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

