### PR TITLE
Add SVE2 AveragingBinarizationV2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -95,7 +95,7 @@
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundInitMask.</li>
- <li>SSE4.1, AVX2, AVX-512BW optimizations of function AveragingBinarizationV2.</li>
+ <li>SSE4.1, AVX2, AVX-512BW, SVE2 optimizations of function AveragingBinarizationV2.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>
@@ -125,6 +125,7 @@
  <li>Tests for verifying functionality of SSE4.1 optimizations of function AveragingBinarizationV2.</li>
  <li>Tests for verifying functionality of AVX2 optimizations of function AveragingBinarizationV2.</li>
  <li>Tests for verifying functionality of AVX-512BW optimizations of function AveragingBinarizationV2.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function AveragingBinarizationV2.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Base64.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Binarization.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="Sve2\Image">
       <UniqueIdentifier>{e24205a3-f4dd-4503-93e8-8f630c4c81b0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sve2\Filter">
+      <UniqueIdentifier>{f2222fb7-bc55-4b81-98be-b2e725a3418b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdSve2.h">
@@ -154,6 +157,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp">
       <Filter>Sve2\Convert</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Binarization.cpp">
+      <Filter>Sve2\Filter</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp">
       <Filter>Sve2\Convert</Filter>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1864,6 +1864,11 @@ SIMD_API void SimdAveragingBinarizationV2(const uint8_t* src, size_t srcStride, 
         Sse41::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+    else
+#endif
         Base::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
 }
 

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1851,28 +1851,40 @@ SIMD_API void SimdAveragingBinarizationV2(const uint8_t* src, size_t srcStride, 
     SIMD_EMPTY();
 #ifdef SIMD_AVX512BW_ENABLE
     if (Avx512bw::Enable && width >= Avx512bw::A)
+    {
         Avx512bw::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
-    else
+        return;
+    }
 #endif
 #ifdef SIMD_AVX2_ENABLE
     if(Avx2::Enable && width >= Avx2::A)
+    {
         Avx2::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
-    else
+        return;
+    }
 #endif
 #ifdef SIMD_SSE41_ENABLE
     if(Sse41::Enable && width >= Sse41::A)
+    {
         Sse41::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
-    else
+        return;
+    }
 #endif
 #ifdef SIMD_SVE2_ENABLE
     if (Sve2::Enable)
+    {
         Sve2::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+        return;
+    }
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
+    {
         Neon::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
-    else
+        return;
+    }
 #endif
-        Base::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
+    Base::AveragingBinarizationV2(src, srcStride, width, height, neighborhood, shift, positive, negative, dst, dstStride);
 }
 
 SIMD_API void SimdConditionalCount8u(const uint8_t * src, size_t stride, size_t width, size_t height,

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -57,6 +57,9 @@ namespace Simd
         void AlphaUnpremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             uint8_t* dst, size_t dstStride, SimdBool argb);
 
+        void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride);
+
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2Binarization.cpp
+++ b/src/Simd/SimdSve2Binarization.cpp
@@ -22,7 +22,6 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
-#include "Simd/SimdPack.h"
 
 namespace Simd
 {
@@ -65,75 +64,58 @@ namespace Simd
             };
         }
 
-        SIMD_INLINE void Add16i(const svuint8_t& value, int32_t* dst, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
-        {
-            const svuint16_t lo = svunpklo_u16(value);
-            const svuint16_t hi = svunpkhi_u16(value);
-            const size_t F = svcntw();
-            svst1_s32(mask0, dst + 0 * F, svadd_s32_x(mask0, svld1_s32(mask0, dst + 0 * F), svreinterpret_s32_u32(svunpklo_u32(lo))));
-            svst1_s32(mask1, dst + 1 * F, svadd_s32_x(mask1, svld1_s32(mask1, dst + 1 * F), svreinterpret_s32_u32(svunpkhi_u32(lo))));
-            svst1_s32(mask2, dst + 2 * F, svadd_s32_x(mask2, svld1_s32(mask2, dst + 2 * F), svreinterpret_s32_u32(svunpklo_u32(hi))));
-            svst1_s32(mask3, dst + 3 * F, svadd_s32_x(mask3, svld1_s32(mask3, dst + 3 * F), svreinterpret_s32_u32(svunpkhi_u32(hi))));
-        }
-
-        SIMD_INLINE void Sub16i(const svuint8_t& value, int32_t* dst, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
-        {
-            const svuint16_t lo = svunpklo_u16(value);
-            const svuint16_t hi = svunpkhi_u16(value);
-            const size_t F = svcntw();
-            svst1_s32(mask0, dst + 0 * F, svsub_s32_x(mask0, svld1_s32(mask0, dst + 0 * F), svreinterpret_s32_u32(svunpklo_u32(lo))));
-            svst1_s32(mask1, dst + 1 * F, svsub_s32_x(mask1, svld1_s32(mask1, dst + 1 * F), svreinterpret_s32_u32(svunpkhi_u32(lo))));
-            svst1_s32(mask2, dst + 2 * F, svsub_s32_x(mask2, svld1_s32(mask2, dst + 2 * F), svreinterpret_s32_u32(svunpklo_u32(hi))));
-            svst1_s32(mask3, dst + 3 * F, svsub_s32_x(mask3, svld1_s32(mask3, dst + 3 * F), svreinterpret_s32_u32(svunpkhi_u32(hi))));
-        }
-
-        SIMD_INLINE void SetMasks(size_t col, size_t width, svbool_t& mask8, svbool_t& mask0, svbool_t& mask1, svbool_t& mask2, svbool_t& mask3)
+        SIMD_INLINE void SetMasks(size_t col, size_t width, svbool_t& mask0, svbool_t& mask1, svbool_t& mask2, svbool_t& mask3)
         {
             const size_t F = svcntw();
-            mask8 = svwhilelt_b8(col, width);
             mask0 = svwhilelt_b32(col + 0 * F, width);
             mask1 = svwhilelt_b32(col + 1 * F, width);
             mask2 = svwhilelt_b32(col + 2 * F, width);
             mask3 = svwhilelt_b32(col + 3 * F, width);
         }
 
-        SIMD_INLINE void AddRow(const uint8_t* src, int32_t* rs, int32_t* ra, const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        SIMD_INLINE void AddRow(const uint8_t* src, int32_t* rs, int32_t* ra, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
         {
-            Add16i(svld1_u8(mask8, src), rs, mask0, mask1, mask2, mask3);
-            Add16i(svdup_n_u8_z(mask8, 1), ra, mask0, mask1, mask2, mask3);
-        }
-
-        SIMD_INLINE void SubRow(const uint8_t* src, int32_t* rs, int32_t* ra, const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
-        {
-            Sub16i(svld1_u8(mask8, src), rs, mask0, mask1, mask2, mask3);
-            Sub16i(svdup_n_u8_z(mask8, 1), ra, mask0, mask1, mask2, mask3);
-        }
-
-        SIMD_INLINE svuint8_t PackMask(const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
-        {
-            const svint32_t negative = svdup_n_s32(-1);
-            const svint32_t zero = svdup_n_s32(0);
-            const svint16_t lo = PackSatIntI32ToI16(svsel_s32(mask0, negative, zero), svsel_s32(mask1, negative, zero));
-            const svint16_t hi = PackSatIntI32ToI16(svsel_s32(mask2, negative, zero), svsel_s32(mask3, negative, zero));
-            return PackSeqI16ToU8(lo, hi);
-        }
-
-        SIMD_INLINE svuint8_t Compare(const uint8_t* src, const int32_t* sum, const int32_t* area, const svint32_t& shift,
-            const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
-        {
-            const svuint8_t s8 = svld1_u8(mask8, src);
-            const svuint16_t lo = svunpklo_u16(s8);
-            const svuint16_t hi = svunpkhi_u16(s8);
             const size_t F = svcntw();
-            const svint32_t v0 = svadd_s32_x(mask0, svreinterpret_s32_u32(svunpklo_u32(lo)), shift);
-            const svint32_t v1 = svadd_s32_x(mask1, svreinterpret_s32_u32(svunpkhi_u32(lo)), shift);
-            const svint32_t v2 = svadd_s32_x(mask2, svreinterpret_s32_u32(svunpklo_u32(hi)), shift);
-            const svint32_t v3 = svadd_s32_x(mask3, svreinterpret_s32_u32(svunpkhi_u32(hi)), shift);
+            svst1_s32(mask0, rs + 0 * F, svadd_s32_x(mask0, svld1_s32(mask0, rs + 0 * F), svld1ub_s32(mask0, src + 0 * F)));
+            svst1_s32(mask1, rs + 1 * F, svadd_s32_x(mask1, svld1_s32(mask1, rs + 1 * F), svld1ub_s32(mask1, src + 1 * F)));
+            svst1_s32(mask2, rs + 2 * F, svadd_s32_x(mask2, svld1_s32(mask2, rs + 2 * F), svld1ub_s32(mask2, src + 2 * F)));
+            svst1_s32(mask3, rs + 3 * F, svadd_s32_x(mask3, svld1_s32(mask3, rs + 3 * F), svld1ub_s32(mask3, src + 3 * F)));
+            svst1_s32(mask0, ra + 0 * F, svadd_n_s32_x(mask0, svld1_s32(mask0, ra + 0 * F), 1));
+            svst1_s32(mask1, ra + 1 * F, svadd_n_s32_x(mask1, svld1_s32(mask1, ra + 1 * F), 1));
+            svst1_s32(mask2, ra + 2 * F, svadd_n_s32_x(mask2, svld1_s32(mask2, ra + 2 * F), 1));
+            svst1_s32(mask3, ra + 3 * F, svadd_n_s32_x(mask3, svld1_s32(mask3, ra + 3 * F), 1));
+        }
+
+        SIMD_INLINE void SubRow(const uint8_t* src, int32_t* rs, int32_t* ra, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            const size_t F = svcntw();
+            svst1_s32(mask0, rs + 0 * F, svsub_s32_x(mask0, svld1_s32(mask0, rs + 0 * F), svld1ub_s32(mask0, src + 0 * F)));
+            svst1_s32(mask1, rs + 1 * F, svsub_s32_x(mask1, svld1_s32(mask1, rs + 1 * F), svld1ub_s32(mask1, src + 1 * F)));
+            svst1_s32(mask2, rs + 2 * F, svsub_s32_x(mask2, svld1_s32(mask2, rs + 2 * F), svld1ub_s32(mask2, src + 2 * F)));
+            svst1_s32(mask3, rs + 3 * F, svsub_s32_x(mask3, svld1_s32(mask3, rs + 3 * F), svld1ub_s32(mask3, src + 3 * F)));
+            svst1_s32(mask0, ra + 0 * F, svsub_n_s32_x(mask0, svld1_s32(mask0, ra + 0 * F), 1));
+            svst1_s32(mask1, ra + 1 * F, svsub_n_s32_x(mask1, svld1_s32(mask1, ra + 1 * F), 1));
+            svst1_s32(mask2, ra + 2 * F, svsub_n_s32_x(mask2, svld1_s32(mask2, ra + 2 * F), 1));
+            svst1_s32(mask3, ra + 3 * F, svsub_n_s32_x(mask3, svld1_s32(mask3, ra + 3 * F), 1));
+        }
+
+        SIMD_INLINE void Compare(const uint8_t* src, const int32_t* sum, const int32_t* area, const svint32_t& shift,
+            const svuint32_t& positive, const svuint32_t& negative, uint8_t* dst,
+            const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            const size_t F = svcntw();
+            const svint32_t v0 = svadd_s32_x(mask0, svld1ub_s32(mask0, src + 0 * F), shift);
+            const svint32_t v1 = svadd_s32_x(mask1, svld1ub_s32(mask1, src + 1 * F), shift);
+            const svint32_t v2 = svadd_s32_x(mask2, svld1ub_s32(mask2, src + 2 * F), shift);
+            const svint32_t v3 = svadd_s32_x(mask3, svld1ub_s32(mask3, src + 3 * F), shift);
             const svbool_t compare0 = svcmpgt_s32(mask0, svmul_s32_x(mask0, v0, svld1_s32(mask0, area + 0 * F)), svld1_s32(mask0, sum + 0 * F));
             const svbool_t compare1 = svcmpgt_s32(mask1, svmul_s32_x(mask1, v1, svld1_s32(mask1, area + 1 * F)), svld1_s32(mask1, sum + 1 * F));
             const svbool_t compare2 = svcmpgt_s32(mask2, svmul_s32_x(mask2, v2, svld1_s32(mask2, area + 2 * F)), svld1_s32(mask2, sum + 2 * F));
             const svbool_t compare3 = svcmpgt_s32(mask3, svmul_s32_x(mask3, v3, svld1_s32(mask3, area + 3 * F)), svld1_s32(mask3, sum + 3 * F));
-            return PackMask(compare0, compare1, compare2, compare3);
+            svst1b_u32(mask0, dst + 0 * F, svsel_u32(compare0, positive, negative));
+            svst1b_u32(mask1, dst + 1 * F, svsel_u32(compare1, positive, negative));
+            svst1b_u32(mask2, dst + 2 * F, svsel_u32(compare2, positive, negative));
+            svst1b_u32(mask3, dst + 3 * F, svsel_u32(compare3, positive, negative));
         }
 
         void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
@@ -143,10 +125,9 @@ namespace Simd
 
             const size_t A = svcntb();
             const size_t alignedWidth = AlignLo(width, A);
-            const svbool_t body8 = svptrue_b8();
             const svbool_t body0 = svptrue_b32(), body1 = svptrue_b32(), body2 = svptrue_b32(), body3 = svptrue_b32();
-            const svuint8_t _positive = svdup_n_u8(positive);
-            const svuint8_t _negative = svdup_n_u8(negative);
+            const svuint32_t _positive = svdup_n_u32(positive);
+            const svuint32_t _negative = svdup_n_u32(negative);
             const svint32_t _shift = svdup_n_s32(shift);
 
             BufferV2 buffer(width, neighborhood + 1, A);
@@ -155,12 +136,12 @@ namespace Simd
             {
                 const uint8_t* ps = src + row * srcStride;
                 for (size_t col = 0; col < alignedWidth; col += A)
-                    AddRow(ps + col, buffer.rs + col, buffer.ra + col, body8, body0, body1, body2, body3);
+                    AddRow(ps + col, buffer.rs + col, buffer.ra + col, body0, body1, body2, body3);
                 if (alignedWidth != width)
                 {
-                    svbool_t tail8, tail0, tail1, tail2, tail3;
-                    SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
-                    AddRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail8, tail0, tail1, tail2, tail3);
+                    svbool_t tail0, tail1, tail2, tail3;
+                    SetMasks(alignedWidth, width, tail0, tail1, tail2, tail3);
+                    AddRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail0, tail1, tail2, tail3);
                 }
             }
 
@@ -170,12 +151,12 @@ namespace Simd
                 {
                     const uint8_t* ps = src + (row + neighborhood) * srcStride;
                     for (size_t col = 0; col < alignedWidth; col += A)
-                        AddRow(ps + col, buffer.rs + col, buffer.ra + col, body8, body0, body1, body2, body3);
+                        AddRow(ps + col, buffer.rs + col, buffer.ra + col, body0, body1, body2, body3);
                     if (alignedWidth != width)
                     {
-                        svbool_t tail8, tail0, tail1, tail2, tail3;
-                        SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
-                        AddRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail8, tail0, tail1, tail2, tail3);
+                        svbool_t tail0, tail1, tail2, tail3;
+                        SetMasks(alignedWidth, width, tail0, tail1, tail2, tail3);
+                        AddRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail0, tail1, tail2, tail3);
                     }
                 }
 
@@ -183,12 +164,12 @@ namespace Simd
                 {
                     const uint8_t* ps = src + (row - neighborhood - 1) * srcStride;
                     for (size_t col = 0; col < alignedWidth; col += A)
-                        SubRow(ps + col, buffer.rs + col, buffer.ra + col, body8, body0, body1, body2, body3);
+                        SubRow(ps + col, buffer.rs + col, buffer.ra + col, body0, body1, body2, body3);
                     if (alignedWidth != width)
                     {
-                        svbool_t tail8, tail0, tail1, tail2, tail3;
-                        SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
-                        SubRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail8, tail0, tail1, tail2, tail3);
+                        svbool_t tail0, tail1, tail2, tail3;
+                        SetMasks(alignedWidth, width, tail0, tail1, tail2, tail3);
+                        SubRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail0, tail1, tail2, tail3);
                     }
                 }
 
@@ -208,16 +189,12 @@ namespace Simd
                 }
 
                 for (size_t col = 0; col < alignedWidth; col += A)
-                {
-                    const svuint8_t mask = Compare(ps + col, buffer.sum + col, buffer.area + col, _shift, body8, body0, body1, body2, body3);
-                    svst1_u8(body8, dst + col, svsel_u8(svcmpne_n_u8(body8, mask, 0), _positive, _negative));
-                }
+                    Compare(ps + col, buffer.sum + col, buffer.area + col, _shift, _positive, _negative, dst + col, body0, body1, body2, body3);
                 if (alignedWidth != width)
                 {
-                    svbool_t tail8, tail0, tail1, tail2, tail3;
-                    SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
-                    const svuint8_t mask = Compare(ps + alignedWidth, buffer.sum + alignedWidth, buffer.area + alignedWidth, _shift, tail8, tail0, tail1, tail2, tail3);
-                    svst1_u8(tail8, dst + alignedWidth, svsel_u8(svcmpne_n_u8(tail8, mask, 0), _positive, _negative));
+                    svbool_t tail0, tail1, tail2, tail3;
+                    SetMasks(alignedWidth, width, tail0, tail1, tail2, tail3);
+                    Compare(ps + alignedWidth, buffer.sum + alignedWidth, buffer.area + alignedWidth, _shift, _positive, _negative, dst + alignedWidth, tail0, tail1, tail2, tail3);
                 }
                 dst += dstStride;
             }

--- a/src/Simd/SimdSve2Binarization.cpp
+++ b/src/Simd/SimdSve2Binarization.cpp
@@ -1,0 +1,227 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdPack.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        namespace
+        {
+            struct BufferV2
+            {
+                BufferV2(size_t width, size_t edge, size_t A)
+                {
+                    _width = AlignHi(width, A);
+                    _edge = AlignHi(edge, A);
+                    _size = _width + 2 * _edge;
+                    size_t size = sizeof(int32_t) * (2 * _size + 2 * _width);
+                    _p = Allocate(size);
+                    memset(_p, 0, size);
+                    int32_t* data = (int32_t*)_p;
+                    rs = data + _edge;
+                    ra = data + _size + _edge;
+                    sum = data + 2 * _size;
+                    area = sum + _width;
+                }
+
+                ~BufferV2()
+                {
+                    Free(_p);
+                }
+
+                int32_t* rs;
+                int32_t* ra;
+                int32_t* sum;
+                int32_t* area;
+            private:
+                size_t _width;
+                size_t _edge;
+                size_t _size;
+                void* _p;
+            };
+        }
+
+        SIMD_INLINE void Add16i(const svuint8_t& value, int32_t* dst, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            const svuint16_t lo = svunpklo_u16(value);
+            const svuint16_t hi = svunpkhi_u16(value);
+            const size_t F = svcntw();
+            svst1_s32(mask0, dst + 0 * F, svadd_s32_x(mask0, svld1_s32(mask0, dst + 0 * F), svreinterpret_s32_u32(svunpklo_u32(lo))));
+            svst1_s32(mask1, dst + 1 * F, svadd_s32_x(mask1, svld1_s32(mask1, dst + 1 * F), svreinterpret_s32_u32(svunpkhi_u32(lo))));
+            svst1_s32(mask2, dst + 2 * F, svadd_s32_x(mask2, svld1_s32(mask2, dst + 2 * F), svreinterpret_s32_u32(svunpklo_u32(hi))));
+            svst1_s32(mask3, dst + 3 * F, svadd_s32_x(mask3, svld1_s32(mask3, dst + 3 * F), svreinterpret_s32_u32(svunpkhi_u32(hi))));
+        }
+
+        SIMD_INLINE void Sub16i(const svuint8_t& value, int32_t* dst, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            const svuint16_t lo = svunpklo_u16(value);
+            const svuint16_t hi = svunpkhi_u16(value);
+            const size_t F = svcntw();
+            svst1_s32(mask0, dst + 0 * F, svsub_s32_x(mask0, svld1_s32(mask0, dst + 0 * F), svreinterpret_s32_u32(svunpklo_u32(lo))));
+            svst1_s32(mask1, dst + 1 * F, svsub_s32_x(mask1, svld1_s32(mask1, dst + 1 * F), svreinterpret_s32_u32(svunpkhi_u32(lo))));
+            svst1_s32(mask2, dst + 2 * F, svsub_s32_x(mask2, svld1_s32(mask2, dst + 2 * F), svreinterpret_s32_u32(svunpklo_u32(hi))));
+            svst1_s32(mask3, dst + 3 * F, svsub_s32_x(mask3, svld1_s32(mask3, dst + 3 * F), svreinterpret_s32_u32(svunpkhi_u32(hi))));
+        }
+
+        SIMD_INLINE void SetMasks(size_t col, size_t width, svbool_t& mask8, svbool_t& mask0, svbool_t& mask1, svbool_t& mask2, svbool_t& mask3)
+        {
+            const size_t F = svcntw();
+            mask8 = svwhilelt_b8(col, width);
+            mask0 = svwhilelt_b32(col + 0 * F, width);
+            mask1 = svwhilelt_b32(col + 1 * F, width);
+            mask2 = svwhilelt_b32(col + 2 * F, width);
+            mask3 = svwhilelt_b32(col + 3 * F, width);
+        }
+
+        SIMD_INLINE void AddRow(const uint8_t* src, int32_t* rs, int32_t* ra, const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            Add16i(svld1_u8(mask8, src), rs, mask0, mask1, mask2, mask3);
+            Add16i(svdup_n_u8_z(mask8, 1), ra, mask0, mask1, mask2, mask3);
+        }
+
+        SIMD_INLINE void SubRow(const uint8_t* src, int32_t* rs, int32_t* ra, const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            Sub16i(svld1_u8(mask8, src), rs, mask0, mask1, mask2, mask3);
+            Sub16i(svdup_n_u8_z(mask8, 1), ra, mask0, mask1, mask2, mask3);
+        }
+
+        SIMD_INLINE svuint8_t PackMask(const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            const svint32_t negative = svdup_n_s32(-1);
+            const svint32_t zero = svdup_n_s32(0);
+            const svint16_t lo = PackSatIntI32ToI16(svsel_s32(mask0, negative, zero), svsel_s32(mask1, negative, zero));
+            const svint16_t hi = PackSatIntI32ToI16(svsel_s32(mask2, negative, zero), svsel_s32(mask3, negative, zero));
+            return PackSeqI16ToU8(lo, hi);
+        }
+
+        SIMD_INLINE svuint8_t Compare(const uint8_t* src, const int32_t* sum, const int32_t* area, const svint32_t& shift,
+            const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            const svuint8_t s8 = svld1_u8(mask8, src);
+            const svuint16_t lo = svunpklo_u16(s8);
+            const svuint16_t hi = svunpkhi_u16(s8);
+            const size_t F = svcntw();
+            const svint32_t v0 = svadd_s32_x(mask0, svreinterpret_s32_u32(svunpklo_u32(lo)), shift);
+            const svint32_t v1 = svadd_s32_x(mask1, svreinterpret_s32_u32(svunpkhi_u32(lo)), shift);
+            const svint32_t v2 = svadd_s32_x(mask2, svreinterpret_s32_u32(svunpklo_u32(hi)), shift);
+            const svint32_t v3 = svadd_s32_x(mask3, svreinterpret_s32_u32(svunpkhi_u32(hi)), shift);
+            const svbool_t compare0 = svcmpgt_s32(mask0, svmul_s32_x(mask0, v0, svld1_s32(mask0, area + 0 * F)), svld1_s32(mask0, sum + 0 * F));
+            const svbool_t compare1 = svcmpgt_s32(mask1, svmul_s32_x(mask1, v1, svld1_s32(mask1, area + 1 * F)), svld1_s32(mask1, sum + 1 * F));
+            const svbool_t compare2 = svcmpgt_s32(mask2, svmul_s32_x(mask2, v2, svld1_s32(mask2, area + 2 * F)), svld1_s32(mask2, sum + 2 * F));
+            const svbool_t compare3 = svcmpgt_s32(mask3, svmul_s32_x(mask3, v3, svld1_s32(mask3, area + 3 * F)), svld1_s32(mask3, sum + 3 * F));
+            return PackMask(compare0, compare1, compare2, compare3);
+        }
+
+        void AveragingBinarizationV2(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t neighborhood, int32_t shift, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > neighborhood && height > neighborhood);
+
+            const size_t A = svcntb();
+            const size_t alignedWidth = AlignLo(width, A);
+            const svbool_t body8 = svptrue_b8();
+            const svbool_t body0 = svptrue_b32(), body1 = svptrue_b32(), body2 = svptrue_b32(), body3 = svptrue_b32();
+            const svuint8_t _positive = svdup_n_u8(positive);
+            const svuint8_t _negative = svdup_n_u8(negative);
+            const svint32_t _shift = svdup_n_s32(shift);
+
+            BufferV2 buffer(width, neighborhood + 1, A);
+
+            for (size_t row = 0; row < neighborhood; ++row)
+            {
+                const uint8_t* ps = src + row * srcStride;
+                for (size_t col = 0; col < alignedWidth; col += A)
+                    AddRow(ps + col, buffer.rs + col, buffer.ra + col, body8, body0, body1, body2, body3);
+                if (alignedWidth != width)
+                {
+                    svbool_t tail8, tail0, tail1, tail2, tail3;
+                    SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
+                    AddRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail8, tail0, tail1, tail2, tail3);
+                }
+            }
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                if (row < height - neighborhood)
+                {
+                    const uint8_t* ps = src + (row + neighborhood) * srcStride;
+                    for (size_t col = 0; col < alignedWidth; col += A)
+                        AddRow(ps + col, buffer.rs + col, buffer.ra + col, body8, body0, body1, body2, body3);
+                    if (alignedWidth != width)
+                    {
+                        svbool_t tail8, tail0, tail1, tail2, tail3;
+                        SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
+                        AddRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail8, tail0, tail1, tail2, tail3);
+                    }
+                }
+
+                if (row > neighborhood)
+                {
+                    const uint8_t* ps = src + (row - neighborhood - 1) * srcStride;
+                    for (size_t col = 0; col < alignedWidth; col += A)
+                        SubRow(ps + col, buffer.rs + col, buffer.ra + col, body8, body0, body1, body2, body3);
+                    if (alignedWidth != width)
+                    {
+                        svbool_t tail8, tail0, tail1, tail2, tail3;
+                        SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
+                        SubRow(ps + alignedWidth, buffer.rs + alignedWidth, buffer.ra + alignedWidth, tail8, tail0, tail1, tail2, tail3);
+                    }
+                }
+
+                int32_t sum = 0, area = 0;
+                for (size_t col = 0; col < neighborhood; ++col)
+                {
+                    sum += buffer.rs[col];
+                    area += buffer.ra[col];
+                }
+                const uint8_t* ps = src + row * srcStride;
+                for (size_t col = 0; col < width; ++col)
+                {
+                    sum += buffer.rs[col + neighborhood] - buffer.rs[col - neighborhood - 1];
+                    area += buffer.ra[col + neighborhood] - buffer.ra[col - neighborhood - 1];
+                    buffer.sum[col] = sum;
+                    buffer.area[col] = area;
+                }
+
+                for (size_t col = 0; col < alignedWidth; col += A)
+                {
+                    const svuint8_t mask = Compare(ps + col, buffer.sum + col, buffer.area + col, _shift, body8, body0, body1, body2, body3);
+                    svst1_u8(body8, dst + col, svsel_u8(svcmpne_n_u8(body8, mask, 0), _positive, _negative));
+                }
+                if (alignedWidth != width)
+                {
+                    svbool_t tail8, tail0, tail1, tail2, tail3;
+                    SetMasks(alignedWidth, width, tail8, tail0, tail1, tail2, tail3);
+                    const svuint8_t mask = Compare(ps + alignedWidth, buffer.sum + alignedWidth, buffer.area + alignedWidth, _shift, tail8, tail0, tail1, tail2, tail3);
+                    svst1_u8(tail8, dst + alignedWidth, svsel_u8(svcmpne_n_u8(tail8, mask, 0), _positive, _negative));
+                }
+                dst += dstStride;
+            }
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Test/TestBinarization.cpp
+++ b/src/Test/TestBinarization.cpp
@@ -308,6 +308,11 @@ namespace Test
             result = result && AveragingBinarizationV2AutoTest(FUNC_AB2(Simd::Avx512bw::AveragingBinarizationV2), FUNC_AB2(SimdAveragingBinarizationV2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AveragingBinarizationV2AutoTest(FUNC_AB2(Simd::Sve2::AveragingBinarizationV2), FUNC_AB2(SimdAveragingBinarizationV2));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdAveragingBinarizationV2`.
- Add SVE2 coverage to `AveragingBinarizationV2AutoTest`.
- Add `SimdSve2Binarization.cpp` to VS2022 SVE2 project files and update 7.2.163 release notes.
- Rewrite the `SimdAveragingBinarizationV2` dispatcher in `SimdLib.cpp` to use explicit returns for AVX-512BW/AVX2/SSE4.1/SVE2/NEON paths, avoiding the fragile preprocessor `else` chain that failed CI.

### Testing
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Simd/SimdSve2Binarization.cpp -o build/cross-check/SimdSve2Binarization.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Simd/SimdLib.cpp -o build/cross-check/SimdLib-sve2.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -march=armv9-a+sve2 -msve-vector-bits=scalable -DSIMD_SVE_DISABLE -I src -c src/Simd/SimdLib.cpp -o build/cross-check/SimdLib-sve2-no-sve.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Test/TestBinarization.cpp -o build/cross-check/TestBinarization-sve2.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=AveragingBinarizationV2 -tt=1 -ts=1`
- `cmake ./prj/cmake -B build-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="aarch64-linux-gnu-g++" -DSIMD_TARGET="" -DSIMD_SHARED=OFF -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_AVX512VNNI=OFF -DSIMD_AMXBF16=OFF` plus generated cross-build `-mtune=native` patched to `-mtune=generic`, then `cmake --build build-sve2 --target Test --parallel$(nproc)`
- `QEMU_CPU=max qemu-aarch64 -L /usr/aarch64-linux-gnu ./build-sve2/Test "-r=." -fi=AveragingBinarizationV2 -tt=1 -ts=1`
- `QEMU_CPU=max,sve-max-vq=1 qemu-aarch64 -L /usr/aarch64-linux-gnu ./build-sve2/Test "-r=." -fi=AveragingBinarizationV2 -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98f4bfc2-4b78-4375-a423-0a550ef7d2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98f4bfc2-4b78-4375-a423-0a550ef7d2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

