### PR TITLE
Add SVE2 BgraToRgb optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -44,6 +44,7 @@
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
+ <li>SVE2 optimizations of function BgraToRgb.</li>
  <li>SVE2 optimizations of function BgrToGray.</li>
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1228,6 +1228,11 @@ SIMD_API void SimdBgraToRgb(const uint8_t* bgra, size_t width, size_t height, si
         Sse41::BgraToRgb(bgra, width, height, bgraStride, rgb, rgbStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgraToRgb(bgra, width, height, bgraStride, rgb, rgbStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgraToRgb(bgra, width, height, bgraStride, rgb, rgbStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -69,6 +69,8 @@ namespace Simd
 
         void BgraToGray(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* gray, size_t grayStride);
 
+        void BgraToRgb(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* rgb, size_t rgbStride);
+
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 

--- a/src/Simd/SimdSve2BgraToBgr.cpp
+++ b/src/Simd/SimdSve2BgraToBgr.cpp
@@ -51,6 +51,32 @@ namespace Simd
                 bgr += bgrStride;
             }
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void BgraToRgb(const uint8_t* bgra, uint8_t* rgb, const svbool_t& mask)
+        {
+            svuint8x4_t _bgra = svld4_u8(mask, bgra);
+            svst3_u8(mask, rgb, svcreate3_u8(svget4(_bgra, 2), svget4(_bgra, 1), svget4(_bgra, 0)));
+        }
+
+        void BgraToRgb(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* rgb, size_t rgbStride)
+        {
+            size_t A = svlen(svuint8_t()), A3 = A * 3, A4 = A * 4;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, bgraOffset = 0, rgbOffset = 0;
+                for (; col < widthA; col += A, bgraOffset += A4, rgbOffset += A3)
+                    BgraToRgb(bgra + bgraOffset, rgb + rgbOffset, body);
+                if (widthA < width)
+                    BgraToRgb(bgra + bgraOffset, rgb + rgbOffset, tail);
+                bgra += bgraStride;
+                rgb += rgbStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestAnyToAny.cpp
+++ b/src/Test/TestAnyToAny.cpp
@@ -201,6 +201,11 @@ namespace Test
             result = result && AnyToAnyAutoTest(View::Bgra32, View::Rgb24, FUNC_O(Simd::Avx512bw::BgraToRgb), FUNC_O(SimdBgraToRgb));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToAnyAutoTest(View::Bgra32, View::Rgb24, FUNC_O(Simd::Sve2::BgraToRgb), FUNC_O(SimdBgraToRgb));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToAnyAutoTest(View::Bgra32, View::Rgb24, FUNC_O(Simd::Neon::BgraToRgb), FUNC_O(SimdBgraToRgb));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `BgraToRgb` using predicated SVE2 `ld4/st3` channel handling.
- Wire `SimdBgraToRgb` dispatch and `BgraToRgbAutoTest` to the SVE2 implementation.
- Update the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgraToRgb -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8-a+sve2 -I src -c src/Simd/SimdSve2BgraToBgr.cpp -o /tmp/SimdSve2BgraToBgr.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-577260fd-c832-4b10-8f84-07cbaa451dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-577260fd-c832-4b10-8f84-07cbaa451dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

