### PR TITLE
Improve SVE2 BgrToRgb performance

### DIFF
--- a/src/Simd/SimdSve2BgrToRgb.cpp
+++ b/src/Simd/SimdSve2BgrToRgb.cpp
@@ -28,25 +28,69 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE void BgrToRgb(const uint8_t* bgr, uint8_t* rgb, const svbool_t& mask)
+        SIMD_INLINE void BgrToRgbTail(const uint8_t* bgr, uint8_t* rgb, const svbool_t& mask)
         {
             svuint8x3_t _bgr = svld3_u8(mask, bgr);
             svst3_u8(mask, rgb, svcreate3_u8(svget3(_bgr, 2), svget3(_bgr, 1), svget3(_bgr, 0)));
         }
 
+        SIMD_INLINE size_t BgrToRgbSrc(size_t offset)
+        {
+            return offset + 2 - 2 * (offset % 3);
+        }
+
+        SIMD_INLINE bool InitBgrToRgbIndex(uint8_t index[4][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t i = 0; i < A; ++i)
+            {
+                size_t src0 = BgrToRgbSrc(i);
+                size_t src1 = BgrToRgbSrc(A + i);
+                size_t src2 = BgrToRgbSrc(2 * A + i);
+                index[0][i] = (uint8_t)src0;
+                index[1][i] = src1 < 2 * A ? (uint8_t)src1 : 0xFF;
+                index[2][i] = src1 >= A ? (uint8_t)(src1 - A) : 0xFF;
+                index[3][i] = (uint8_t)(src2 - A);
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_TO_RGB_INDEX[4][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool BGR_TO_RGB_INDEX_INITED = InitBgrToRgbIndex(BGR_TO_RGB_INDEX);
+
+        SIMD_INLINE void BgrToRgb(const uint8_t* bgr, uint8_t* rgb, size_t A, const svuint8_t& index0,
+            const svuint8_t& index10, const svuint8_t& index11, const svuint8_t& index2, const svbool_t& mask)
+        {
+            svuint8_t bgr0 = svld1_u8(mask, bgr + 0 * A);
+            svuint8_t bgr1 = svld1_u8(mask, bgr + 1 * A);
+            svuint8_t bgr2 = svld1_u8(mask, bgr + 2 * A);
+            svuint8x2_t bgr01 = svcreate2_u8(bgr0, bgr1);
+            svuint8x2_t bgr12 = svcreate2_u8(bgr1, bgr2);
+
+            svst1_u8(mask, rgb + 0 * A, svtbl2_u8(bgr01, index0));
+            svst1_u8(mask, rgb + 1 * A, svorr_u8_x(mask, svtbl2_u8(bgr01, index10), svtbl2_u8(bgr12, index11)));
+            svst1_u8(mask, rgb + 2 * A, svtbl2_u8(bgr12, index2));
+        }
+
         void BgrToRgb(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* rgb, size_t rgbStride)
         {
             size_t A = svlen(svuint8_t()), A3 = A * 3;
-            size_t widthA = AlignLo(width, A), sizeA = widthA * 3;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t widthA = AlignLo(width, A);
             const svbool_t body = svptrue_b8();
             const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t index0 = svld1_u8(body, BGR_TO_RGB_INDEX[0]);
+            const svuint8_t index10 = svld1_u8(body, BGR_TO_RGB_INDEX[1]);
+            const svuint8_t index11 = svld1_u8(body, BGR_TO_RGB_INDEX[2]);
+            const svuint8_t index2 = svld1_u8(body, BGR_TO_RGB_INDEX[3]);
             for (size_t row = 0; row < height; ++row)
             {
-                size_t offset = 0;
-                for (; offset < sizeA; offset += A3)
-                    BgrToRgb(bgr + offset, rgb + offset, body);
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    BgrToRgb(bgr + offset, rgb + offset, A, index0, index10, index11, index2, body);
                 if (widthA < width)
-                    BgrToRgb(bgr + offset, rgb + offset, tail);
+                    BgrToRgbTail(bgr + offset, rgb + offset, tail);
                 bgr += bgrStride;
                 rgb += rgbStride;
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Optimize `Sve2::BgrToRgb` full-vector processing with contiguous SVE2 loads/stores and table shuffles.
- Keep the original predicated `ld3/st3` implementation for tail pixels.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgrToRgb -tt=1 -ts=1` from `build/`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -c src/Simd/SimdSve2BgrToRgb.cpp -o /tmp/SimdSve2BgrToRgb.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -S src/Simd/SimdSve2BgrToRgb.cpp -o /tmp/SimdSve2BgrToRgb.s && rg "\btbl\b|\bld3b\b|\bst3b\b" /tmp/SimdSve2BgrToRgb.s`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41488270-5c45-49af-881b-6f74ab489ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41488270-5c45-49af-881b-6f74ab489ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

