### PR TITLE
Add SVE2 Reorder32bit optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function BgraToGray.</li>
  <li>SVE2 optimizations of function RgbaToGray.</li>
  <li>SVE2 optimizations of function Reorder16bit.</li>
+ <li>SVE2 optimizations of function Reorder32bit.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4408,6 +4408,11 @@ SIMD_API void SimdReorder32bit(const uint8_t * src, size_t size, uint8_t * dst)
         Sse41::Reorder32bit(src, size, dst);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Reorder32bit(src, size, dst);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && size >= Neon::A)
         Neon::Reorder32bit(src, size, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -70,6 +70,8 @@ namespace Simd
 
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
 
+        void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);
+
         void RgbaToGray(const uint8_t* rgba, size_t width, size_t height, size_t rgbaStride, uint8_t* gray, size_t grayStride);
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Reorder.cpp
+++ b/src/Simd/SimdSve2Reorder.cpp
@@ -48,6 +48,26 @@ namespace Simd
             if (i < size16)
                 Reorder16bit(s + i, svwhilelt_b16(i, size16), d + i);
         }
+
+        SIMD_INLINE void Reorder32bit(const uint32_t * src, const svbool_t & mask, uint32_t * dst)
+        {
+            svst1_u32(mask, dst, svrevb_u32_x(mask, svld1_u32(mask, src)));
+        }
+
+        void Reorder32bit(const uint8_t * src, size_t size, uint8_t * dst)
+        {
+            assert(size % 4 == 0);
+
+            size_t A = svlen(svuint32_t()), size32 = size / 4, sizeA = AlignLo(size32, A);
+            const uint32_t * s = (const uint32_t*)src;
+            uint32_t * d = (uint32_t*)dst;
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            for (; i < sizeA; i += A)
+                Reorder32bit(s + i, body, d + i);
+            if (i < size32)
+                Reorder32bit(s + i, svwhilelt_b32(i, size32), d + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestReorder.cpp
+++ b/src/Test/TestReorder.cpp
@@ -138,6 +138,11 @@ namespace Test
             result = result && ReorderAutoTest(FUNC(Simd::Avx512bw::Reorder32bit), FUNC(SimdReorder32bit), 4);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ReorderAutoTest(FUNC(Simd::Sve2::Reorder32bit), FUNC(SimdReorder32bit), 4);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ReorderAutoTest(FUNC(Simd::Neon::Reorder32bit), FUNC(SimdReorder32bit), 4);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Sve2::Reorder32bit` using SVE2 byte-reversal loads/stores with predicated tail handling.
- Route `SimdReorder32bit` through the SVE2 implementation when available.
- Add SVE2 `Reorder32bit` auto-test coverage and update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=Reorder32bit -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -fsyntax-only -I./src -I./build src/Simd/SimdSve2Reorder.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -O2 -c -I./src -I./build src/Simd/SimdSve2Reorder.cpp -o /tmp/SimdSve2Reorder.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80baded0-c54f-468b-a1cb-dcab8a06c87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80baded0-c54f-468b-a1cb-dcab8a06c87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

