### PR TITLE
Add SVE2 AlphaPremultiply optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -88,6 +88,7 @@
  <li>SVE2 optimizations of function AlphaBlendingBgraToYuv420p.</li>
  <li>SVE2 optimizations of function AlphaBlendingUniform.</li>
  <li>SVE2 optimizations of function AlphaFilling.</li>
+ <li>SVE2 optimizations of function AlphaPremultiply.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -713,6 +713,11 @@ SIMD_API void SimdAlphaPremultiply(const uint8_t* src, size_t srcStride, size_t 
         Sse41::AlphaPremultiply(src, srcStride, width, height, dst, dstStride, argb);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AlphaPremultiply(src, srcStride, width, height, dst, dstStride, argb);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable)
         Neon::AlphaPremultiply(src, srcStride, width, height, dst, dstStride, argb);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -51,6 +51,9 @@ namespace Simd
         void AlphaFilling(uint8_t* dst, size_t dstStride, size_t width, size_t height, const uint8_t* channel,
             size_t channelCount, const uint8_t* alpha, size_t alphaStride);
 
+        void AlphaPremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t* dst, size_t dstStride, SimdBool argb);
+
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2AlphaBlending.cpp
+++ b/src/Simd/SimdSve2AlphaBlending.cpp
@@ -435,6 +435,67 @@ namespace Simd
                 break;
             }
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint8_t AlphaPremultiply(const svuint8_t& value, const svuint8_t& alpha, const svuint16_t& _1)
+        {
+            svuint16_t lo = svmlalb_u16(_1, value, alpha);
+            svuint16_t hi = svmlalt_u16(_1, value, alpha);
+            lo = svaddwt_u16(lo, To8u(lo));
+            hi = svaddwt_u16(hi, To8u(hi));
+            return svshrnt_n_u16(svshrnb_n_u16(lo, 8), hi, 8);
+        }
+
+        template<bool argb> void AlphaPremultiply(const uint8_t* src, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask);
+
+        template<> SIMD_INLINE void AlphaPremultiply<false>(const uint8_t* src, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svuint8x4_t bgra = svld4_u8(mask, src);
+            svuint8_t alpha = svget4(bgra, 3);
+            svst4_u8(mask, dst, svcreate4_u8(
+                AlphaPremultiply(svget4(bgra, 0), alpha, _1),
+                AlphaPremultiply(svget4(bgra, 1), alpha, _1),
+                AlphaPremultiply(svget4(bgra, 2), alpha, _1),
+                alpha));
+        }
+
+        template<> SIMD_INLINE void AlphaPremultiply<true>(const uint8_t* src, uint8_t* dst, const svuint16_t& _1, const svbool_t& mask)
+        {
+            svuint8x4_t argb = svld4_u8(mask, src);
+            svuint8_t alpha = svget4(argb, 0);
+            svst4_u8(mask, dst, svcreate4_u8(
+                alpha,
+                AlphaPremultiply(svget4(argb, 1), alpha, _1),
+                AlphaPremultiply(svget4(argb, 2), alpha, _1),
+                AlphaPremultiply(svget4(argb, 3), alpha, _1)));
+        }
+
+        template<bool argb> void AlphaPremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svlen(svuint8_t()), widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint16_t _1 = svdup_n_u16(1);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A * 4)
+                    AlphaPremultiply<argb>(src + offset, dst + offset, _1, body);
+                if (widthA < width)
+                    AlphaPremultiply<argb>(src + offset, dst + offset, _1, tail);
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        void AlphaPremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdBool argb)
+        {
+            if (argb)
+                AlphaPremultiply<true>(src, srcStride, width, height, dst, dstStride);
+            else
+                AlphaPremultiply<false>(src, srcStride, width, height, dst, dstStride);
+        }
     }
 #endif
 }

--- a/src/Test/TestDrawing.cpp
+++ b/src/Test/TestDrawing.cpp
@@ -619,6 +619,11 @@ namespace Test
             result = result && AlphaPremultiplyAutoTest(false, FUNC_AP(Simd::Avx512bw::AlphaPremultiply), FUNC_AP(SimdAlphaPremultiply));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AlphaPremultiplyAutoTest(false, FUNC_AP(Simd::Sve2::AlphaPremultiply), FUNC_AP(SimdAlphaPremultiply));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AlphaPremultiplyAutoTest(false, FUNC_AP(Simd::Neon::AlphaPremultiply), FUNC_AP(SimdAlphaPremultiply));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdAlphaPremultiply`.
- Register SVE2 coverage in `AlphaPremultiplyAutoTest`.
- Document the new optimization in the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2AlphaBlending.cpp`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AlphaPremultiply -tt=1 -ts=1`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD~1..HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fb1831d-da64-4af9-aeff-66177c37ee8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fb1831d-da64-4af9-aeff-66177c37ee8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

