### PR TITLE
Add SVE2 BgrToLab optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -53,6 +53,7 @@
  <li>SVE2 optimizations of function Bgr48pToBgra32.</li>
  <li>SVE2 optimizations of function BgrToHsl.</li>
  <li>SVE2 optimizations of function BgrToHsv.</li>
+ <li>SVE2 optimizations of function BgrToLab.</li>
  <li>SVE2 optimizations of function Reorder16bit.</li>
  <li>SVE2 optimizations of function Reorder32bit.</li>
  <li>SVE2 optimizations of function Reorder64bit.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -33,6 +33,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToHsl.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToHsv.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgrToLab.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -53,6 +53,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToHsv.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgrToLab.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1590,6 +1590,11 @@ SIMD_API void SimdBgrToLab(const uint8_t* bgr, size_t bgrStride, size_t width, s
         Sse41::BgrToLab(bgr, bgrStride, width, height, lab, labStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgrToLab(bgr, bgrStride, width, height, lab, labStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::BgrToLab(bgr, bgrStride, width, height, lab, labStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -86,6 +86,8 @@ namespace Simd
 
         void BgrToHsv(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* hsv, size_t hsvStride);
 
+        void BgrToLab(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height, uint8_t* lab, size_t labStride);
+
         void ConditionalCount8u(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t value, SimdCompareType compareType, uint32_t* count);
 
         void ConditionalCount16i(const uint8_t* src, size_t stride, size_t width, size_t height, int16_t value, SimdCompareType compareType, uint32_t* count);

--- a/src/Simd/SimdSve2BgrToLab.cpp
+++ b/src/Simd/SimdSve2BgrToLab.cpp
@@ -1,0 +1,132 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdBgrToLab.h"
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svint32_t CbrtIndex(const svint32_t& r, const svint32_t& g, const svint32_t& b,
+            const svint32_t& c0, const svint32_t& c1, const svint32_t& c2)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t i = svadd_s32_x(mask, svadd_s32_x(mask, svmul_s32_x(mask, r, c0), svmul_s32_x(mask, g, c1)), svmul_s32_x(mask, b, c2));
+            return svasr_n_s32_x(mask, svadd_n_s32_x(mask, i, Base::LAB_ROUND), Base::LAB_SHIFT);
+        }
+
+        SIMD_INLINE svuint8_t PackI32ToU8(const svint32_t& v0, const svint32_t& v1, const svint32_t& v2, const svint32_t& v3)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint16_t lo = svqxtnt_s32(svqxtnb_s32(svmin_n_s32_x(mask, svmax_n_s32_x(mask, v0, 0), 255)),
+                svmin_n_s32_x(mask, svmax_n_s32_x(mask, v1, 0), 255));
+            svint16_t hi = svqxtnt_s32(svqxtnb_s32(svmin_n_s32_x(mask, svmax_n_s32_x(mask, v2, 0), 255)),
+                svmin_n_s32_x(mask, svmax_n_s32_x(mask, v3, 0), 255));
+            return svqxtnt_u16(svqxtnb_u16(svreinterpret_u16_s16(lo)), svreinterpret_u16_s16(hi));
+        }
+
+        SIMD_INLINE svint32_t LoadGamma(const svuint32_t& value)
+        {
+            const svbool_t mask = svptrue_b32();
+            return svreinterpret_s32_u32(svld1_gather_u32index_u32(mask, Base::LabGammaTab, value));
+        }
+
+        SIMD_INLINE svint32_t LoadCbrt(const svint32_t& index)
+        {
+            const svbool_t mask = svptrue_b32();
+            return svreinterpret_s32_u32(svld1_gather_s32index_u32(mask, Base::LabCbrtTab, index));
+        }
+
+        SIMD_INLINE void BgrToLab32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red, svint32_t& L, svint32_t& a, svint32_t& b,
+            const svint32_t& c0, const svint32_t& c1, const svint32_t& c2, const svint32_t& c3, const svint32_t& c4, const svint32_t& c5,
+            const svint32_t& c6, const svint32_t& c7, const svint32_t& c8)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t R = LoadGamma(red);
+            svint32_t G = LoadGamma(green);
+            svint32_t B = LoadGamma(blue);
+
+            svint32_t fX = LoadCbrt(CbrtIndex(R, G, B, c0, c1, c2));
+            svint32_t fY = LoadCbrt(CbrtIndex(R, G, B, c3, c4, c5));
+            svint32_t fZ = LoadCbrt(CbrtIndex(R, G, B, c6, c7, c8));
+
+            L = svasr_n_s32_x(mask, svadd_s32_x(mask, svmul_n_s32_x(mask, fY, Base::LAB_L_SCALE), svdup_n_s32(Base::LAB_L_SHIFT)), Base::LAB_SHIFT2);
+            a = svasr_n_s32_x(mask, svadd_s32_x(mask, svmul_n_s32_x(mask, svsub_s32_x(mask, fX, fY), Base::LAB_A_SCALE), svdup_n_s32(Base::LAB_AB_SHIFT)), Base::LAB_SHIFT2);
+            b = svasr_n_s32_x(mask, svadd_s32_x(mask, svmul_n_s32_x(mask, svsub_s32_x(mask, fY, fZ), Base::LAB_B_SCALE), svdup_n_s32(Base::LAB_AB_SHIFT)), Base::LAB_SHIFT2);
+        }
+
+        SIMD_INLINE void BgrToLab(const uint8_t* bgr, uint8_t* lab, const svbool_t& mask,
+            const svint32_t& c0, const svint32_t& c1, const svint32_t& c2, const svint32_t& c3, const svint32_t& c4, const svint32_t& c5,
+            const svint32_t& c6, const svint32_t& c7, const svint32_t& c8)
+        {
+            svuint8x3_t _bgr = svld3_u8(mask, bgr);
+            svuint16_t blueLo = svmovlb_u16(svget3(_bgr, 0));
+            svuint16_t blueHi = svmovlt_u16(svget3(_bgr, 0));
+            svuint16_t greenLo = svmovlb_u16(svget3(_bgr, 1));
+            svuint16_t greenHi = svmovlt_u16(svget3(_bgr, 1));
+            svuint16_t redLo = svmovlb_u16(svget3(_bgr, 2));
+            svuint16_t redHi = svmovlt_u16(svget3(_bgr, 2));
+
+            svint32_t L0, L1, L2, L3, a0, a1, a2, a3, b0, b1, b2, b3;
+            BgrToLab32(svmovlb_u32(blueLo), svmovlb_u32(greenLo), svmovlb_u32(redLo), L0, a0, b0, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+            BgrToLab32(svmovlt_u32(blueLo), svmovlt_u32(greenLo), svmovlt_u32(redLo), L1, a1, b1, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+            BgrToLab32(svmovlb_u32(blueHi), svmovlb_u32(greenHi), svmovlb_u32(redHi), L2, a2, b2, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+            BgrToLab32(svmovlt_u32(blueHi), svmovlt_u32(greenHi), svmovlt_u32(redHi), L3, a3, b3, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+
+            svst3_u8(mask, lab, svcreate3_u8(PackI32ToU8(L0, L1, L2, L3), PackI32ToU8(a0, a1, a2, a3), PackI32ToU8(b0, b1, b2, b3)));
+        }
+
+        void BgrToLab(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height, uint8_t* lab, size_t labStride)
+        {
+            Base::LabInitTabs();
+            size_t A = svlen(svuint8_t()), A3 = A * 3;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svint32_t c0 = svdup_n_s32(Base::LabCoeffsTab[0]);
+            const svint32_t c1 = svdup_n_s32(Base::LabCoeffsTab[1]);
+            const svint32_t c2 = svdup_n_s32(Base::LabCoeffsTab[2]);
+            const svint32_t c3 = svdup_n_s32(Base::LabCoeffsTab[3]);
+            const svint32_t c4 = svdup_n_s32(Base::LabCoeffsTab[4]);
+            const svint32_t c5 = svdup_n_s32(Base::LabCoeffsTab[5]);
+            const svint32_t c6 = svdup_n_s32(Base::LabCoeffsTab[6]);
+            const svint32_t c7 = svdup_n_s32(Base::LabCoeffsTab[7]);
+            const svint32_t c8 = svdup_n_s32(Base::LabCoeffsTab[8]);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    BgrToLab(bgr + offset, lab + offset, body, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+                if (widthA < width)
+                    BgrToLab(bgr + offset, lab + offset, tail, c0, c1, c2, c3, c4, c5, c6, c7, c8);
+                bgr += bgrStride;
+                lab += labStride;
+            }
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestAnyToAny.cpp
+++ b/src/Test/TestAnyToAny.cpp
@@ -381,6 +381,11 @@ namespace Test
             result = result && AnyToAnyAutoTest(View::Bgr24, View::Lab24, FUNC_N(Simd::Avx512bw::BgrToLab), FUNC_N(SimdBgrToLab));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToAnyAutoTest(View::Bgr24, View::Lab24, FUNC_N(Simd::Sve2::BgrToLab), FUNC_N(SimdBgrToLab));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::F)
             result = result && AnyToAnyAutoTest(View::Bgr24, View::Lab24, FUNC_N(Simd::Neon::BgrToLab), FUNC_N(SimdBgrToLab));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation of `BgrToLab` using predicated BGR loads, table gathers, SIMD Lab arithmetic, and predicated LAB stores.
* Wire SVE2 `BgrToLab` into dispatch, auto tests, VS2022 SVE2 project files, and 7.2.163 release notes.

### Testing
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2BgrToLab.cpp`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I src src/Test/TestAnyToAny.cpp`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdLib.cpp`
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgrToLab -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bb9b0ef-5c63-47b0-8c05-b5da83e475d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bb9b0ef-5c63-47b0-8c05-b5da83e475d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

