### PR TITLE
Add AVX-512BW AveragingBinarizationV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -97,6 +97,7 @@
  <li>SVE2 optimizations of function BackgroundInitMask.</li>
  <li>SSE4.1 optimizations of function AveragingBinarizationV2.</li>
  <li>AVX2 optimizations of function AveragingBinarizationV2.</li>
+ <li>AVX-512BW optimizations of function AveragingBinarizationV2.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>
@@ -120,6 +121,7 @@
 <ul>
  <li>Tests for verifying functionality of SSE4.1 optimizations of function AveragingBinarizationV2.</li>
  <li>Tests for verifying functionality of AVX2 optimizations of function AveragingBinarizationV2.</li>
+ <li>Tests for verifying functionality of AVX-512BW optimizations of function AveragingBinarizationV2.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Avx512bw.vcxproj
+++ b/prj/vs2022/Avx512bw.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwBgrToLab.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwBgrToRgb.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwBgrToYuvV2.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdAvx2Binarization.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwBinarization.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwConditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwCpu.cpp" />

--- a/prj/vs2022/Avx512bw.vcxproj.filters
+++ b/prj/vs2022/Avx512bw.vcxproj.filters
@@ -439,6 +439,9 @@
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwBinarization.cpp">
       <Filter>Avx512bw\Filter</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx2Binarization.cpp">
+      <Filter>Avx512bw\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwCpu.cpp">
       <Filter>Avx512bw\System</Filter>
     </ClCompile>

--- a/src/Simd/SimdAvx512bw.h
+++ b/src/Simd/SimdAvx512bw.h
@@ -159,6 +159,9 @@ namespace Simd
             uint8_t value, size_t neighborhood, uint8_t threshold, uint8_t positive, uint8_t negative,
             uint8_t * dst, size_t dstStride, SimdCompareType compareType);
 
+        void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride);
+
         void ConditionalCount8u(const uint8_t * src, size_t stride, size_t width, size_t height, uint8_t value, SimdCompareType compareType, uint32_t * count);
 
         void ConditionalCount16i(const uint8_t * src, size_t stride, size_t width, size_t height, int16_t value, SimdCompareType compareType, uint32_t * count);

--- a/src/Simd/SimdAvx512bwBinarization.cpp
+++ b/src/Simd/SimdAvx512bwBinarization.cpp
@@ -285,6 +285,173 @@ namespace Simd
                 assert(0);
             }
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        namespace
+        {
+            struct BufferV2
+            {
+                BufferV2(size_t width, size_t edge)
+                {
+                    _width = AlignHi(width, A);
+                    _edge = AlignHi(edge, A);
+                    _size = _width + 2 * _edge;
+                    size_t size = sizeof(int32_t) * (2 * _size + 2 * _width);
+                    _p = Allocate(size);
+                    memset(_p, 0, size);
+                    int32_t* data = (int32_t*)_p;
+                    rs = data + _edge;
+                    ra = data + _size + _edge;
+                    sum = data + 2 * _size;
+                    area = sum + _width;
+                }
+
+                ~BufferV2()
+                {
+                    Free(_p);
+                }
+
+                int32_t* rs;
+                int32_t* ra;
+                int32_t* sum;
+                int32_t* area;
+            private:
+                size_t _width;
+                size_t _edge;
+                size_t _size;
+                void* _p;
+            };
+        }
+
+        template <bool align> SIMD_INLINE void Add32i(const __m512i& value, int32_t* dst)
+        {
+            Store<align>((__m512i*)dst + 0, _mm512_add_epi32(Load<align>((__m512i*)dst + 0), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 0))));
+            Store<align>((__m512i*)dst + 1, _mm512_add_epi32(Load<align>((__m512i*)dst + 1), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 1))));
+            Store<align>((__m512i*)dst + 2, _mm512_add_epi32(Load<align>((__m512i*)dst + 2), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 2))));
+            Store<align>((__m512i*)dst + 3, _mm512_add_epi32(Load<align>((__m512i*)dst + 3), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 3))));
+        }
+
+        template <bool align> SIMD_INLINE void Sub32i(const __m512i& value, int32_t* dst)
+        {
+            Store<align>((__m512i*)dst + 0, _mm512_sub_epi32(Load<align>((__m512i*)dst + 0), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 0))));
+            Store<align>((__m512i*)dst + 1, _mm512_sub_epi32(Load<align>((__m512i*)dst + 1), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 1))));
+            Store<align>((__m512i*)dst + 2, _mm512_sub_epi32(Load<align>((__m512i*)dst + 2), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 2))));
+            Store<align>((__m512i*)dst + 3, _mm512_sub_epi32(Load<align>((__m512i*)dst + 3), _mm512_cvtepu8_epi32(_mm512_extracti32x4_epi32(value, 3))));
+        }
+
+        template <bool srcAlign, bool dstAlign> SIMD_INLINE void AddRow(const uint8_t* src, int32_t* rs, int32_t* ra, const __m512i& valueMask, const __m512i& countMask)
+        {
+            Add32i<dstAlign>(_mm512_and_si512(Load<srcAlign>((__m512i*)src), valueMask), rs);
+            Add32i<dstAlign>(countMask, ra);
+        }
+
+        template <bool srcAlign, bool dstAlign> SIMD_INLINE void SubRow(const uint8_t* src, int32_t* rs, int32_t* ra, const __m512i& valueMask, const __m512i& countMask)
+        {
+            Sub32i<dstAlign>(_mm512_and_si512(Load<srcAlign>((__m512i*)src), valueMask), rs);
+            Sub32i<dstAlign>(countMask, ra);
+        }
+
+        template <bool srcAlign, bool bufAlign> SIMD_INLINE __mmask64 CompareV2(const uint8_t* src, const int32_t* sum, const int32_t* area, const __m512i& shift)
+        {
+            union Mask
+            {
+                __mmask16 m16[4];
+                __mmask64 m64[1];
+            } mask;
+            const __m512i v0 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 0)), shift);
+            const __m512i v1 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 1)), shift);
+            const __m512i v2 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 2)), shift);
+            const __m512i v3 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 3)), shift);
+            mask.m16[0] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v0, Load<bufAlign>((__m512i*)area + 0)), Load<bufAlign>((__m512i*)sum + 0));
+            mask.m16[1] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v1, Load<bufAlign>((__m512i*)area + 1)), Load<bufAlign>((__m512i*)sum + 1));
+            mask.m16[2] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v2, Load<bufAlign>((__m512i*)area + 2)), Load<bufAlign>((__m512i*)sum + 2));
+            mask.m16[3] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v3, Load<bufAlign>((__m512i*)area + 3)), Load<bufAlign>((__m512i*)sum + 3));
+            return mask.m64[0];
+        }
+
+        template <bool align> void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > neighborhood && height > neighborhood && width >= A);
+            if (align)
+                assert(Aligned(src) && Aligned(srcStride) && Aligned(dst) && Aligned(dstStride));
+
+            const size_t alignedWidth = AlignLo(width, A);
+            const __m512i tailValueMask = SetMask<uint8_t>(0, A - width + alignedWidth, 0xFF);
+            const __m512i tailCountMask = SetMask<uint8_t>(0, A - width + alignedWidth, 1);
+            const __m512i _positive = _mm512_set1_epi8(positive);
+            const __m512i _negative = _mm512_set1_epi8(negative);
+            const __m512i _shift = _mm512_set1_epi32(shift);
+
+            BufferV2 buffer(width, neighborhood + 1);
+
+            for (size_t row = 0; row < neighborhood; ++row)
+            {
+                const uint8_t* ps = src + row * srcStride;
+                for (size_t col = 0; col < alignedWidth; col += A)
+                    AddRow<align, true>(ps + col, buffer.rs + col, buffer.ra + col, K_INV_ZERO, K8_01);
+                if (alignedWidth != width)
+                    AddRow<false, false>(ps + width - A, buffer.rs + width - A, buffer.ra + width - A, tailValueMask, tailCountMask);
+            }
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                if (row < height - neighborhood)
+                {
+                    const uint8_t* ps = src + (row + neighborhood) * srcStride;
+                    for (size_t col = 0; col < alignedWidth; col += A)
+                        AddRow<align, true>(ps + col, buffer.rs + col, buffer.ra + col, K_INV_ZERO, K8_01);
+                    if (alignedWidth != width)
+                        AddRow<false, false>(ps + width - A, buffer.rs + width - A, buffer.ra + width - A, tailValueMask, tailCountMask);
+                }
+
+                if (row > neighborhood)
+                {
+                    const uint8_t* ps = src + (row - neighborhood - 1) * srcStride;
+                    for (size_t col = 0; col < alignedWidth; col += A)
+                        SubRow<align, true>(ps + col, buffer.rs + col, buffer.ra + col, K_INV_ZERO, K8_01);
+                    if (alignedWidth != width)
+                        SubRow<false, false>(ps + width - A, buffer.rs + width - A, buffer.ra + width - A, tailValueMask, tailCountMask);
+                }
+
+                int32_t sum = 0, area = 0;
+                for (size_t col = 0; col < neighborhood; ++col)
+                {
+                    sum += buffer.rs[col];
+                    area += buffer.ra[col];
+                }
+                const uint8_t* ps = src + row * srcStride;
+                for (size_t col = 0; col < width; ++col)
+                {
+                    sum += buffer.rs[col + neighborhood] - buffer.rs[col - neighborhood - 1];
+                    area += buffer.ra[col + neighborhood] - buffer.ra[col - neighborhood - 1];
+                    buffer.sum[col] = sum;
+                    buffer.area[col] = area;
+                }
+
+                for (size_t col = 0; col < alignedWidth; col += A)
+                {
+                    __mmask64 mask = CompareV2<align, true>(ps + col, buffer.sum + col, buffer.area + col, _shift);
+                    Store<align>((__m512i*)(dst + col), _mm512_mask_blend_epi8(mask, _negative, _positive));
+                }
+                if (alignedWidth != width)
+                {
+                    __mmask64 mask = CompareV2<false, false>(ps + width - A, buffer.sum + width - A, buffer.area + width - A, _shift);
+                    Store<false>((__m512i*)(dst + width - A), _mm512_mask_blend_epi8(mask, _negative, _positive));
+                }
+                dst += dstStride;
+            }
+        }
+
+        void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
+        {
+            if (Aligned(src) && Aligned(srcStride) && Aligned(dst) && Aligned(dstStride))
+                AveragingBinarizationV2<true>(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+            else
+                AveragingBinarizationV2<false>(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+        }
     }
 #endif// SIMD_AVX512BW_ENABLE
 }

--- a/src/Simd/SimdAvx512bwBinarization.cpp
+++ b/src/Simd/SimdAvx512bwBinarization.cpp
@@ -359,10 +359,10 @@ namespace Simd
                 __mmask16 m16[4];
                 __mmask64 m64[1];
             } mask;
-            const __m512i v0 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 0)), shift);
-            const __m512i v1 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 1)), shift);
-            const __m512i v2 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 2)), shift);
-            const __m512i v3 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Load<srcAlign>((__m128i*)src + 3)), shift);
+            const __m512i v0 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Sse41::Load<srcAlign>((__m128i*)src + 0)), shift);
+            const __m512i v1 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Sse41::Load<srcAlign>((__m128i*)src + 1)), shift);
+            const __m512i v2 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Sse41::Load<srcAlign>((__m128i*)src + 2)), shift);
+            const __m512i v3 = _mm512_add_epi32(_mm512_cvtepu8_epi32(Sse41::Load<srcAlign>((__m128i*)src + 3)), shift);
             mask.m16[0] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v0, Load<bufAlign>((__m512i*)area + 0)), Load<bufAlign>((__m512i*)sum + 0));
             mask.m16[1] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v1, Load<bufAlign>((__m512i*)area + 1)), Load<bufAlign>((__m512i*)sum + 1));
             mask.m16[2] = _mm512_cmpgt_epi32_mask(_mm512_mullo_epi32(v2, Load<bufAlign>((__m512i*)area + 2)), Load<bufAlign>((__m512i*)sum + 2));
@@ -378,8 +378,10 @@ namespace Simd
                 assert(Aligned(src) && Aligned(srcStride) && Aligned(dst) && Aligned(dstStride));
 
             const size_t alignedWidth = AlignLo(width, A);
-            const __m512i tailValueMask = SetMask<uint8_t>(0, A - width + alignedWidth, 0xFF);
-            const __m512i tailCountMask = SetMask<uint8_t>(0, A - width + alignedWidth, 1);
+            const size_t tail = width - alignedWidth;
+            const __mmask64 tailMask = tail ? TailMask64(tail) << (A - tail) : 0;
+            const __m512i tailValueMask = _mm512_mask_blend_epi8(tailMask, K_ZERO, K_INV_ZERO);
+            const __m512i tailCountMask = _mm512_mask_blend_epi8(tailMask, K_ZERO, K8_01);
             const __m512i _positive = _mm512_set1_epi8(positive);
             const __m512i _negative = _mm512_set1_epi8(negative);
             const __m512i _shift = _mm512_set1_epi32(shift);

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1849,6 +1849,11 @@ SIMD_API void SimdAveragingBinarizationV2(const uint8_t* src, size_t srcStride, 
     size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
 {
     SIMD_EMPTY();
+#ifdef SIMD_AVX512BW_ENABLE
+    if (Avx512bw::Enable && width >= Avx512bw::A)
+        Avx512bw::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_AVX2_ENABLE
     if(Avx2::Enable && width >= Avx2::A)
         Avx2::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);

--- a/src/Test/TestBinarization.cpp
+++ b/src/Test/TestBinarization.cpp
@@ -303,6 +303,11 @@ namespace Test
             result = result && AveragingBinarizationV2AutoTest(FUNC_AB2(Simd::Avx2::AveragingBinarizationV2), FUNC_AB2(SimdAveragingBinarizationV2));
 #endif
 
+#ifdef SIMD_AVX512BW_ENABLE
+        if (Simd::Avx512bw::Enable && TestAvx512bw(options) && W >= Simd::Avx512bw::A)
+            result = result && AveragingBinarizationV2AutoTest(FUNC_AB2(Simd::Avx512bw::AveragingBinarizationV2), FUNC_AB2(SimdAveragingBinarizationV2));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add AVX-512BW implementation and dispatch for `SimdAveragingBinarizationV2`.
- Add AVX-512BW coverage to `AveragingBinarizationV2AutoTest`.
- Update VS2022 Avx512bw project metadata and 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AveragingBinarizationV2 -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3eb5343-4eac-409c-91cf-1b8076f5cca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3eb5343-4eac-409c-91cf-1b8076f5cca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

