### PR TITLE
Add SVE2 BackgroundGrowRangeSlow optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -94,6 +94,7 @@
  <li>SVE2 optimizations of function AlphaFilling.</li>
  <li>SVE2 optimizations of function AlphaPremultiply.</li>
  <li>SVE2 optimizations of function AlphaUnpremultiply.</li>
+ <li>SVE2 optimizations of function BackgroundGrowRangeSlow.</li>
  <li>SVE2 optimizations of function BackgroundGrowRangeFast.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRangeMasked.</li>
  <li>SVE2 optimizations of function BackgroundAdjustRange.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -776,6 +776,11 @@ SIMD_API void SimdBackgroundGrowRangeSlow(const uint8_t * value, size_t valueStr
         Sse41::BackgroundGrowRangeSlow(value, valueStride, width, height, lo, loStride, hi, hiStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::BackgroundGrowRangeSlow(value, valueStride, width, height, lo, loStride, hi, hiStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::BackgroundGrowRangeSlow(value, valueStride, width, height, lo, loStride, hi, hiStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -70,6 +70,9 @@ namespace Simd
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 
+        void BackgroundGrowRangeSlow(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
+
         void BackgroundGrowRangeFast(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
 

--- a/src/Simd/SimdSve2Background.cpp
+++ b/src/Simd/SimdSve2Background.cpp
@@ -28,6 +28,43 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE void BackgroundGrowRangeSlow(const uint8_t* value, uint8_t* lo, uint8_t* hi,
+            const svuint8_t& _1, const svbool_t& mask)
+        {
+            svuint8_t _value = svld1_u8(mask, value);
+            svuint8_t _lo = svld1_u8(mask, lo);
+            svuint8_t _hi = svld1_u8(mask, hi);
+
+            svbool_t inc = svcmpgt_u8(mask, _value, _hi);
+            svbool_t dec = svcmplt_u8(mask, _value, _lo);
+
+            svst1_u8(mask, lo, svqsub_u8(_lo, svand_u8_z(dec, _1, _1)));
+            svst1_u8(mask, hi, svqadd_u8(_hi, svand_u8_z(inc, _1, _1)));
+        }
+
+        void BackgroundGrowRangeSlow(const uint8_t* value, size_t valueStride, size_t width, size_t height,
+            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            svuint8_t _1 = svdup_n_u8(1);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    BackgroundGrowRangeSlow(value + col, lo + col, hi + col, _1, body);
+                if (widthA < width)
+                    BackgroundGrowRangeSlow(value + col, lo + col, hi + col, _1, tail);
+                value += valueStride;
+                lo += loStride;
+                hi += hiStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void BackgroundGrowRangeFast(const uint8_t* value, uint8_t* lo, uint8_t* hi, const svbool_t& mask)
         {
             svuint8_t _value = svld1_u8(mask, value);

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -469,6 +469,11 @@ namespace Test
             result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve::BackgroundGrowRangeSlow), FUNC1(SimdBackgroundGrowRangeSlow));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve2::BackgroundGrowRangeSlow), FUNC1(SimdBackgroundGrowRangeSlow));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdBackgroundGrowRangeSlow`.
- Extend the background auto-test to cover `Simd::Sve2::BackgroundGrowRangeSlow`.
- Document the optimization in release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BackgroundGrowRangeSlow -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -O2 -I./src -c src/Simd/SimdSve2Background.cpp -o /tmp/SimdSve2Background.o`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -O2 -I./src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib.aarch64.o`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -O2 -I./src -c src/Test/TestBackground.cpp -o /tmp/TestBackground.aarch64.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c733a04-e337-4145-aa69-998c0c15130f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c733a04-e337-4145-aa69-998c0c15130f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

