### PR TITLE
Add SVE2 AbsSecondDerivativeHistogram optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -81,6 +81,7 @@
  <li>SVE2 optimizations of function ConditionalSquareSum.</li>
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
  <li>SVE2 optimizations of function ConditionalFill.</li>
+ <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -40,6 +40,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToYuvV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
   </ItemGroup>

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp">
+      <Filter>Sve2\Statistics</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2970,6 +2970,11 @@ SIMD_API void SimdAbsSecondDerivativeHistogram(const uint8_t *src, size_t width,
         Sse41::AbsSecondDerivativeHistogram(src, width, height, stride, step, indent, histogram);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AbsSecondDerivativeHistogram(src, width, height, stride, step, indent, histogram);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A + 2 * indent)
         Neon::AbsSecondDerivativeHistogram(src, width, height, stride, step, indent, histogram);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -38,6 +38,9 @@ namespace Simd
         void AlphaBlending(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
             const uint8_t* alpha, size_t alphaStride, uint8_t* dst, size_t dstStride);
 
+        void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
+            size_t step, size_t indent, uint32_t* histogram);
+
         void BackgroundIncrementCount(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
             uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride);

--- a/src/Simd/SimdSve2Histogram.cpp
+++ b/src/Simd/SimdSve2Histogram.cpp
@@ -1,0 +1,130 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        namespace
+        {
+            template<class T> struct Buffer
+            {
+                Buffer(size_t rowSize, size_t histogramSize)
+                {
+                    _p = Allocate(sizeof(T) * rowSize + 4 * sizeof(uint32_t) * histogramSize);
+                    v = (T*)_p;
+                    h[0] = (uint32_t*)(v + rowSize);
+                    h[1] = h[0] + histogramSize;
+                    h[2] = h[1] + histogramSize;
+                    h[3] = h[2] + histogramSize;
+                    memset(h[0], 0, 4 * sizeof(uint32_t) * histogramSize);
+                }
+
+                ~Buffer()
+                {
+                    Free(_p);
+                }
+
+                T* v;
+                uint32_t* h[4];
+            private:
+                void* _p;
+            };
+        }
+
+        SIMD_INLINE svuint8_t Average2(const svuint8_t& a, const svuint8_t& b)
+        {
+            svuint16_t lo = svadd_n_u16_x(svptrue_b16(), svaddlb_u16(a, b), 1);
+            svuint16_t hi = svadd_n_u16_x(svptrue_b16(), svaddlt_u16(a, b), 1);
+            return svshrnt_n_u16(svshrnb_n_u16(lo, 1), hi, 1);
+        }
+
+        SIMD_INLINE svuint8_t AbsSecondDerivative(const uint8_t* src, ptrdiff_t step, const svbool_t& mask)
+        {
+            const svuint8_t s0 = svld1_u8(mask, src - step);
+            const svuint8_t s1 = svld1_u8(mask, src);
+            const svuint8_t s2 = svld1_u8(mask, src + step);
+            return svabd_u8_x(mask, Average2(s0, s2), s1);
+        }
+
+        SIMD_INLINE void AbsSecondDerivative(const uint8_t* src, ptrdiff_t colStep, ptrdiff_t rowStep, uint8_t* dst, const svbool_t& mask)
+        {
+            const svuint8_t sdX = AbsSecondDerivative(src, colStep, mask);
+            const svuint8_t sdY = AbsSecondDerivative(src, rowStep, mask);
+            svst1_u8(mask, dst, svmax_u8_x(mask, sdY, sdX));
+        }
+
+        SIMD_INLINE void SumHistograms(uint32_t* src, size_t start, uint32_t* dst)
+        {
+            uint32_t* src0 = src + start;
+            uint32_t* src1 = src0 + start + HISTOGRAM_SIZE;
+            uint32_t* src2 = src1 + start + HISTOGRAM_SIZE;
+            uint32_t* src3 = src2 + start + HISTOGRAM_SIZE;
+            for (size_t i = 0; i < HISTOGRAM_SIZE; ++i)
+                dst[i] = src0[i] + src1[i] + src2[i] + src3[i];
+        }
+
+        void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
+            size_t step, size_t indent, uint32_t* histogram)
+        {
+            assert(width > 2 * indent && height > 2 * indent && indent >= step);
+
+            size_t A = svlen(svuint8_t());
+            src += indent * (stride + 1);
+            height -= 2 * indent;
+            width -= 2 * indent;
+
+            Buffer<uint8_t> buffer(AlignHiAny(width, A), HISTOGRAM_SIZE);
+            ptrdiff_t rowStep = step * stride;
+            size_t widthA = AlignLoAny(width, A);
+            size_t alignedWidth4 = Simd::AlignLo(width, 4);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    AbsSecondDerivative(src + col, step, rowStep, buffer.v + col, body);
+                if (widthA < width)
+                    AbsSecondDerivative(src + col, step, rowStep, buffer.v + col, tail);
+
+                for (col = 0; col < alignedWidth4; col += 4)
+                {
+                    ++buffer.h[0][buffer.v[col + 0]];
+                    ++buffer.h[1][buffer.v[col + 1]];
+                    ++buffer.h[2][buffer.v[col + 2]];
+                    ++buffer.h[3][buffer.v[col + 3]];
+                }
+                for (; col < width; ++col)
+                    ++buffer.h[0][buffer.v[col + 0]];
+                src += stride;
+            }
+
+            SumHistograms(buffer.h[0], 0, histogram);
+        }
+    }
+#endif
+}

--- a/src/Test/TestHistogram.cpp
+++ b/src/Test/TestHistogram.cpp
@@ -258,6 +258,11 @@ namespace Test
             result = result && AbsSecondDerivativeHistogramAutoTest(Simd::Avx512bw::A, FUNC_ASDH(Simd::Avx512bw::AbsSecondDerivativeHistogram), FUNC_ASDH(SimdAbsSecondDerivativeHistogram));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AbsSecondDerivativeHistogramAutoTest(SIMD_SVE2_VECTOR_SIZE_MAX, FUNC_ASDH(Simd::Sve2::AbsSecondDerivativeHistogram), FUNC_ASDH(SimdAbsSecondDerivativeHistogram));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AbsSecondDerivativeHistogramAutoTest(Simd::Neon::A, FUNC_ASDH(Simd::Neon::AbsSecondDerivativeHistogram), FUNC_ASDH(SimdAbsSecondDerivativeHistogram));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `AbsSecondDerivativeHistogram` and dispatch it from the public API.
- Add SVE2 coverage to `AbsSecondDerivativeHistogramAutoTest`.
- Register `SimdSve2Histogram.cpp` in VS2022 SVE2 project files and release notes.

### Testing
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -I./src -c src/Simd/SimdSve2Histogram.cpp -o /tmp/SimdSve2Histogram.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AbsSecondDerivativeHistogram -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e15961ad-08e5-45db-a31e-f07e2deb6549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e15961ad-08e5-45db-a31e-f07e2deb6549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

