### PR TITLE
Add SVE2 BFloat16ToFloat32 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
+ <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Base64.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BayerToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Binarization.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2BFloat16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBayer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToGray.cpp" />
@@ -51,6 +52,7 @@
     <ClInclude Include="..\..\src\Simd\SimdBase.h" />
     <ClInclude Include="..\..\src\Simd\SimdBase64.h" />
     <ClInclude Include="..\..\src\Simd\SimdBayer.h" />
+    <ClInclude Include="..\..\src\Simd\SimdBFloat16.h" />
     <ClInclude Include="..\..\src\Simd\SimdBgrToLab.h" />
     <ClInclude Include="..\..\src\Simd\SimdCast.h" />
     <ClInclude Include="..\..\src\Simd\SimdCompare.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\..\src\Simd\SimdBayer.h">
       <Filter>Inc</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Simd\SimdBFloat16.h">
+      <Filter>Inc</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdBgrToLab.h">
       <Filter>Inc</Filter>
     </ClInclude>
@@ -160,6 +163,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Binarization.cpp">
       <Filter>Sve2\Filter</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2BFloat16.cpp">
+      <Filter>Sve2\Convert</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BgraToBgr.cpp">
       <Filter>Sve2\Convert</Filter>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2609,10 +2609,17 @@ SIMD_API void SimdFloat32ToBFloat16(const float* src, size_t size, uint16_t* dst
 SIMD_API void SimdBFloat16ToFloat32(const uint16_t* src, size_t size, float* dst)
 {
     SIMD_EMPTY();
-    typedef void(*SimdBFloat16ToFloat32Ptr) (const uint16_t* src, size_t size, float* dst);
-    const static SimdBFloat16ToFloat32Ptr simdBFloat16ToFloat32 = SIMD_FUNC4(BFloat16ToFloat32, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BFloat16ToFloat32(src, size, dst);
+    else
+#endif
+    {
+        typedef void(*SimdBFloat16ToFloat32Ptr) (const uint16_t* src, size_t size, float* dst);
+        const static SimdBFloat16ToFloat32Ptr simdBFloat16ToFloat32 = SIMD_FUNC4(BFloat16ToFloat32, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
-    simdBFloat16ToFloat32(src, size, dst);
+        simdBFloat16ToFloat32(src, size, dst);
+    }
 }
 
 SIMD_API void SimdFloat32ToFloat16(const float * src, size_t size, uint16_t * dst)

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -95,6 +95,8 @@ namespace Simd
         void Base64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst, size_t* dstSize);
 
         void Base64Encode(const uint8_t* src, size_t size, uint8_t* dst);
+
+        void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 

--- a/src/Simd/SimdSve2BFloat16.cpp
+++ b/src/Simd/SimdSve2BFloat16.cpp
@@ -1,0 +1,52 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdBFloat16.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void BFloat16ToFloat32(const uint16_t* src, const svbool_t& mask, float* dst)
+        {
+            svuint16_t zero = svdup_n_u16(0);
+            svuint16_t _src = svld1_u16(mask, src);
+            svst1_u16(mask, (uint16_t*)dst + 0 * svlen(svuint16_t()), svzip1_u16(zero, _src));
+            svst1_u16(mask, (uint16_t*)dst + 1 * svlen(svuint16_t()), svzip2_u16(zero, _src));
+        }
+
+        void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst)
+        {
+            size_t A = svlen(svuint16_t()), sizeA = AlignLo(size, A);
+            const svbool_t body = svptrue_b16();
+            size_t i = 0;
+            for (; i < sizeA; i += A)
+                BFloat16ToFloat32(src + i, body, dst + i);
+            for (; i < size; ++i)
+                dst[i] = Base::BFloat16ToFloat32(src[i]);
+        }
+    }
+#endif
+}

--- a/src/Test/TestBFloat16.cpp
+++ b/src/Test/TestBFloat16.cpp
@@ -198,6 +198,11 @@ namespace Test
             result = result && BFloat16ToFloat32AutoTest(FUNC_BS(Simd::Avx512bw::BFloat16ToFloat32), FUNC_BS(SimdBFloat16ToFloat32));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BFloat16ToFloat32AutoTest(FUNC_BS(Simd::Sve2::BFloat16ToFloat32), FUNC_BS(SimdBFloat16ToFloat32));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && BFloat16ToFloat32AutoTest(FUNC_BS(Simd::Neon::BFloat16ToFloat32), FUNC_BS(SimdBFloat16ToFloat32));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `BFloat16ToFloat32` using `svzip1_u16` and `svzip2_u16`.
- Dispatch `SimdBFloat16ToFloat32` to SVE2 when available.
- Add SVE2 BF16 auto-test coverage and Visual Studio project entries.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BFloat16 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2BFloat16.cpp`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Test/TestBFloat16.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c104bf98-f598-47e7-8c7c-db9ca7be49ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c104bf98-f598-47e7-8c7c-db9ca7be49ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

