### PR TITLE
Add SVE2 BgrToBgra optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
+ <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgrToGray.</li>
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1404,6 +1404,11 @@ SIMD_API void SimdBgrToBgra(const uint8_t *bgr, size_t width, size_t height, siz
         Sse41::BgrToBgra(bgr, width, height, bgrStride, bgra, bgraStride, alpha);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgrToBgra(bgr, width, height, bgrStride, bgra, bgraStride, alpha);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgrToBgra(bgr, width, height, bgrStride, bgra, bgraStride, alpha);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -68,6 +68,8 @@ namespace Simd
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 
+        void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
+
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);
 
         void ConditionalCount8u(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t value, SimdCompareType compareType, uint32_t* count);

--- a/src/Simd/SimdSve2BgrToBgra.cpp
+++ b/src/Simd/SimdSve2BgrToBgra.cpp
@@ -28,6 +28,33 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE void BgrToBgra(const uint8_t* bgr, uint8_t* bgra, const svuint8_t& alpha, const svbool_t& mask)
+        {
+            svuint8x3_t _bgr = svld3_u8(mask, bgr);
+            svst4_u8(mask, bgra, svcreate4_u8(svget3(_bgr, 0), svget3(_bgr, 1), svget3(_bgr, 2), alpha));
+        }
+
+        void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha)
+        {
+            size_t A = svlen(svuint8_t()), A3 = A * 3, A4 = A * 4;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _alpha = svdup_n_u8(alpha);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, bgrOffset = 0, bgraOffset = 0;
+                for (; col < widthA; col += A, bgrOffset += A3, bgraOffset += A4)
+                    BgrToBgra(bgr + bgrOffset, bgra + bgraOffset, _alpha, body);
+                if (widthA < width)
+                    BgrToBgra(bgr + bgrOffset, bgra + bgraOffset, _alpha, tail);
+                bgr += bgrStride;
+                bgra += bgraStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void Bgr48pToBgra32(const uint8_t* blue, const uint8_t* green, const uint8_t* red, uint8_t* bgra,
             const svuint8_t& alpha, const svbool_t& mask)
         {

--- a/src/Test/TestAnyToBgra.cpp
+++ b/src/Test/TestAnyToBgra.cpp
@@ -103,6 +103,11 @@ namespace Test
             result = result && AnyToBgraAutoTest(View::Bgr24, FUNC(Simd::Avx512bw::BgrToBgra), FUNC(SimdBgrToBgra));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToBgraAutoTest(View::Bgr24, FUNC(Simd::Sve2::BgrToBgra), FUNC(SimdBgrToBgra));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToBgraAutoTest(View::Bgr24, FUNC(Simd::Neon::BgrToBgra), FUNC(SimdBgrToBgra));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBgrToBgra`.
- Register `Sve2::BgrToBgra` in `BgrToBgraAutoTest`.
- Document the new optimization in release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=BgrToBgra -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2BgrToBgra.cpp -o /tmp/SimdSve2BgrToBgra.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdLib.cpp -o /tmp/SimdLibSve2.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Test/TestAnyToBgra.cpp -o /tmp/TestAnyToBgraSve2.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e434db1-3da7-48af-80d0-861fb219bacc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e434db1-3da7-48af-80d0-861fb219bacc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

