### PR TITLE
Add SVE2 descriptor MxNp optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -49,6 +49,7 @@
  <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
+ <li>SVE2 optimizations of function DescrIntCosineDistancesMxNp.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -39,7 +39,7 @@ namespace Simd
         {
             _cosineDistance = GetCosineDistance(_depth);
             _macroCosineDistancesDirect = GetMacroCosineDistancesDirect(_depth);
-            _microMd = 1;
+            _microMd = 4;
             _microNd = 1;
 
             _unpackNormA = GetUnpackNorm(false);
@@ -48,7 +48,7 @@ namespace Simd
             _unpackDataB = GetUnpackData(_depth);
             _macroCosineDistancesUnpack = GetMacroCosineDistancesUnpack(_depth);
             _unpSize = _size;
-            _microMu = 1;
+            _microMu = 4;
             _microNu = 1;
         }
 

--- a/src/Simd/SimdSve2DescrIntCdd.cpp
+++ b/src/Simd/SimdSve2DescrIntCdd.cpp
@@ -128,13 +128,178 @@ namespace Simd
             Base::DecodeCosineDistance(a, b, abSum, distance);
         }
 
+        template<int bits> struct CorrelationsMx1
+        {
+            template<int M> static SIMD_INLINE void Run(const uint8_t* const* A, const uint8_t* B, size_t size, uint32_t* ab)
+            {
+                assert(size % 8 == 0 && size >= 8);
+                size_t blocks = size / 8, vectorBlocks = blocks - 1, i = 0;
+                svuint64_t sums0 = svdup_n_u64(0), sums1 = sums0, sums2 = sums0, sums3 = sums0;
+                const uint8_t* b = B + 16;
+                for (; i < vectorBlocks; i += svcntd())
+                {
+                    svbool_t mask = svwhilelt_b64(i, vectorBlocks);
+                    svuint64_t offsets = svindex_u64(uint64_t(i * bits), bits);
+                    svuint64_t _b = svld1_gather_u64offset_u64(mask, (const uint64_t*)b, offsets);
+                    if (M > 0)
+                    {
+                        svuint64_t _a = svld1_gather_u64offset_u64(mask, (const uint64_t*)(A[0] + 16), offsets);
+                        sums0 = svadd_u64_m(mask, sums0, CorrelationBlock<bits>(_a, _b, mask));
+                    }
+                    if (M > 1)
+                    {
+                        svuint64_t _a = svld1_gather_u64offset_u64(mask, (const uint64_t*)(A[1] + 16), offsets);
+                        sums1 = svadd_u64_m(mask, sums1, CorrelationBlock<bits>(_a, _b, mask));
+                    }
+                    if (M > 2)
+                    {
+                        svuint64_t _a = svld1_gather_u64offset_u64(mask, (const uint64_t*)(A[2] + 16), offsets);
+                        sums2 = svadd_u64_m(mask, sums2, CorrelationBlock<bits>(_a, _b, mask));
+                    }
+                    if (M > 3)
+                    {
+                        svuint64_t _a = svld1_gather_u64offset_u64(mask, (const uint64_t*)(A[3] + 16), offsets);
+                        sums3 = svadd_u64_m(mask, sums3, CorrelationBlock<bits>(_a, _b, mask));
+                    }
+                }
+                uint64_t ab0 = svaddv_u64(svptrue_b64(), sums0), ab1 = svaddv_u64(svptrue_b64(), sums1);
+                uint64_t ab2 = svaddv_u64(svptrue_b64(), sums2), ab3 = svaddv_u64(svptrue_b64(), sums3);
+                for (size_t tail = vectorBlocks; tail < blocks; ++tail)
+                {
+                    uint64_t _b = LoadBlock<bits>(b + tail * bits);
+                    if (M > 0)
+                        ab0 += CorrelationBlock<bits>(LoadBlock<bits>(A[0] + 16 + tail * bits), _b);
+                    if (M > 1)
+                        ab1 += CorrelationBlock<bits>(LoadBlock<bits>(A[1] + 16 + tail * bits), _b);
+                    if (M > 2)
+                        ab2 += CorrelationBlock<bits>(LoadBlock<bits>(A[2] + 16 + tail * bits), _b);
+                    if (M > 3)
+                        ab3 += CorrelationBlock<bits>(LoadBlock<bits>(A[3] + 16 + tail * bits), _b);
+                }
+                if (M > 0) ab[0] = (uint32_t)ab0;
+                if (M > 1) ab[1] = (uint32_t)ab1;
+                if (M > 2) ab[2] = (uint32_t)ab2;
+                if (M > 3) ab[3] = (uint32_t)ab3;
+            }
+        };
+
+        template<> struct CorrelationsMx1<4>
+        {
+            template<int M> static SIMD_INLINE void Run(const uint8_t* const* A, const uint8_t* B, size_t size, uint32_t* ab)
+            {
+                assert(size % 8 == 0 && size >= 8);
+                const size_t byteSize = size / 2;
+                const svuint8_t zero = svdup_n_u8(0);
+                svuint32_t sums0 = svdup_n_u32(0), sums1 = sums0, sums2 = sums0, sums3 = sums0;
+                const uint8_t* b = B + 16;
+                for (size_t i = 0; i < byteSize; i += svcntb())
+                {
+                    svbool_t mask = svwhilelt_b8(i, byteSize);
+                    svuint8_t _b = svsel_u8(mask, svld1_u8(mask, b + i), zero);
+                    svuint8_t b0 = svand_n_u8_z(mask, _b, 0x0F);
+                    svuint8_t b1 = svlsr_n_u8_z(mask, _b, 4);
+                    if (M > 0)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[0] + 16 + i), zero);
+                        sums0 = svdot_u32(sums0, svand_n_u8_z(mask, _a, 0x0F), b0);
+                        sums0 = svdot_u32(sums0, svlsr_n_u8_z(mask, _a, 4), b1);
+                    }
+                    if (M > 1)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[1] + 16 + i), zero);
+                        sums1 = svdot_u32(sums1, svand_n_u8_z(mask, _a, 0x0F), b0);
+                        sums1 = svdot_u32(sums1, svlsr_n_u8_z(mask, _a, 4), b1);
+                    }
+                    if (M > 2)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[2] + 16 + i), zero);
+                        sums2 = svdot_u32(sums2, svand_n_u8_z(mask, _a, 0x0F), b0);
+                        sums2 = svdot_u32(sums2, svlsr_n_u8_z(mask, _a, 4), b1);
+                    }
+                    if (M > 3)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[3] + 16 + i), zero);
+                        sums3 = svdot_u32(sums3, svand_n_u8_z(mask, _a, 0x0F), b0);
+                        sums3 = svdot_u32(sums3, svlsr_n_u8_z(mask, _a, 4), b1);
+                    }
+                }
+                if (M > 0) ab[0] = (uint32_t)svaddv_u32(svptrue_b32(), sums0);
+                if (M > 1) ab[1] = (uint32_t)svaddv_u32(svptrue_b32(), sums1);
+                if (M > 2) ab[2] = (uint32_t)svaddv_u32(svptrue_b32(), sums2);
+                if (M > 3) ab[3] = (uint32_t)svaddv_u32(svptrue_b32(), sums3);
+            }
+        };
+
+        template<> struct CorrelationsMx1<8>
+        {
+            template<int M> static SIMD_INLINE void Run(const uint8_t* const* A, const uint8_t* B, size_t size, uint32_t* ab)
+            {
+                assert(size % 8 == 0 && size >= 8);
+                const svuint8_t zero = svdup_n_u8(0);
+                svuint32_t sums0 = svdup_n_u32(0), sums1 = sums0, sums2 = sums0, sums3 = sums0;
+                const uint8_t* b = B + 16;
+                for (size_t i = 0; i < size; i += svcntb())
+                {
+                    svbool_t mask = svwhilelt_b8(i, size);
+                    svuint8_t _b = svsel_u8(mask, svld1_u8(mask, b + i), zero);
+                    if (M > 0)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[0] + 16 + i), zero);
+                        sums0 = svdot_u32(sums0, _a, _b);
+                    }
+                    if (M > 1)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[1] + 16 + i), zero);
+                        sums1 = svdot_u32(sums1, _a, _b);
+                    }
+                    if (M > 2)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[2] + 16 + i), zero);
+                        sums2 = svdot_u32(sums2, _a, _b);
+                    }
+                    if (M > 3)
+                    {
+                        svuint8_t _a = svsel_u8(mask, svld1_u8(mask, A[3] + 16 + i), zero);
+                        sums3 = svdot_u32(sums3, _a, _b);
+                    }
+                }
+                if (M > 0) ab[0] = (uint32_t)svaddv_u32(svptrue_b32(), sums0);
+                if (M > 1) ab[1] = (uint32_t)svaddv_u32(svptrue_b32(), sums1);
+                if (M > 2) ab[2] = (uint32_t)svaddv_u32(svptrue_b32(), sums2);
+                if (M > 3) ab[3] = (uint32_t)svaddv_u32(svptrue_b32(), sums3);
+            }
+        };
+
+        template<int bits, int M> SIMD_INLINE void MicroCosineDistancesDirectMx1(const uint8_t* const* A, const uint8_t* B, size_t size, float* distances, size_t stride)
+        {
+            uint32_t ab[4];
+            CorrelationsMx1<bits>::template Run<M>(A, B, size, ab);
+            if (M > 0) Base::DecodeCosineDistance(A[0], B, (float)ab[0], distances + 0 * stride);
+            if (M > 1) Base::DecodeCosineDistance(A[1], B, (float)ab[1], distances + 1 * stride);
+            if (M > 2) Base::DecodeCosineDistance(A[2], B, (float)ab[2], distances + 2 * stride);
+            if (M > 3) Base::DecodeCosineDistance(A[3], B, (float)ab[3], distances + 3 * stride);
+        }
+
         template<int bits> void MacroCosineDistancesDirect(size_t M, size_t N, const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            for (size_t i = 0; i < M; ++i)
+            size_t M4 = AlignLoAny(M, 4), i = 0;
+            for (; i < M4; i += 4)
             {
-                const uint8_t* a = A[i];
                 for (size_t j = 0; j < N; ++j)
-                    CosineDistance<bits>(a, B[j], size, distances + i * stride + j);
+                    MicroCosineDistancesDirectMx1<bits, 4>(A + i, B[j], size, distances + j, stride);
+                distances += 4 * stride;
+            }
+            if (i < M)
+            {
+                for (size_t j = 0; j < N; ++j)
+                {
+                    switch (M - i)
+                    {
+                    case 1: MicroCosineDistancesDirectMx1<bits, 1>(A + i, B[j], size, distances + j, stride); break;
+                    case 2: MicroCosineDistancesDirectMx1<bits, 2>(A + i, B[j], size, distances + j, stride); break;
+                    case 3: MicroCosineDistancesDirectMx1<bits, 3>(A + i, B[j], size, distances + j, stride); break;
+                    }
+                }
             }
         }
 

--- a/src/Simd/SimdSve2DescrIntCdu.cpp
+++ b/src/Simd/SimdSve2DescrIntCdu.cpp
@@ -133,16 +133,69 @@ namespace Simd
             return Simd::RestrictRange(1.0f - ab / (a[3] * b[3]), 0.0f, 2.0f);
         }
 
+        template<int M> SIMD_INLINE void CorrelationsMx1(size_t K, const uint8_t* ad, const uint8_t* bd, uint32_t* ab)
+        {
+            const svuint8_t zero = svdup_n_u8(0);
+            svuint32_t sums0 = svdup_n_u32(0), sums1 = sums0, sums2 = sums0, sums3 = sums0;
+            for (size_t i = 0; i < K; i += svcntb())
+            {
+                svbool_t mask = svwhilelt_b8(i, K);
+                svuint8_t b = svsel_u8(mask, svld1_u8(mask, bd + i), zero);
+                if (M > 0)
+                {
+                    svuint8_t a = svsel_u8(mask, svld1_u8(mask, ad + 0 * K + i), zero);
+                    sums0 = svdot_u32(sums0, a, b);
+                }
+                if (M > 1)
+                {
+                    svuint8_t a = svsel_u8(mask, svld1_u8(mask, ad + 1 * K + i), zero);
+                    sums1 = svdot_u32(sums1, a, b);
+                }
+                if (M > 2)
+                {
+                    svuint8_t a = svsel_u8(mask, svld1_u8(mask, ad + 2 * K + i), zero);
+                    sums2 = svdot_u32(sums2, a, b);
+                }
+                if (M > 3)
+                {
+                    svuint8_t a = svsel_u8(mask, svld1_u8(mask, ad + 3 * K + i), zero);
+                    sums3 = svdot_u32(sums3, a, b);
+                }
+            }
+            if (M > 0) ab[0] = (uint32_t)svaddv_u32(svptrue_b32(), sums0);
+            if (M > 1) ab[1] = (uint32_t)svaddv_u32(svptrue_b32(), sums1);
+            if (M > 2) ab[2] = (uint32_t)svaddv_u32(svptrue_b32(), sums2);
+            if (M > 3) ab[3] = (uint32_t)svaddv_u32(svptrue_b32(), sums3);
+        }
+
+        template<int M> SIMD_INLINE void MacroCorrelationMx1(size_t K, const uint8_t* ad, const float* an, const uint8_t* bd, const float* bn, float* distances, size_t stride)
+        {
+            uint32_t ab[4];
+            CorrelationsMx1<M>(K, ad, bd, ab);
+            if (M > 0) distances[0 * stride] = DecodeCosineDistance(an + 0 * 4, bn, ab[0]);
+            if (M > 1) distances[1 * stride] = DecodeCosineDistance(an + 1 * 4, bn, ab[1]);
+            if (M > 2) distances[2 * stride] = DecodeCosineDistance(an + 2 * 4, bn, ab[2]);
+            if (M > 3) distances[3 * stride] = DecodeCosineDistance(an + 3 * 4, bn, ab[3]);
+        }
+
         void MacroCorrelation(size_t M, size_t N, size_t K, const uint8_t* ad, const float* an, const uint8_t* bd, const float* bn, float* distances, size_t stride)
         {
-            for (size_t i = 0; i < M; ++i)
+            size_t M4 = AlignLoAny(M, 4);
+            for (size_t j = 0; j < N; ++j)
             {
-                const uint8_t* a = ad + i * K;
-                const float* na = an + i * 4;
-                for (size_t j = 0; j < N; ++j)
+                size_t i = 0;
+                const uint8_t* b = bd + j * K;
+                const float* nb = bn + j * 4;
+                for (; i < M4; i += 4)
+                    MacroCorrelationMx1<4>(K, ad + i * K, an + i * 4, b, nb, distances + i * stride + j, stride);
+                if (i < M)
                 {
-                    const uint8_t* b = bd + j * K;
-                    distances[i * stride + j] = DecodeCosineDistance(na, bn + j * 4, Correlation8u(a, b, K));
+                    switch (M - i)
+                    {
+                    case 1: MacroCorrelationMx1<1>(K, ad + i * K, an + i * 4, b, nb, distances + i * stride + j, stride); break;
+                    case 2: MacroCorrelationMx1<2>(K, ad + i * K, an + i * 4, b, nb, distances + i * stride + j, stride); break;
+                    case 3: MacroCorrelationMx1<3>(K, ad + i * K, an + i * 4, b, nb, distances + i * stride + j, stride); break;
+                    }
                 }
             }
         }

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -705,7 +705,7 @@ namespace Test
     {
         bool result = true;
 
-        for (size_t depth = 7; depth <= 8; depth++)
+        for (size_t depth = 4; depth <= 8; depth++)
         {
             result = result && DescrIntCosineDistancesMxNpAutoTest(256, 128, 256, depth, f1, f2);
             result = result && DescrIntCosineDistancesMxNpAutoTest(128, 128, 512, depth, f1, f2);
@@ -747,6 +747,11 @@ namespace Test
 #if defined(SIMD_AMXBF16_ENABLE)
         if (Simd::AmxBf16::Enable && TestAmxBf16(options))
             result = result && DescrIntCosineDistancesMxNpAutoTest(FUNC_DI(Simd::AmxBf16::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntCosineDistancesMxNpAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif
 
 #if defined(SIMD_NEON_ENABLE)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 four-row micro-kernels for direct and unpacked descriptor integer cosine matrix paths used by `SimdDescrIntCosineDistancesMxNp`.
- Exercise `DescrIntCosineDistancesMxNp` over all descriptor depths and add SVE2 auto-test dispatch.
- Document the SVE2 `DescrIntCosineDistancesMxNp` optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=DescrIntCosineDistancesMxNp -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I./src ./src/Simd/SimdSve2DescrInt.cpp ./src/Simd/SimdSve2DescrIntCdd.cpp ./src/Simd/SimdSve2DescrIntCdu.cpp`

[descr_int_mxnp_test.log](https://cursor.com/agents/bc-d6214016-500f-4847-8aed-4332bb0561df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdescr_int_mxnp_test.log)
[sve2_descr_int_syntax_check.log](https://cursor.com/agents/bc-d6214016-500f-4847-8aed-4332bb0561df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsve2_descr_int_syntax_check.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6214016-500f-4847-8aed-4332bb0561df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6214016-500f-4847-8aed-4332bb0561df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

