### PR TITLE
Add NEON AveragingBinarizationV2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -95,7 +95,7 @@
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundInitMask.</li>
- <li>SSE4.1, AVX2, AVX-512BW optimizations of function AveragingBinarizationV2.</li>
+ <li>SSE4.1, AVX2, AVX-512BW, NEON optimizations of function AveragingBinarizationV2.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>
@@ -125,6 +125,7 @@
  <li>Tests for verifying functionality of SSE4.1 optimizations of function AveragingBinarizationV2.</li>
  <li>Tests for verifying functionality of AVX2 optimizations of function AveragingBinarizationV2.</li>
  <li>Tests for verifying functionality of AVX-512BW optimizations of function AveragingBinarizationV2.</li>
+ <li>Tests for verifying functionality of NEON optimizations of function AveragingBinarizationV2.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1864,6 +1864,11 @@ SIMD_API void SimdAveragingBinarizationV2(const uint8_t* src, size_t srcStride, 
         Sse41::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
     else
 #endif
+#ifdef SIMD_NEON_ENABLE
+    if (Neon::Enable && width >= Neon::A)
+        Neon::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+    else
+#endif
         Base::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
 }
 

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -169,6 +169,9 @@ namespace Simd
             uint8_t value, size_t neighborhood, uint8_t threshold, uint8_t positive, uint8_t negative,
             uint8_t * dst, size_t dstStride, SimdCompareType compareType);
 
+        void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride);
+
         void ConditionalCount8u(const uint8_t * src, size_t stride, size_t width, size_t height,
             uint8_t value, SimdCompareType compareType, uint32_t * count);
 

--- a/src/Simd/SimdNeonBinarization.cpp
+++ b/src/Simd/SimdNeonBinarization.cpp
@@ -272,6 +272,180 @@ namespace Simd
                 assert(0);
             }
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        namespace
+        {
+            struct BufferV2
+            {
+                BufferV2(size_t width, size_t edge)
+                {
+                    _width = AlignHi(width, A);
+                    _edge = AlignHi(edge, A);
+                    _size = _width + 2 * _edge;
+                    size_t size = sizeof(int32_t) * (2 * _size + 2 * _width);
+                    _p = Allocate(size);
+                    memset(_p, 0, size);
+                    int32_t* data = (int32_t*)_p;
+                    rs = data + _edge;
+                    ra = data + _size + _edge;
+                    sum = data + 2 * _size;
+                    area = sum + _width;
+                }
+
+                ~BufferV2()
+                {
+                    Free(_p);
+                }
+
+                int32_t* rs;
+                int32_t* ra;
+                int32_t* sum;
+                int32_t* area;
+            private:
+                size_t _width;
+                size_t _edge;
+                size_t _size;
+                void* _p;
+            };
+        }
+
+        template <bool align> SIMD_INLINE void Add16i(const uint8x16_t& value, int32_t* dst)
+        {
+            const uint16x8_t lo = vmovl_u8(vget_low_u8(value));
+            const uint16x8_t hi = vmovl_u8(vget_high_u8(value));
+            Store<align>(dst + 0 * F, vaddq_s32(Load<align>(dst + 0 * F), vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(lo)))));
+            Store<align>(dst + 1 * F, vaddq_s32(Load<align>(dst + 1 * F), vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(lo)))));
+            Store<align>(dst + 2 * F, vaddq_s32(Load<align>(dst + 2 * F), vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(hi)))));
+            Store<align>(dst + 3 * F, vaddq_s32(Load<align>(dst + 3 * F), vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(hi)))));
+        }
+
+        template <bool align> SIMD_INLINE void Sub16i(const uint8x16_t& value, int32_t* dst)
+        {
+            const uint16x8_t lo = vmovl_u8(vget_low_u8(value));
+            const uint16x8_t hi = vmovl_u8(vget_high_u8(value));
+            Store<align>(dst + 0 * F, vsubq_s32(Load<align>(dst + 0 * F), vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(lo)))));
+            Store<align>(dst + 1 * F, vsubq_s32(Load<align>(dst + 1 * F), vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(lo)))));
+            Store<align>(dst + 2 * F, vsubq_s32(Load<align>(dst + 2 * F), vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(hi)))));
+            Store<align>(dst + 3 * F, vsubq_s32(Load<align>(dst + 3 * F), vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(hi)))));
+        }
+
+        template <bool srcAlign, bool dstAlign> SIMD_INLINE void AddRow(const uint8_t* src, int32_t* rs, int32_t* ra, const uint8x16_t& valueMask, const uint8x16_t& countMask)
+        {
+            Add16i<dstAlign>(vandq_u8(Load<srcAlign>(src), valueMask), rs);
+            Add16i<dstAlign>(countMask, ra);
+        }
+
+        template <bool srcAlign, bool dstAlign> SIMD_INLINE void SubRow(const uint8_t* src, int32_t* rs, int32_t* ra, const uint8x16_t& valueMask, const uint8x16_t& countMask)
+        {
+            Sub16i<dstAlign>(vandq_u8(Load<srcAlign>(src), valueMask), rs);
+            Sub16i<dstAlign>(countMask, ra);
+        }
+
+        SIMD_INLINE uint8x16_t PackMask(const uint32x4_t& m0, const uint32x4_t& m1, const uint32x4_t& m2, const uint32x4_t& m3)
+        {
+            return vcombine_u8(vmovn_u16(vcombine_u16(vmovn_u32(m0), vmovn_u32(m1))), vmovn_u16(vcombine_u16(vmovn_u32(m2), vmovn_u32(m3))));
+        }
+
+        template <bool srcAlign, bool bufAlign> SIMD_INLINE uint8x16_t Compare(const uint8_t* src, const int32_t* sum, const int32_t* area, const int32x4_t& shift)
+        {
+            const uint8x16_t s8 = Load<srcAlign>(src);
+            const uint16x8_t lo = vmovl_u8(vget_low_u8(s8));
+            const uint16x8_t hi = vmovl_u8(vget_high_u8(s8));
+            const int32x4_t v0 = vaddq_s32(vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(lo))), shift);
+            const int32x4_t v1 = vaddq_s32(vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(lo))), shift);
+            const int32x4_t v2 = vaddq_s32(vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(hi))), shift);
+            const int32x4_t v3 = vaddq_s32(vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(hi))), shift);
+            const uint32x4_t m0 = vcgtq_s32(vmulq_s32(v0, Load<bufAlign>(area + 0 * F)), Load<bufAlign>(sum + 0 * F));
+            const uint32x4_t m1 = vcgtq_s32(vmulq_s32(v1, Load<bufAlign>(area + 1 * F)), Load<bufAlign>(sum + 1 * F));
+            const uint32x4_t m2 = vcgtq_s32(vmulq_s32(v2, Load<bufAlign>(area + 2 * F)), Load<bufAlign>(sum + 2 * F));
+            const uint32x4_t m3 = vcgtq_s32(vmulq_s32(v3, Load<bufAlign>(area + 3 * F)), Load<bufAlign>(sum + 3 * F));
+            return PackMask(m0, m1, m2, m3);
+        }
+
+        template <bool align> void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > neighborhood && height > neighborhood && width >= A);
+            if (align)
+                assert(Aligned(src) && Aligned(srcStride) && Aligned(dst) && Aligned(dstStride));
+
+            const size_t alignedWidth = AlignLo(width, A);
+            const uint8x16_t tailValueMask = ShiftLeft(K8_FF, A - width + alignedWidth);
+            const uint8x16_t tailCountMask = ShiftLeft(K8_01, A - width + alignedWidth);
+            const uint8x16_t _positive = vdupq_n_u8(positive);
+            const uint8x16_t _negative = vdupq_n_u8(negative);
+            const int32x4_t _shift = vdupq_n_s32(shift);
+
+            BufferV2 buffer(width, neighborhood + 1);
+
+            for (size_t row = 0; row < neighborhood; ++row)
+            {
+                const uint8_t* ps = src + row * srcStride;
+                for (size_t col = 0; col < alignedWidth; col += A)
+                    AddRow<align, true>(ps + col, buffer.rs + col, buffer.ra + col, K8_FF, K8_01);
+                if (alignedWidth != width)
+                    AddRow<false, false>(ps + width - A, buffer.rs + width - A, buffer.ra + width - A, tailValueMask, tailCountMask);
+            }
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                if (row < height - neighborhood)
+                {
+                    const uint8_t* ps = src + (row + neighborhood) * srcStride;
+                    for (size_t col = 0; col < alignedWidth; col += A)
+                        AddRow<align, true>(ps + col, buffer.rs + col, buffer.ra + col, K8_FF, K8_01);
+                    if (alignedWidth != width)
+                        AddRow<false, false>(ps + width - A, buffer.rs + width - A, buffer.ra + width - A, tailValueMask, tailCountMask);
+                }
+
+                if (row > neighborhood)
+                {
+                    const uint8_t* ps = src + (row - neighborhood - 1) * srcStride;
+                    for (size_t col = 0; col < alignedWidth; col += A)
+                        SubRow<align, true>(ps + col, buffer.rs + col, buffer.ra + col, K8_FF, K8_01);
+                    if (alignedWidth != width)
+                        SubRow<false, false>(ps + width - A, buffer.rs + width - A, buffer.ra + width - A, tailValueMask, tailCountMask);
+                }
+
+                int32_t sum = 0, area = 0;
+                for (size_t col = 0; col < neighborhood; ++col)
+                {
+                    sum += buffer.rs[col];
+                    area += buffer.ra[col];
+                }
+                const uint8_t* ps = src + row * srcStride;
+                for (size_t col = 0; col < width; ++col)
+                {
+                    sum += buffer.rs[col + neighborhood] - buffer.rs[col - neighborhood - 1];
+                    area += buffer.ra[col + neighborhood] - buffer.ra[col - neighborhood - 1];
+                    buffer.sum[col] = sum;
+                    buffer.area[col] = area;
+                }
+
+                for (size_t col = 0; col < alignedWidth; col += A)
+                {
+                    const uint8x16_t mask = Compare<align, true>(ps + col, buffer.sum + col, buffer.area + col, _shift);
+                    Store<align>(dst + col, vbslq_u8(mask, _positive, _negative));
+                }
+                if (alignedWidth != width)
+                {
+                    const uint8x16_t mask = Compare<false, false>(ps + width - A, buffer.sum + width - A, buffer.area + width - A, _shift);
+                    Store<false>(dst + width - A, vbslq_u8(mask, _positive, _negative));
+                }
+                dst += dstStride;
+            }
+        }
+
+        void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
+        {
+            if (Aligned(src) && Aligned(srcStride) && Aligned(dst) && Aligned(dstStride))
+                AveragingBinarizationV2<true>(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+            else
+                AveragingBinarizationV2<false>(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+        }
     }
 #endif// SIMD_NEON_ENABLE
 }

--- a/src/Test/TestBinarization.cpp
+++ b/src/Test/TestBinarization.cpp
@@ -308,6 +308,11 @@ namespace Test
             result = result && AveragingBinarizationV2AutoTest(FUNC_AB2(Simd::Avx512bw::AveragingBinarizationV2), FUNC_AB2(SimdAveragingBinarizationV2));
 #endif
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
+            result = result && AveragingBinarizationV2AutoTest(FUNC_AB2(Simd::Neon::AveragingBinarizationV2), FUNC_AB2(SimdAveragingBinarizationV2));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add NEON implementation and dispatch for `SimdAveragingBinarizationV2`.
- Add NEON coverage to `AveragingBinarizationV2AutoTest`.
- Update 7.2.163 release notes for the new NEON optimization and tests.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=AveragingBinarizationV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -I src -c src/Simd/SimdNeonBinarization.cpp -o build/cross-check/SimdNeonBinarization.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -I src -c src/Simd/SimdLib.cpp -o build/cross-check/SimdLib.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -I src -c src/Test/TestBinarization.cpp -o build/cross-check/TestBinarization.o`
- ARM64 CMake/qemu validation: built `Test` with `aarch64-linux-gnu-g++`, patched generated cross-build `-mtune=native` to `-mtune=generic`, then ran `qemu-aarch64 -L /usr/aarch64-linux-gnu ./build-aarch64-cross/Test "-r=." -fi=AveragingBinarizationV2 -tt=1 -ts=1`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98f4bfc2-4b78-4375-a423-0a550ef7d2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98f4bfc2-4b78-4375-a423-0a550ef7d2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

