### PR TITLE
Add SVE2 Bgr48pToBgra32 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -46,6 +46,7 @@
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>
  <li>SVE2 optimizations of function RgbaToGray.</li>
+ <li>SVE2 optimizations of function Bgr48pToBgra32.</li>
  <li>SVE2 optimizations of function Reorder16bit.</li>
  <li>SVE2 optimizations of function Reorder32bit.</li>
  <li>SVE2 optimizations of function Reorder64bit.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBgra.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1431,6 +1431,11 @@ SIMD_API void SimdBgr48pToBgra32(const uint8_t * blue, size_t blueStride, size_t
         Sse41::Bgr48pToBgra32(blue, blueStride, width, height, green, greenStride, red, redStride, bgra, bgraStride, alpha);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Bgr48pToBgra32(blue, blueStride, width, height, green, greenStride, red, redStride, bgra, bgraStride, alpha);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::Bgr48pToBgra32(blue, blueStride, width, height, green, greenStride, red, redStride, bgra, bgraStride, alpha);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -65,6 +65,9 @@ namespace Simd
       
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
+        void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
+            const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
+
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);
 
         void ConditionalCount8u(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t value, SimdCompareType compareType, uint32_t* count);

--- a/src/Simd/SimdSve2BgrToBgra.cpp
+++ b/src/Simd/SimdSve2BgrToBgra.cpp
@@ -1,0 +1,63 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void Bgr48pToBgra32(const uint8_t* blue, const uint8_t* green, const uint8_t* red, uint8_t* bgra,
+            const svuint8_t& alpha, const svbool_t& mask)
+        {
+            svuint8_t _blue = svget2(svld2_u8(mask, blue), 0);
+            svuint8_t _green = svget2(svld2_u8(mask, green), 0);
+            svuint8_t _red = svget2(svld2_u8(mask, red), 0);
+            svst4_u8(mask, bgra, svcreate4_u8(_blue, _green, _red, alpha));
+        }
+
+        void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
+            const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha)
+        {
+            size_t A = svlen(svuint8_t()), A2 = A * 2, A4 = A * 4;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _alpha = svdup_n_u8(alpha);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, srcOffset = 0, dstOffset = 0;
+                for (; col < widthA; col += A, srcOffset += A2, dstOffset += A4)
+                    Bgr48pToBgra32(blue + srcOffset, green + srcOffset, red + srcOffset, bgra + dstOffset, _alpha, body);
+                if (widthA < width)
+                    Bgr48pToBgra32(blue + srcOffset, green + srcOffset, red + srcOffset, bgra + dstOffset, _alpha, tail);
+                blue += blueStride;
+                green += greenStride;
+                red += redStride;
+                bgra += bgraStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestBgr48pToBgra32.cpp
+++ b/src/Test/TestBgr48pToBgra32.cpp
@@ -108,6 +108,11 @@ namespace Test
             result = result && Bgr48pToBgra32AutoTest(FUNC(Simd::Avx512bw::Bgr48pToBgra32), FUNC(SimdBgr48pToBgra32));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Bgr48pToBgra32AutoTest(FUNC(Simd::Sve2::Bgr48pToBgra32), FUNC(SimdBgr48pToBgra32));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::HA)
             result = result && Bgr48pToBgra32AutoTest(FUNC(Simd::Neon::Bgr48pToBgra32), FUNC(SimdBgr48pToBgra32));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `Bgr48pToBgra32` using scalable predicates for body and tail processing.
- Dispatch the public API to the SVE2 path when available and add SVE2 auto-test coverage.
- Add the new source to the VS2022 SVE2 project and document it in release 7.2.163.

### Validation
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -O3 -fPIC -I src -c src/Simd/SimdSve2BgrToBgra.cpp -o /tmp/SimdSve2BgrToBgra.o`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -O3 -fPIC -I src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib-sve2.o`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Bgr48pToBgra32 -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e35b2d41-af4d-463d-9d12-c70de8efa77a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e35b2d41-af4d-463d-9d12-c70de8efa77a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

