### PR TITLE
reject out-of-range palette indices in png ExpandPalette

### DIFF
--- a/src/Simd/SimdBaseImageLoadPng.cpp
+++ b/src/Simd/SimdBaseImageLoadPng.cpp
@@ -839,7 +839,8 @@ namespace Simd
                     ComputeTransparency(_buffer.data, _width * _height, _outN, _tc);
             }
 
-            ExpandPalette();
+            if (!ExpandPalette())
+                return false;
 
             ConvertImage();
 
@@ -1229,15 +1230,20 @@ namespace Simd
             return 1;
         }
 
-        void ImagePngLoader::ExpandPalette()
+        bool ImagePngLoader::ExpandPalette()
         {
             if (_paletteChannels)
             {
+                size_t length = _palette.size / 4, size = size_t(_width) * _height;
+                for (size_t i = 0; i < size; ++i)
+                    if (_buffer.data[i] >= length)
+                        return static_cast<bool>(CorruptPngError("bad palette index"));
                 _outN = Max(_paletteChannels, _outN);
                 Array8u buf(_width * _height * _outN);
                 _expandPalette(_buffer.data, _width * _height, _outN, _palette.data, buf.data);
                 _buffer.Swap(buf);
             }
+            return true;
         }
 
         void ImagePngLoader::ConvertImage()

--- a/src/Simd/SimdImageLoad.h
+++ b/src/Simd/SimdImageLoad.h
@@ -197,7 +197,7 @@ namespace Simd
             InputMemoryStream MergedDataStream();
             bool CreateImage(const uint8_t* data, size_t size);
             bool CreateImageRaw(const uint8_t* data, uint32_t size, uint32_t width, uint32_t height);
-            void ExpandPalette();
+            bool ExpandPalette();
             void ConvertImage();
         };
 


### PR DESCRIPTION
the png loader's `ExpandPalette` reads `palette[index*4]` for each decoded pixel, but `ReadPalette` sizes `_palette` as `length*4` bytes with `length` the plte entry count, which can be as small as one. nothing constrains the decoded indices to that range, so a paletted image whose bytes exceed the palette length walks `Base::ExpandPalette` off the end of the allocation, an out-of-bounds read of up to about 1020 bytes for a near-empty palette. this is reachable only in the base decoder selected on neon and plain builds; the sse41 port keeps a fixed 1024-byte palette and is unaffected. bounding each index against the palette length before expansion keeps the read inside the allocation and rejects the malformed input the way the neighbouring chunk parsers already do.