### PR TITLE
Add SVE2 Base64 encode optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -62,6 +62,7 @@
  <li>SVE2 optimizations of function BgraToBayer.</li>
  <li>SVE2 optimizations of function BgrToBayer.</li>
  <li>SVE2 optimizations of function Base64Decode.</li>
+ <li>SVE2 optimizations of function Base64Encode.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1052,6 +1052,11 @@ SIMD_API void SimdBase64Encode(const uint8_t* src, size_t size, uint8_t* dst)
         Sse41::Base64Encode(src, size, dst);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Base64Encode(src, size, dst);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable)
         Neon::Base64Encode(src, size, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -64,6 +64,8 @@ namespace Simd
         void BayerToBgra(const uint8_t* bayer, size_t width, size_t height, size_t bayerStride, SimdPixelFormatType bayerFormat, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 
         void Base64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst, size_t* dstSize);
+
+        void Base64Encode(const uint8_t* src, size_t size, uint8_t* dst);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 

--- a/src/Simd/SimdSve2Base64.cpp
+++ b/src/Simd/SimdSve2Base64.cpp
@@ -75,6 +75,56 @@ namespace Simd
                 Base::Base64Decode3(src, dst);
             *dstSize = srcSize / 4 * 3 + Base::Base64DecodeTail(src, dst) - 3;
         }
+
+        //---------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint8_t ToBase64(const svuint8_t& src, const svbool_t& mask)
+        {
+            svbool_t upper = svnot_b_z(mask, svcmpgt_n_u8(mask, src, 25));
+            svbool_t lower = svand_b_z(mask, svcmpgt_n_u8(mask, src, 25), svnot_b_z(mask, svcmpgt_n_u8(mask, src, 51)));
+            svbool_t digit = svand_b_z(mask, svcmpgt_n_u8(mask, src, 51), svnot_b_z(mask, svcmpgt_n_u8(mask, src, 61)));
+
+            svuint8_t dst = svdup_n_u8('/');
+            dst = svsel_u8(svcmpeq_n_u8(mask, src, 62), svdup_n_u8('+'), dst);
+            dst = svsel_u8(digit, svsub_n_u8_x(mask, src, 4), dst);
+            dst = svsel_u8(lower, svadd_n_u8_x(mask, src, 'a' - 26), dst);
+            dst = svsel_u8(upper, svadd_n_u8_x(mask, src, 'A'), dst);
+            return dst;
+        }
+
+        SIMD_INLINE void Base64Encode(const uint8_t* src, uint8_t* dst, const svbool_t& mask)
+        {
+            svuint8x3_t _src = svld3_u8(mask, src);
+            svuint8_t src0 = svget3(_src, 0);
+            svuint8_t src1 = svget3(_src, 1);
+            svuint8_t src2 = svget3(_src, 2);
+
+            svuint8_t dst0 = svlsr_n_u8_x(mask, svand_n_u8_x(mask, src0, 0xFC), 2);
+            svuint8_t dst1 = svorr_u8_x(mask, svlsl_n_u8_x(mask, svand_n_u8_x(mask, src0, 0x03), 4), svlsr_n_u8_x(mask, svand_n_u8_x(mask, src1, 0xF0), 4));
+            svuint8_t dst2 = svorr_u8_x(mask, svlsl_n_u8_x(mask, svand_n_u8_x(mask, src1, 0x0F), 2), svlsr_n_u8_x(mask, svand_n_u8_x(mask, src2, 0xC0), 6));
+            svuint8_t dst3 = svand_n_u8_x(mask, src2, 0x3F);
+
+            dst0 = ToBase64(dst0, mask);
+            dst1 = ToBase64(dst1, mask);
+            dst2 = ToBase64(dst2, mask);
+            dst3 = ToBase64(dst3, mask);
+
+            svst4_u8(mask, dst, svcreate4_u8(dst0, dst1, dst2, dst3));
+        }
+
+        void Base64Encode(const uint8_t* src, size_t size, uint8_t* dst)
+        {
+            size_t size3 = AlignLoAny(size, 3);
+            size_t A = svlen(svuint8_t()), srcStep = A * 3, dstStep = A * 4;
+            size_t sizeA = size >= srcStep - 1 ? AlignLoAny(size - (srcStep - 1), srcStep) : 0;
+            const svbool_t body = svptrue_b8();
+            for (const uint8_t* bodyA = src + sizeA; src < bodyA; src += srcStep, dst += dstStep)
+                Base64Encode(src, dst, body);
+            for (const uint8_t* body3 = src + size3 - sizeA; src < body3; src += 3, dst += 4)
+                Base::Base64Encode3(src, dst);
+            if (size - size3)
+                Base::Base64EncodeTail(src, size - size3, dst);
+        }
     }
 #endif
 }

--- a/src/Test/TestBase64.cpp
+++ b/src/Test/TestBase64.cpp
@@ -206,6 +206,11 @@ namespace Test
             result = result && Base64EncodeAutoTest(FUNC_E(Simd::Avx512bw::Base64Encode), FUNC_E(SimdBase64Encode));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Base64EncodeAutoTest(FUNC_E(Simd::Sve2::Base64Encode), FUNC_E(SimdBase64Encode));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && Base64EncodeAutoTest(FUNC_E(Simd::Neon::Base64Encode), FUNC_E(SimdBase64Encode));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 vectorized `Base64Encode` implementation and dispatch wiring.
- Cover SVE2 `Base64Encode` in the existing Base64 auto-test matrix.
- Document the optimization in the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=Base64Encode -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -I build -fsyntax-only src/Simd/SimdSve2Base64.cpp`
- Temporary AArch64/SVE2 QEMU harness: scalar vs SVE2 `Base64Encode` matched for sizes 0..8192.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95aba983-3505-4229-858b-391c50e5aea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95aba983-3505-4229-858b-391c50e5aea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

