### PR TITLE
Add SVE2 BgraToYuv444pV2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -53,6 +53,7 @@
  <li>SVE2 optimizations of function RgbaToGray.</li>
  <li>SVE2 optimizations of function BgraToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgraToYuv422pV2.</li>
+ <li>SVE2 optimizations of function BgraToYuv444pV2.</li>
  <li>SVE2 optimizations of function Bgr48pToBgra32.</li>
  <li>SVE2 optimizations of function BgrToHsl.</li>
  <li>SVE2 optimizations of function BgrToHsv.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1365,6 +1365,11 @@ SIMD_API void SimdBgraToYuv444pV2(const uint8_t* bgra, size_t bgraStride, size_t
         Sse41::BgraToYuv444pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgraToYuv444pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgraToYuv444pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -83,6 +83,9 @@ namespace Simd
         void BgraToYuv422pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
             uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
 
+        void BgraToYuv444pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
+
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 

--- a/src/Simd/SimdSve2BgraToYuvV2.cpp
+++ b/src/Simd/SimdSve2BgraToYuvV2.cpp
@@ -87,6 +87,13 @@ namespace Simd
                 BgrToU32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::UV_Z);
         }
 
+        template<class T> SIMD_INLINE svuint8_t BgrToU8(const svuint8_t& blue, const svuint8_t& green, const svuint8_t& red)
+        {
+            return PackSaturatedI16ToU8(
+                BgrToU16<T>(svmovlb_u16(blue), svmovlb_u16(green), svmovlb_u16(red)),
+                BgrToU16<T>(svmovlt_u16(blue), svmovlt_u16(green), svmovlt_u16(red)));
+        }
+
         template<class T> SIMD_INLINE svint32_t BgrToV32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red)
         {
             const svbool_t mask = svptrue_b32();
@@ -105,6 +112,13 @@ namespace Simd
                 BgrToV32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::UV_Z);
         }
 
+        template<class T> SIMD_INLINE svuint8_t BgrToV8(const svuint8_t& blue, const svuint8_t& green, const svuint8_t& red)
+        {
+            return PackSaturatedI16ToU8(
+                BgrToV16<T>(svmovlb_u16(blue), svmovlb_u16(green), svmovlb_u16(red)),
+                BgrToV16<T>(svmovlt_u16(blue), svmovlt_u16(green), svmovlt_u16(red)));
+        }
+
         SIMD_INLINE svuint16_t Average(const svuint8_t& row0, const svuint8_t& row1)
         {
             const svbool_t mask = svptrue_b16();
@@ -119,6 +133,51 @@ namespace Simd
             const svbool_t mask = svptrue_b16();
             svuint16_t sum = svadd_u16_x(mask, svmovlb_u16(svuzp1_u8(row, row)), svmovlb_u16(svuzp2_u8(row, row)));
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, 1), 1);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <class T> SIMD_INLINE void BgraToYuv444pV2(const uint8_t* bgra, uint8_t* y, uint8_t* u, uint8_t* v, const svbool_t& mask)
+        {
+            svuint8x4_t _bgra = svld4_u8(mask, bgra);
+            svuint8_t blue = svget4(_bgra, 0);
+            svuint8_t green = svget4(_bgra, 1);
+            svuint8_t red = svget4(_bgra, 2);
+            svst1_u8(mask, y, BgrToY8<T>(blue, green, red));
+            svst1_u8(mask, u, BgrToU8<T>(blue, green, red));
+            svst1_u8(mask, v, BgrToV8<T>(blue, green, red));
+        }
+
+        template <class T> void BgraToYuv444pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            size_t A = svlen(svuint8_t());
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t col = 0; col < width; col += A)
+                {
+                    size_t block = Simd::Min(A, width - col);
+                    BgraToYuv444pV2<T>(bgra + col * 4, y + col, u + col, v + col, svwhilelt_b8(size_t(0), block));
+                }
+                bgra += bgraStride;
+                y += yStride;
+                u += uStride;
+                v += vStride;
+            }
+        }
+
+        void BgraToYuv444pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: BgraToYuv444pV2<Base::Bt601>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt709: BgraToYuv444pV2<Base::Bt709>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt2020: BgraToYuv444pV2<Base::Bt2020>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvTrect871: BgraToYuv444pV2<Base::Trect871>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            default:
+                assert(0);
+            }
         }
 
         template <class T> SIMD_INLINE void BgraToYuv420pV2(const uint8_t* bgra0, size_t bgraStride, uint8_t* y0, size_t yStride,

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -302,6 +302,11 @@ namespace Test
             result = result && AnyToYuvV2AutoTest(View::Bgra32, 1, 1, FUNC_YUV2(Simd::Avx512bw::BgraToYuv444pV2), FUNC_YUV2(SimdBgraToYuv444pV2));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToYuvV2AutoTest(View::Bgra32, 1, 1, FUNC_YUV2(Simd::Sve2::BgraToYuv444pV2), FUNC_YUV2(SimdBgraToYuv444pV2));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AnyToYuvV2AutoTest(View::Bgra32, 1, 1, FUNC_YUV2(Simd::Neon::BgraToYuv444pV2), FUNC_YUV2(SimdBgraToYuv444pV2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation for `BgraToYuv444pV2`.
- Route `SimdBgraToYuv444pV2` through SVE2 when available.
- Add SVE2 coverage to `BgraToYuv444pV2AutoTest` and update 7.2.163 release notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgraToYuv444pV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -fsyntax-only -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src ./src/Simd/SimdSve2BgraToYuvV2.cpp`
- `aarch64-linux-gnu-g++ -fsyntax-only -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src ./src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -fsyntax-only -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src ./src/Test/TestAnyToYuv.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b86c9153-b886-40d6-b355-9d8fb8693523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b86c9153-b886-40d6-b355-9d8fb8693523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

