### PR TITLE
Add SVE2 AlphaBlending optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -60,6 +60,7 @@
  <li>SVE2 optimizations of function ConditionalSquareSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
+ <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -22,6 +22,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2AlphaBlending.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2AlphaBlending.cpp">
+      <Filter>Sve2\Motion</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -555,6 +555,11 @@ SIMD_API void SimdAlphaBlending(const uint8_t *src, size_t srcStride, size_t wid
         Sse41::AlphaBlending(src, srcStride, width, height, channelCount, alpha, alphaStride, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AlphaBlending(src, srcStride, width, height, channelCount, alpha, alphaStride, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::AlphaBlending(src, srcStride, width, height, channelCount, alpha, alphaStride, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -35,6 +35,9 @@ namespace Simd
             const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride,
             uint16_t weight, uint8_t* difference, size_t differenceStride);
 
+        void AlphaBlending(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            const uint8_t* alpha, size_t alphaStride, uint8_t* dst, size_t dstStride);
+
         void BackgroundIncrementCount(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
             uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride);

--- a/src/Simd/SimdSve2AlphaBlending.cpp
+++ b/src/Simd/SimdSve2AlphaBlending.cpp
@@ -1,0 +1,136 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdAlphaBlending.h"
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint16_t DivideBy255(const svuint16_t& value)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svlsr_n_u16_x(mask, svadd_u16_x(mask, svadd_u16_x(mask, value, svdup_n_u16(1)), svlsr_n_u16_x(mask, value, 8)), 8);
+        }
+
+        SIMD_INLINE svuint8_t AlphaBlending(const svuint8_t& src, const svuint8_t& dst, const svuint8_t& alpha)
+        {
+            const svbool_t mask = svptrue_b16();
+            svuint16_t alphaLo = svmovlb_u16(alpha);
+            svuint16_t alphaHi = svmovlt_u16(alpha);
+            svuint16_t invAlphaLo = svsub_u16_x(mask, svdup_n_u16(0xFF), alphaLo);
+            svuint16_t invAlphaHi = svsub_u16_x(mask, svdup_n_u16(0xFF), alphaHi);
+            svuint16_t lo = svadd_u16_x(mask, svmul_u16_x(mask, svmovlb_u16(src), alphaLo), svmul_u16_x(mask, svmovlb_u16(dst), invAlphaLo));
+            svuint16_t hi = svadd_u16_x(mask, svmul_u16_x(mask, svmovlt_u16(src), alphaHi), svmul_u16_x(mask, svmovlt_u16(dst), invAlphaHi));
+            return svqxtnt_u16(svqxtnb_u16(DivideBy255(lo)), DivideBy255(hi));
+        }
+
+        template<size_t channelCount> struct AlphaBlender
+        {
+            void operator()(const uint8_t* src, uint8_t* dst, const svuint8_t& alpha, const svbool_t& mask);
+        };
+
+        template<> struct AlphaBlender<1>
+        {
+            SIMD_INLINE void operator()(const uint8_t* src, uint8_t* dst, const svuint8_t& alpha, const svbool_t& mask)
+            {
+                svst1_u8(mask, dst, AlphaBlending(svld1_u8(mask, src), svld1_u8(mask, dst), alpha));
+            }
+        };
+
+        template<> struct AlphaBlender<2>
+        {
+            SIMD_INLINE void operator()(const uint8_t* src, uint8_t* dst, const svuint8_t& alpha, const svbool_t& mask)
+            {
+                svuint8x2_t _src = svld2_u8(mask, src);
+                svuint8x2_t _dst = svld2_u8(mask, dst);
+                svst2_u8(mask, dst, svcreate2_u8(
+                    AlphaBlending(svget2(_src, 0), svget2(_dst, 0), alpha),
+                    AlphaBlending(svget2(_src, 1), svget2(_dst, 1), alpha)));
+            }
+        };
+
+        template<> struct AlphaBlender<3>
+        {
+            SIMD_INLINE void operator()(const uint8_t* src, uint8_t* dst, const svuint8_t& alpha, const svbool_t& mask)
+            {
+                svuint8x3_t _src = svld3_u8(mask, src);
+                svuint8x3_t _dst = svld3_u8(mask, dst);
+                svst3_u8(mask, dst, svcreate3_u8(
+                    AlphaBlending(svget3(_src, 0), svget3(_dst, 0), alpha),
+                    AlphaBlending(svget3(_src, 1), svget3(_dst, 1), alpha),
+                    AlphaBlending(svget3(_src, 2), svget3(_dst, 2), alpha)));
+            }
+        };
+
+        template<> struct AlphaBlender<4>
+        {
+            SIMD_INLINE void operator()(const uint8_t* src, uint8_t* dst, const svuint8_t& alpha, const svbool_t& mask)
+            {
+                svuint8x4_t _src = svld4_u8(mask, src);
+                svuint8x4_t _dst = svld4_u8(mask, dst);
+                svst4_u8(mask, dst, svcreate4_u8(
+                    AlphaBlending(svget4(_src, 0), svget4(_dst, 0), alpha),
+                    AlphaBlending(svget4(_src, 1), svget4(_dst, 1), alpha),
+                    AlphaBlending(svget4(_src, 2), svget4(_dst, 2), alpha),
+                    AlphaBlending(svget4(_src, 3), svget4(_dst, 3), alpha)));
+            }
+        };
+
+        template<size_t channelCount> void AlphaBlending(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* alpha, size_t alphaStride, uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svlen(svuint8_t()), widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A * channelCount)
+                    AlphaBlender<channelCount>()(src + offset, dst + offset, svld1_u8(body, alpha + col), body);
+                if (widthA < width)
+                    AlphaBlender<channelCount>()(src + offset, dst + offset, svld1_u8(tail, alpha + col), tail);
+                src += srcStride;
+                alpha += alphaStride;
+                dst += dstStride;
+            }
+        }
+
+        void AlphaBlending(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            const uint8_t* alpha, size_t alphaStride, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount >= 1 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: AlphaBlending<1>(src, srcStride, width, height, alpha, alphaStride, dst, dstStride); break;
+            case 2: AlphaBlending<2>(src, srcStride, width, height, alpha, alphaStride, dst, dstStride); break;
+            case 3: AlphaBlending<3>(src, srcStride, width, height, alpha, alphaStride, dst, dstStride); break;
+            case 4: AlphaBlending<4>(src, srcStride, width, height, alpha, alphaStride, dst, dstStride); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestDrawing.cpp
+++ b/src/Test/TestDrawing.cpp
@@ -114,6 +114,11 @@ namespace Test
             result = result && AlphaBlendingAutoTest(FUNC_AB(Simd::Avx512bw::AlphaBlending), FUNC_AB(SimdAlphaBlending));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AlphaBlendingAutoTest(FUNC_AB(Simd::Sve2::AlphaBlending), FUNC_AB(SimdAlphaBlending));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AlphaBlendingAutoTest(FUNC_AB(Simd::Neon::AlphaBlending), FUNC_AB(SimdAlphaBlending));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation for `SimdAlphaBlending`.
- Dispatch to SVE2 before NEON on SVE2-capable ARM builds.
- Register SVE2 AlphaBlending autotest and update VS2022 SVE2 project files.
- Document the release note under 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AlphaBlending -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2AlphaBlending.cpp -o /tmp/SimdSve2AlphaBlending.o`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TARGET="aarch64" -DSIMD_SVE2=ON -DSIMD_SHARED=OFF -DSIMD_TEST=OFF -DSIMD_PYTHON=OFF -DSIMD_INSTALL=OFF -DSIMD_UNINSTALL=OFF`
- `cmake --build build-aarch64-sve2 --parallel$(nproc)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd15f1dc-992a-469d-b43d-f1401e3b39d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd15f1dc-992a-469d-b43d-f1401e3b39d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

