### PR TITLE
fix out-of-bounds jbias read in JpegExtendReceive

### DIFF
--- a/src/Simd/SimdAvx2ImageLoadJpeg.cpp
+++ b/src/Simd/SimdAvx2ImageLoadJpeg.cpp
@@ -474,7 +474,7 @@ namespace Simd
 
             sgn = (jpeg__int32)j->code_buffer >> 31; // sign bit is always in MSB
             k = jpeg_lrot(j->code_buffer, n);
-            if (n < 0 || n >= (int)(sizeof(jpeg__bmask) / sizeof(*jpeg__bmask))) return 0;
+            if (n < 0 || n >= (int)(sizeof(jpeg__jbias) / sizeof(*jpeg__jbias))) return 0;
             j->code_buffer = k & ~jpeg__bmask[n];
             k &= jpeg__bmask[n];
             j->code_bits -= n;

--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -207,7 +207,7 @@ namespace Simd
                 JpegGrowBufferUnsafe(j);
             int sgn = (int32_t)j->code_buffer >> 31;
             unsigned int k = JpegLrot(j->code_buffer, n);
-            if (n < 0 || n >= (int)(sizeof(JpegBmask) / sizeof(*JpegBmask))) 
+            if (n < 0 || n >= (int)(sizeof(_jbias) / sizeof(*_jbias))) 
                 return 0;
             j->code_buffer = k & ~JpegBmask[n];
             k &= JpegBmask[n];


### PR DESCRIPTION
**Out-of-bounds read in JpegExtendReceive**

A crafted DHT can give a DC symbol a magnitude category of 16, and the DC decode path only rejects `n < 0` before extending, so `JpegExtendReceive` is reached with `n == 16`. The range guard there is sized from `JpegBmask` (17 entries), but the function also indexes the parallel `_jbias` table which only holds 16, so `n == 16` reads one element past its end (ASan reports a global-buffer-overflow). Bounding `n` by the smaller `_jbias` keeps both table reads in range and looks the more maintainable place to put the limit since it covers every caller. The Avx2 decoder carries the same off-by-one; Sse41 reuses the base entropy path so it needs no separate change.