### PR TITLE
Add SVE2 AlphaUnpremultiply optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -89,6 +89,7 @@
  <li>SVE2 optimizations of function AlphaBlendingUniform.</li>
  <li>SVE2 optimizations of function AlphaFilling.</li>
  <li>SVE2 optimizations of function AlphaPremultiply.</li>
+ <li>SVE2 optimizations of function AlphaUnpremultiply.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -744,6 +744,11 @@ SIMD_API void SimdAlphaUnpremultiply(const uint8_t* src, size_t srcStride, size_
         Sse41::AlphaUnpremultiply(src, srcStride, width, height, dst, dstStride, argb);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AlphaUnpremultiply(src, srcStride, width, height, dst, dstStride, argb);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable)
         Neon::AlphaUnpremultiply(src, srcStride, width, height, dst, dstStride, argb);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -54,6 +54,9 @@ namespace Simd
         void AlphaPremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             uint8_t* dst, size_t dstStride, SimdBool argb);
 
+        void AlphaUnpremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t* dst, size_t dstStride, SimdBool argb);
+
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2AlphaBlending.cpp
+++ b/src/Simd/SimdSve2AlphaBlending.cpp
@@ -496,6 +496,88 @@ namespace Simd
             else
                 AlphaPremultiply<false>(src, srcStride, width, height, dst, dstStride);
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint32_t AlphaUnpremultiply32(const svuint32_t& value, const svuint32_t& alpha,
+            const svfloat32_t& _0, const svfloat32_t& _255)
+        {
+            const svbool_t mask = svptrue_b32();
+            svfloat32_t scale = svdiv_f32_x(mask, _255, svcvt_f32_u32_x(mask, svmax_n_u32_x(mask, alpha, 1)));
+            scale = svsel_f32(svcmpeq_n_u32(mask, alpha, 0), _0, scale);
+            return svcvt_u32_f32_x(mask, svmin_f32_x(mask, svmul_f32_x(mask, svcvt_f32_u32_x(mask, value), scale), _255));
+        }
+
+        SIMD_INLINE svuint8_t AlphaUnpremultiply(const svuint8_t& value, const svuint8_t& alpha,
+            const svfloat32_t& _0, const svfloat32_t& _255)
+        {
+            svuint16_t valueLo = svmovlb_u16(value);
+            svuint16_t valueHi = svmovlt_u16(value);
+            svuint16_t alphaLo = svmovlb_u16(alpha);
+            svuint16_t alphaHi = svmovlt_u16(alpha);
+
+            svuint16_t lo = svqxtnt_u32(svqxtnb_u32(AlphaUnpremultiply32(svmovlb_u32(valueLo), svmovlb_u32(alphaLo), _0, _255)),
+                AlphaUnpremultiply32(svmovlt_u32(valueLo), svmovlt_u32(alphaLo), _0, _255));
+            svuint16_t hi = svqxtnt_u32(svqxtnb_u32(AlphaUnpremultiply32(svmovlb_u32(valueHi), svmovlb_u32(alphaHi), _0, _255)),
+                AlphaUnpremultiply32(svmovlt_u32(valueHi), svmovlt_u32(alphaHi), _0, _255));
+            return svqxtnt_u16(svqxtnb_u16(lo), hi);
+        }
+
+        template<bool argb> void AlphaUnpremultiply(const uint8_t* src, uint8_t* dst,
+            const svfloat32_t& _0, const svfloat32_t& _255, const svbool_t& mask);
+
+        template<> SIMD_INLINE void AlphaUnpremultiply<false>(const uint8_t* src, uint8_t* dst,
+            const svfloat32_t& _0, const svfloat32_t& _255, const svbool_t& mask)
+        {
+            svuint8x4_t bgra = svld4_u8(mask, src);
+            svuint8_t alpha = svget4(bgra, 3);
+            svst4_u8(mask, dst, svcreate4_u8(
+                AlphaUnpremultiply(svget4(bgra, 0), alpha, _0, _255),
+                AlphaUnpremultiply(svget4(bgra, 1), alpha, _0, _255),
+                AlphaUnpremultiply(svget4(bgra, 2), alpha, _0, _255),
+                alpha));
+        }
+
+        template<> SIMD_INLINE void AlphaUnpremultiply<true>(const uint8_t* src, uint8_t* dst,
+            const svfloat32_t& _0, const svfloat32_t& _255, const svbool_t& mask)
+        {
+            svuint8x4_t argb = svld4_u8(mask, src);
+            svuint8_t alpha = svget4(argb, 0);
+            svst4_u8(mask, dst, svcreate4_u8(
+                alpha,
+                AlphaUnpremultiply(svget4(argb, 1), alpha, _0, _255),
+                AlphaUnpremultiply(svget4(argb, 2), alpha, _0, _255),
+                AlphaUnpremultiply(svget4(argb, 3), alpha, _0, _255)));
+        }
+
+        template<bool argb> void AlphaUnpremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svlen(svuint8_t()), widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svfloat32_t _0 = svdup_n_f32(0.0f);
+            const svfloat32_t _255 = svdup_n_f32(255.00001f);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A * 4)
+                    AlphaUnpremultiply<argb>(src + offset, dst + offset, _0, _255, body);
+                if (widthA < width)
+                    AlphaUnpremultiply<argb>(src + offset, dst + offset, _0, _255, tail);
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        void AlphaUnpremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t* dst, size_t dstStride, SimdBool argb)
+        {
+            if (argb)
+                AlphaUnpremultiply<true>(src, srcStride, width, height, dst, dstStride);
+            else
+                AlphaUnpremultiply<false>(src, srcStride, width, height, dst, dstStride);
+        }
     }
 #endif
 }

--- a/src/Test/TestDrawing.cpp
+++ b/src/Test/TestDrawing.cpp
@@ -654,6 +654,11 @@ namespace Test
             result = result && AlphaPremultiplyAutoTest(true, FUNC_AP(Simd::Avx512bw::AlphaUnpremultiply), FUNC_AP(SimdAlphaUnpremultiply));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AlphaPremultiplyAutoTest(true, FUNC_AP(Simd::Sve2::AlphaUnpremultiply), FUNC_AP(SimdAlphaUnpremultiply));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && AlphaPremultiplyAutoTest(true, FUNC_AP(Simd::Neon::AlphaUnpremultiply), FUNC_AP(SimdAlphaUnpremultiply));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdAlphaUnpremultiply` for BGRA/RGBA and ARGB layouts.
- Wire SVE2 dispatch and auto-test coverage.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AlphaUnpremultiply -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2AlphaBlending.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bb9efa9-a7f4-45a1-b60a-da35c3628d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bb9efa9-a7f4-45a1-b60a-da35c3628d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

