### PR TITLE
Add SVE2 optimization for BgraToYuva420pV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -55,6 +55,7 @@
  <li>SVE2 optimizations of function BgraToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgraToYuv422pV2.</li>
  <li>SVE2 optimizations of function BgraToYuv444pV2.</li>
+ <li>SVE2 optimizations of function BgraToYuva420pV2.</li>
  <li>SVE2 optimizations of function Bgr48pToBgra32.</li>
  <li>SVE2 optimizations of function BgrToHsl.</li>
  <li>SVE2 optimizations of function BgrToHsv.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -1427,6 +1427,11 @@ SIMD_API void SimdBgraToYuva420pV2(const uint8_t* bgra, size_t bgraStride, size_
         Sse41::BgraToYuva420pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BgraToYuva420pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::BgraToYuva420pV2(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -120,6 +120,10 @@ namespace Simd
         void BgraToYuv444pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
             uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, SimdYuvType yuvType);
 
+        void BgraToYuva420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride,
+            uint8_t* a, size_t aStride, SimdYuvType yuvType);
+
         void Bgr48pToBgra32(const uint8_t* blue, size_t blueStride, size_t width, size_t height,
             const uint8_t* green, size_t greenStride, const uint8_t* red, size_t redStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 

--- a/src/Simd/SimdSve2BgraToYuvV2.cpp
+++ b/src/Simd/SimdSve2BgraToYuvV2.cpp
@@ -136,6 +136,71 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        template <class T> SIMD_INLINE void BgraToYuva420pV2(const uint8_t* bgra0, size_t bgraStride, uint8_t* y0, size_t yStride,
+            uint8_t* u, uint8_t* v, uint8_t* a0, size_t aStride, const svbool_t& maskY, const svbool_t& maskUv)
+        {
+            const uint8_t* bgra1 = bgra0 + bgraStride;
+            uint8_t* y1 = y0 + yStride;
+            uint8_t* a1 = a0 + aStride;
+
+            svuint8x4_t bgra00 = svld4_u8(maskY, bgra0);
+            svuint8x4_t bgra10 = svld4_u8(maskY, bgra1);
+
+            svst1_u8(maskY, y0, BgrToY8<T>(svget4(bgra00, 0), svget4(bgra00, 1), svget4(bgra00, 2)));
+            svst1_u8(maskY, y1, BgrToY8<T>(svget4(bgra10, 0), svget4(bgra10, 1), svget4(bgra10, 2)));
+            svst1_u8(maskY, a0, svget4(bgra00, 3));
+            svst1_u8(maskY, a1, svget4(bgra10, 3));
+
+            svuint16_t blue = AverageUv(svget4(bgra00, 0), svget4(bgra10, 0), maskY);
+            svuint16_t green = AverageUv(svget4(bgra00, 1), svget4(bgra10, 1), maskY);
+            svuint16_t red = AverageUv(svget4(bgra00, 2), svget4(bgra10, 2), maskY);
+
+            svst1_u8(maskUv, u, PackSeqI16ToU8(BgrToU16<T>(To16i(blue), To16i(green), To16i(red)), svundef_s16()));
+            svst1_u8(maskUv, v, PackSeqI16ToU8(BgrToV16<T>(To16i(blue), To16i(green), To16i(red)), svundef_s16()));
+        }
+
+        template <class T> void BgraToYuva420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, uint8_t* a, size_t aStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0) && (width >= 2) && (height >= 2));
+
+            size_t A = svlen(svuint8_t()), HA = A / 2, A4 = A * 4;
+            size_t widthA = AlignLo(width, A), tail = width - widthA;
+            const svbool_t bodyY = svptrue_b8();
+            const svbool_t bodyUv = svwhilelt_b8(size_t(0), HA);
+            const svbool_t tailY = svwhilelt_b8(size_t(0), tail);
+            const svbool_t tailUv = svwhilelt_b8(size_t(0), tail / 2);
+            for (size_t row = 0; row < height; row += 2)
+            {
+                size_t colBgra = 0, colY = 0, colUv = 0;
+                for (; colY < widthA; colBgra += A4, colY += A, colUv += HA)
+                    BgraToYuva420pV2<T>(bgra + colBgra, bgraStride, y + colY, yStride, u + colUv, v + colUv, a + colY, aStride, bodyY, bodyUv);
+                if (colY < width)
+                    BgraToYuva420pV2<T>(bgra + colBgra, bgraStride, y + colY, yStride, u + colUv, v + colUv, a + colY, aStride, tailY, tailUv);
+                bgra += 2 * bgraStride;
+                y += 2 * yStride;
+                u += uStride;
+                v += vStride;
+                a += 2 * aStride;
+            }
+        }
+
+        void BgraToYuva420pV2(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride, uint8_t* a, size_t aStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: BgraToYuva420pV2<Base::Bt601>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride); break;
+            case SimdYuvBt709: BgraToYuva420pV2<Base::Bt709>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride); break;
+            case SimdYuvBt2020: BgraToYuva420pV2<Base::Bt2020>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride); break;
+            case SimdYuvTrect871: BgraToYuva420pV2<Base::Trect871>(bgra, bgraStride, width, height, y, yStride, u, uStride, v, vStride, a, aStride); break;
+            default:
+                assert(0);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         template <class T> SIMD_INLINE void BgraToYuv422pV2(const uint8_t* bgra, uint8_t* y, uint8_t* u, uint8_t* v,
             const svbool_t& maskY, const svbool_t& maskUv)
         {

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -510,6 +510,11 @@ namespace Test
             result = result && BgraToYuvaV2AutoTest(2, 2, FUNC_YUVA2(Simd::Avx512bw::BgraToYuva420pV2), FUNC_YUVA2(SimdBgraToYuva420pV2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BgraToYuvaV2AutoTest(2, 2, FUNC_YUVA2(Simd::Sve2::BgraToYuva420pV2), FUNC_YUVA2(SimdBgraToYuva420pV2));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::DA)
             result = result && BgraToYuvaV2AutoTest(2, 2, FUNC_YUVA2(Simd::Neon::BgraToYuva420pV2), FUNC_YUVA2(SimdBgraToYuva420pV2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBgraToYuva420pV2`.
- Add SVE2 coverage to `BgraToYuva420pV2AutoTest`.
- Document the SVE2 optimization in the 7.2.163 release notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=BgraToYuva420pV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I./src -c src/Simd/SimdSve2BgraToYuvV2.cpp -o /tmp/SimdSve2BgraToYuvV2.o`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I./src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib_aarch64.o`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I./src -c src/Test/TestAnyToYuv.cpp -o /tmp/TestAnyToYuv_aarch64.o`
- `git -c core.whitespace=trailing-space,space-before-tab,cr-at-eol diff --check origin/dev..HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-402151da-0cef-47e1-a68e-23032c6aaf40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-402151da-0cef-47e1-a68e-23032c6aaf40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

