### PR TITLE
validate pxm header dimensions before allocation

### DIFF
--- a/src/Simd/SimdBaseImageLoadPpm.cpp
+++ b/src/Simd/SimdBaseImageLoadPpm.cpp
@@ -53,6 +53,16 @@ namespace Simd
             uint8_t byte;
             if (!(_stream.Read(byte) && byte == '\n'))
                 return false;
+            // width and height come straight from the textual header with no upper bound, unlike the
+            // PNG and BMP loaders. _size = width * channels below is evaluated in uint32 and wraps for
+            // large width, and on 32-bit builds the height * stride allocation in Recreate overflows
+            // size_t, leaving a short buffer that the per-row copy in FromStream then overruns. Cap the
+            // dimensions the way ImagePngLoader::ReadHeader already does.
+            const uint32_t MAX_SIZE = 1 << 24;
+            if (width > MAX_SIZE || height > MAX_SIZE)
+                return false;
+            if ((uint32_t(1) << 30) / width / 4 < height)
+                return false;
             _image.Recreate(width, height, (Image::Format)_param.format);
             _block = height;
             if (_param.file == SimdImageFilePgmTxt || _param.file == SimdImageFilePgmBin)


### PR DESCRIPTION
The PGM/PPM reader pulls width and height straight out of the textual header through `ReadUnsigned` and feeds them into `_image.Recreate` and `_size = width * channels`, but nothing caps either value. The PNG and BMP loaders already reject anything above `1 << 24` here, so this is the one decoder that still trusts whatever the file claims. For a PPM the `width * 3` is worked out in `uint32` and wraps for a large width, so `_size` ends up tiny while the image is built at the declared width, and on a 32-bit build the `height * stride` allocation inside `Recreate` overflows `size_t` the same way, handing back a short buffer that the per-row copy in `FromStream` then walks off the end of. I noticed it while checking why the other loaders carry the dimension guard and this one does not. Capping width and height the way `ImagePngLoader::ReadHeader` does closes both the wrap and the undersized allocation. The check sits in the shared `ImagePxmLoader::ReadHeader`, so all four PGM/PPM variants are covered in one place.