### PR TITLE
Validate BMP dimensions before size calculations

### DIFF
--- a/src/Simd/SimdBaseImageLoadBmp.cpp
+++ b/src/Simd/SimdBaseImageLoadBmp.cpp
@@ -84,7 +84,7 @@ namespace Simd
             if (headerSize == 12)
             {
                 uint16_t w, h;
-                if (!_stream.Read16u(w) || !_stream.Read16u(h) || w * h == 0)
+                if (!_stream.Read16u(w) || !_stream.Read16u(h) || uint32_t(w) * uint32_t(h) == 0)
                     return false;
                 _width = w;
                 _height = h;
@@ -167,22 +167,20 @@ namespace Simd
 
             }
             if (_bpp < 8)
-                return false;  
-            if (_bpp == 8)
-            {
-                _size = _width;
-                _pad = (int32_t)AlignHi(_size, 4) - _size;
-            }
-            else if (_bpp == 24)
-            {
-                _size = _width * 3;
-                _pad = (int32_t)AlignHi(_size, 4) - _size;
-            }
-            else
-            {
-                _size = _width * 4;
-                _pad = 0;
-            }
+                return false;
+            // Reject malformed dimensions before any size arithmetic. _width and _height are
+            // attacker-controlled 32-bit values read from the file header; computing _size and the
+            // image allocation (height * stride) from unbounded dimensions overflows size_t on 32-bit
+            // builds, yielding a short buffer that the per-row copy loop in FromStream then overruns.
+            // Mirror the limits already enforced by the PNG loader (see ImagePngLoader::ReadHeader).
+            const uint32_t MAX_SIZE = 1 << 24;
+            if (_width > MAX_SIZE || _height > MAX_SIZE)
+                return false;
+            const uint32_t channels = (_bpp == 8 ? 1 : (_bpp == 24 ? 3 : 4));
+            if ((uint32_t(1) << 30) / _width / channels < _height)
+                return false;
+            _size = _width * channels;
+            _pad = (_bpp == 8 || _bpp == 24) ? (uint32_t)(AlignHi(_size, 4) - _size) : 0;
             if (_param.format == SimdPixelFormatNone)
             {
                 if (_bpp == 32)


### PR DESCRIPTION
## Summary

This change strengthens BMP header validation by validating image dimensions before any size calculations are performed.

### Changes

* Validate BMP width and height before computing row sizes.
* Add overflow-safe size checks for image dimensions and channel count.
* Apply the same dimension and allocation-size limits already used by the PNG loader.
* Fix integer overflow caused by implicit promotion in the BMP v2 (`headerSize == 12`) dimension validation path.

### Benefits

* Prevents arithmetic overflow during BMP size calculations.
* Rejects malformed BMP files with invalid or excessive dimensions.
* Improves consistency between BMP and PNG image loaders.
* Preserves existing behavior for valid BMP images.