### PR TITLE
Add SVE2 AlphaBlending2x optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,6 +84,7 @@
  <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
+ <li>SVE2 optimizations of function AlphaBlending2x.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -588,6 +588,11 @@ SIMD_API void SimdAlphaBlending2x(const uint8_t* src0, size_t src0Stride, const 
         Sse41::AlphaBlending2x(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AlphaBlending2x(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::AlphaBlending2x(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -38,6 +38,10 @@ namespace Simd
         void AlphaBlending(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
             const uint8_t* alpha, size_t alphaStride, uint8_t* dst, size_t dstStride);
 
+        void AlphaBlending2x(const uint8_t* src0, size_t src0Stride, const uint8_t* alpha0, size_t alpha0Stride,
+            const uint8_t* src1, size_t src1Stride, const uint8_t* alpha1, size_t alpha1Stride,
+            size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2AlphaBlending.cpp
+++ b/src/Simd/SimdSve2AlphaBlending.cpp
@@ -117,6 +117,107 @@ namespace Simd
             case 4: AlphaBlending<4>(src, srcStride, width, height, alpha, alphaStride, dst, dstStride); break;
             }
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint8_t AlphaBlending2x(const svuint8_t& src0, const svuint8_t& alpha0, const svuint8_t& ialpha0,
+            const svuint8_t& src1, const svuint8_t& alpha1, const svuint8_t& ialpha1, const svuint8_t& dst, const svuint16_t& _1)
+        {
+            return AlphaBlending(src1, AlphaBlending(src0, dst, alpha0, ialpha0, _1), alpha1, ialpha1, _1);
+        }
+
+        template<size_t channelCount> void MakeAlphaBlending2x(const uint8_t* src0, const svuint8_t& alpha0, const svuint8_t& ialpha0,
+            const uint8_t* src1, const svuint8_t& alpha1, const svuint8_t& ialpha1, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask);
+
+        template<> SIMD_INLINE void MakeAlphaBlending2x<1>(const uint8_t* src0, const svuint8_t& alpha0, const svuint8_t& ialpha0,
+            const uint8_t* src1, const svuint8_t& alpha1, const svuint8_t& ialpha1, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svst1_u8(mask, dst, AlphaBlending2x(svld1_u8(mask, src0), alpha0, ialpha0, svld1_u8(mask, src1), alpha1, ialpha1, svld1_u8(mask, dst), _1));
+        }
+
+        template<> SIMD_INLINE void MakeAlphaBlending2x<2>(const uint8_t* src0, const svuint8_t& alpha0, const svuint8_t& ialpha0,
+            const uint8_t* src1, const svuint8_t& alpha1, const svuint8_t& ialpha1, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svuint8x2_t _src0 = svld2_u8(mask, src0);
+            svuint8x2_t _src1 = svld2_u8(mask, src1);
+            svuint8x2_t _dst = svld2_u8(mask, dst);
+            svst2_u8(mask, dst, svcreate2_u8(
+                AlphaBlending2x(svget2(_src0, 0), alpha0, ialpha0, svget2(_src1, 0), alpha1, ialpha1, svget2(_dst, 0), _1),
+                AlphaBlending2x(svget2(_src0, 1), alpha0, ialpha0, svget2(_src1, 1), alpha1, ialpha1, svget2(_dst, 1), _1)));
+        }
+
+        template<> SIMD_INLINE void MakeAlphaBlending2x<3>(const uint8_t* src0, const svuint8_t& alpha0, const svuint8_t& ialpha0,
+            const uint8_t* src1, const svuint8_t& alpha1, const svuint8_t& ialpha1, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svuint8x3_t _src0 = svld3_u8(mask, src0);
+            svuint8x3_t _src1 = svld3_u8(mask, src1);
+            svuint8x3_t _dst = svld3_u8(mask, dst);
+            svst3_u8(mask, dst, svcreate3_u8(
+                AlphaBlending2x(svget3(_src0, 0), alpha0, ialpha0, svget3(_src1, 0), alpha1, ialpha1, svget3(_dst, 0), _1),
+                AlphaBlending2x(svget3(_src0, 1), alpha0, ialpha0, svget3(_src1, 1), alpha1, ialpha1, svget3(_dst, 1), _1),
+                AlphaBlending2x(svget3(_src0, 2), alpha0, ialpha0, svget3(_src1, 2), alpha1, ialpha1, svget3(_dst, 2), _1)));
+        }
+
+        template<> SIMD_INLINE void MakeAlphaBlending2x<4>(const uint8_t* src0, const svuint8_t& alpha0, const svuint8_t& ialpha0,
+            const uint8_t* src1, const svuint8_t& alpha1, const svuint8_t& ialpha1, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svuint8x4_t _src0 = svld4_u8(mask, src0);
+            svuint8x4_t _src1 = svld4_u8(mask, src1);
+            svuint8x4_t _dst = svld4_u8(mask, dst);
+            svst4_u8(mask, dst, svcreate4_u8(
+                AlphaBlending2x(svget4(_src0, 0), alpha0, ialpha0, svget4(_src1, 0), alpha1, ialpha1, svget4(_dst, 0), _1),
+                AlphaBlending2x(svget4(_src0, 1), alpha0, ialpha0, svget4(_src1, 1), alpha1, ialpha1, svget4(_dst, 1), _1),
+                AlphaBlending2x(svget4(_src0, 2), alpha0, ialpha0, svget4(_src1, 2), alpha1, ialpha1, svget4(_dst, 2), _1),
+                AlphaBlending2x(svget4(_src0, 3), alpha0, ialpha0, svget4(_src1, 3), alpha1, ialpha1, svget4(_dst, 3), _1)));
+        }
+
+        template<size_t channelCount> SIMD_INLINE void MakeAlphaBlending2x(const uint8_t* src0, const uint8_t* alpha0,
+            const uint8_t* src1, const uint8_t* alpha1, uint8_t* dst, const svuint16_t& _1, const svuint8_t& _255, const svbool_t& mask)
+        {
+            svuint8_t _alpha0 = svld1_u8(mask, alpha0);
+            svuint8_t _alpha1 = svld1_u8(mask, alpha1);
+            svuint8_t ialpha0 = svsub_u8_x(mask, _255, _alpha0);
+            svuint8_t ialpha1 = svsub_u8_x(mask, _255, _alpha1);
+            MakeAlphaBlending2x<channelCount>(src0, _alpha0, ialpha0, src1, _alpha1, ialpha1, dst, _1, mask);
+        }
+
+        template<size_t channelCount> void AlphaBlending2x(const uint8_t* src0, size_t src0Stride, const uint8_t* alpha0, size_t alpha0Stride,
+            const uint8_t* src1, size_t src1Stride, const uint8_t* alpha1, size_t alpha1Stride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svlen(svuint8_t()), widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            svuint16_t _1 = svdup_n_u16(1);
+            svuint8_t _255 = svdup_n_u8(255);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A * channelCount)
+                    MakeAlphaBlending2x<channelCount>(src0 + offset, alpha0 + col, src1 + offset, alpha1 + col, dst + offset, _1, _255, body);
+                if (widthA < width)
+                    MakeAlphaBlending2x<channelCount>(src0 + offset, alpha0 + col, src1 + offset, alpha1 + col, dst + offset, _1, _255, tail);
+                src0 += src0Stride;
+                alpha0 += alpha0Stride;
+                src1 += src1Stride;
+                alpha1 += alpha1Stride;
+                dst += dstStride;
+            }
+        }
+
+        void AlphaBlending2x(const uint8_t* src0, size_t src0Stride, const uint8_t* alpha0, size_t alpha0Stride,
+            const uint8_t* src1, size_t src1Stride, const uint8_t* alpha1, size_t alpha1Stride,
+            size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount >= 1 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: AlphaBlending2x<1>(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, dst, dstStride); break;
+            case 2: AlphaBlending2x<2>(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, dst, dstStride); break;
+            case 3: AlphaBlending2x<3>(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, dst, dstStride); break;
+            case 4: AlphaBlending2x<4>(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, dst, dstStride); break;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestDrawing.cpp
+++ b/src/Test/TestDrawing.cpp
@@ -220,6 +220,11 @@ namespace Test
             result = result && AlphaBlending2xAutoTest(FUNC_AB2(Simd::Avx512bw::AlphaBlending2x), FUNC_AB2(SimdAlphaBlending2x));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AlphaBlending2xAutoTest(FUNC_AB2(Simd::Sve2::AlphaBlending2x), FUNC_AB2(SimdAlphaBlending2x));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AlphaBlending2xAutoTest(FUNC_AB2(Simd::Neon::AlphaBlending2x), FUNC_AB2(SimdAlphaBlending2x));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `AlphaBlending2x` for 1-4 channel images.
- Wire SVE2 dispatch and auto-test coverage for `SimdAlphaBlending2x`.
- Document the new optimization in release 7.2.163 notes.

### Validation
- Native Release build with `gcc/g++` completed successfully.
- Focused `AlphaBlending2x` auto test completed successfully on the native host.
- AArch64/SVE2 library target cross build completed successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bea46f3-36f4-4673-b890-bd43bb51278a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bea46f3-36f4-4673-b890-bd43bb51278a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

