### PR TITLE
Add SVE2 Reorder64bit optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function RgbaToGray.</li>
  <li>SVE2 optimizations of function Reorder16bit.</li>
  <li>SVE2 optimizations of function Reorder32bit.</li>
+ <li>SVE2 optimizations of function Reorder64bit.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4439,6 +4439,11 @@ SIMD_API void SimdReorder64bit(const uint8_t * src, size_t size, uint8_t * dst)
         Sse41::Reorder64bit(src, size, dst);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Reorder64bit(src, size, dst);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && size >= Neon::A)
         Neon::Reorder64bit(src, size, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -72,6 +72,8 @@ namespace Simd
 
         void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);
 
+        void Reorder64bit(const uint8_t* src, size_t size, uint8_t* dst);
+
         void RgbaToGray(const uint8_t* rgba, size_t width, size_t height, size_t rgbaStride, uint8_t* gray, size_t grayStride);
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2Reorder.cpp
+++ b/src/Simd/SimdSve2Reorder.cpp
@@ -68,6 +68,26 @@ namespace Simd
             if (i < size32)
                 Reorder32bit(s + i, svwhilelt_b32(i, size32), d + i);
         }
+
+        SIMD_INLINE void Reorder64bit(const uint64_t * src, const svbool_t & mask, uint64_t * dst)
+        {
+            svst1_u64(mask, dst, svrevb_u64_x(mask, svld1_u64(mask, src)));
+        }
+
+        void Reorder64bit(const uint8_t * src, size_t size, uint8_t * dst)
+        {
+            assert(size % 8 == 0);
+
+            size_t A = svlen(svuint64_t()), size64 = size / 8, sizeA = AlignLo(size64, A);
+            const uint64_t * s = (const uint64_t*)src;
+            uint64_t * d = (uint64_t*)dst;
+            const svbool_t body = svptrue_b64();
+            size_t i = 0;
+            for (; i < sizeA; i += A)
+                Reorder64bit(s + i, body, d + i);
+            if (i < size64)
+                Reorder64bit(s + i, svwhilelt_b64(i, size64), d + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestReorder.cpp
+++ b/src/Test/TestReorder.cpp
@@ -173,6 +173,11 @@ namespace Test
             result = result && ReorderAutoTest(FUNC(Simd::Avx512bw::Reorder64bit), FUNC(SimdReorder64bit), 8);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ReorderAutoTest(FUNC(Simd::Sve2::Reorder64bit), FUNC(SimdReorder64bit), 8);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ReorderAutoTest(FUNC(Simd::Neon::Reorder64bit), FUNC(SimdReorder64bit), 8);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and public dispatch for `SimdReorder64bit`.
- Cover the SVE2 function in `Reorder64bitAutoTest`.
- Document the release-note entry for version 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Reorder64bit -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I src -c src/Simd/SimdSve2Reorder.cpp -o /tmp/SimdSve2Reorder.o`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD~1..HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e398618a-9a88-468f-b207-8808da15918e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e398618a-9a88-468f-b207-8808da15918e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

