### PR TITLE
Add SVE2 optimization for CosineDistancesMxNa16f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -44,6 +44,7 @@
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
+ <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2744,6 +2744,11 @@ SIMD_API void SimdCosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uin
         Avx2::CosineDistancesMxNa16f(M, N, K, A, B, distances);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::CosineDistancesMxNa16f(M, N, K, A, B, distances);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && K >= Neon::F)
         Neon::CosineDistancesMxNa16f(M, N, K, A, B, distances);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -109,6 +109,8 @@ namespace Simd
 
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
+        void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);
+
         void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -22,6 +22,8 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
+#include "Simd/SimdArray.h"
+#include "Simd/SimdCpu.h"
 
 namespace Simd
 {
@@ -65,6 +67,259 @@ namespace Simd
             float _ab = svaddv_f32(body32, svadd_f32_x(body32, ab0, ab1));
             float _bb = svaddv_f32(body32, svadd_f32_x(body32, bb0, bb1));
             *distance = 1.0f - _ab / ::sqrt(_aa * _bb);
+        }
+
+        SIMD_INLINE void Load16f(const uint16_t* src, const svbool_t& load, const svbool_t& lo, const svbool_t& hi, svfloat32_t& dst0, svfloat32_t& dst1)
+        {
+            svfloat16_t _src = svreinterpret_f16_u16(svld1_u16(load, src));
+            dst0 = svcvt_f32_f16_x(lo, _src);
+            dst1 = svcvtlt_f32_f16_x(hi, _src);
+        }
+
+        SIMD_INLINE void Square16f(const uint16_t* a, const svbool_t& load, const svbool_t& lo, const svbool_t& hi, svfloat32_t& sum0, svfloat32_t& sum1)
+        {
+            svfloat32_t a0, a1;
+            Load16f(a, load, lo, hi, a0, a1);
+            sum0 = svmla_f32_m(lo, sum0, a0, a0);
+            sum1 = svmla_f32_m(hi, sum1, a1, a1);
+        }
+
+        SIMD_INLINE void Product16f(const svbool_t& lo, const svbool_t& hi, const svfloat32_t& a0, const svfloat32_t& a1,
+            const svfloat32_t& b0, const svfloat32_t& b1, svfloat32_t& sum0, svfloat32_t& sum1)
+        {
+            sum0 = svmla_f32_m(lo, sum0, a0, b0);
+            sum1 = svmla_f32_m(hi, sum1, a1, b1);
+        }
+
+        SIMD_INLINE float Sum16f(const svbool_t& body, const svfloat32_t& sum0, const svfloat32_t& sum1)
+        {
+            return svaddv_f32(body, svadd_f32_x(body, sum0, sum1));
+        }
+
+        static void Squares(size_t M, size_t K, const uint16_t* const* A, float* squares)
+        {
+            size_t A_ = svlen(svuint16_t()), KA = AlignLoAny(K, A_);
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            for (size_t i = 0; i < M; ++i)
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+                size_t k = 0;
+                for (; k < KA; k += A_)
+                    Square16f(A[i] + k, body16, body32, body32, sum0, sum1);
+                if (k < K)
+                {
+                    size_t tail = K - k;
+                    Square16f(A[i] + k, svwhilelt_b16(size_t(0), tail),
+                        svwhilelt_b32(size_t(0), (tail + 1) / 2), svwhilelt_b32(size_t(0), tail / 2), sum0, sum1);
+                }
+                squares[i] = Sum16f(body32, sum0, sum1);
+            }
+        }
+
+        SIMD_INLINE void StoreDistance4(const svbool_t& body, const float* aa, const float* bb, float* distances,
+            const svfloat32_t& c0l, const svfloat32_t& c0h, const svfloat32_t& c1l, const svfloat32_t& c1h,
+            const svfloat32_t& c2l, const svfloat32_t& c2h, const svfloat32_t& c3l, const svfloat32_t& c3h)
+        {
+            distances[0] = 1.0f - Sum16f(body, c0l, c0h) / ::sqrt(aa[0] * bb[0]);
+            distances[1] = 1.0f - Sum16f(body, c1l, c1h) / ::sqrt(aa[0] * bb[1]);
+            distances[2] = 1.0f - Sum16f(body, c2l, c2h) / ::sqrt(aa[0] * bb[2]);
+            distances[3] = 1.0f - Sum16f(body, c3l, c3h) / ::sqrt(aa[0] * bb[3]);
+        }
+
+        static void MicroCosineDistances2x4(size_t K, const uint16_t* const* A, const uint16_t* const* B, const float* aa, const float* bb, float* distances, size_t stride)
+        {
+            size_t A_ = svlen(svuint16_t()), KA = AlignLoAny(K, A_), k = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            svfloat32_t c00l = svdup_n_f32(0.0f), c00h = svdup_n_f32(0.0f), c01l = c00l, c01h = c00h, c02l = c00l, c02h = c00h, c03l = c00l, c03h = c00h;
+            svfloat32_t c10l = svdup_n_f32(0.0f), c10h = svdup_n_f32(0.0f), c11l = c10l, c11h = c10h, c12l = c10l, c12h = c10h, c13l = c10l, c13h = c10h;
+            for (; k < KA; k += A_)
+            {
+                svfloat32_t a0l, a0h, a1l, a1h, b0l, b0h;
+                Load16f(A[0] + k, body16, body32, body32, a0l, a0h);
+                Load16f(A[1] + k, body16, body32, body32, a1l, a1h);
+                Load16f(B[0] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c00l, c00h);
+                Product16f(body32, body32, a1l, a1h, b0l, b0h, c10l, c10h);
+                Load16f(B[1] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c01l, c01h);
+                Product16f(body32, body32, a1l, a1h, b0l, b0h, c11l, c11h);
+                Load16f(B[2] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c02l, c02h);
+                Product16f(body32, body32, a1l, a1h, b0l, b0h, c12l, c12h);
+                Load16f(B[3] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c03l, c03h);
+                Product16f(body32, body32, a1l, a1h, b0l, b0h, c13l, c13h);
+            }
+            if (k < K)
+            {
+                size_t tail = K - k;
+                svbool_t load = svwhilelt_b16(size_t(0), tail);
+                svbool_t lo = svwhilelt_b32(size_t(0), (tail + 1) / 2);
+                svbool_t hi = svwhilelt_b32(size_t(0), tail / 2);
+                svfloat32_t a0l, a0h, a1l, a1h, b0l, b0h;
+                Load16f(A[0] + k, load, lo, hi, a0l, a0h);
+                Load16f(A[1] + k, load, lo, hi, a1l, a1h);
+                Load16f(B[0] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c00l, c00h);
+                Product16f(lo, hi, a1l, a1h, b0l, b0h, c10l, c10h);
+                Load16f(B[1] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c01l, c01h);
+                Product16f(lo, hi, a1l, a1h, b0l, b0h, c11l, c11h);
+                Load16f(B[2] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c02l, c02h);
+                Product16f(lo, hi, a1l, a1h, b0l, b0h, c12l, c12h);
+                Load16f(B[3] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c03l, c03h);
+                Product16f(lo, hi, a1l, a1h, b0l, b0h, c13l, c13h);
+            }
+            StoreDistance4(body32, aa + 0, bb, distances + 0 * stride, c00l, c00h, c01l, c01h, c02l, c02h, c03l, c03h);
+            StoreDistance4(body32, aa + 1, bb, distances + 1 * stride, c10l, c10h, c11l, c11h, c12l, c12h, c13l, c13h);
+        }
+
+        static void MicroCosineDistances2x1(size_t K, const uint16_t* const* A, const uint16_t* const* B, const float* aa, const float* bb, float* distances, size_t stride)
+        {
+            size_t A_ = svlen(svuint16_t()), KA = AlignLoAny(K, A_), k = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            svfloat32_t c00l = svdup_n_f32(0.0f), c00h = svdup_n_f32(0.0f), c10l = c00l, c10h = c00h;
+            for (; k < KA; k += A_)
+            {
+                svfloat32_t a0l, a0h, a1l, a1h, b0l, b0h;
+                Load16f(B[0] + k, body16, body32, body32, b0l, b0h);
+                Load16f(A[0] + k, body16, body32, body32, a0l, a0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c00l, c00h);
+                Load16f(A[1] + k, body16, body32, body32, a1l, a1h);
+                Product16f(body32, body32, a1l, a1h, b0l, b0h, c10l, c10h);
+            }
+            if (k < K)
+            {
+                size_t tail = K - k;
+                svbool_t load = svwhilelt_b16(size_t(0), tail);
+                svbool_t lo = svwhilelt_b32(size_t(0), (tail + 1) / 2);
+                svbool_t hi = svwhilelt_b32(size_t(0), tail / 2);
+                svfloat32_t a0l, a0h, a1l, a1h, b0l, b0h;
+                Load16f(B[0] + k, load, lo, hi, b0l, b0h);
+                Load16f(A[0] + k, load, lo, hi, a0l, a0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c00l, c00h);
+                Load16f(A[1] + k, load, lo, hi, a1l, a1h);
+                Product16f(lo, hi, a1l, a1h, b0l, b0h, c10l, c10h);
+            }
+            distances[0 * stride] = 1.0f - Sum16f(body32, c00l, c00h) / ::sqrt(aa[0] * bb[0]);
+            distances[1 * stride] = 1.0f - Sum16f(body32, c10l, c10h) / ::sqrt(aa[1] * bb[0]);
+        }
+
+        static void MicroCosineDistances1x4(size_t K, const uint16_t* const* A, const uint16_t* const* B, const float* aa, const float* bb, float* distances, size_t stride)
+        {
+            size_t A_ = svlen(svuint16_t()), KA = AlignLoAny(K, A_), k = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            svfloat32_t c00l = svdup_n_f32(0.0f), c00h = svdup_n_f32(0.0f), c01l = c00l, c01h = c00h, c02l = c00l, c02h = c00h, c03l = c00l, c03h = c00h;
+            for (; k < KA; k += A_)
+            {
+                svfloat32_t a0l, a0h, b0l, b0h;
+                Load16f(A[0] + k, body16, body32, body32, a0l, a0h);
+                Load16f(B[0] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c00l, c00h);
+                Load16f(B[1] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c01l, c01h);
+                Load16f(B[2] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c02l, c02h);
+                Load16f(B[3] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c03l, c03h);
+            }
+            if (k < K)
+            {
+                size_t tail = K - k;
+                svbool_t load = svwhilelt_b16(size_t(0), tail);
+                svbool_t lo = svwhilelt_b32(size_t(0), (tail + 1) / 2);
+                svbool_t hi = svwhilelt_b32(size_t(0), tail / 2);
+                svfloat32_t a0l, a0h, b0l, b0h;
+                Load16f(A[0] + k, load, lo, hi, a0l, a0h);
+                Load16f(B[0] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c00l, c00h);
+                Load16f(B[1] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c01l, c01h);
+                Load16f(B[2] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c02l, c02h);
+                Load16f(B[3] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c03l, c03h);
+            }
+            StoreDistance4(body32, aa, bb, distances, c00l, c00h, c01l, c01h, c02l, c02h, c03l, c03h);
+        }
+
+        static void MicroCosineDistances1x1(size_t K, const uint16_t* const* A, const uint16_t* const* B, const float* aa, const float* bb, float* distances, size_t stride)
+        {
+            size_t A_ = svlen(svuint16_t()), KA = AlignLoAny(K, A_), k = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            svfloat32_t c00l = svdup_n_f32(0.0f), c00h = svdup_n_f32(0.0f);
+            for (; k < KA; k += A_)
+            {
+                svfloat32_t a0l, a0h, b0l, b0h;
+                Load16f(A[0] + k, body16, body32, body32, a0l, a0h);
+                Load16f(B[0] + k, body16, body32, body32, b0l, b0h);
+                Product16f(body32, body32, a0l, a0h, b0l, b0h, c00l, c00h);
+            }
+            if (k < K)
+            {
+                size_t tail = K - k;
+                svbool_t load = svwhilelt_b16(size_t(0), tail);
+                svbool_t lo = svwhilelt_b32(size_t(0), (tail + 1) / 2);
+                svbool_t hi = svwhilelt_b32(size_t(0), tail / 2);
+                svfloat32_t a0l, a0h, b0l, b0h;
+                Load16f(A[0] + k, load, lo, hi, a0l, a0h);
+                Load16f(B[0] + k, load, lo, hi, b0l, b0h);
+                Product16f(lo, hi, a0l, a0h, b0l, b0h, c00l, c00h);
+            }
+            distances[0 * stride] = 1.0f - Sum16f(body32, c00l, c00h) / ::sqrt(aa[0] * bb[0]);
+        }
+
+        const size_t MicroM = 2;
+        static void MacroCosineDistances(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, const float* aa, const float* bb, float* distances, size_t stride)
+        {
+            size_t M2 = AlignLoAny(M, 2);
+            size_t N4 = AlignLoAny(N, 4);
+            size_t i = 0;
+            for (; i < M2; i += 2)
+            {
+                size_t j = 0;
+                for (; j < N4; j += 4)
+                    MicroCosineDistances2x4(K, A + i, B + j, aa + i, bb + j, distances + j, stride);
+                for (; j < N; j += 1)
+                    MicroCosineDistances2x1(K, A + i, B + j, aa + i, bb + j, distances + j, stride);
+                distances += 2 * stride;
+            }
+            for (; i < M; ++i)
+            {
+                size_t j = 0;
+                for (; j < N4; j += 4)
+                    MicroCosineDistances1x4(K, A + i, B + j, aa + i, bb + j, distances + j, stride);
+                for (; j < N; j += 1)
+                    MicroCosineDistances1x1(K, A + i, B + j, aa + i, bb + j, distances + j, stride);
+                distances += 1 * stride;
+            }
+        }
+
+        void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances)
+        {
+            const size_t L2 = Base::AlgCacheL2();
+            size_t mN = AlignLoAny(L2 / 2 / K, 4);
+            size_t mM = AlignLoAny(L2 / 2 / K, MicroM);
+            Array32f aa(mM), bb(N);
+            for (size_t i = 0; i < M; i += mM)
+            {
+                size_t dM = Simd::Min(M, i + mM) - i;
+                Squares(dM, K, A + i, aa.data);
+                for (size_t j = 0; j < N; j += mN)
+                {
+                    size_t dN = Simd::Min(N, j + mN) - j;
+                    if (i == 0)
+                        Squares(dN, K, B + j, bb.data + j);
+                    MacroCosineDistances(dM, dN, K, A + i, B + j, aa.data, bb.data + j, distances + i * N + j, N);
+                }
+            }
         }
     }
 #endif

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -528,6 +528,11 @@ namespace Test
             result = result && CosineDistancesMxNa16fAutoTest(EPS, FUNC_CDA(Simd::Avx512bw::CosineDistancesMxNa16f), FUNC_CDA(SimdCosineDistancesMxNa16f));
 #endif
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && CosineDistancesMxNa16fAutoTest(EPS, FUNC_CDA(Simd::Sve2::CosineDistancesMxNa16f), FUNC_CDA(SimdCosineDistancesMxNa16f));
+#endif
+
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && CosineDistancesMxNa16fAutoTest(EPS, FUNC_CDA(Simd::Neon::CosineDistancesMxNa16f), FUNC_CDA(SimdCosineDistancesMxNa16f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdCosineDistancesMxNa16f`.
- Extend float16 auto-tests to compare the SVE2 implementation.
- Update 7.2.163 release notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./Test "-r=.." -fi=CosineDistancesMxNa16f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2+fp16 -I./src -fsyntax-only src/Simd/SimdSve2Float16.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d11f63a2-62b1-44ff-894a-2b670adb7604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d11f63a2-62b1-44ff-894a-2b670adb7604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

