### PR TITLE
Add SVE2 BackgroundGrowRangeFast

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -94,6 +94,7 @@
  <li>SVE2 optimizations of function AlphaFilling.</li>
  <li>SVE2 optimizations of function AlphaPremultiply.</li>
  <li>SVE2 optimizations of function AlphaUnpremultiply.</li>
+ <li>SVE2 optimizations of function BackgroundGrowRangeFast.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>
  <li>SVE2 optimizations of function BackgroundShiftRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -808,6 +808,11 @@ SIMD_API void SimdBackgroundGrowRangeFast(const uint8_t * value, size_t valueStr
         Sse41::BackgroundGrowRangeFast(value, valueStride, width, height, lo, loStride, hi, hiStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BackgroundGrowRangeFast(value, valueStride, width, height, lo, loStride, hi, hiStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::BackgroundGrowRangeFast(value, valueStride, width, height, lo, loStride, hi, hiStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -70,6 +70,9 @@ namespace Simd
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 
+        void BackgroundGrowRangeFast(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
+
         void BackgroundIncrementCount(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* loValue, size_t loValueStride, const uint8_t* hiValue, size_t hiValueStride,
             uint8_t* loCount, size_t loCountStride, uint8_t* hiCount, size_t hiCountStride);

--- a/src/Simd/SimdSve2Background.cpp
+++ b/src/Simd/SimdSve2Background.cpp
@@ -28,6 +28,38 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE void BackgroundGrowRangeFast(const uint8_t* value, uint8_t* lo, uint8_t* hi, const svbool_t& mask)
+        {
+            svuint8_t _value = svld1_u8(mask, value);
+            svuint8_t _lo = svld1_u8(mask, lo);
+            svuint8_t _hi = svld1_u8(mask, hi);
+
+            svst1_u8(mask, lo, svmin_u8_x(mask, _lo, _value));
+            svst1_u8(mask, hi, svmax_u8_x(mask, _hi, _value));
+        }
+
+        void BackgroundGrowRangeFast(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    BackgroundGrowRangeFast(value + col, lo + col, hi + col, body);
+                if (widthA < width)
+                    BackgroundGrowRangeFast(value + col, lo + col, hi + col, tail);
+                value += valueStride;
+                lo += loStride;
+                hi += hiStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void BackgroundIncrementCount(const uint8_t* value, const uint8_t* loValue, const uint8_t* hiValue,
             uint8_t* loCount, uint8_t* hiCount, const svuint8_t& _1, const svbool_t& mask)
         {

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -504,6 +504,11 @@ namespace Test
             result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve::BackgroundGrowRangeFast), FUNC1(SimdBackgroundGrowRangeFast));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve2::BackgroundGrowRangeFast), FUNC1(SimdBackgroundGrowRangeFast));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBackgroundGrowRangeFast`.
- Extend `BackgroundGrowRangeFastAutoTest` to cover the SVE2 path.
- Document the SVE2 optimization in release `7.2.163`.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && cd build && ./Test "-r=.." -fi=BackgroundGrowRangeFast -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.2-a+sve2 -I./src -fsyntax-only src/Simd/SimdSve2Background.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.2-a+sve2 -I./src -I./src/Test -fsyntax-only src/Test/TestBackground.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81bbdc57-b2e5-4389-b38b-2f2267d55905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81bbdc57-b2e5-4389-b38b-2f2267d55905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

