### PR TITLE
validate lbp feature rect values before indexing

### DIFF
--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -305,6 +305,8 @@ namespace Simd
                     {
                         Data::LbpFeature feature;
                         std::vector<int> values = Xml::GetValues<int>(featureNode, Names::rect);
+                        if (values.size() < 4)
+                            SIMD_EX("Invalid LBP feature: malformed rect!");
                         feature.rect.x = values[0];
                         feature.rect.y = values[1];
                         feature.rect.width = values[2];


### PR DESCRIPTION
The detection module parses OpenCV-style cascade XML through SimdDetectionLoadStringXml, and for an LBP cascade each feature's rect is read with GetValues<int> and then indexed at positions 0 through 3 without checking how many numbers were actually present. That vector comes straight from the text content of the <rect> element, so a cascade whose rect lists fewer than four integers leaves it shorter than the code assumes and the reads at values[2] and values[3] run off the end of the heap allocation. ASan reports it as a heap-buffer-overflow read, and a file with a single short rect is enough to reach it. The HAAR branch just above already rejects the same shape with a values.size() check, but the LBP branch was left without one. I have added the matching guard before the LBP rect is consumed, so a malformed feature now raises the usual exception instead of reading past the buffer. Keeping it at the same spot as the HAAR check should make the two paths a little easier to keep in step.