### PR TITLE
Add SVE2 CosineDistance16f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
+ <li>SVE2 optimizations of function CosineDistance16f.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToYuvV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -188,6 +188,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2718,6 +2718,11 @@ SIMD_API void SimdCosineDistance16f(const uint16_t * a, const uint16_t * b, size
         Avx2::CosineDistance16f(a, b, size, distance);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::CosineDistance16f(a, b, size, distance);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && size >= Neon::F)
         Neon::CosineDistance16f(a, b, size, distance);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -100,6 +100,10 @@ namespace Simd
         void Base64Encode(const uint8_t* src, size_t size, uint8_t* dst);
 
         void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst);
+
+#ifdef SIMD_NEON_FP16_ENABLE
+        void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
+#endif
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -1,0 +1,71 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void CosineDistance16f(const uint16_t* a, const uint16_t* b, const svbool_t& load, const svbool_t& lo, const svbool_t& hi,
+            svfloat32_t& aa0, svfloat32_t& aa1, svfloat32_t& ab0, svfloat32_t& ab1, svfloat32_t& bb0, svfloat32_t& bb1)
+        {
+            svfloat16_t _a = svreinterpret_f16_u16(svld1_u16(load, a));
+            svfloat16_t _b = svreinterpret_f16_u16(svld1_u16(load, b));
+            svfloat32_t a0 = svcvt_f32_f16_x(lo, _a);
+            svfloat32_t b0 = svcvt_f32_f16_x(lo, _b);
+            aa0 = svmla_f32_x(lo, aa0, a0, a0);
+            ab0 = svmla_f32_x(lo, ab0, a0, b0);
+            bb0 = svmla_f32_x(lo, bb0, b0, b0);
+            svfloat32_t a1 = svcvtlt_f32_f16_x(hi, _a);
+            svfloat32_t b1 = svcvtlt_f32_f16_x(hi, _b);
+            aa1 = svmla_f32_x(hi, aa1, a1, a1);
+            ab1 = svmla_f32_x(hi, ab1, a1, b1);
+            bb1 = svmla_f32_x(hi, bb1, b1, b1);
+        }
+
+        void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance)
+        {
+            size_t A = svlen(svuint16_t()), sizeA = AlignLo(size, A), i = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            svfloat32_t aa0 = svdup_n_f32(0.0f), aa1 = svdup_n_f32(0.0f);
+            svfloat32_t ab0 = svdup_n_f32(0.0f), ab1 = svdup_n_f32(0.0f);
+            svfloat32_t bb0 = svdup_n_f32(0.0f), bb1 = svdup_n_f32(0.0f);
+            for (; i < sizeA; i += A)
+                CosineDistance16f(a + i, b + i, body16, body32, body32, aa0, aa1, ab0, ab1, bb0, bb1);
+            if (i < size)
+            {
+                size_t tail = size - i;
+                CosineDistance16f(a + i, b + i, svwhilelt_b16(size_t(0), tail),
+                    svwhilelt_b32(size_t(0), (tail + 1) / 2), svwhilelt_b32(size_t(0), tail / 2), aa0, aa1, ab0, ab1, bb0, bb1);
+            }
+            float _aa = svaddv_f32(body32, svadd_f32_x(body32, aa0, aa1));
+            float _ab = svaddv_f32(body32, svadd_f32_x(body32, ab0, ab1));
+            float _bb = svaddv_f32(body32, svadd_f32_x(body32, bb0, bb1));
+            *distance = 1.0f - _ab / ::sqrt(_aa * _bb);
+        }
+    }
+#endif
+}

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -305,6 +305,11 @@ namespace Test
             result = result && DifferenceSum16fAutoTest(EPS, FUNC_S(Simd::Avx512bw::CosineDistance16f), FUNC_S(SimdCosineDistance16f), check);
 #endif
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSum16fAutoTest(EPS, FUNC_S(Simd::Sve2::CosineDistance16f), FUNC_S(SimdCosineDistance16f), check);
+#endif
+
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSum16fAutoTest(EPS, FUNC_S(Simd::Neon::CosineDistance16f), FUNC_S(SimdCosineDistance16f), check);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 FP16 implementation of `CosineDistance16f` with predicated tail handling.
- Wire SVE2 dispatch, auto-test coverage, VS2022 project entries, and 7.2.163 release notes.

### Verification
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.2-a+sve2+fp16 -I src -c src/Simd/SimdSve2Float16.cpp -o /tmp/SimdSve2Float16.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=CosineDistance16f -tt=1 -ts=1`
- AArch64 QEMU harness comparing `Simd::Sve2::CosineDistance16f` with `Simd::Base::CosineDistance16f` for sizes 1..257 passed with `max_diff=0.000000000`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1f1ee38-687e-41f5-8640-f87a5a8f9230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1f1ee38-687e-41f5-8640-f87a5a8f9230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

