### PR TITLE
Add SVE2 BgraToBayer optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -54,6 +54,7 @@
  <li>SVE2 optimizations of function Reorder64bit.</li>
  <li>SVE2 optimizations of function BayerToBgr.</li>
  <li>SVE2 optimizations of function BayerToBgra.</li>
+ <li>SVE2 optimizations of function BgraToBayer.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -53,6 +53,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1135,6 +1135,11 @@ SIMD_API void SimdBgraToBayer(const uint8_t * bgra, size_t width, size_t height,
         Sse41::BgraToBayer(bgra, width, height, bgraStride, bayer, bayerStride, bayerFormat);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgraToBayer(bgra, width, height, bgraStride, bayer, bayerStride, bayerFormat);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgraToBayer(bgra, width, height, bgraStride, bayer, bayerStride, bayerFormat);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -65,6 +65,8 @@ namespace Simd
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 
+        void BgraToBayer(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
+
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2BgraToBayer.cpp
+++ b/src/Simd/SimdSve2BgraToBayer.cpp
@@ -1,0 +1,90 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template <int c0, int c1> SIMD_INLINE void BgraToBayer(const uint8_t* bgra, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
+        {
+            svuint8x4_t _bgra = svld4_u8(mask, bgra);
+            svst1_u8(mask, bayer, svsel_u8(even, svget4(_bgra, c0), svget4(_bgra, c1)));
+        }
+
+        template <int c00, int c01, int c10, int c11> void BgraToBayer(const uint8_t* bgra, size_t width, size_t height,
+            size_t bgraStride, uint8_t* bayer, size_t bayerStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0));
+
+            size_t A = svlen(svuint8_t()), A4 = A * 4;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svbool_t even = svcmpeq_n_u8(body, svand_n_u8_x(body, svindex_u8(0, 1), 1), 0);
+            for (size_t row = 0; row < height; row += 2)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A4)
+                    BgraToBayer<c00, c01>(bgra + offset, bayer + col, body, even);
+                if (widthA < width)
+                    BgraToBayer<c00, c01>(bgra + offset, bayer + col, tail, even);
+                bgra += bgraStride;
+                bayer += bayerStride;
+
+                col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A4)
+                    BgraToBayer<c10, c11>(bgra + offset, bayer + col, body, even);
+                if (widthA < width)
+                    BgraToBayer<c10, c11>(bgra + offset, bayer + col, tail, even);
+                bgra += bgraStride;
+                bayer += bayerStride;
+            }
+        }
+
+        void BgraToBayer(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bayer,
+            size_t bayerStride, SimdPixelFormatType bayerFormat)
+        {
+            switch (bayerFormat)
+            {
+            case SimdPixelFormatBayerGrbg:
+                BgraToBayer<1, 2, 0, 1>(bgra, width, height, bgraStride, bayer, bayerStride);
+                break;
+            case SimdPixelFormatBayerGbrg:
+                BgraToBayer<1, 0, 2, 1>(bgra, width, height, bgraStride, bayer, bayerStride);
+                break;
+            case SimdPixelFormatBayerRggb:
+                BgraToBayer<2, 1, 1, 0>(bgra, width, height, bgraStride, bayer, bayerStride);
+                break;
+            case SimdPixelFormatBayerBggr:
+                BgraToBayer<0, 1, 1, 2>(bgra, width, height, bgraStride, bayer, bayerStride);
+                break;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToBayer.cpp
+++ b/src/Test/TestAnyToBayer.cpp
@@ -135,6 +135,11 @@ namespace Test
             result = result && AnyToBayerAutoTest(View::Bgra32, FUNC(Simd::Avx512bw::BgraToBayer), FUNC(SimdBgraToBayer));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToBayerAutoTest(View::Bgra32, FUNC(Simd::Sve2::BgraToBayer), FUNC(SimdBgraToBayer));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToBayerAutoTest(View::Bgra32, FUNC(Simd::Neon::BgraToBayer), FUNC(SimdBgraToBayer));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBgraToBayer`.
- Extend `BgraToBayerAutoTest` to cover `Simd::Sve2::BgraToBayer`.
- Register the new SVE2 source in the VS2022 project files and update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=BgraToBayer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Simd/SimdSve2BgraToBayer.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -I src/Test -std=c++17 -fsyntax-only src/Test/TestAnyToBayer.cpp`
- Temporary AArch64/SVE2 QEMU harness: `qemu-aarch64 -cpu max ./build/sve2_bgra_to_bayer_check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3918a051-73d2-4a10-8375-0c9bf050ed6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3918a051-73d2-4a10-8375-0c9bf050ed6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

