### PR TITLE
Add SVE2 BgraToYuv420pV2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -50,6 +50,7 @@
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>
  <li>SVE2 optimizations of function RgbaToGray.</li>
+ <li>SVE2 optimizations of function BgraToYuv420pV2.</li>
  <li>SVE2 optimizations of function Bgr48pToBgra32.</li>
  <li>SVE2 optimizations of function BgrToHsl.</li>
  <li>SVE2 optimizations of function BgrToHsv.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgraToYuvV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -74,6 +74,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2BgraToYuvV2.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1301,6 +1301,11 @@ SIMD_API void SimdBgraToYuv420pV2(const uint8_t* bgra, size_t bgraStride, size_t
         Sse41::BgraToYuv420pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgraToYuv420pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::BgraToYuv420pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -77,6 +77,9 @@ namespace Simd
 
         void BgraToRgba(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* rgba, size_t rgbaStride);
 
+        void BgraToYuv420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
+
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 

--- a/src/Simd/SimdSve2BgraToYuvV2.cpp
+++ b/src/Simd/SimdSve2BgraToYuvV2.cpp
@@ -39,9 +39,9 @@ namespace Simd
             return svqxtunt_s16(svqxtunb_s16(lo), hi);
         }
 
-        SIMD_INLINE svuint8_t PackSaturatedI16ToU8(const svint16_t& value)
+        SIMD_INLINE svuint8_t PackSequentialI16ToU8(const svint16_t& value)
         {
-            return svqxtunb_s16(value);
+            return PackSaturatedI16ToU8(svuzp1_s16(value, value), svuzp2_s16(value, value));
         }
 
         template<class T> SIMD_INLINE svint32_t BgrToY32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red)
@@ -130,8 +130,8 @@ namespace Simd
             svuint16_t green = Average(svget4(bgra00, 1), svget4(bgra10, 1));
             svuint16_t red = Average(svget4(bgra00, 2), svget4(bgra10, 2));
 
-            svst1_u8(maskUv, u, PackSaturatedI16ToU8(BgrToU16<T>(blue, green, red)));
-            svst1_u8(maskUv, v, PackSaturatedI16ToU8(BgrToV16<T>(blue, green, red)));
+            svst1_u8(maskUv, u, PackSequentialI16ToU8(BgrToU16<T>(blue, green, red)));
+            svst1_u8(maskUv, v, PackSequentialI16ToU8(BgrToV16<T>(blue, green, red)));
         }
 
         template <class T> void BgraToYuv420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2BgraToYuvV2.cpp
+++ b/src/Simd/SimdSve2BgraToYuvV2.cpp
@@ -1,0 +1,173 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdYuvToBgr.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svint16_t PackI32ToI16(const svint32_t& lo, const svint32_t& hi)
+        {
+            return svqxtnt_s32(svqxtnb_s32(lo), hi);
+        }
+
+        SIMD_INLINE svuint8_t PackSaturatedI16ToU8(const svint16_t& lo, const svint16_t& hi)
+        {
+            return svqxtunt_s16(svqxtunb_s16(lo), hi);
+        }
+
+        SIMD_INLINE svuint8_t PackSaturatedI16ToU8(const svint16_t& value)
+        {
+            return svqxtunb_s16(value);
+        }
+
+        template<class T> SIMD_INLINE svint32_t BgrToY32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t y = svdup_n_s32(T::B_ROUND);
+            y = svadd_s32_x(mask, y, svmul_n_s32_x(mask, svreinterpret_s32_u32(blue), T::B_2_Y));
+            y = svadd_s32_x(mask, y, svmul_n_s32_x(mask, svreinterpret_s32_u32(green), T::G_2_Y));
+            y = svadd_s32_x(mask, y, svmul_n_s32_x(mask, svreinterpret_s32_u32(red), T::R_2_Y));
+            return svasr_n_s32_x(mask, y, T::B_SHIFT);
+        }
+
+        template<class T> SIMD_INLINE svint16_t BgrToY16(const svuint16_t& blue, const svuint16_t& green, const svuint16_t& red)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_n_s16_x(mask, PackI32ToI16(
+                BgrToY32<T>(svmovlb_u32(blue), svmovlb_u32(green), svmovlb_u32(red)),
+                BgrToY32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::Y_LO);
+        }
+
+        template<class T> SIMD_INLINE svuint8_t BgrToY8(const svuint8_t& blue, const svuint8_t& green, const svuint8_t& red)
+        {
+            return PackSaturatedI16ToU8(
+                BgrToY16<T>(svmovlb_u16(blue), svmovlb_u16(green), svmovlb_u16(red)),
+                BgrToY16<T>(svmovlt_u16(blue), svmovlt_u16(green), svmovlt_u16(red)));
+        }
+
+        template<class T> SIMD_INLINE svint32_t BgrToU32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t u = svdup_n_s32(T::B_ROUND);
+            u = svadd_s32_x(mask, u, svmul_n_s32_x(mask, svreinterpret_s32_u32(blue), T::B_2_U));
+            u = svadd_s32_x(mask, u, svmul_n_s32_x(mask, svreinterpret_s32_u32(green), T::G_2_U));
+            u = svadd_s32_x(mask, u, svmul_n_s32_x(mask, svreinterpret_s32_u32(red), T::R_2_U));
+            return svasr_n_s32_x(mask, u, T::B_SHIFT);
+        }
+
+        template<class T> SIMD_INLINE svint16_t BgrToU16(const svuint16_t& blue, const svuint16_t& green, const svuint16_t& red)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_n_s16_x(mask, PackI32ToI16(
+                BgrToU32<T>(svmovlb_u32(blue), svmovlb_u32(green), svmovlb_u32(red)),
+                BgrToU32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::UV_Z);
+        }
+
+        template<class T> SIMD_INLINE svint32_t BgrToV32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t v = svdup_n_s32(T::B_ROUND);
+            v = svadd_s32_x(mask, v, svmul_n_s32_x(mask, svreinterpret_s32_u32(blue), T::B_2_V));
+            v = svadd_s32_x(mask, v, svmul_n_s32_x(mask, svreinterpret_s32_u32(green), T::G_2_V));
+            v = svadd_s32_x(mask, v, svmul_n_s32_x(mask, svreinterpret_s32_u32(red), T::R_2_V));
+            return svasr_n_s32_x(mask, v, T::B_SHIFT);
+        }
+
+        template<class T> SIMD_INLINE svint16_t BgrToV16(const svuint16_t& blue, const svuint16_t& green, const svuint16_t& red)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_n_s16_x(mask, PackI32ToI16(
+                BgrToV32<T>(svmovlb_u32(blue), svmovlb_u32(green), svmovlb_u32(red)),
+                BgrToV32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::UV_Z);
+        }
+
+        SIMD_INLINE svuint16_t Average(const svuint8_t& row0, const svuint8_t& row1)
+        {
+            const svbool_t mask = svptrue_b16();
+            svuint16_t sum = svadd_u16_x(mask, svmovlb_u16(svuzp1_u8(row0, row0)), svmovlb_u16(svuzp2_u8(row0, row0)));
+            sum = svadd_u16_x(mask, sum, svmovlb_u16(svuzp1_u8(row1, row1)));
+            sum = svadd_u16_x(mask, sum, svmovlb_u16(svuzp2_u8(row1, row1)));
+            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, 2), 2);
+        }
+
+        template <class T> SIMD_INLINE void BgraToYuv420pV2(const uint8_t* bgra0, size_t bgraStride, uint8_t* y0, size_t yStride,
+            uint8_t* u, uint8_t* v, const svbool_t& maskY, const svbool_t& maskUv)
+        {
+            const uint8_t* bgra1 = bgra0 + bgraStride;
+            uint8_t* y1 = y0 + yStride;
+
+            svuint8x4_t bgra00 = svld4_u8(maskY, bgra0);
+            svuint8x4_t bgra10 = svld4_u8(maskY, bgra1);
+
+            svst1_u8(maskY, y0, BgrToY8<T>(svget4(bgra00, 0), svget4(bgra00, 1), svget4(bgra00, 2)));
+            svst1_u8(maskY, y1, BgrToY8<T>(svget4(bgra10, 0), svget4(bgra10, 1), svget4(bgra10, 2)));
+
+            svuint16_t blue = Average(svget4(bgra00, 0), svget4(bgra10, 0));
+            svuint16_t green = Average(svget4(bgra00, 1), svget4(bgra10, 1));
+            svuint16_t red = Average(svget4(bgra00, 2), svget4(bgra10, 2));
+
+            svst1_u8(maskUv, u, PackSaturatedI16ToU8(BgrToU16<T>(blue, green, red)));
+            svst1_u8(maskUv, v, PackSaturatedI16ToU8(BgrToV16<T>(blue, green, red)));
+        }
+
+        template <class T> void BgraToYuv420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0) && (width >= 2) && (height >= 2));
+
+            size_t A = svlen(svuint8_t());
+            for (size_t row = 0; row < height; row += 2)
+            {
+                for (size_t col = 0; col < width; col += A)
+                {
+                    size_t block = Simd::Min(A, width - col);
+                    BgraToYuv420pV2<T>(bgra + col * 4, bgraStride, y + col, yStride, u + col / 2, v + col / 2,
+                        svwhilelt_b8(size_t(0), block), svwhilelt_b8(size_t(0), block / 2));
+                }
+                bgra += 2 * bgraStride;
+                y += 2 * yStride;
+                u += uStride;
+                v += vStride;
+            }
+        }
+
+        void BgraToYuv420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: BgraToYuv420pV2<Base::Bt601>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt709: BgraToYuv420pV2<Base::Bt709>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt2020: BgraToYuv420pV2<Base::Bt2020>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvTrect871: BgraToYuv420pV2<Base::Trect871>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -232,6 +232,11 @@ namespace Test
             result = result && AnyToYuvV2AutoTest(View::Bgra32, 2, 2, FUNC_YUV2(Simd::Avx512bw::BgraToYuv420pV2), FUNC_YUV2(SimdBgraToYuv420pV2));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToYuvV2AutoTest(View::Bgra32, 2, 2, FUNC_YUV2(Simd::Sve2::BgraToYuv420pV2), FUNC_YUV2(SimdBgraToYuv420pV2));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AnyToYuvV2AutoTest(View::Bgra32, 2, 2, FUNC_YUV2(Simd::Neon::BgraToYuv420pV2), FUNC_YUV2(SimdBgraToYuv420pV2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `BgraToYuv420pV2` for ARM/ARM64 builds.
- Wire SVE2 dispatch and auto-test coverage.
- Add the new source to VS2022 SVE2 project files and update 7.2.163 release notes.
- Fix SVE2 chroma narrowing so sequential 16-bit U/V samples are packed into contiguous byte lanes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgraToYuv420pV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I/workspace/src -fsyntax-only /workspace/src/Simd/SimdSve2BgraToYuvV2.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I/workspace/src -fsyntax-only /workspace/src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8bec35c-d110-472a-a3ee-f388ce66c06c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8bec35c-d110-472a-a3ee-f388ce66c06c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

