### PR TITLE
Optimize SVE2 BGRA to Bayer conversion

### DIFF
--- a/src/Simd/SimdSve2BgraToBayer.cpp
+++ b/src/Simd/SimdSve2BgraToBayer.cpp
@@ -36,31 +36,40 @@ namespace Simd
             BgraToBayerRg,
         };
 
-        SIMD_INLINE bool InitBgraToBayerIndex(uint8_t index[4][SIMD_SVE2_VECTOR_SIZE_MAX])
+        SIMD_INLINE bool InitBgraToBayerIndex(uint8_t index[4][2][SIMD_SVE2_VECTOR_SIZE_MAX])
         {
             size_t A = svlen(svuint8_t());
             assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
             for (size_t i = 0; i < A; ++i)
             {
-                size_t offset = 4 * i;
-                index[BgraToBayerGr][i] = (uint8_t)(offset + (i & 1 ? 2 : 1));
-                index[BgraToBayerBg][i] = (uint8_t)(offset + (i & 1 ? 1 : 0));
-                index[BgraToBayerGb][i] = (uint8_t)(offset + (i & 1 ? 0 : 1));
-                index[BgraToBayerRg][i] = (uint8_t)(offset + (i & 1 ? 1 : 2));
+                size_t offset = 4 * i, half = 2 * A;
+                size_t bgra[4];
+                bgra[BgraToBayerGr] = offset + (i & 1 ? 2 : 1);
+                bgra[BgraToBayerBg] = offset + (i & 1 ? 1 : 0);
+                bgra[BgraToBayerGb] = offset + (i & 1 ? 0 : 1);
+                bgra[BgraToBayerRg] = offset + (i & 1 ? 1 : 2);
+                for (size_t k = 0; k < 4; ++k)
+                {
+                    index[k][0][i] = bgra[k] < half ? (uint8_t)bgra[k] : 0xFF;
+                    index[k][1][i] = bgra[k] >= half ? (uint8_t)(bgra[k] - half) : 0xFF;
+                }
             }
             return true;
         }
 
-        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGRA_TO_BAYER_INDEX[4][SIMD_SVE2_VECTOR_SIZE_MAX];
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGRA_TO_BAYER_INDEX[4][2][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool BGRA_TO_BAYER_INDEX_INITED = InitBgraToBayerIndex(BGRA_TO_BAYER_INDEX);
 
-        SIMD_INLINE void BgraToBayer(const uint8_t* bgra, uint8_t* bayer, size_t A, const svuint8_t& index, const svbool_t& mask)
+        SIMD_INLINE void BgraToBayer(const uint8_t* bgra, uint8_t* bayer, size_t A,
+            const svuint8_t& index0, const svuint8_t& index1, const svbool_t& mask)
         {
             svuint8_t bgra0 = svld1_u8(mask, bgra + 0 * A);
             svuint8_t bgra1 = svld1_u8(mask, bgra + 1 * A);
             svuint8_t bgra2 = svld1_u8(mask, bgra + 2 * A);
             svuint8_t bgra3 = svld1_u8(mask, bgra + 3 * A);
-            svst1_u8(mask, bayer, svtbl4_u8(svcreate4_u8(bgra0, bgra1, bgra2, bgra3), index));
+            svuint8_t bayer0 = svtbl2_u8(svcreate2_u8(bgra0, bgra1), index0);
+            svuint8_t bayer1 = svtbl2_u8(svcreate2_u8(bgra2, bgra3), index1);
+            svst1_u8(mask, bayer, svorr_u8_x(mask, bayer0, bayer1));
         }
 
         template <int c0, int c1> SIMD_INLINE void BgraToBayerTail(const uint8_t* bgra, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
@@ -80,13 +89,15 @@ namespace Simd
             const svbool_t body = svptrue_b8();
             const svbool_t tail = svwhilelt_b8(widthA, width);
             const svbool_t even = svcmpeq_n_u8(body, svand_n_u8_x(body, svindex_u8(0, 1), 1), 0);
-            const svuint8_t index0 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i0]);
-            const svuint8_t index1 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i1]);
+            const svuint8_t index00 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i0][0]);
+            const svuint8_t index01 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i0][1]);
+            const svuint8_t index10 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i1][0]);
+            const svuint8_t index11 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i1][1]);
             for (size_t row = 0; row < height; row += 2)
             {
                 size_t col = 0, offset = 0;
                 for (; col < widthA; col += A, offset += A4)
-                    BgraToBayer(bgra + offset, bayer + col, A, index0, body);
+                    BgraToBayer(bgra + offset, bayer + col, A, index00, index01, body);
                 if (widthA < width)
                     BgraToBayerTail<c00, c01>(bgra + offset, bayer + col, tail, even);
                 bgra += bgraStride;
@@ -94,7 +105,7 @@ namespace Simd
 
                 col = 0, offset = 0;
                 for (; col < widthA; col += A, offset += A4)
-                    BgraToBayer(bgra + offset, bayer + col, A, index1, body);
+                    BgraToBayer(bgra + offset, bayer + col, A, index10, index11, body);
                 if (widthA < width)
                     BgraToBayerTail<c10, c11>(bgra + offset, bayer + col, tail, even);
                 bgra += bgraStride;

--- a/src/Simd/SimdSve2BgraToBayer.cpp
+++ b/src/Simd/SimdSve2BgraToBayer.cpp
@@ -28,37 +28,75 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        template <int c0, int c1> SIMD_INLINE void BgraToBayer(const uint8_t* bgra, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
+        enum BgraToBayerIndexType
+        {
+            BgraToBayerGr,
+            BgraToBayerBg,
+            BgraToBayerGb,
+            BgraToBayerRg,
+        };
+
+        SIMD_INLINE bool InitBgraToBayerIndex(uint8_t index[4][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t i = 0; i < A; ++i)
+            {
+                size_t offset = 4 * i;
+                index[BgraToBayerGr][i] = (uint8_t)(offset + (i & 1 ? 2 : 1));
+                index[BgraToBayerBg][i] = (uint8_t)(offset + (i & 1 ? 1 : 0));
+                index[BgraToBayerGb][i] = (uint8_t)(offset + (i & 1 ? 0 : 1));
+                index[BgraToBayerRg][i] = (uint8_t)(offset + (i & 1 ? 1 : 2));
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGRA_TO_BAYER_INDEX[4][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool BGRA_TO_BAYER_INDEX_INITED = InitBgraToBayerIndex(BGRA_TO_BAYER_INDEX);
+
+        SIMD_INLINE void BgraToBayer(const uint8_t* bgra, uint8_t* bayer, size_t A, const svuint8_t& index, const svbool_t& mask)
+        {
+            svuint8_t bgra0 = svld1_u8(mask, bgra + 0 * A);
+            svuint8_t bgra1 = svld1_u8(mask, bgra + 1 * A);
+            svuint8_t bgra2 = svld1_u8(mask, bgra + 2 * A);
+            svuint8_t bgra3 = svld1_u8(mask, bgra + 3 * A);
+            svst1_u8(mask, bayer, svtbl4_u8(svcreate4_u8(bgra0, bgra1, bgra2, bgra3), index));
+        }
+
+        template <int c0, int c1> SIMD_INLINE void BgraToBayerTail(const uint8_t* bgra, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
         {
             svuint8x4_t _bgra = svld4_u8(mask, bgra);
             svst1_u8(mask, bayer, svsel_u8(even, svget4(_bgra, c0), svget4(_bgra, c1)));
         }
 
-        template <int c00, int c01, int c10, int c11> void BgraToBayer(const uint8_t* bgra, size_t width, size_t height,
+        template <BgraToBayerIndexType i0, BgraToBayerIndexType i1, int c00, int c01, int c10, int c11> void BgraToBayer(const uint8_t* bgra, size_t width, size_t height,
             size_t bgraStride, uint8_t* bayer, size_t bayerStride)
         {
             assert((width % 2 == 0) && (height % 2 == 0));
 
             size_t A = svlen(svuint8_t()), A4 = A * 4;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
             size_t widthA = AlignLo(width, A);
             const svbool_t body = svptrue_b8();
             const svbool_t tail = svwhilelt_b8(widthA, width);
             const svbool_t even = svcmpeq_n_u8(body, svand_n_u8_x(body, svindex_u8(0, 1), 1), 0);
+            const svuint8_t index0 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i0]);
+            const svuint8_t index1 = svld1_u8(body, BGRA_TO_BAYER_INDEX[i1]);
             for (size_t row = 0; row < height; row += 2)
             {
                 size_t col = 0, offset = 0;
                 for (; col < widthA; col += A, offset += A4)
-                    BgraToBayer<c00, c01>(bgra + offset, bayer + col, body, even);
+                    BgraToBayer(bgra + offset, bayer + col, A, index0, body);
                 if (widthA < width)
-                    BgraToBayer<c00, c01>(bgra + offset, bayer + col, tail, even);
+                    BgraToBayerTail<c00, c01>(bgra + offset, bayer + col, tail, even);
                 bgra += bgraStride;
                 bayer += bayerStride;
 
                 col = 0, offset = 0;
                 for (; col < widthA; col += A, offset += A4)
-                    BgraToBayer<c10, c11>(bgra + offset, bayer + col, body, even);
+                    BgraToBayer(bgra + offset, bayer + col, A, index1, body);
                 if (widthA < width)
-                    BgraToBayer<c10, c11>(bgra + offset, bayer + col, tail, even);
+                    BgraToBayerTail<c10, c11>(bgra + offset, bayer + col, tail, even);
                 bgra += bgraStride;
                 bayer += bayerStride;
             }
@@ -70,16 +108,16 @@ namespace Simd
             switch (bayerFormat)
             {
             case SimdPixelFormatBayerGrbg:
-                BgraToBayer<1, 2, 0, 1>(bgra, width, height, bgraStride, bayer, bayerStride);
+                BgraToBayer<BgraToBayerGr, BgraToBayerBg, 1, 2, 0, 1>(bgra, width, height, bgraStride, bayer, bayerStride);
                 break;
             case SimdPixelFormatBayerGbrg:
-                BgraToBayer<1, 0, 2, 1>(bgra, width, height, bgraStride, bayer, bayerStride);
+                BgraToBayer<BgraToBayerGb, BgraToBayerRg, 1, 0, 2, 1>(bgra, width, height, bgraStride, bayer, bayerStride);
                 break;
             case SimdPixelFormatBayerRggb:
-                BgraToBayer<2, 1, 1, 0>(bgra, width, height, bgraStride, bayer, bayerStride);
+                BgraToBayer<BgraToBayerRg, BgraToBayerGb, 2, 1, 1, 0>(bgra, width, height, bgraStride, bayer, bayerStride);
                 break;
             case SimdPixelFormatBayerBggr:
-                BgraToBayer<0, 1, 1, 2>(bgra, width, height, bgraStride, bayer, bayerStride);
+                BgraToBayer<BgraToBayerBg, BgraToBayerGr, 0, 1, 1, 2>(bgra, width, height, bgraStride, bayer, bayerStride);
                 break;
             default:
                 assert(0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Rework `Sve2::BgraToBayer` full-vector rows to load contiguous BGRA bytes and build Bayer output with `svtbl2_u8` table lookups.
- Add precomputed Bayer table indices for the four row patterns and preserve the existing `svld4_u8` tail path for masked partial vectors.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./Test "-r=.." -fi=BgraToBayer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -O2 -I src -c src/Simd/SimdSve2BgraToBayer.cpp -o /tmp/SimdSve2BgraToBayer.o`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -O2 -I src -S src/Simd/SimdSve2BgraToBayer.cpp -o /tmp/SimdSve2BgraToBayer.s` plus `tbl` assembly check
- Temporary AArch64/QEMU harness comparing `Simd::Sve2::BgraToBayer` against `Simd::Base::BgraToBayer` for all Bayer formats and tail-covering sizes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac37579f-fa25-4642-8f8e-95db41b8fa03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac37579f-fa25-4642-8f8e-95db41b8fa03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

