### PR TITLE
Remove SVE BackgroundGrowRangeFast

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -117,6 +117,7 @@
 <h5>Removing</h5>
 <ul>
  <li>SVE optimization of function BgrToRgb.</li>
+ <li>SVE optimization of function BackgroundGrowRangeFast.</li>
  <li>Synet support for Visual Studio (32-bit platform).</li>
 </ul>
 <h5>Bug fixing</h5>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -818,11 +818,6 @@ SIMD_API void SimdBackgroundGrowRangeFast(const uint8_t * value, size_t valueStr
         Sve2::BackgroundGrowRangeFast(value, valueStride, width, height, lo, loStride, hi, hiStride);
     else
 #endif
-#ifdef SIMD_SVE_ENABLE
-    if (Sve::Enable)
-        Sve::BackgroundGrowRangeFast(value, valueStride, width, height, lo, loStride, hi, hiStride);
-    else
-#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::BackgroundGrowRangeFast(value, valueStride, width, height, lo, loStride, hi, hiStride);

--- a/src/Simd/SimdSve1.h
+++ b/src/Simd/SimdSve1.h
@@ -49,9 +49,6 @@ namespace Simd
         void BackgroundGrowRangeSlow(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
 
-        void BackgroundGrowRangeFast(const uint8_t* value, size_t valueStride, size_t width, size_t height,
-            uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
-
         void DeinterleaveUv(const uint8_t* uv, size_t uvStride, size_t width, size_t height, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride);
 
         void DeinterleaveBgr(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,

--- a/src/Simd/SimdSve1Background.cpp
+++ b/src/Simd/SimdSve1Background.cpp
@@ -62,36 +62,6 @@ namespace Simd
             }
         }
 
-        //--------------------------------------------------------------------------------------------------
-
-        SIMD_INLINE void BackgroundGrowRangeFast(const uint8_t* value, uint8_t* lo, uint8_t* hi, const svbool_t& mask)
-        {
-            svuint8_t _value = svld1_u8(mask, value);
-            svuint8_t _lo = svld1_u8(mask, lo);
-            svuint8_t _hi = svld1_u8(mask, hi);
-
-            svst1_u8(mask, lo, svmin_u8_x(mask, _lo, _value));
-            svst1_u8(mask, hi, svmax_u8_x(mask, _hi, _value));
-        }
-
-        void BackgroundGrowRangeFast(const uint8_t* value, size_t valueStride, size_t width, size_t height, uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride)
-        {
-            size_t A = svlen(svuint8_t());
-            size_t widthA = AlignLo(width, A);
-            const svbool_t body = svwhilelt_b8(size_t(0), A);
-            const svbool_t tail = svwhilelt_b8(widthA, width);
-            for (size_t row = 0; row < height; ++row)
-            {
-                size_t col = 0;
-                for (; col < widthA; col += A)
-                    BackgroundGrowRangeFast(value + col, lo + col, hi + col, body);
-                if (widthA < width)
-                    BackgroundGrowRangeFast(value + col, lo + col, hi + col, tail);
-                value += valueStride;
-                lo += loStride;
-                hi += hiStride;
-            }
-        }
     }
 #endif
 }

--- a/src/Test/TestBackground.cpp
+++ b/src/Test/TestBackground.cpp
@@ -504,11 +504,6 @@ namespace Test
             result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Neon::BackgroundGrowRangeFast), FUNC1(SimdBackgroundGrowRangeFast));
 #endif
 
-#ifdef SIMD_SVE_ENABLE
-        if (Simd::Sve::Enable && TestSve(options))
-            result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve::BackgroundGrowRangeFast), FUNC1(SimdBackgroundGrowRangeFast));
-#endif
-
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
             result = result && BackgroundChangeRangeAutoTest(FUNC1(Simd::Sve2::BackgroundGrowRangeFast), FUNC1(SimdBackgroundGrowRangeFast));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the SVE1 `BackgroundGrowRangeFast` implementation, declaration, dispatch path, and SVE-specific test call.
- Keep `SimdSve1Background.cpp` in the project because it still contains `BackgroundGrowRangeSlow`.
- Record the removal in the 7.2.163 release notes.

### Testing
- `! rg "Sve::BackgroundGrowRangeFast|Simd::Sve::BackgroundGrowRangeFast" .`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel "$(nproc)"`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BackgroundGrowRangeFast -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5cb3cf7-479a-45af-ab26-ea6545e3ed9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5cb3cf7-479a-45af-ab26-ea6545e3ed9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

