### PR TITLE
Add SVE2 ContourMetricsMasked optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -101,6 +101,7 @@
  <li>SVE2 optimizations of function AveragingBinarization.</li>
  <li>SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function AveragingBinarizationV2.</li>
  <li>SVE2 optimizations of function ContourMetrics.</li>
+ <li>SVE2 optimizations of function ContourMetricsMasked.</li>
  <li>SVE2 optimizations of function ContourAnchors.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5138,6 +5138,11 @@ SIMD_API void SimdContourMetricsMasked(const uint8_t * src, size_t srcStride, si
         Sse41::ContourMetricsMasked(src, srcStride, width, height, mask, maskStride, indexMin, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::ContourMetricsMasked(src, srcStride, width, height, mask, maskStride, indexMin, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::ContourMetricsMasked(src, srcStride, width, height, mask, maskStride, indexMin, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -164,6 +164,9 @@ namespace Simd
 
         void ContourMetrics(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
+        void ContourMetricsMasked(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t indexMin, uint8_t* dst, size_t dstStride);
+
         void ContourAnchors(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t step, int16_t threshold, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -49,12 +49,17 @@ namespace Simd
             return svabs_s16_x(mask, svsub_s16_x(mask, bottom, top));
         }
 
-        SIMD_INLINE void ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        SIMD_INLINE svint16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
         {
             svint16_t dx = SobelDxAbs(s0, s1, s2, mask);
             svint16_t dy = SobelDyAbs(s0, s2, mask);
             svint16_t sum = svlsl_n_s16_x(mask, svadd_s16_x(mask, dx, dy), 1);
-            svst1_s16(mask, dst, svadd_s16_x(mask, sum, svsel_s16(svcmplt_s16(mask, dx, dy), svdup_n_s16(1), svdup_n_s16(0))));
+            return svadd_s16_x(mask, sum, svsel_s16(svcmplt_s16(mask, dx, dy), svdup_n_s16(1), svdup_n_s16(0)));
+        }
+
+        SIMD_INLINE void ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        {
+            svst1_s16(mask, dst, ContourMetrics(s0, s1, s2, mask));
         }
 
         void ContourMetrics(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
@@ -87,6 +92,50 @@ namespace Simd
             assert(dstStride % sizeof(int16_t) == 0);
 
             ContourMetrics(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
+        SIMD_INLINE void ContourMetricsMasked(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            const uint8_t* mask, uint8_t indexMin, int16_t* dst, const svbool_t& tail)
+        {
+            svuint16_t _mask = svld1ub_u16(tail, mask);
+            svbool_t valid = svcmpge_n_u16(tail, _mask, indexMin);
+            svst1_s16(tail, dst, svsel_s16(valid, ContourMetrics(s0, s1, s2, tail), svdup_n_s16(0)));
+        }
+
+        void ContourMetricsMasked(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t indexMin, int16_t* dst, size_t dstStride)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t * src0, * src1, * src2;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + srcStride * (row - 1);
+                src1 = src0 + srcStride;
+                src2 = src1 + srcStride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                dst[0] = mask[0] < indexMin ? 0 : ContourMetrics(src0, src1, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    ContourMetricsMasked(src0 + col - 1, src1 + col - 1, src2 + col - 1,
+                        mask + col, indexMin, dst + col, svwhilelt_b16(col, width - 1));
+                dst[width - 1] = mask[width - 1] < indexMin ? 0 : ContourMetrics(src0, src1, src2, width - 2, width - 1, width - 1);
+
+                dst += dstStride;
+                mask += maskStride;
+            }
+        }
+
+        void ContourMetricsMasked(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t indexMin, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            ContourMetricsMasked(src, srcStride, width, height, mask, maskStride, indexMin, (int16_t*)dst, dstStride / sizeof(int16_t));
         }
 
         //-------------------------------------------------------------------------------------------------

--- a/src/Test/TestContour.cpp
+++ b/src/Test/TestContour.cpp
@@ -107,6 +107,11 @@ namespace Test
             result = result && ContourMetricsMaskedAutoTest(FUNC_M(Simd::Avx512bw::ContourMetricsMasked), FUNC_M(SimdContourMetricsMasked));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ContourMetricsMaskedAutoTest(FUNC_M(Simd::Sve2::ContourMetricsMasked), FUNC_M(SimdContourMetricsMasked));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W > Simd::Neon::A)
             result = result && ContourMetricsMaskedAutoTest(FUNC_M(Simd::Neon::ContourMetricsMasked), FUNC_M(SimdContourMetricsMasked));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdContourMetricsMasked` in `SimdSve2Sobel.cpp`.
- Wire SVE2 declaration and runtime dispatch for `SimdContourMetricsMasked`.
- Add SVE2 coverage to `ContourMetricsMaskedAutoTest` and update the 7.2.163 release notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=ContourMetricsMasked -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++11 -I src -I . -c src/Simd/SimdSve2Sobel.cpp -o /tmp/SimdSve2Sobel.o`
- Temporary AArch64/QEMU comparison of `Simd::Sve2::ContourMetricsMasked` against `Simd::Base::ContourMetricsMasked` across varied sizes, strides, and thresholds: passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee100f9-0b69-48b5-abc6-637f2de0cd56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee100f9-0b69-48b5-abc6-637f2de0cd56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

