### PR TITLE
validate output size in png convert_format16

### DIFF
--- a/src/Simd/SimdSse41ImageLoadPng.cpp
+++ b/src/Simd/SimdSse41ImageLoadPng.cpp
@@ -337,7 +337,7 @@ namespace Simd
             if (req_comp == img_n) return data;
             PNG_ASSERT(req_comp >= 1 && req_comp <= 4);
 
-            good = (png__uint16*)png__malloc(req_comp * x * y * 2);
+            good = (png__uint16*)png__malloc_mad4(req_comp, x, y, 2, 0);
             if (good == NULL) {
                 PNG_FREE(data);
                 return (png__uint16*)png__errpuc("outofmem", "Out of memory");


### PR DESCRIPTION
The PNG loader always asks the stb-derived decoder for four output components, so a 16-bit image whose stored colour type has fewer channels (greyscale, greyscale+alpha or RGB) is routed through png__convert_format16 to be widened to RGBA. That function sizes its destination with a plain png__malloc(req_comp * x * y * 2), and since x and y are unsigned the expression is evaluated in 32-bit and quietly wraps once the pixel count passes 2^29; the IHDR sanity check only keeps x*y*img_n below 2^30, which leaves room for exactly that. The outcome is a short allocation followed by a full req_comp*x*y*2 write in the conversion loop, so a crafted 16-bit image can drive a heap overflow. I came across it because png__convert_format, the 8-bit twin a few lines above, already goes through the checked png__malloc_mad3 helper, and convert_format16 looked like the only allocation in the file still using the raw form. Routing it through the existing png__malloc_mad4(req_comp, x, y, 2, 0) keeps the result identical for well-formed images and otherwise falls into the out-of-memory path that is already handled just below. I have kept the change to that single call so nothing else shifts.