### PR TITLE
Harden InputMemoryStream Bounds Checks Against Integer Overflow

### DIFF
--- a/src/Simd/SimdMemoryStream.h
+++ b/src/Simd/SimdMemoryStream.h
@@ -93,7 +93,12 @@ namespace Simd
 
         SIMD_INLINE bool CanRead(size_t size) const
         {
-            return _pos + size <= _size;
+            // Overflow-safe form of "_pos + size <= _size": with attacker
+            // controlled sizes (e.g. a PNG chunk size) "_pos + size" can wrap
+            // around on 32-bit builds and pass the check, leading to an
+            // out-of-bounds read. The class invariant _pos <= _size keeps
+            // "_size - _pos" well defined.
+            return size <= _size - _pos;
         }
         
         SIMD_INLINE size_t Read(size_t size, void* data)
@@ -210,7 +215,8 @@ namespace Simd
 
         SIMD_INLINE bool Skip(size_t size)
         {
-            if (_pos + size <= _size)
+            // Overflow-safe bounds check, see CanRead() above.
+            if (size <= _size - _pos)
             {
                 _pos += size;
                 return true;


### PR DESCRIPTION
## Summary
Harden `InputMemoryStream` bounds checks against integer overflow when validating read and skip operations.

## Changes
- Replace `_pos + size <= _size` with the overflow-safe form `size <= _size - _pos`.
- Apply the same validation logic to both `CanRead()` and `Skip()`.
- Preserve existing behavior for valid inputs while preventing overflow from bypassing bounds checks.

## Benefits
- Prevents integer-overflow-induced bounds check bypasses.
- Strengthens validation for untrusted image input parsing.
- Improves memory-safety guarantees across all loaders using `InputMemoryStream`.
- Centralizes protection in a shared stream primitive rather than individual decoder paths.