### PR TITLE
Add SVE2 DescrInt MxNa optimizations

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
+ <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrInt.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -200,6 +200,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp">
       <Filter>Sve2\Descriptors</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp">
+      <Filter>Sve2\Descriptors</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -283,6 +283,11 @@ namespace Simd
         //-------------------------------------------------------------------------------------------------
 
         Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth);
+        Base::DescrInt::MacroCosineDistancesDirectPtr GetMacroCosineDistancesDirect(size_t depth);
+
+        Base::DescrInt::UnpackNormPtr GetUnpackNorm(bool transpose);
+        Base::DescrInt::UnpackDataPtr GetUnpackData(size_t depth);
+        Base::DescrInt::MacroCosineDistancesUnpackPtr GetMacroCosineDistancesUnpack(size_t depth);
 
         //-------------------------------------------------------------------------------------------------
 

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -38,6 +38,18 @@ namespace Simd
 #endif
         {
             _cosineDistance = GetCosineDistance(_depth);
+            _macroCosineDistancesDirect = GetMacroCosineDistancesDirect(_depth);
+            _microMd = 1;
+            _microNd = 1;
+
+            _unpackNormA = GetUnpackNorm(false);
+            _unpackNormB = GetUnpackNorm(true);
+            _unpackDataA = GetUnpackData(_depth);
+            _unpackDataB = GetUnpackData(_depth);
+            _macroCosineDistancesUnpack = GetMacroCosineDistancesUnpack(_depth);
+            _unpSize = _size;
+            _microMu = 1;
+            _microNu = 1;
         }
 
         //-------------------------------------------------------------------------------------------------

--- a/src/Simd/SimdSve2DescrIntCdd.cpp
+++ b/src/Simd/SimdSve2DescrIntCdd.cpp
@@ -128,16 +128,39 @@ namespace Simd
             Base::DecodeCosineDistance(a, b, abSum, distance);
         }
 
+        template<int bits> void MacroCosineDistancesDirect(size_t M, size_t N, const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
+        {
+            for (size_t i = 0; i < M; ++i)
+            {
+                const uint8_t* a = A[i];
+                for (size_t j = 0; j < N; ++j)
+                    CosineDistance<bits>(a, B[j], size, distances + i * stride + j);
+            }
+        }
+
         Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth)
         {
             switch (depth)
             {
             case 4: return CosineDistance<4>;
-            //case 5: return CosineDistance<5>;
-            //case 6: return CosineDistance<6>;
-            //case 7: return CosineDistance<7>;
+            case 5: return CosineDistance<5>;
+            case 6: return CosineDistance<6>;
+            case 7: return CosineDistance<7>;
             case 8: return CosineDistance<8>;
             default: return Neon::GetCosineDistance(depth);
+            }
+        }
+
+        Base::DescrInt::MacroCosineDistancesDirectPtr GetMacroCosineDistancesDirect(size_t depth)
+        {
+            switch (depth)
+            {
+            case 4: return MacroCosineDistancesDirect<4>;
+            case 5: return MacroCosineDistancesDirect<5>;
+            case 6: return MacroCosineDistancesDirect<6>;
+            case 7: return MacroCosineDistancesDirect<7>;
+            case 8: return MacroCosineDistancesDirect<8>;
+            default: return NULL;
             }
         }
     }

--- a/src/Simd/SimdSve2DescrIntCdu.cpp
+++ b/src/Simd/SimdSve2DescrIntCdu.cpp
@@ -1,0 +1,156 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdDescrInt.h"
+#include "Simd/SimdDescrIntCommon.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        static void UnpackNorm(size_t count, const uint8_t* const* src, float* dst, size_t stride)
+        {
+            for (size_t i = 0; i < count; ++i)
+            {
+                const float* ps = (const float*)src[i];
+                float* pd = dst + i * 4;
+                pd[0] = ps[0];
+                pd[1] = ps[1];
+                pd[2] = ps[2];
+                pd[3] = ps[3];
+            }
+        }
+
+        Base::DescrInt::UnpackNormPtr GetUnpackNorm(bool transpose)
+        {
+            return UnpackNorm;
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<int bits> SIMD_INLINE uint64_t LoadBitsBlock(const uint8_t* src)
+        {
+            uint64_t value = 0;
+            for (size_t i = 0; i < bits; ++i)
+                value |= uint64_t(src[i]) << (8 * i);
+            return value;
+        }
+
+        template<int bits> void UnpackData(size_t count, const uint8_t* const* src, size_t size, uint8_t* dst, size_t stride)
+        {
+            const uint64_t mask = (uint64_t(1) << bits) - 1;
+            for (size_t i = 0; i < count; ++i)
+            {
+                const uint8_t* ps = src[i] + 16;
+                uint8_t* pd = dst + i * size;
+                for (size_t j = 0; j < size; j += 8, ps += bits, pd += 8)
+                {
+                    uint64_t value = LoadBitsBlock<bits>(ps);
+                    pd[0] = uint8_t((value >> (0 * bits)) & mask);
+                    pd[1] = uint8_t((value >> (1 * bits)) & mask);
+                    pd[2] = uint8_t((value >> (2 * bits)) & mask);
+                    pd[3] = uint8_t((value >> (3 * bits)) & mask);
+                    pd[4] = uint8_t((value >> (4 * bits)) & mask);
+                    pd[5] = uint8_t((value >> (5 * bits)) & mask);
+                    pd[6] = uint8_t((value >> (6 * bits)) & mask);
+                    pd[7] = uint8_t((value >> (7 * bits)) & mask);
+                }
+            }
+        }
+
+        template<> void UnpackData<8>(size_t count, const uint8_t* const* src, size_t size, uint8_t* dst, size_t stride)
+        {
+            const svuint8_t zero = svdup_n_u8(0);
+            for (size_t i = 0; i < count; ++i)
+            {
+                const uint8_t* ps = src[i] + 16;
+                uint8_t* pd = dst + i * size;
+                for (size_t j = 0; j < size; j += svcntb())
+                {
+                    svbool_t mask = svwhilelt_b8(j, size);
+                    svuint8_t value = svsel_u8(mask, svld1_u8(mask, ps + j), zero);
+                    svst1_u8(mask, pd + j, value);
+                }
+            }
+        }
+
+        Base::DescrInt::UnpackDataPtr GetUnpackData(size_t depth)
+        {
+            switch (depth)
+            {
+            case 4: return UnpackData<4>;
+            case 5: return UnpackData<5>;
+            case 6: return UnpackData<6>;
+            case 7: return UnpackData<7>;
+            case 8: return UnpackData<8>;
+            default: return NULL;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE uint32_t Correlation8u(const uint8_t* a, const uint8_t* b, size_t size)
+        {
+            const svuint8_t zero = svdup_n_u8(0);
+            svuint32_t sums = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += svcntb())
+            {
+                svbool_t mask = svwhilelt_b8(i, size);
+                svuint8_t _a = svsel_u8(mask, svld1_u8(mask, a + i), zero);
+                svuint8_t _b = svsel_u8(mask, svld1_u8(mask, b + i), zero);
+                sums = svdot_u32(sums, _a, _b);
+            }
+            return (uint32_t)svaddv_u32(svptrue_b32(), sums);
+        }
+
+        SIMD_INLINE float DecodeCosineDistance(const float* a, const float* b, uint32_t abSum)
+        {
+            float ab = float(abSum) * a[0] * b[0] + a[2] * b[1] + b[2] * a[1];
+            return Simd::RestrictRange(1.0f - ab / (a[3] * b[3]), 0.0f, 2.0f);
+        }
+
+        void MacroCorrelation(size_t M, size_t N, size_t K, const uint8_t* ad, const float* an, const uint8_t* bd, const float* bn, float* distances, size_t stride)
+        {
+            for (size_t i = 0; i < M; ++i)
+            {
+                const uint8_t* a = ad + i * K;
+                const float* na = an + i * 4;
+                for (size_t j = 0; j < N; ++j)
+                {
+                    const uint8_t* b = bd + j * K;
+                    distances[i * stride + j] = DecodeCosineDistance(na, bn + j * 4, Correlation8u(a, b, K));
+                }
+            }
+        }
+
+        Base::DescrInt::MacroCosineDistancesUnpackPtr GetMacroCosineDistancesUnpack(size_t depth)
+        {
+            return MacroCorrelation;
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -656,6 +656,11 @@ namespace Test
         if (Simd::AmxBf16::Enable && TestAmxBf16(options))
             result = result && DescrIntCosineDistancesMxNaAutoTest(FUNC_DI(Simd::AmxBf16::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntCosineDistancesMxNaAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
         
 #if defined(SIMD_NEON_ENABLE)
         if (Simd::Neon::Enable && TestNeon(options))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 direct and unpacked cosine distance matrix paths for integer descriptors.
- Register SVE2 coverage in `DescrIntCosineDistancesMxNaAutoTest`.
- Add the new SVE2 descriptor source to the VS2022 project and note the release change.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=DescrIntCosineDistancesMxNa -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -fsyntax-only src/Simd/SimdSve2DescrInt.cpp src/Simd/SimdSve2DescrIntCdd.cpp src/Simd/SimdSve2DescrIntCdu.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Simd/SimdSve2DescrInt.cpp -o /tmp/SimdSve2DescrInt.o && aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Simd/SimdSve2DescrIntCdd.cpp -o /tmp/SimdSve2DescrIntCdd.o && aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -c src/Simd/SimdSve2DescrIntCdu.cpp -o /tmp/SimdSve2DescrIntCdu.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-497640bc-b83c-4ebb-8bef-b6f848e91cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-497640bc-b83c-4ebb-8bef-b6f848e91cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

