### PR TITLE
Add SVE2 optimization for BgrToYuv444pV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -60,6 +60,7 @@
  <li>SVE2 optimizations of function BgrToLab.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
+ <li>SVE2 optimizations of function BgrToYuv444pV2.</li>
  <li>SVE2 optimizations of function Reorder16bit.</li>
  <li>SVE2 optimizations of function Reorder32bit.</li>
  <li>SVE2 optimizations of function Reorder64bit.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1747,6 +1747,11 @@ SIMD_API void SimdBgrToYuv444pV2(const uint8_t* bgr, size_t bgrStride, size_t wi
         Sse41::BgrToYuv444pV2(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgrToYuv444pV2(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BgrToYuv444pV2(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -109,6 +109,9 @@ namespace Simd
         void BgrToYuv422pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
 
+        void BgrToYuv444pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
+
         void ConditionalCount8u(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t value, SimdCompareType compareType, uint32_t* count);
 
         void ConditionalCount16i(const uint8_t* src, size_t stride, size_t width, size_t height, int16_t value, SimdCompareType compareType, uint32_t* count);

--- a/src/Simd/SimdSve2BgrToYuvV2.cpp
+++ b/src/Simd/SimdSve2BgrToYuvV2.cpp
@@ -87,6 +87,13 @@ namespace Simd
                 BgrToU32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::UV_Z);
         }
 
+        template<class T> SIMD_INLINE svuint8_t BgrToU8(const svuint8_t& blue, const svuint8_t& green, const svuint8_t& red)
+        {
+            return PackSaturatedI16ToU8(
+                BgrToU16<T>(svmovlb_u16(blue), svmovlb_u16(green), svmovlb_u16(red)),
+                BgrToU16<T>(svmovlt_u16(blue), svmovlt_u16(green), svmovlt_u16(red)));
+        }
+
         template<class T> SIMD_INLINE svint32_t BgrToV32(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red)
         {
             const svbool_t mask = svptrue_b32();
@@ -105,6 +112,13 @@ namespace Simd
                 BgrToV32<T>(svmovlt_u32(blue), svmovlt_u32(green), svmovlt_u32(red))), T::UV_Z);
         }
 
+        template<class T> SIMD_INLINE svuint8_t BgrToV8(const svuint8_t& blue, const svuint8_t& green, const svuint8_t& red)
+        {
+            return PackSaturatedI16ToU8(
+                BgrToV16<T>(svmovlb_u16(blue), svmovlb_u16(green), svmovlb_u16(red)),
+                BgrToV16<T>(svmovlt_u16(blue), svmovlt_u16(green), svmovlt_u16(red)));
+        }
+
         SIMD_INLINE svuint16_t Average(const svuint8_t& row0, const svuint8_t& row1)
         {
             const svbool_t mask = svptrue_b16();
@@ -119,6 +133,51 @@ namespace Simd
             const svbool_t mask = svptrue_b16();
             svuint16_t sum = svadd_u16_x(mask, svmovlb_u16(row), svmovlt_u16(row));
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, 1), 1);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <class T> SIMD_INLINE void BgrToYuv444pV2(const uint8_t* bgr, uint8_t* y, uint8_t* u, uint8_t* v, const svbool_t& mask)
+        {
+            svuint8x3_t _bgr = svld3_u8(mask, bgr);
+            svuint8_t blue = svget3(_bgr, 0);
+            svuint8_t green = svget3(_bgr, 1);
+            svuint8_t red = svget3(_bgr, 2);
+            svst1_u8(mask, y, BgrToY8<T>(blue, green, red));
+            svst1_u8(mask, u, BgrToU8<T>(blue, green, red));
+            svst1_u8(mask, v, BgrToV8<T>(blue, green, red));
+        }
+
+        template <class T> void BgrToYuv444pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            size_t A = svlen(svuint8_t());
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t col = 0; col < width; col += A)
+                {
+                    size_t block = Simd::Min(A, width - col);
+                    BgrToYuv444pV2<T>(bgr + col * 3, y + col, u + col, v + col, svwhilelt_b8(size_t(0), block));
+                }
+                bgr += bgrStride;
+                y += yStride;
+                u += uStride;
+                v += vStride;
+            }
+        }
+
+        void BgrToYuv444pV2(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: BgrToYuv444pV2<Base::Bt601>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt709: BgrToYuv444pV2<Base::Bt709>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvBt2020: BgrToYuv444pV2<Base::Bt2020>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            case SimdYuvTrect871: BgrToYuv444pV2<Base::Trect871>(bgr, bgrStride, width, height, y, yStride, u, uStride, v, vStride); break;
+            default:
+                assert(0);
+            }
         }
 
         //-------------------------------------------------------------------------------------------------

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -407,6 +407,11 @@ namespace Test
             result = result && AnyToYuvV2AutoTest(View::Bgr24, 1, 1, FUNC_YUV2(Simd::Avx512bw::BgrToYuv444pV2), FUNC_YUV2(SimdBgrToYuv444pV2));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToYuvV2AutoTest(View::Bgr24, 1, 1, FUNC_YUV2(Simd::Sve2::BgrToYuv444pV2), FUNC_YUV2(SimdBgrToYuv444pV2));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AnyToYuvV2AutoTest(View::Bgr24, 1, 1, FUNC_YUV2(Simd::Neon::BgrToYuv444pV2), FUNC_YUV2(SimdBgrToYuv444pV2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBgrToYuv444pV2`.
- Extend `BgrToYuv444pV2AutoTest` coverage for SVE2.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=BgrToYuv444pV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -fsyntax-only src/Simd/SimdSve2BgrToYuvV2.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a81a568-1321-4830-9440-49a5f9236014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a81a568-1321-4830-9440-49a5f9236014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

