### PR TITLE
Validate HAAR feature rectangle data when loading XML cascades

### DIFF
--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -279,7 +279,11 @@ namespace Simd
                         Xml::Node * rectsNode = featureNode->FirstNode(Names::rects);
                         for (Xml::Node * rectNode = rectsNode->FirstNode(); rectNode != NULL; rectNode = rectNode->NextSibling(), rectIndex++)
                         {
+                            if (rectIndex >= Data::HaarFeature::RECT_NUM)
+                                SIMD_EX("Invalid HAAR feature: too many rects!");
                             std::vector<double> values = Xml::GetValues<double>(rectNode);
+                            if (values.size() < 5)
+                                SIMD_EX("Invalid HAAR feature: malformed rect!");
                             feature.rect[rectIndex].r.x = (int)values[0];
                             feature.rect[rectIndex].r.y = (int)values[1];
                             feature.rect[rectIndex].r.width = (int)values[2];


### PR DESCRIPTION
## Summary

Validate HAAR feature rectangle data while loading XML cascades.

## Changes

* Validate that the number of parsed HAAR rectangles does not exceed `Data::HaarFeature::RECT_NUM`.
* Validate that each HAAR rectangle contains the expected number of values before accessing them.

## Why

HAAR feature rectangles are stored in a fixed-size array and the parser assumes that each rectangle entry contains five values.

Malformed XML input can violate these assumptions, leading to out-of-bounds array or vector access during parsing.

## Result

Malformed HAAR feature data is now rejected through the existing error-handling path.

Valid cascades are unaffected and continue to load as before.