### PR TITLE
Add SVE2 Base64 decode optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -61,6 +61,7 @@
  <li>SVE2 optimizations of function BayerToBgra.</li>
  <li>SVE2 optimizations of function BgraToBayer.</li>
  <li>SVE2 optimizations of function BgrToBayer.</li>
+ <li>SVE2 optimizations of function Base64Decode.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AlphaBlending.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Base64.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -38,6 +38,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Base64.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp">
       <Filter>Sve2\System</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1021,6 +1021,11 @@ SIMD_API void SimdBase64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst,
         Sse41::Base64Decode(src, srcSize, dst, dstSize);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Base64Decode(src, srcSize, dst, dstSize);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable)
         Neon::Base64Decode(src, srcSize, dst, dstSize);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -62,6 +62,8 @@ namespace Simd
         void BayerToBgr(const uint8_t* bayer, size_t width, size_t height, size_t bayerStride, SimdPixelFormatType bayerFormat, uint8_t* bgr, size_t bgrStride);
 
         void BayerToBgra(const uint8_t* bayer, size_t width, size_t height, size_t bayerStride, SimdPixelFormatType bayerFormat, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
+
+        void Base64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst, size_t* dstSize);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 

--- a/src/Simd/SimdSve2Base64.cpp
+++ b/src/Simd/SimdSve2Base64.cpp
@@ -1,0 +1,81 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdBase64.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint8_t FromBase64(const svuint8_t& src, const svbool_t& mask)
+        {
+            const svuint8_t zero = svdup_n_u8(0);
+            svuint8_t dst = zero;
+
+            svbool_t upper = svand_b_z(mask, svcmpgt_n_u8(mask, src, 'A' - 1), svnot_b_z(mask, svcmpgt_n_u8(mask, src, 'Z')));
+            svbool_t lower = svand_b_z(mask, svcmpgt_n_u8(mask, src, 'a' - 1), svnot_b_z(mask, svcmpgt_n_u8(mask, src, 'z')));
+            svbool_t digit = svand_b_z(mask, svcmpgt_n_u8(mask, src, '0' - 1), svnot_b_z(mask, svcmpgt_n_u8(mask, src, '9')));
+            svbool_t slash = svorr_b_z(mask, svcmpeq_n_u8(mask, src, '/'), svcmpeq_n_u8(mask, src, '_'));
+
+            dst = svsel_u8(upper, svsub_n_u8_x(mask, src, 'A'), dst);
+            dst = svsel_u8(lower, svsub_n_u8_x(mask, src, 'a' - 26), dst);
+            dst = svsel_u8(digit, svadd_n_u8_x(mask, src, 52 - '0'), dst);
+            dst = svsel_u8(svcmpeq_n_u8(mask, src, '+'), svdup_n_u8(62), dst);
+            dst = svsel_u8(slash, svdup_n_u8(63), dst);
+            return dst;
+        }
+
+        SIMD_INLINE void Base64Decode(const uint8_t* src, uint8_t* dst, const svbool_t& mask)
+        {
+            svuint8x4_t _src = svld4_u8(mask, src);
+            svuint8_t src0 = FromBase64(svget4(_src, 0), mask);
+            svuint8_t src1 = FromBase64(svget4(_src, 1), mask);
+            svuint8_t src2 = FromBase64(svget4(_src, 2), mask);
+            svuint8_t src3 = FromBase64(svget4(_src, 3), mask);
+
+            svuint8_t dst0 = svorr_u8_x(mask, svlsl_n_u8_x(mask, src0, 2), svlsr_n_u8_x(mask, svand_n_u8_x(mask, src1, 0x30), 4));
+            svuint8_t dst1 = svorr_u8_x(mask, svlsl_n_u8_x(mask, svand_n_u8_x(mask, src1, 0x0F), 4), svlsr_n_u8_x(mask, svand_n_u8_x(mask, src2, 0x3C), 2));
+            svuint8_t dst2 = svorr_u8_x(mask, svlsl_n_u8_x(mask, svand_n_u8_x(mask, src2, 0x03), 6), src3);
+
+            svst3_u8(mask, dst, svcreate3_u8(dst0, dst1, dst2));
+        }
+
+        void Base64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst, size_t* dstSize)
+        {
+            assert(srcSize % 4 == 0 && srcSize >= 4);
+
+            size_t A = svlen(svuint8_t()), srcStep = A * 4, dstStep = A * 3;
+            size_t srcSizeA = srcSize > srcStep ? AlignLoAny(srcSize - srcStep, srcStep) : 0;
+            const svbool_t body = svptrue_b8();
+            for (const uint8_t* bodyA = src + srcSizeA; src < bodyA; src += srcStep, dst += dstStep)
+                Base64Decode(src, dst, body);
+            for (const uint8_t* tail = src + srcSize - srcSizeA - 4; src < tail; src += 4, dst += 3)
+                Base::Base64Decode3(src, dst);
+            *dstSize = srcSize / 4 * 3 + Base::Base64DecodeTail(src, dst) - 3;
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestBase64.cpp
+++ b/src/Test/TestBase64.cpp
@@ -113,6 +113,11 @@ namespace Test
             result = result && Base64DecodeAutoTest(FUNC_D(Simd::Avx512bw::Base64Decode), FUNC_D(SimdBase64Decode));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Base64DecodeAutoTest(FUNC_D(Simd::Sve2::Base64Decode), FUNC_D(SimdBase64Decode));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && Base64DecodeAutoTest(FUNC_D(Simd::Neon::Base64Decode), FUNC_D(SimdBase64Decode));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 Base64Decode implementation and dispatch.
- Cover SVE2 Base64Decode in auto tests.
- Add VS2022 SVE2 project entries and 7.2.163 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=Base64Decode -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -I src -I src/Simd -fsyntax-only src/Simd/SimdSve2Base64.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -O2 -I src -I src/Simd -c src/Simd/SimdSve2Base64.cpp -o /tmp/SimdSve2Base64.o`
- Temporary ARM64/QEMU harness: `SVE2 Base64Decode harness passed 18 cases.`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd8065f-da1c-4eed-819f-88c7df82a3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd8065f-da1c-4eed-819f-88c7df82a3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

