### PR TITLE
Add SVE2 AlphaFilling optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -87,6 +87,7 @@
  <li>SVE2 optimizations of function AlphaBlending2x.</li>
  <li>SVE2 optimizations of function AlphaBlendingBgraToYuv420p.</li>
  <li>SVE2 optimizations of function AlphaBlendingUniform.</li>
+ <li>SVE2 optimizations of function AlphaFilling.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -682,6 +682,11 @@ SIMD_API void SimdAlphaFilling(uint8_t * dst, size_t dstStride, size_t width, si
         Sse41::AlphaFilling(dst, dstStride, width, height, channel, channelCount, alpha, alphaStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AlphaFilling(dst, dstStride, width, height, channel, channelCount, alpha, alphaStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::AlphaFilling(dst, dstStride, width, height, channel, channelCount, alpha, alphaStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -48,6 +48,9 @@ namespace Simd
         void AlphaBlendingUniform(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
             uint8_t alpha, uint8_t* dst, size_t dstStride);
 
+        void AlphaFilling(uint8_t* dst, size_t dstStride, size_t width, size_t height, const uint8_t* channel,
+            size_t channelCount, const uint8_t* alpha, size_t alphaStride);
+
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2AlphaBlending.cpp
+++ b/src/Simd/SimdSve2AlphaBlending.cpp
@@ -328,6 +328,113 @@ namespace Simd
                 dst += dstStride;
             }
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<size_t channelCount> struct AlphaFiller;
+
+        template<> struct AlphaFiller<1>
+        {
+            static SIMD_INLINE void Run(uint8_t* dst, const svuint8_t& c0, const svuint8_t& c1, const svuint8_t& c2, const svuint8_t& c3,
+                const svuint8_t& alpha, const svuint8_t& ialpha, const svuint16_t& _1, const svbool_t& mask)
+            {
+                svst1_u8(mask, dst, AlphaBlending(c0, svld1_u8(mask, dst), alpha, ialpha, _1));
+            }
+        };
+
+        template<> struct AlphaFiller<2>
+        {
+            static SIMD_INLINE void Run(uint8_t* dst, const svuint8_t& c0, const svuint8_t& c1, const svuint8_t& c2, const svuint8_t& c3,
+                const svuint8_t& alpha, const svuint8_t& ialpha, const svuint16_t& _1, const svbool_t& mask)
+            {
+                svuint8x2_t _dst = svld2_u8(mask, dst);
+                svst2_u8(mask, dst, svcreate2_u8(
+                    AlphaBlending(c0, svget2(_dst, 0), alpha, ialpha, _1),
+                    AlphaBlending(c1, svget2(_dst, 1), alpha, ialpha, _1)));
+            }
+        };
+
+        template<> struct AlphaFiller<3>
+        {
+            static SIMD_INLINE void Run(uint8_t* dst, const svuint8_t& c0, const svuint8_t& c1, const svuint8_t& c2, const svuint8_t& c3,
+                const svuint8_t& alpha, const svuint8_t& ialpha, const svuint16_t& _1, const svbool_t& mask)
+            {
+                svuint8x3_t _dst = svld3_u8(mask, dst);
+                svst3_u8(mask, dst, svcreate3_u8(
+                    AlphaBlending(c0, svget3(_dst, 0), alpha, ialpha, _1),
+                    AlphaBlending(c1, svget3(_dst, 1), alpha, ialpha, _1),
+                    AlphaBlending(c2, svget3(_dst, 2), alpha, ialpha, _1)));
+            }
+        };
+
+        template<> struct AlphaFiller<4>
+        {
+            static SIMD_INLINE void Run(uint8_t* dst, const svuint8_t& c0, const svuint8_t& c1, const svuint8_t& c2, const svuint8_t& c3,
+                const svuint8_t& alpha, const svuint8_t& ialpha, const svuint16_t& _1, const svbool_t& mask)
+            {
+                svuint8x4_t _dst = svld4_u8(mask, dst);
+                svst4_u8(mask, dst, svcreate4_u8(
+                    AlphaBlending(c0, svget4(_dst, 0), alpha, ialpha, _1),
+                    AlphaBlending(c1, svget4(_dst, 1), alpha, ialpha, _1),
+                    AlphaBlending(c2, svget4(_dst, 2), alpha, ialpha, _1),
+                    AlphaBlending(c3, svget4(_dst, 3), alpha, ialpha, _1)));
+            }
+        };
+
+        template<size_t channelCount> void AlphaFilling(uint8_t* dst, size_t dstStride, size_t width, size_t height,
+            const svuint8_t& c0, const svuint8_t& c1, const svuint8_t& c2, const svuint8_t& c3, const uint8_t* alpha, size_t alphaStride)
+        {
+            size_t A = svlen(svuint8_t()), widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint16_t _1 = svdup_n_u16(1);
+            const svuint8_t _255 = svdup_n_u8(255);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A * channelCount)
+                {
+                    svuint8_t _alpha = svld1_u8(body, alpha + col);
+                    AlphaFiller<channelCount>::Run(dst + offset, c0, c1, c2, c3, _alpha, svsub_u8_x(body, _255, _alpha), _1, body);
+                }
+                if (widthA < width)
+                {
+                    svuint8_t _alpha = svld1_u8(tail, alpha + col);
+                    AlphaFiller<channelCount>::Run(dst + offset, c0, c1, c2, c3, _alpha, svsub_u8_x(tail, _255, _alpha), _1, tail);
+                }
+                alpha += alphaStride;
+                dst += dstStride;
+            }
+        }
+
+        void AlphaFilling(uint8_t* dst, size_t dstStride, size_t width, size_t height, const uint8_t* channel, size_t channelCount, const uint8_t* alpha, size_t alphaStride)
+        {
+            assert(channelCount >= 1 && channelCount <= 4);
+
+            svuint8_t c0 = svdup_n_u8(channel[0]);
+            svuint8_t c1 = c0, c2 = c0, c3 = c0;
+            switch (channelCount)
+            {
+            case 1:
+                AlphaFilling<1>(dst, dstStride, width, height, c0, c1, c2, c3, alpha, alphaStride);
+                break;
+            case 2:
+                c1 = svdup_n_u8(channel[1]);
+                AlphaFilling<2>(dst, dstStride, width, height, c0, c1, c2, c3, alpha, alphaStride);
+                break;
+            case 3:
+                c1 = svdup_n_u8(channel[1]);
+                c2 = svdup_n_u8(channel[2]);
+                AlphaFilling<3>(dst, dstStride, width, height, c0, c1, c2, c3, alpha, alphaStride);
+                break;
+            case 4:
+                c1 = svdup_n_u8(channel[1]);
+                c2 = svdup_n_u8(channel[2]);
+                c3 = svdup_n_u8(channel[3]);
+                AlphaFilling<4>(dst, dstStride, width, height, c0, c1, c2, c3, alpha, alphaStride);
+                break;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestDrawing.cpp
+++ b/src/Test/TestDrawing.cpp
@@ -523,6 +523,11 @@ namespace Test
             result = result && AlphaFillingAutoTest(FUNC_AF(Simd::Avx512bw::AlphaFilling), FUNC_AF(SimdAlphaFilling));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AlphaFillingAutoTest(FUNC_AF(Simd::Sve2::AlphaFilling), FUNC_AF(SimdAlphaFilling));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AlphaFillingAutoTest(FUNC_AF(Simd::Neon::AlphaFilling), FUNC_AF(SimdAlphaFilling));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdAlphaFilling`.
- Add SVE2 coverage to `AlphaFillingAutoTest`.
- Document the SVE2 `AlphaFilling` optimization in release 7.2.163.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `(cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AlphaFilling -tt=1 -ts=1)`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -fsyntax-only -I./src ./src/Simd/SimdSve2AlphaBlending.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -fsyntax-only -I./src ./src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -fsyntax-only -I./src ./src/Test/TestDrawing.cpp`

Validation log: `/opt/cursor/artifacts/alpha_filling_sve2_validation.log`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04834276-6839-4ad2-98b9-05bfe65e6354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04834276-6839-4ad2-98b9-05bfe65e6354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

