### PR TITLE
Add SVE2 optimization for Binarization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -96,6 +96,7 @@
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundInitMask.</li>
+ <li>SVE2 optimizations of function Binarization.</li>
  <li>SVE2 optimizations of function AveragingBinarization.</li>
  <li>SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function AveragingBinarizationV2.</li>
  <li>Support of RISCV/RISCV64 platform.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1809,6 +1809,11 @@ SIMD_API void SimdBinarization(const uint8_t * src, size_t srcStride, size_t wid
         Sse41::Binarization(src, srcStride, width, height, value, positive, negative, dst, dstStride, compareType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Binarization(src, srcStride, width, height, value, positive, negative, dst, dstStride, compareType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::Binarization(src, srcStride, width, height, value, positive, negative, dst, dstStride, compareType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -57,6 +57,9 @@ namespace Simd
         void AlphaUnpremultiply(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             uint8_t* dst, size_t dstStride, SimdBool argb);
 
+        void Binarization(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t value, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride, SimdCompareType compareType);
+
         void AveragingBinarization(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             uint8_t value, size_t neighborhood, uint8_t threshold, uint8_t positive, uint8_t negative,
             uint8_t* dst, size_t dstStride, SimdCompareType compareType);

--- a/src/Simd/SimdSve2Binarization.cpp
+++ b/src/Simd/SimdSve2Binarization.cpp
@@ -29,6 +29,58 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE    
     namespace Sve2
     {
+        template <SimdCompareType compareType> SIMD_INLINE void Binarization(const uint8_t* src, const svuint8_t& value,
+            const svuint8_t& positive, const svuint8_t& negative, uint8_t* dst, const svbool_t& mask)
+        {
+            const svuint8_t _src = svld1_u8(mask, src);
+            svst1_u8(mask, dst, svsel_u8(Compare8u<compareType>(mask, _src, value), positive, negative));
+        }
+
+        template <SimdCompareType compareType> void Binarization(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t value, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride)
+        {
+            const size_t A = svcntb();
+            const size_t alignedWidth = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svuint8_t _value = svdup_n_u8(value);
+            const svuint8_t _positive = svdup_n_u8(positive);
+            const svuint8_t _negative = svdup_n_u8(negative);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t col = 0; col < alignedWidth; col += A)
+                    Binarization<compareType>(src + col, _value, _positive, _negative, dst + col, body);
+                if (alignedWidth != width)
+                    Binarization<compareType>(src + alignedWidth, _value, _positive, _negative, dst + alignedWidth, svwhilelt_b8(alignedWidth, width));
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        void Binarization(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t value, uint8_t positive, uint8_t negative, uint8_t* dst, size_t dstStride, SimdCompareType compareType)
+        {
+            switch (compareType)
+            {
+            case SimdCompareEqual:
+                return Binarization<SimdCompareEqual>(src, srcStride, width, height, value, positive, negative, dst, dstStride);
+            case SimdCompareNotEqual:
+                return Binarization<SimdCompareNotEqual>(src, srcStride, width, height, value, positive, negative, dst, dstStride);
+            case SimdCompareGreater:
+                return Binarization<SimdCompareGreater>(src, srcStride, width, height, value, positive, negative, dst, dstStride);
+            case SimdCompareGreaterOrEqual:
+                return Binarization<SimdCompareGreaterOrEqual>(src, srcStride, width, height, value, positive, negative, dst, dstStride);
+            case SimdCompareLesser:
+                return Binarization<SimdCompareLesser>(src, srcStride, width, height, value, positive, negative, dst, dstStride);
+            case SimdCompareLesserOrEqual:
+                return Binarization<SimdCompareLesserOrEqual>(src, srcStride, width, height, value, positive, negative, dst, dstStride);
+            default:
+                assert(0);
+            }
+        }
+
+        //--------------------------------------------------------------------------------------------------
+
         namespace
         {
             struct Buffer

--- a/src/Test/TestBinarization.cpp
+++ b/src/Test/TestBinarization.cpp
@@ -117,6 +117,11 @@ namespace Test
             result = result && BinarizationAutoTest(FUNC_B(Simd::Avx512bw::Binarization), FUNC_B(SimdBinarization));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BinarizationAutoTest(FUNC_B(Simd::Sve2::Binarization), FUNC_B(SimdBinarization));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && BinarizationAutoTest(FUNC_B(Simd::Neon::Binarization), FUNC_B(SimdBinarization));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Adds an SVE2 implementation of `Binarization` and wires it into `SimdBinarization` dispatch.
* Extends `BinarizationAutoTest` coverage for direct SVE2 validation.
* Updates 7.2.163 release notes for the new optimization.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Binarization -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2Binarization.cpp`
* `rg "SimdSve2Binarization\.cpp" prj/vs2022/Sve2.vcxproj prj/vs2022/Sve2.vcxproj.filters`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-233f5400-5da7-4552-ac57-6b51001d1162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-233f5400-5da7-4552-ac57-6b51001d1162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

