### PR TITLE
use scalar converters for narrow bmp in SetConverters

### DIFF
--- a/src/Simd/SimdAvx2ImageLoad.cpp
+++ b/src/Simd/SimdAvx2ImageLoad.cpp
@@ -131,6 +131,13 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            // The vector converters below need width >= A; they process the final
+            // columns as width - A, which wraps in size_t for a narrower row and reads
+            // and writes off the end of it. SetConverters runs before _image exists, so
+            // test _width and keep the scalar Base converters below A, as PXM does.
+            Base::ImageBmpLoader::SetConverters();
+            if (_width < A)
+                return;
             if (_bpp == 8)
             {
                 switch (_param.format)

--- a/src/Simd/SimdAvx512bwImageLoad.cpp
+++ b/src/Simd/SimdAvx512bwImageLoad.cpp
@@ -127,6 +127,13 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            // The vector converters below need width >= A; they process the final
+            // columns as width - A, which wraps in size_t for a narrower row and reads
+            // and writes off the end of it. SetConverters runs before _image exists, so
+            // test _width and keep the scalar Base converters below A, as PXM does.
+            Base::ImageBmpLoader::SetConverters();
+            if (_width < A)
+                return;
             if (_bpp == 8)
             {
                 switch (_param.format)

--- a/src/Simd/SimdNeonImageLoad.cpp
+++ b/src/Simd/SimdNeonImageLoad.cpp
@@ -127,6 +127,13 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            // The vector converters below need width >= A; they process the final
+            // columns as width - A, which wraps in size_t for a narrower row and reads
+            // and writes off the end of it. SetConverters runs before _image exists, so
+            // test _width and keep the scalar Base converters below A, as PXM does.
+            Base::ImageBmpLoader::SetConverters();
+            if (_width < A)
+                return;
             if (_bpp == 8)
             {
                 switch (_param.format)

--- a/src/Simd/SimdSse41ImageLoad.cpp
+++ b/src/Simd/SimdSse41ImageLoad.cpp
@@ -132,6 +132,13 @@ namespace Simd
 
         void ImageBmpLoader::SetConverters()
         {
+            // The vector converters below need width >= A; they process the final
+            // columns as width - A, which wraps in size_t for a narrower row and reads
+            // and writes off the end of it. SetConverters runs before _image exists, so
+            // test _width and keep the scalar Base converters below A, as PXM does.
+            Base::ImageBmpLoader::SetConverters();
+            if (_width < A)
+                return;
             if (_bpp == 8)
             {
                 switch (_param.format)


### PR DESCRIPTION
The BMP decoder chooses its row converter in SetConverters, and the SSE41/AVX2/AVX512/NEON overrides install the vectorised converters (GrayToBgr, GrayToBgra and the bgr/bgra family) whenever the requested output format differs from the BMP's own. Those converters assume the width is at least the vector size A and handle the final column group as width - A, but the width is taken straight from the file header and is unsigned, so for any BMP narrower than A the subtraction wraps and the converter loads a vector and stores three or four bytes per lane from a wild offset past the row. The PXM loaders already sidestep this by keeping the scalar Base converters until the image is at least A wide; the BMP loader simply never grew the same guard. I came across it while fuzzing the loaders with the PngSuite and a handful of generated BMPs: a 1 to 15 pixel wide 8-bit BMP requested as Bgr24 or Bgra32 trips the width >= A assert in GrayToBgr on a debug build, and ASan reports a heap-buffer-overflow read of A bytes under a release build. The fix sends sub-A widths back to the scalar Base converters in all four SIMD overrides, mirroring the PXM loaders; SetConverters runs before the image is allocated, so it checks _width rather than _image.width. Wider images keep the vector path unchanged, and I have left the converter selection as the only thing that moves.
