### PR TITLE
Add SVE2 BgraToRgba optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -45,6 +45,7 @@
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>
+ <li>SVE2 optimizations of function BgraToRgba.</li>
  <li>SVE2 optimizations of function BgrToGray.</li>
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1259,6 +1259,11 @@ SIMD_API void SimdBgraToRgba(const uint8_t* bgra, size_t width, size_t height, s
         Sse41::BgraToRgba(bgra, width, height, bgraStride, rgba, rgbaStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgraToRgba(bgra, width, height, bgraStride, rgba, rgbaStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgraToRgba(bgra, width, height, bgraStride, rgba, rgbaStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -71,6 +71,8 @@ namespace Simd
 
         void BgraToRgb(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* rgb, size_t rgbStride);
 
+        void BgraToRgba(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* rgba, size_t rgbaStride);
+
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 

--- a/src/Simd/SimdSve2BgraToBgr.cpp
+++ b/src/Simd/SimdSve2BgraToBgr.cpp
@@ -77,6 +77,32 @@ namespace Simd
                 rgb += rgbStride;
             }
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void BgraToRgba(const uint8_t* bgra, uint8_t* rgba, const svbool_t& mask)
+        {
+            svuint8x4_t _bgra = svld4_u8(mask, bgra);
+            svst4_u8(mask, rgba, svcreate4_u8(svget4(_bgra, 2), svget4(_bgra, 1), svget4(_bgra, 0), svget4(_bgra, 3)));
+        }
+
+        void BgraToRgba(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* rgba, size_t rgbaStride)
+        {
+            size_t A = svlen(svuint8_t()), A4 = A * 4;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A4)
+                    BgraToRgba(bgra + offset, rgba + offset, body);
+                if (widthA < width)
+                    BgraToRgba(bgra + offset, rgba + offset, tail);
+                bgra += bgraStride;
+                rgba += rgbaStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestAnyToAny.cpp
+++ b/src/Test/TestAnyToAny.cpp
@@ -236,6 +236,11 @@ namespace Test
             result = result && AnyToAnyAutoTest(View::Bgra32, View::Rgba32, FUNC_O(Simd::Avx512bw::BgraToRgba), FUNC_O(SimdBgraToRgba));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToAnyAutoTest(View::Bgra32, View::Rgba32, FUNC_O(Simd::Sve2::BgraToRgba), FUNC_O(SimdBgraToRgba));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToAnyAutoTest(View::Bgra32, View::Rgba32, FUNC_O(Simd::Neon::BgraToRgba), FUNC_O(SimdBgraToRgba));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `BgraToRgba` in `SimdSve2BgraToBgr.cpp`.
- Route `SimdBgraToRgba` through SVE2 when available and add SVE2 coverage to `BgraToRgbaAutoTest`.
- Update 7.2.163 release notes for the new optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgraToRgba -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src -std=c++17 -O2 -DNDEBUG -c src/Simd/SimdSve2BgraToBgr.cpp -o /tmp/SimdSve2BgraToBgr.o`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="" -DSIMD_TARGET=aarch64 -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_TEST=OFF -DSIMD_SHARED=OFF -DSIMD_PYTHON=OFF -DSIMD_GET_VERSION=OFF`
- `cmake --build build-aarch64-sve2 --target Simd --parallel$(nproc)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8213d4b8-0b2e-42cd-b526-59ee5019fc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8213d4b8-0b2e-42cd-b526-59ee5019fc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

