### PR TITLE
Optimize SVE2 BgraToBgr packing

### DIFF
--- a/src/Simd/SimdSve2BgraToBgr.cpp
+++ b/src/Simd/SimdSve2BgraToBgr.cpp
@@ -28,25 +28,58 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE void BgraToBgr(const uint8_t* bgra, uint8_t* bgr, const svbool_t& mask)
+        SIMD_INLINE void BgraToBgrTail(const uint8_t* bgra, uint8_t* bgr, const svbool_t& mask)
         {
             svuint8x4_t _bgra = svld4_u8(mask, bgra);
             svst3_u8(mask, bgr, svcreate3_u8(svget4(_bgra, 0), svget4(_bgra, 1), svget4(_bgra, 2)));
         }
 
+        SIMD_INLINE void InitBgraToBgrIndex(size_t A, uint8_t index[3][64])
+        {
+            for (size_t k = 0; k < 3; ++k)
+            {
+                size_t dst = k * A;
+                size_t src = k * A;
+                for (size_t i = 0; i < A; ++i)
+                {
+                    size_t offset = dst + i;
+                    index[k][i] = (uint8_t)(4 * (offset / 3) + offset % 3 - src);
+                }
+            }
+        }
+
+        SIMD_INLINE void BgraToBgr(const uint8_t* bgra, uint8_t* bgr, size_t A,
+            const svuint8_t& index0, const svuint8_t& index1, const svuint8_t& index2, const svbool_t& mask)
+        {
+            svuint8_t bgra0 = svld1_u8(mask, bgra + 0 * A);
+            svuint8_t bgra1 = svld1_u8(mask, bgra + 1 * A);
+            svuint8_t bgra2 = svld1_u8(mask, bgra + 2 * A);
+            svuint8_t bgra3 = svld1_u8(mask, bgra + 3 * A);
+
+            svst1_u8(mask, bgr + 0 * A, svtbl2_u8(svcreate2_u8(bgra0, bgra1), index0));
+            svst1_u8(mask, bgr + 1 * A, svtbl2_u8(svcreate2_u8(bgra1, bgra2), index1));
+            svst1_u8(mask, bgr + 2 * A, svtbl2_u8(svcreate2_u8(bgra2, bgra3), index2));
+        }
+
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride)
         {
             size_t A = svlen(svuint8_t()), A3 = A * 3, A4 = A * 4;
+            assert(A <= 64);
             size_t widthA = AlignLo(width, A);
             const svbool_t body = svptrue_b8();
             const svbool_t tail = svwhilelt_b8(widthA, width);
+            SIMD_ALIGNED(64) uint8_t _index[3][64];
+            InitBgraToBgrIndex(A, _index);
+            const svuint8_t index0 = svld1_u8(body, _index[0]);
+            const svuint8_t index1 = svld1_u8(body, _index[1]);
+            const svuint8_t index2 = svld1_u8(body, _index[2]);
             for (size_t row = 0; row < height; ++row)
             {
                 size_t col = 0, bgraOffset = 0, bgrOffset = 0;
                 for (; col < widthA; col += A, bgraOffset += A4, bgrOffset += A3)
-                    BgraToBgr(bgra + bgraOffset, bgr + bgrOffset, body);
+                    BgraToBgr(bgra + bgraOffset, bgr + bgrOffset, A, index0, index1, index2, body);
                 if (widthA < width)
-                    BgraToBgr(bgra + bgraOffset, bgr + bgrOffset, tail);
+                    BgraToBgrTail(bgra + bgraOffset, bgr + bgrOffset, tail);
                 bgra += bgraStride;
                 bgr += bgrStride;
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Rework `Sve2::BgraToBgr` full-width blocks to pack `4 * VL` BGRA bytes into `3 * VL` BGR bytes with `svtbl2_u8` table lookups.
- Keep the existing `svld4_u8`/`svst3_u8` path for tail pixels.

### Testing
- `aarch64-linux-gnu-g++ -std=c++11 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Simd/SimdSve2BgraToBgr.cpp -o /tmp/SimdSve2BgraToBgr.o`
- Focused QEMU AArch64/SVE2 harness passed for VL=16, VL=32, and VL=64.
- Index mapping formula checked for VL=16, VL=32, VL=48, and VL=64.
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgraToBgr -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f75570c9-afe0-44a4-a27b-2a72df233260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f75570c9-afe0-44a4-a27b-2a72df233260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

