### PR TITLE
Add SVE2 optimization for packed fp16 cosine distances

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -45,6 +45,7 @@
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
+ <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2770,6 +2770,11 @@ SIMD_API void SimdCosineDistancesMxNp16f(size_t M, size_t N, size_t K, const uin
         Avx2::CosineDistancesMxNp16f(M, N, K, A, B, distances);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::CosineDistancesMxNp16f(M, N, K, A, B, distances);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && K >= Neon::F)
         Neon::CosineDistancesMxNp16f(M, N, K, A, B, distances);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -111,6 +111,8 @@ namespace Simd
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);
 
+        void CosineDistancesMxNp16f(size_t M, size_t N, size_t K, const uint16_t* A, const uint16_t* B, float* distances);
+
         void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -321,6 +321,34 @@ namespace Simd
                 }
             }
         }
+
+        void CosineDistancesMxNp16f(size_t M, size_t N, size_t K, const uint16_t* A, const uint16_t* B, float* distances)
+        {
+            const size_t L2 = Base::AlgCacheL2();
+            size_t mN = AlignLoAny(L2 / 2 / K, 4);
+            size_t mM = AlignLoAny(L2 / 2 / K, MicroM);
+            Array32f aa(mM), bb(N);
+            Array16ucp ap(mM), bp(N);
+            for (size_t i = 0; i < M; i += mM)
+            {
+                size_t dM = Simd::Min(M, i + mM) - i;
+                for (size_t k = 0; k < dM; ++k)
+                    ap[k] = A + k * K;
+                Squares(dM, K, ap.data, aa.data);
+                for (size_t j = 0; j < N; j += mN)
+                {
+                    size_t dN = Simd::Min(N, j + mN) - j;
+                    if (i == 0)
+                    {
+                        for (size_t k = j, n = j + dN; k < n; ++k)
+                            bp[k] = B + k * K;
+                        Squares(dN, K, bp.data + j, bb.data + j);
+                    }
+                    MacroCosineDistances(dM, dN, K, ap.data, bp.data + j, aa.data, bb.data + j, distances + i * N + j, N);
+                }
+                A += dM * K;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -430,6 +430,11 @@ namespace Test
             result = result && CosineDistancesMxNp16fAutoTest(EPS, FUNC_CDP(Simd::Avx512bw::CosineDistancesMxNp16f), FUNC_CDP(SimdCosineDistancesMxNp16f));
 #endif
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && CosineDistancesMxNp16fAutoTest(EPS, FUNC_CDP(Simd::Sve2::CosineDistancesMxNp16f), FUNC_CDP(SimdCosineDistancesMxNp16f));
+#endif
+
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && CosineDistancesMxNp16fAutoTest(EPS, FUNC_CDP(Simd::Neon::CosineDistancesMxNp16f), FUNC_CDP(SimdCosineDistancesMxNp16f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdCosineDistancesMxNp16f`.
- Add SVE2 coverage in `CosineDistancesMxNp16fAutoTest`.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=CosineDistancesMxNp16f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -I src -march=armv9-a+sve2+fp16 -msve-vector-bits=scalable src/Simd/SimdSve2Float16.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84c28099-7172-4f26-a28e-ac3484d66ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84c28099-7172-4f26-a28e-ac3484d66ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

