### PR TITLE
reject undecodable bmp bit depths in ParseHeader

### DIFF
--- a/src/Simd/SimdBaseImageLoadBmp.cpp
+++ b/src/Simd/SimdBaseImageLoadBmp.cpp
@@ -166,7 +166,12 @@ namespace Simd
                 }
 
             }
-            if (_bpp < 8)
+            // Only 8, 24 and 32-bit BMPs are actually decoded. The bit-field masks parsed
+            // above for a 16-bit image are never applied and SetConverters has no converter
+            // for it, so for any depth other than 8 or 24 channels defaults to 4 and a row
+            // falls through to a raw memcpy of _width * 4 bytes into a destination sized for
+            // the requested output format, writing past the image allocation.
+            if (_bpp != 8 && _bpp != 24 && _bpp != 32)
                 return false;
             // Reject malformed dimensions before any size arithmetic. _width and _height are
             // attacker-controlled 32-bit values read from the file header; computing _size and the


### PR DESCRIPTION
**Heap overflow on undecodable BMP bit depths**
For any depth other than 8 or 24 `ParseHeader` sets `channels` to 4, so a 16-bit BMP (accepted by both the BITFIELDS and the uncompressed paths) ends up with `_size = _width * 4` while the bit-field masks it parses are never applied and no converter exists for it. `FromStream` then copies `_width * 4` bytes per row into a destination sized for the requested Gray8/Bgr24 output and runs past the image allocation, so rejecting the depths the loader cannot actually decode in `ParseHeader` looks like the least invasive place to stop it. Proper 16-bit handling could be added later as a separate change.