### PR TITLE
Add SVE2 optimization for CosineDistance32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -44,6 +44,7 @@
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
+ <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -191,6 +191,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>

--- a/src/Simd/SimdEnable.h
+++ b/src/Simd/SimdEnable.h
@@ -157,6 +157,12 @@ namespace Simd
 #define SIMD_NEON_FUNC(func)
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+#define SIMD_SVE2_FUNC(func) Simd::Sve2::Enable ? Simd::Sve2::func :
+#else
+#define SIMD_SVE2_FUNC(func)
+#endif
+
 #ifdef SIMD_HVX_ENABLE
 #define SIMD_HVX_FUNC(func) Simd::Hvx::Enable ? Simd::Hvx::func :
 #else

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2871,7 +2871,7 @@ SIMD_API void SimdCosineDistance32f(const float * a, const float * b, size_t siz
 {
     SIMD_EMPTY();
     typedef void(*SimdCosineDistance32fPtr) (const float * a, const float * b, size_t size, float * distance);
-    const static SimdCosineDistance32fPtr simdCosineDistance32f = SIMD_FUNC4(CosineDistance32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdCosineDistance32fPtr simdCosineDistance32f = SIMD_FUNC5(CosineDistance32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdCosineDistance32f(a, b, size, distance);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -104,6 +104,8 @@ namespace Simd
 #ifdef SIMD_NEON_FP16_ENABLE
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 #endif
+
+        void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 

--- a/src/Simd/SimdSve2Float32.cpp
+++ b/src/Simd/SimdSve2Float32.cpp
@@ -1,0 +1,67 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void CosineDistance32f(const float* a, const float* b, const svbool_t& mask,
+            svfloat32_t& aa, svfloat32_t& ab, svfloat32_t& bb)
+        {
+            svfloat32_t _a = svld1_f32(mask, a);
+            svfloat32_t _b = svld1_f32(mask, b);
+            aa = svmla_f32_m(mask, aa, _a, _a);
+            ab = svmla_f32_m(mask, ab, _a, _b);
+            bb = svmla_f32_m(mask, bb, _b, _b);
+        }
+
+        void CosineDistance32f(const float* a, const float* b, size_t size, float* distance)
+        {
+            size_t F = svcntw(), DF = 2 * F, sizeDF = AlignLo(size, DF), sizeF = AlignLo(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t aa0 = svdup_n_f32(0.0f), aa1 = svdup_n_f32(0.0f);
+            svfloat32_t ab0 = svdup_n_f32(0.0f), ab1 = svdup_n_f32(0.0f);
+            svfloat32_t bb0 = svdup_n_f32(0.0f), bb1 = svdup_n_f32(0.0f);
+            for (; i < sizeDF; i += DF)
+            {
+                CosineDistance32f(a + i, b + i, body, aa0, ab0, bb0);
+                CosineDistance32f(a + i + F, b + i + F, body, aa1, ab1, bb1);
+            }
+            aa0 = svadd_f32_x(body, aa0, aa1);
+            ab0 = svadd_f32_x(body, ab0, ab1);
+            bb0 = svadd_f32_x(body, bb0, bb1);
+            for (; i < sizeF; i += F)
+                CosineDistance32f(a + i, b + i, body, aa0, ab0, bb0);
+            if (i < size)
+                CosineDistance32f(a + i, b + i, svwhilelt_b32(i, size), aa0, ab0, bb0);
+            float _aa = svaddv_f32(body, aa0);
+            float _ab = svaddv_f32(body, ab0);
+            float _bb = svaddv_f32(body, bb0);
+            *distance = 1.0f - _ab / ::sqrt(_aa * _bb);
+        }
+    }
+#endif
+}

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -199,7 +199,7 @@ namespace Test
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Sse41::SquaredDifferenceSum), FUNC_S(SimdSquaredDifferenceSum), 1);
-#endif 
+#endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -480,7 +480,7 @@ namespace Test
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
             result = result && DifferenceSum32fAutoTest(EPS, FUNC_F(Simd::Sve2::CosineDistance32f), FUNC_F(SimdCosineDistance32f));
-#endif 
+#endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -477,6 +477,11 @@ namespace Test
             result = result && DifferenceSum32fAutoTest(EPS, FUNC_F(Simd::Avx512bw::CosineDistance32f), FUNC_F(SimdCosineDistance32f));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSum32fAutoTest(EPS, FUNC_F(Simd::Sve2::CosineDistance32f), FUNC_F(SimdCosineDistance32f));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSum32fAutoTest(EPS, FUNC_F(Simd::Neon::CosineDistance32f), FUNC_F(SimdCosineDistance32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `CosineDistance32f` with predicated tail handling.
- Route `SimdCosineDistance32f` through SVE2 dispatch when available.
- Add SVE2 coverage to `CosineDistance32fAutoTest`, update VS project files, and document the 7.2.163 release note.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=CosineDistance32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2Float32.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdLib.cpp`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check origin/dev..HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df5bfa88-2e7e-4478-8398-af316481de2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df5bfa88-2e7e-4478-8398-af316481de2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

