### PR TITLE
Add SVE2 ContourMetrics optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -100,6 +100,7 @@
  <li>SVE2 optimizations of function Binarization.</li>
  <li>SVE2 optimizations of function AveragingBinarization.</li>
  <li>SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function AveragingBinarizationV2.</li>
+ <li>SVE2 optimizations of function ContourMetrics.</li>
  <li>SVE2 optimizations of function ContourAnchors.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5106,6 +5106,11 @@ SIMD_API void SimdContourMetrics(const uint8_t * src, size_t srcStride, size_t w
         Sse41::ContourMetrics(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::ContourMetrics(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::ContourMetrics(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -162,6 +162,8 @@ namespace Simd
 
         void ConditionalFill(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t threshold, SimdCompareType compareType, uint8_t value, uint8_t* dst, size_t dstStride);
 
+        void ContourMetrics(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
         void ContourAnchors(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t step, int16_t threshold, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -28,6 +28,69 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE int16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+        {
+            int dx = Simd::Abs((s0[x2] + 2 * s1[x2] + s2[x2]) - (s0[x0] + 2 * s1[x0] + s2[x0]));
+            int dy = Simd::Abs((s2[x0] + 2 * s2[x1] + s2[x2]) - (s0[x0] + 2 * s0[x1] + s0[x2]));
+            return (int16_t)((dx + dy) * 2 + (dx >= dy ? 0 : 1));
+        }
+
+        SIMD_INLINE svint16_t SobelDxAbs(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+        {
+            svint16_t left = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s1), 1)), svld1ub_s16(mask, s2));
+            svint16_t right = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0 + 2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s1 + 2), 1)), svld1ub_s16(mask, s2 + 2));
+            return svabs_s16_x(mask, svsub_s16_x(mask, right, left));
+        }
+
+        SIMD_INLINE svint16_t SobelDyAbs(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
+        {
+            svint16_t top = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s0 + 1), 1)), svld1ub_s16(mask, s0 + 2));
+            svint16_t bottom = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s2 + 1), 1)), svld1ub_s16(mask, s2 + 2));
+            return svabs_s16_x(mask, svsub_s16_x(mask, bottom, top));
+        }
+
+        SIMD_INLINE void ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        {
+            svint16_t dx = SobelDxAbs(s0, s1, s2, mask);
+            svint16_t dy = SobelDyAbs(s0, s2, mask);
+            svint16_t sum = svlsl_n_s16_x(mask, svadd_s16_x(mask, dx, dy), 1);
+            svst1_s16(mask, dst, svadd_s16_x(mask, sum, svsel_s16(svcmplt_s16(mask, dx, dy), svdup_n_s16(1), svdup_n_s16(0))));
+        }
+
+        void ContourMetrics(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t * src0, * src1, * src2;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + srcStride * (row - 1);
+                src1 = src0 + srcStride;
+                src2 = src1 + srcStride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                dst[0] = ContourMetrics(src0, src1, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    ContourMetrics(src0 + col - 1, src1 + col - 1, src2 + col - 1, dst + col, svwhilelt_b16(col, width - 1));
+                dst[width - 1] = ContourMetrics(src0, src1, src2, width - 2, width - 1, width - 1);
+
+                dst += dstStride;
+            }
+        }
+
+        void ContourMetrics(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            ContourMetrics(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE svint16_t Half(const uint16_t* src, const svbool_t& mask)
         {
             return svreinterpret_s16_u16(svlsr_n_u16_x(mask, svld1_u16(mask, src), 1));

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -853,6 +853,11 @@ namespace
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::ContourMetrics), FUNC_G(SimdContourMetrics));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::ContourMetrics), FUNC_G(SimdContourMetrics));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Neon::ContourMetrics), FUNC_G(SimdContourMetrics));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and public dispatch for `SimdContourMetrics`.
- Add SVE2 coverage to `ContourMetricsAutoTest`.
- Document the release-note entry for version 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" ./Test "-r=.." -fi=ContourMetrics -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -fsyntax-only -I src src/Simd/SimdSve2Sobel.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -fsyntax-only -I src src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -fsyntax-only -I src src/Test/TestFilter.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-580a300d-a2d0-4a0f-bed5-17a22cfe4f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-580a300d-a2d0-4a0f-bed5-17a22cfe4f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

