### PR TITLE
Add SVE2 ConditionalFill optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,7 @@
  <li>SVE2 optimizations of function ConditionalSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
+ <li>SVE2 optimizations of function ConditionalFill.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2000,6 +2000,11 @@ SIMD_API void SimdConditionalFill(const uint8_t * src, size_t srcStride, size_t 
         Sse41::ConditionalFill(src, srcStride, width, height, threshold, compareType, value, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::ConditionalFill(src, srcStride, width, height, threshold, compareType, value, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::ConditionalFill(src, srcStride, width, height, threshold, compareType, value, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -122,6 +122,8 @@ namespace Simd
 
         void ConditionalSquareGradientSum(const uint8_t* src, size_t srcStride, size_t width, size_t height, const uint8_t* mask, size_t maskStride, uint8_t value, SimdCompareType compareType, uint64_t* sum);
 
+        void ConditionalFill(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t threshold, SimdCompareType compareType, uint8_t value, uint8_t* dst, size_t dstStride);
+
         void CorrelationSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum);
 
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Conditional.cpp
+++ b/src/Simd/SimdSve2Conditional.cpp
@@ -322,6 +322,60 @@ namespace Simd
                 assert(0);
             }
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template <SimdCompareType compareType> SIMD_INLINE
+        void ConditionalFill(const uint8_t* src, const svbool_t& mask, const svuint8_t& threshold, const svuint8_t& value, uint8_t* dst)
+        {
+            svuint8_t _src = svld1_u8(mask, src);
+            svuint8_t _dst = svld1_u8(mask, dst);
+            svbool_t cond = Compare8u<compareType>(mask, _src, threshold);
+            svst1_u8(mask, dst, svsel_u8(cond, value, _dst));
+        }
+
+        template <SimdCompareType compareType>
+        void ConditionalFill(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t threshold, uint8_t value, uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            svuint8_t _threshold = svdup_n_u8(threshold), _value = svdup_n_u8(value);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    ConditionalFill<compareType>(src + col, body, _threshold, _value, dst + col);
+                if (widthA < width)
+                    ConditionalFill<compareType>(src + col, tail, _threshold, _value, dst + col);
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        void ConditionalFill(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t threshold, SimdCompareType compareType, uint8_t value, uint8_t* dst, size_t dstStride)
+        {
+            switch (compareType)
+            {
+            case SimdCompareEqual:
+                return ConditionalFill<SimdCompareEqual>(src, srcStride, width, height, threshold, value, dst, dstStride);
+            case SimdCompareNotEqual:
+                return ConditionalFill<SimdCompareNotEqual>(src, srcStride, width, height, threshold, value, dst, dstStride);
+            case SimdCompareGreater:
+                return ConditionalFill<SimdCompareGreater>(src, srcStride, width, height, threshold, value, dst, dstStride);
+            case SimdCompareGreaterOrEqual:
+                return ConditionalFill<SimdCompareGreaterOrEqual>(src, srcStride, width, height, threshold, value, dst, dstStride);
+            case SimdCompareLesser:
+                return ConditionalFill<SimdCompareLesser>(src, srcStride, width, height, threshold, value, dst, dstStride);
+            case SimdCompareLesserOrEqual:
+                return ConditionalFill<SimdCompareLesserOrEqual>(src, srcStride, width, height, threshold, value, dst, dstStride);
+            default:
+                assert(0);
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestConditional.cpp
+++ b/src/Test/TestConditional.cpp
@@ -486,6 +486,11 @@ namespace Test
             result = result && ConditionalFillAutoTest(FUNC_F(Simd::Neon::ConditionalFill), FUNC_F(SimdConditionalFill));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ConditionalFillAutoTest(FUNC_F(Simd::Sve2::ConditionalFill), FUNC_F(SimdConditionalFill));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdConditionalFill`.
- Extend `ConditionalFillAutoTest` coverage for direct SVE2 validation.
- Update 7.2.163 release notes.

### Testing
- Passed `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`.
- Passed `cmake --build build --parallel$(nproc)`.
- Passed `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=ConditionalFill -tt=1 -ts=1`.
- Passed `aarch64-linux-gnu-g++ -std=c++17 -march=armv8-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2Conditional.cpp`.
- Passed `aarch64-linux-gnu-g++ -std=c++17 -march=armv8-a+sve2 -I src -fsyntax-only src/Simd/SimdLib.cpp src/Test/TestConditional.cpp`.

Note: x86 host cannot execute SVE2 at runtime, so AArch64 SVE2 validation is compile-only here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ba66116-23ca-4f5c-a60d-7d6e75e11be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ba66116-23ca-4f5c-a60d-7d6e75e11be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

