### PR TITLE
Add SVE2 AlphaBlendingUniform optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -85,6 +85,7 @@
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function AlphaBlending2x.</li>
+ <li>SVE2 optimizations of function AlphaBlendingUniform.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -646,6 +646,11 @@ SIMD_API void SimdAlphaBlendingUniform(const uint8_t* src, size_t srcStride, siz
         Sse41::AlphaBlendingUniform(src, srcStride, width, height, channelCount, alpha, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AlphaBlendingUniform(src, srcStride, width, height, channelCount, alpha, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::AlphaBlendingUniform(src, srcStride, width, height, channelCount, alpha, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -42,6 +42,9 @@ namespace Simd
             const uint8_t* src1, size_t src1Stride, const uint8_t* alpha1, size_t alpha1Stride,
             size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void AlphaBlendingUniform(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            uint8_t alpha, uint8_t* dst, size_t dstStride);
+
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2AlphaBlending.cpp
+++ b/src/Simd/SimdSve2AlphaBlending.cpp
@@ -218,6 +218,38 @@ namespace Simd
             case 4: AlphaBlending2x<4>(src0, src0Stride, alpha0, alpha0Stride, src1, src1Stride, alpha1, alpha1Stride, width, height, dst, dstStride); break;
             }
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE void MakeAlphaBlendingUniform(const uint8_t* src, uint8_t* dst,
+            const svuint8_t& alpha, const svuint8_t& ialpha, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svst1_u8(mask, dst, AlphaBlending(svld1_u8(mask, src), svld1_u8(mask, dst), alpha, ialpha, _1));
+        }
+
+        void AlphaBlendingUniform(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            uint8_t alpha, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount >= 1 && channelCount <= 4);
+
+            size_t size = width * channelCount;
+            size_t A = svlen(svuint8_t()), sizeA = AlignLo(size, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(sizeA, size);
+            svuint16_t _1 = svdup_n_u16(1);
+            svuint8_t _alpha = svdup_n_u8(alpha);
+            svuint8_t ialpha = svdup_n_u8(255 - alpha);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t offset = 0;
+                for (; offset < sizeA; offset += A)
+                    MakeAlphaBlendingUniform(src + offset, dst + offset, _alpha, ialpha, _1, body);
+                if (sizeA < size)
+                    MakeAlphaBlendingUniform(src + offset, dst + offset, _alpha, ialpha, _1, tail);
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestDrawing.cpp
+++ b/src/Test/TestDrawing.cpp
@@ -418,6 +418,11 @@ namespace Test
             result = result && AlphaBlendingUniformAutoTest(FUNC_ABU(Simd::Avx512bw::AlphaBlendingUniform), FUNC_ABU(SimdAlphaBlendingUniform));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AlphaBlendingUniformAutoTest(FUNC_ABU(Simd::Sve2::AlphaBlendingUniform), FUNC_ABU(SimdAlphaBlendingUniform));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AlphaBlendingUniformAutoTest(FUNC_ABU(Simd::Neon::AlphaBlendingUniform), FUNC_ABU(SimdAlphaBlendingUniform));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `AlphaBlendingUniform` using predicated byte vector loads/stores and the existing SVE2 alpha blending primitive.
- Dispatch `SimdAlphaBlendingUniform` through SVE2 when available and add SVE2 coverage to `AlphaBlendingUniformAutoTest`.
- Document the new SVE2 optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AlphaBlendingUniform -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.6-a+sve2 -I src -c src/Simd/SimdSve2AlphaBlending.cpp -o /tmp/SimdSve2AlphaBlending.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.6-a+sve2 -I src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.6-a+sve2 -I src -I src/Test -c src/Test/TestDrawing.cpp -o /tmp/TestDrawing.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539ee743-5824-4cea-a726-affda4a6ed8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539ee743-5824-4cea-a726-affda4a6ed8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

