### PR TITLE
Optimize SVE2 BgrToBayer table lookup

### DIFF
--- a/src/Simd/SimdSve2BgrToBayer.cpp
+++ b/src/Simd/SimdSve2BgrToBayer.cpp
@@ -28,37 +28,85 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        template <int c0, int c1> SIMD_INLINE void BgrToBayer(const uint8_t* bgr, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
+        enum BgrToBayerIndexType
+        {
+            BgrToBayerGr,
+            BgrToBayerBg,
+            BgrToBayerGb,
+            BgrToBayerRg,
+        };
+
+        SIMD_INLINE bool InitBgrToBayerIndex(uint8_t index[4][2][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t i = 0; i < A; ++i)
+            {
+                size_t offset = 3 * i, half = 2 * A;
+                size_t bgr[4];
+                bgr[BgrToBayerGr] = offset + (i & 1 ? 2 : 1);
+                bgr[BgrToBayerBg] = offset + (i & 1 ? 1 : 0);
+                bgr[BgrToBayerGb] = offset + (i & 1 ? 0 : 1);
+                bgr[BgrToBayerRg] = offset + (i & 1 ? 1 : 2);
+                for (size_t k = 0; k < 4; ++k)
+                {
+                    index[k][0][i] = bgr[k] < half ? (uint8_t)bgr[k] : 0xFF;
+                    index[k][1][i] = bgr[k] >= half ? (uint8_t)(bgr[k] - half) : 0xFF;
+                }
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_TO_BAYER_INDEX[4][2][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool BGR_TO_BAYER_INDEX_INITED = InitBgrToBayerIndex(BGR_TO_BAYER_INDEX);
+
+        SIMD_INLINE void BgrToBayer(const uint8_t* bgr, uint8_t* bayer, size_t A,
+            const svuint8_t& index0, const svuint8_t& index1, const svbool_t& mask)
+        {
+            svuint8_t bgr0 = svld1_u8(mask, bgr + 0 * A);
+            svuint8_t bgr1 = svld1_u8(mask, bgr + 1 * A);
+            svuint8_t bgr2 = svld1_u8(mask, bgr + 2 * A);
+            svuint8_t bayer0 = svtbl2_u8(svcreate2_u8(bgr0, bgr1), index0);
+            svuint8_t bayer1 = svtbl_u8(bgr2, index1);
+            svst1_u8(mask, bayer, svorr_u8_x(mask, bayer0, bayer1));
+        }
+
+        template <int c0, int c1> SIMD_INLINE void BgrToBayerTail(const uint8_t* bgr, uint8_t* bayer, const svbool_t& mask, const svbool_t& even)
         {
             svuint8x3_t _bgr = svld3_u8(mask, bgr);
             svst1_u8(mask, bayer, svsel_u8(even, svget3(_bgr, c0), svget3(_bgr, c1)));
         }
 
-        template <int c00, int c01, int c10, int c11> void BgrToBayer(const uint8_t* bgr, size_t width, size_t height,
+        template <BgrToBayerIndexType i0, BgrToBayerIndexType i1, int c00, int c01, int c10, int c11> void BgrToBayer(const uint8_t* bgr, size_t width, size_t height,
             size_t bgrStride, uint8_t* bayer, size_t bayerStride)
         {
             assert((width % 2 == 0) && (height % 2 == 0));
 
             size_t A = svlen(svuint8_t()), A3 = A * 3;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
             size_t widthA = AlignLo(width, A);
             const svbool_t body = svptrue_b8();
             const svbool_t tail = svwhilelt_b8(widthA, width);
             const svbool_t even = svcmpeq_n_u8(body, svand_n_u8_x(body, svindex_u8(0, 1), 1), 0);
+            const svuint8_t index00 = svld1_u8(body, BGR_TO_BAYER_INDEX[i0][0]);
+            const svuint8_t index01 = svld1_u8(body, BGR_TO_BAYER_INDEX[i0][1]);
+            const svuint8_t index10 = svld1_u8(body, BGR_TO_BAYER_INDEX[i1][0]);
+            const svuint8_t index11 = svld1_u8(body, BGR_TO_BAYER_INDEX[i1][1]);
             for (size_t row = 0; row < height; row += 2)
             {
                 size_t col = 0, offset = 0;
                 for (; col < widthA; col += A, offset += A3)
-                    BgrToBayer<c00, c01>(bgr + offset, bayer + col, body, even);
+                    BgrToBayer(bgr + offset, bayer + col, A, index00, index01, body);
                 if (widthA < width)
-                    BgrToBayer<c00, c01>(bgr + offset, bayer + col, tail, even);
+                    BgrToBayerTail<c00, c01>(bgr + offset, bayer + col, tail, even);
                 bgr += bgrStride;
                 bayer += bayerStride;
 
                 col = 0, offset = 0;
                 for (; col < widthA; col += A, offset += A3)
-                    BgrToBayer<c10, c11>(bgr + offset, bayer + col, body, even);
+                    BgrToBayer(bgr + offset, bayer + col, A, index10, index11, body);
                 if (widthA < width)
-                    BgrToBayer<c10, c11>(bgr + offset, bayer + col, tail, even);
+                    BgrToBayerTail<c10, c11>(bgr + offset, bayer + col, tail, even);
                 bgr += bgrStride;
                 bayer += bayerStride;
             }
@@ -70,16 +118,16 @@ namespace Simd
             switch (bayerFormat)
             {
             case SimdPixelFormatBayerGrbg:
-                BgrToBayer<1, 2, 0, 1>(bgr, width, height, bgrStride, bayer, bayerStride);
+                BgrToBayer<BgrToBayerGr, BgrToBayerBg, 1, 2, 0, 1>(bgr, width, height, bgrStride, bayer, bayerStride);
                 break;
             case SimdPixelFormatBayerGbrg:
-                BgrToBayer<1, 0, 2, 1>(bgr, width, height, bgrStride, bayer, bayerStride);
+                BgrToBayer<BgrToBayerGb, BgrToBayerRg, 1, 0, 2, 1>(bgr, width, height, bgrStride, bayer, bayerStride);
                 break;
             case SimdPixelFormatBayerRggb:
-                BgrToBayer<2, 1, 1, 0>(bgr, width, height, bgrStride, bayer, bayerStride);
+                BgrToBayer<BgrToBayerRg, BgrToBayerGb, 2, 1, 1, 0>(bgr, width, height, bgrStride, bayer, bayerStride);
                 break;
             case SimdPixelFormatBayerBggr:
-                BgrToBayer<0, 1, 1, 2>(bgr, width, height, bgrStride, bayer, bayerStride);
+                BgrToBayer<BgrToBayerBg, BgrToBayerGr, 0, 1, 1, 2>(bgr, width, height, bgrStride, bayer, bayerStride);
                 break;
             default:
                 assert(0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Optimizes `Sve2::BgrToBayer` body processing with precomputed table indexes and `svtbl`/`svtbl2` lookups, matching the existing `Sve2::BgraToBayer` approach.
- Keeps the existing `svld3_u8` path for tails.

### Testing
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -I./src -fsyntax-only src/Simd/SimdSve2BgrToBayer.cpp`
- `python3` deterministic table-index parity/channel mapping check for A=16,32,64
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=BgrToBayer -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69818b84-26c3-4e3f-a4c4-78abc629f8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69818b84-26c3-4e3f-a4c4-78abc629f8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

