### PR TITLE
Add SVE2 descriptor integer cosine distance

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
+ <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -42,6 +42,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToYuvV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrInt.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
@@ -64,6 +66,8 @@
     <ClInclude Include="..\..\src\Simd\SimdConversion.h" />
     <ClInclude Include="..\..\src\Simd\SimdCpu.h" />
     <ClInclude Include="..\..\src\Simd\SimdDefs.h" />
+    <ClInclude Include="..\..\src\Simd\SimdDescrInt.h" />
+    <ClInclude Include="..\..\src\Simd\SimdDescrIntCommon.h" />
     <ClInclude Include="..\..\src\Simd\SimdEnable.h" />
     <ClInclude Include="..\..\src\Simd\SimdExtract.h" />
     <ClInclude Include="..\..\src\Simd\SimdInit.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -78,6 +78,12 @@
     <ClInclude Include="..\..\src\Simd\SimdDefs.h">
       <Filter>Inc</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Simd\SimdDescrInt.h">
+      <Filter>Inc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Simd\SimdDescrIntCommon.h">
+      <Filter>Inc</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdEnable.h">
       <Filter>Inc</Filter>
     </ClInclude>
@@ -187,6 +193,12 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp">
       <Filter>Sve2\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrInt.cpp">
+      <Filter>Sve2\Descriptors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp">
+      <Filter>Sve2\Descriptors</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
       <Filter>Sve2\Math</Filter>

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -266,5 +266,28 @@ namespace Simd
         void* DescrIntInit(size_t size, size_t depth);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+#ifdef SIMD_NEON_ENABLE
+        class DescrInt : public Neon::DescrInt
+#else
+        class DescrInt : public Base::DescrInt
+#endif
+        {
+        public:
+            DescrInt(size_t size, size_t depth);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth);
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* DescrIntInit(size_t size, size_t depth);
+    }
+#endif
 }
 #endif//__SimdDescrInt_h__

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2110,7 +2110,7 @@ SIMD_API void* SimdDescrIntInit(size_t size, size_t depth)
 {
     SIMD_EMPTY();
     typedef void* (*SimdDescrIntInitPtr) (size_t size, size_t depth);
-    const static SimdDescrIntInitPtr simdDescrIntInit = SIMD_FUNC6(DescrIntInit, SIMD_AMXBF16_FUNC, SIMD_AVX512VNNI_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdDescrIntInitPtr simdDescrIntInit = SIMD_FUNC7(DescrIntInit, SIMD_AMXBF16_FUNC, SIMD_AVX512VNNI_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdDescrIntInit(size, depth);
 }

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -1,0 +1,53 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdDescrInt.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        DescrInt::DescrInt(size_t size, size_t depth)
+#ifdef SIMD_NEON_ENABLE
+            : Neon::DescrInt(size, depth)
+#else
+            : Base::DescrInt(size, depth)
+#endif
+        {
+            _cosineDistance = GetCosineDistance(_depth);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* DescrIntInit(size_t size, size_t depth)
+        {
+            if (!Base::DescrInt::Valid(size, depth))
+                return NULL;
+            return new Sve2::DescrInt(size, depth);
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Simd/SimdSve2DescrIntCdd.cpp
+++ b/src/Simd/SimdSve2DescrIntCdd.cpp
@@ -85,8 +85,8 @@ namespace Simd
                 sums = svadd_u64_m(mask, sums, CorrelationBlock<bits>(_a, _b, mask));
             }
             uint64_t sum = svaddv_u64(svptrue_b64(), sums);
-            for (; i < blocks; ++i)
-                sum += CorrelationBlock<bits>(LoadBlock<bits>(a + i * bits), LoadBlock<bits>(b + i * bits));
+            for (size_t tail = vectorBlocks; tail < blocks; ++tail)
+                sum += CorrelationBlock<bits>(LoadBlock<bits>(a + tail * bits), LoadBlock<bits>(b + tail * bits));
             return (int32_t)sum;
         }
 

--- a/src/Simd/SimdSve2DescrIntCdd.cpp
+++ b/src/Simd/SimdSve2DescrIntCdd.cpp
@@ -1,0 +1,145 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdDescrInt.h"
+#include "Simd/SimdDescrIntCommon.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template<int bits> SIMD_INLINE uint64_t LoadBlock(const uint8_t* src)
+        {
+            uint64_t value = 0;
+            for (size_t i = 0; i < bits; ++i)
+                value |= uint64_t(src[i]) << (8 * i);
+            return value;
+        }
+
+        template<int bits> SIMD_INLINE uint64_t CorrelationBlock(uint64_t a, uint64_t b)
+        {
+            const uint64_t mask = (uint64_t(1) << bits) - 1;
+            uint64_t sum = 0;
+            for (size_t i = 0; i < 8; ++i)
+                sum += ((a >> (i * bits)) & mask) * ((b >> (i * bits)) & mask);
+            return sum;
+        }
+
+        template<int bits> SIMD_INLINE svuint64_t CorrelationBlock(const svuint64_t& a, const svuint64_t& b, const svbool_t& mask)
+        {
+            const uint64_t valueMask = (uint64_t(1) << bits) - 1;
+            svuint64_t sum = svdup_n_u64(0);
+#define SIMD_SVE2_DESCR_INT_CORRELATE(shift) \
+            { \
+                svuint64_t _a = svand_n_u64_x(mask, svlsr_n_u64_x(mask, a, shift), valueMask); \
+                svuint64_t _b = svand_n_u64_x(mask, svlsr_n_u64_x(mask, b, shift), valueMask); \
+                sum = svmla_u64_m(mask, sum, _a, _b); \
+            }
+            SIMD_SVE2_DESCR_INT_CORRELATE(0 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(1 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(2 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(3 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(4 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(5 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(6 * bits);
+            SIMD_SVE2_DESCR_INT_CORRELATE(7 * bits);
+#undef SIMD_SVE2_DESCR_INT_CORRELATE
+            return sum;
+        }
+
+        template<int bits> int32_t Correlation(const uint8_t* a, const uint8_t* b, size_t size)
+        {
+            assert(size % 8 == 0 && size >= 8);
+            size_t blocks = size / 8, vectorBlocks = blocks - 1, i = 0;
+            svuint64_t sums = svdup_n_u64(0);
+            for (; i < vectorBlocks; i += svcntd())
+            {
+                svbool_t mask = svwhilelt_b64(i, vectorBlocks);
+                svuint64_t offsets = svindex_u64(uint64_t(i * bits), bits);
+                svuint64_t _a = svld1_gather_u64offset_u64(mask, (const uint64_t*)a, offsets);
+                svuint64_t _b = svld1_gather_u64offset_u64(mask, (const uint64_t*)b, offsets);
+                sums = svadd_u64_m(mask, sums, CorrelationBlock<bits>(_a, _b, mask));
+            }
+            uint64_t sum = svaddv_u64(svptrue_b64(), sums);
+            for (; i < blocks; ++i)
+                sum += CorrelationBlock<bits>(LoadBlock<bits>(a + i * bits), LoadBlock<bits>(b + i * bits));
+            return (int32_t)sum;
+        }
+
+        template<> int32_t Correlation<4>(const uint8_t* a, const uint8_t* b, size_t size)
+        {
+            assert(size % 8 == 0 && size >= 8);
+            const size_t byteSize = size / 2;
+            const svuint8_t zero = svdup_n_u8(0);
+            svuint32_t sums = svdup_n_u32(0);
+            for (size_t i = 0; i < byteSize; i += svcntb())
+            {
+                svbool_t mask = svwhilelt_b8(i, byteSize);
+                svuint8_t _a = svsel_u8(mask, svld1_u8(mask, a + i), zero);
+                svuint8_t _b = svsel_u8(mask, svld1_u8(mask, b + i), zero);
+                sums = svdot_u32(sums, svand_n_u8_z(mask, _a, 0x0F), svand_n_u8_z(mask, _b, 0x0F));
+                sums = svdot_u32(sums, svlsr_n_u8_z(mask, _a, 4), svlsr_n_u8_z(mask, _b, 4));
+            }
+            return (int32_t)svaddv_u32(svptrue_b32(), sums);
+        }
+
+        template<> int32_t Correlation<8>(const uint8_t* a, const uint8_t* b, size_t size)
+        {
+            assert(size % 8 == 0 && size >= 8);
+            const svuint8_t zero = svdup_n_u8(0);
+            svuint32_t sums = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += svcntb())
+            {
+                svbool_t mask = svwhilelt_b8(i, size);
+                svuint8_t _a = svsel_u8(mask, svld1_u8(mask, a + i), zero);
+                svuint8_t _b = svsel_u8(mask, svld1_u8(mask, b + i), zero);
+                sums = svdot_u32(sums, _a, _b);
+            }
+            return (int32_t)svaddv_u32(svptrue_b32(), sums);
+        }
+
+        template<int bits> void CosineDistance(const uint8_t* a, const uint8_t* b, size_t size, float* distance)
+        {
+            float abSum = (float)Correlation<bits>(a + 16, b + 16, size);
+            Base::DecodeCosineDistance(a, b, abSum, distance);
+        }
+
+        Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth)
+        {
+            switch (depth)
+            {
+            case 4: return CosineDistance<4>;
+            case 5: return CosineDistance<5>;
+            case 6: return CosineDistance<6>;
+            case 7: return CosineDistance<7>;
+            case 8: return CosineDistance<8>;
+            default: assert(0); return NULL;
+            }
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -562,6 +562,11 @@ namespace Test
         if (Simd::AmxBf16::Enable && TestAmxBf16(options))
             result = result && DescrIntCosineDistanceAutoTest(FUNC_DI(Simd::AmxBf16::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntCosineDistanceAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
         
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 `DescrInt` context that overrides `DescrIntCosineDistance` with SVE2 descriptor correlation kernels.
- Wire SVE2 descriptor init dispatch, autotest coverage, Visual Studio project entries, and 7.2.163 release notes.
- Fix packed 5/6/7-bit SVE2 tail handling so the final scalar block is not skipped after a predicated vector loop.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=DescrIntCosineDistance -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I src -march=armv8.6-a+sve2 -fsyntax-only src/Simd/SimdSve2DescrInt.cpp src/Simd/SimdSve2DescrIntCdd.cpp`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I src -march=armv8.6-a+sve2 -fsyntax-only src/Simd/SimdLib.cpp src/Test/TestDescrInt.cpp`
- Temporary QEMU AArch64/SVE2 packed-correlation repro: depth 5, 6, and 7 scalar/SVE2 sums match after the tail fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-562cf01a-69cd-4d1b-8b20-149d7908a687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-562cf01a-69cd-4d1b-8b20-149d7908a687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

