### PR TITLE
Add SVE2 BgrToBayer optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -57,6 +57,7 @@
  <li>SVE2 optimizations of function BayerToBgr.</li>
  <li>SVE2 optimizations of function BayerToBgra.</li>
  <li>SVE2 optimizations of function BgraToBayer.</li>
+ <li>SVE2 optimizations of function BgrToBayer.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBayer.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1398,6 +1398,11 @@ SIMD_API void SimdBgrToBayer(const uint8_t * bgr, size_t width, size_t height, s
         Sse41::BgrToBayer(bgr, width, height, bgrStride, bayer, bayerStride, bayerFormat);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgrToBayer(bgr, width, height, bgrStride, bayer, bayerStride, bayerFormat);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgrToBayer(bgr, width, height, bgrStride, bayer, bayerStride, bayerFormat);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -76,6 +76,8 @@ namespace Simd
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 
+        void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
+
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 
         void BgrToGray(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* gray, size_t grayStride);

--- a/src/Simd/SimdSve2BgrToBayer.cpp
+++ b/src/Simd/SimdSve2BgrToBayer.cpp
@@ -1,0 +1,90 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template <int c0, int c1> SIMD_INLINE void BgrToBayer(const uint8_t* bgr, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
+        {
+            svuint8x3_t _bgr = svld3_u8(mask, bgr);
+            svst1_u8(mask, bayer, svsel_u8(even, svget3(_bgr, c0), svget3(_bgr, c1)));
+        }
+
+        template <int c00, int c01, int c10, int c11> void BgrToBayer(const uint8_t* bgr, size_t width, size_t height,
+            size_t bgrStride, uint8_t* bayer, size_t bayerStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0));
+
+            size_t A = svlen(svuint8_t()), A3 = A * 3;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svbool_t even = svcmpeq_n_u8(body, svand_n_u8_x(body, svindex_u8(0, 1), 1), 0);
+            for (size_t row = 0; row < height; row += 2)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    BgrToBayer<c00, c01>(bgr + offset, bayer + col, body, even);
+                if (widthA < width)
+                    BgrToBayer<c00, c01>(bgr + offset, bayer + col, tail, even);
+                bgr += bgrStride;
+                bayer += bayerStride;
+
+                col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    BgrToBayer<c10, c11>(bgr + offset, bayer + col, body, even);
+                if (widthA < width)
+                    BgrToBayer<c10, c11>(bgr + offset, bayer + col, tail, even);
+                bgr += bgrStride;
+                bayer += bayerStride;
+            }
+        }
+
+        void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer,
+            size_t bayerStride, SimdPixelFormatType bayerFormat)
+        {
+            switch (bayerFormat)
+            {
+            case SimdPixelFormatBayerGrbg:
+                BgrToBayer<1, 2, 0, 1>(bgr, width, height, bgrStride, bayer, bayerStride);
+                break;
+            case SimdPixelFormatBayerGbrg:
+                BgrToBayer<1, 0, 2, 1>(bgr, width, height, bgrStride, bayer, bayerStride);
+                break;
+            case SimdPixelFormatBayerRggb:
+                BgrToBayer<2, 1, 1, 0>(bgr, width, height, bgrStride, bayer, bayerStride);
+                break;
+            case SimdPixelFormatBayerBggr:
+                BgrToBayer<0, 1, 1, 2>(bgr, width, height, bgrStride, bayer, bayerStride);
+                break;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToBayer.cpp
+++ b/src/Test/TestAnyToBayer.cpp
@@ -105,6 +105,11 @@ namespace Test
             result = result && AnyToBayerAutoTest(View::Bgr24, FUNC(Simd::Avx512bw::BgrToBayer), FUNC(SimdBgrToBayer));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToBayerAutoTest(View::Bgr24, FUNC(Simd::Sve2::BgrToBayer), FUNC(SimdBgrToBayer));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToBayerAutoTest(View::Bgr24, FUNC(Simd::Neon::BgrToBayer), FUNC(SimdBgrToBayer));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Simd::Sve2::BgrToBayer` using predicated SVE2 `svld3_u8` channel loads and tail handling.
- Dispatch `SimdBgrToBayer` to SVE2 when available and add the SVE2 auto-test comparison.
- Add the new SVE2 source to VS2022 project metadata and the 7.2.163 release notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=BgrToBayer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -O3 -fPIC -I src -c src/Simd/SimdSve2BgrToBayer.cpp -o /tmp/SimdSve2BgrToBayer.o`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TARGET=aarch64 -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_SHARED=ON -DSIMD_PYTHON=OFF && cmake --build build-aarch64-sve2 --parallel$(nproc)`
- `QEMU_CPU=max qemu-aarch64 -L /usr/aarch64-linux-gnu -E LD_LIBRARY_PATH="$(pwd)" ./Test "-r=.." -fi=BgrToBayer -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febc43a1-a5e0-4bf4-b91e-7c4ecfe9d360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febc43a1-a5e0-4bf4-b91e-7c4ecfe9d360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

