### PR TITLE
Add SVE2 ContourAnchors optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -100,6 +100,7 @@
  <li>SVE2 optimizations of function Binarization.</li>
  <li>SVE2 optimizations of function AveragingBinarization.</li>
  <li>SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function AveragingBinarizationV2.</li>
+ <li>SVE2 optimizations of function ContourAnchors.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -194,6 +194,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Base64.cpp">
       <Filter>Sve2\System</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5159,6 +5159,11 @@ SIMD_API void SimdContourAnchors(const uint8_t * src, size_t srcStride, size_t w
         Sse41::ContourAnchors(src, srcStride, width, height, step, threshold, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::ContourAnchors(src, srcStride, width, height, step, threshold, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::ContourAnchors(src, srcStride, width, height, step, threshold, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -162,6 +162,9 @@ namespace Simd
 
         void ConditionalFill(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t threshold, SimdCompareType compareType, uint8_t value, uint8_t* dst, size_t dstStride);
 
+        void ContourAnchors(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t step, int16_t threshold, uint8_t* dst, size_t dstStride);
+
         void CorrelationSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum);
 
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -1,0 +1,82 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svint16_t Half(const uint16_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s16_u16(svlsr_n_u16_x(mask, svld1_u16(mask, src), 1));
+        }
+
+        SIMD_INLINE void Anchor(const uint16_t* src, size_t stride, const svint16_t& threshold, uint8_t* dst, const svbool_t& mask)
+        {
+            svuint16_t _src = svld1_u16(mask, src);
+            svuint16_t direction = svand_n_u16_x(mask, _src, 1);
+            svuint16_t magnitude = svlsr_n_u16_x(mask, _src, 1);
+            svint16_t value = svsub_s16_x(mask, svreinterpret_s16_u16(magnitude), threshold);
+
+            svbool_t vertical = svand_b_z(mask, svcmpeq_n_u16(mask, direction, 1),
+                svand_b_z(mask, svcmpge_s16(mask, value, Half(src - 1, mask)), svcmpge_s16(mask, value, Half(src + 1, mask))));
+            svbool_t horizontal = svand_b_z(mask, svcmpeq_n_u16(mask, direction, 0),
+                svand_b_z(mask, svcmpge_s16(mask, value, Half(src - stride, mask)), svcmpge_s16(mask, value, Half(src + stride, mask))));
+            svbool_t anchor = svand_b_z(mask, svcmpgt_n_u16(mask, magnitude, 0), svorr_b_z(mask, vertical, horizontal));
+
+            svst1b_u16(mask, dst, svsel_u16(anchor, svdup_n_u16(0xFF), svdup_n_u16(0)));
+        }
+
+        void ContourAnchors(const uint16_t* src, size_t srcStride, size_t width, size_t height,
+            size_t step, int16_t threshold, uint8_t* dst, size_t dstStride)
+        {
+            const size_t A = svcnth();
+            const svint16_t _threshold = svdup_n_s16(threshold);
+
+            memset(dst, 0, width);
+            memset(dst + dstStride * (height - 1), 0, width);
+            src += srcStride;
+            dst += dstStride;
+            for (size_t row = 1; row < height - 1; row += step)
+            {
+                dst[0] = 0;
+                for (size_t col = 1; col < width - 1; col += A)
+                    Anchor(src + col, srcStride, _threshold, dst + col, svwhilelt_b16(col, width - 1));
+                dst[width - 1] = 0;
+                src += step * srcStride;
+                dst += step * dstStride;
+            }
+        }
+
+        void ContourAnchors(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t step, int16_t threshold, uint8_t* dst, size_t dstStride)
+        {
+            assert(srcStride % sizeof(int16_t) == 0);
+
+            ContourAnchors((const uint16_t*)src, srcStride / sizeof(int16_t), width, height, step, threshold, dst, dstStride);
+        }
+    }
+#endif
+}

--- a/src/Test/TestContour.cpp
+++ b/src/Test/TestContour.cpp
@@ -198,6 +198,11 @@ namespace Test
             result = result && ContourAnchorsAutoTest(FUNC_A(Simd::Neon::ContourAnchors), FUNC_A(SimdContourAnchors));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ContourAnchorsAutoTest(FUNC_A(Simd::Sve2::ContourAnchors), FUNC_A(SimdContourAnchors));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdContourAnchors`.
- Add SVE2 coverage to `Test::ContourAnchorsAutoTest`.
- Add Visual Studio SVE2 project entries and release note for version 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=ContourAnchors -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Sobel.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Test/TestContour.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2f4781d-d637-449f-8193-9adfc5f13fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2f4781d-d637-449f-8193-9adfc5f13fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

