### PR TITLE
Add SVE2 BgrToYuv422pV2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -59,6 +59,7 @@
  <li>SVE2 optimizations of function BgrToHsv.</li>
  <li>SVE2 optimizations of function BgrToLab.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
+ <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
  <li>SVE2 optimizations of function Reorder16bit.</li>
  <li>SVE2 optimizations of function Reorder32bit.</li>
  <li>SVE2 optimizations of function Reorder64bit.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1715,6 +1715,11 @@ SIMD_API void SimdBgrToYuv422pV2(const uint8_t* bgr, size_t bgrStride, size_t wi
         Sse41::BgrToYuv422pV2(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgrToYuv422pV2(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::BgrToYuv422pV2(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -106,6 +106,9 @@ namespace Simd
         void BgrToYuv420pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
 
+        void BgrToYuv422pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
+
         void ConditionalCount8u(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t value, SimdCompareType compareType, uint32_t* count);
 
         void ConditionalCount16i(const uint8_t* src, size_t stride, size_t width, size_t height, int16_t value, SimdCompareType compareType, uint32_t* count);

--- a/src/Simd/SimdSve2BgrToYuvV2.cpp
+++ b/src/Simd/SimdSve2BgrToYuvV2.cpp
@@ -114,6 +114,13 @@ namespace Simd
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, 2), 2);
         }
 
+        SIMD_INLINE svuint16_t Average(const svuint8_t& row)
+        {
+            const svbool_t mask = svptrue_b16();
+            svuint16_t sum = svadd_u16_x(mask, svmovlb_u16(row), svmovlt_u16(row));
+            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, 1), 1);
+        }
+
         //-------------------------------------------------------------------------------------------------
 
         template <class T> SIMD_INLINE void BgrToYuv420pV2(const uint8_t* bgr0, size_t bgrStride, uint8_t* y0, size_t yStride,
@@ -166,6 +173,58 @@ namespace Simd
             case SimdYuvBt709: BgrToYuv420pV2<Base::Bt709>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
             case SimdYuvBt2020: BgrToYuv420pV2<Base::Bt2020>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
             case SimdYuvTrect871: BgrToYuv420pV2<Base::Trect871>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            default:
+                assert(0);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <class T> SIMD_INLINE void BgrToYuv422pV2(const uint8_t* bgr, uint8_t* y, uint8_t* u, uint8_t* v,
+            const svbool_t& maskY, const svbool_t& maskUv)
+        {
+            svuint8x3_t _bgr = svld3_u8(maskY, bgr);
+
+            svst1_u8(maskY, y, BgrToY8<T>(svget3(_bgr, 0), svget3(_bgr, 1), svget3(_bgr, 2)));
+
+            svuint16_t blue = Average(svget3(_bgr, 0));
+            svuint16_t green = Average(svget3(_bgr, 1));
+            svuint16_t red = Average(svget3(_bgr, 2));
+
+            svst1_u8(maskUv, u, PackSequentialI16ToU8(BgrToU16<T>(blue, green, red)));
+            svst1_u8(maskUv, v, PackSequentialI16ToU8(BgrToV16<T>(blue, green, red)));
+        }
+
+        template <class T> void BgrToYuv422pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            assert((width % 2 == 0) && (width >= 2));
+
+            size_t A = svlen(svuint8_t());
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t col = 0; col < width; col += A)
+                {
+                    size_t block = Simd::Min(A, width - col);
+                    BgrToYuv422pV2<T>(bgr + col * 3, y + col, u + col / 2, v + col / 2,
+                        svwhilelt_b8(size_t(0), block), svwhilelt_b8(size_t(0), block / 2));
+                }
+                bgr += bgrStride;
+                y += yStride;
+                u += uStride;
+                v += vStride;
+            }
+        }
+
+        void BgrToYuv422pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: BgrToYuv422pV2<Base::Bt601>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt709: BgrToYuv422pV2<Base::Bt709>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt2020: BgrToYuv422pV2<Base::Bt2020>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvTrect871: BgrToYuv422pV2<Base::Trect871>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
             default:
                 assert(0);
             }

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -372,6 +372,11 @@ namespace Test
             result = result && AnyToYuvV2AutoTest(View::Bgr24, 2, 1, FUNC_YUV2(Simd::Avx512bw::BgrToYuv422pV2), FUNC_YUV2(SimdBgrToYuv422pV2));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToYuvV2AutoTest(View::Bgr24, 2, 1, FUNC_YUV2(Simd::Sve2::BgrToYuv422pV2), FUNC_YUV2(SimdBgrToYuv422pV2));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AnyToYuvV2AutoTest(View::Bgr24, 2, 1, FUNC_YUV2(Simd::Neon::BgrToYuv422pV2), FUNC_YUV2(SimdBgrToYuv422pV2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `BgrToYuv422pV2`.
- Dispatch `SimdBgrToYuv422pV2` to SVE2 before NEON when available.
- Add SVE2 coverage to `BgrToYuv422pV2AutoTest` and update release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BgrToYuv422pV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -fPIC -I./src -march=armv8.6-a+sve2 -c src/Simd/SimdSve2BgrToYuvV2.cpp -o build/SimdSve2BgrToYuvV2.o`
- Emulated ARM64/SVE2 harness comparing `Simd::Sve2::BgrToYuv422pV2` with `Simd::Base::BgrToYuv422pV2` across multiple widths, heights, and YUV types.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e4a7b7-b817-4339-b16d-cec93c565651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e4a7b7-b817-4339-b16d-cec93c565651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

