### PR TITLE
Add SVE2 optimization for DescrIntEncode32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
+ <li>SVE2 optimizations of function DescrIntEncode32f.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNp.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrInt.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntEnc.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp">
       <Filter>Sve2\Descriptors</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntEnc.cpp">
+      <Filter>Sve2\Descriptors</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -282,6 +282,8 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        Base::DescrInt::Encode32fPtr GetEncode32f(size_t depth);
+
         Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth);
         Base::DescrInt::MacroCosineDistancesDirectPtr GetMacroCosineDistancesDirect(size_t depth);
 

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -37,6 +37,8 @@ namespace Simd
             : Base::DescrInt(size, depth)
 #endif
         {
+            _encode32f = GetEncode32f(_depth);
+
             _cosineDistance = GetCosineDistance(_depth);
             _macroCosineDistancesDirect = GetMacroCosineDistancesDirect(_depth);
             _microMd = 4;

--- a/src/Simd/SimdSve2DescrIntEnc.cpp
+++ b/src/Simd/SimdSve2DescrIntEnc.cpp
@@ -36,7 +36,7 @@ namespace Simd
         {
             svfloat32_t value = svmul_f32_x(mask, svsub_f32_x(mask, svld1_f32(mask, src), min), scale);
             svuint32_t encoded = svmin_u32_x(mask, svcvt_u32_f32_x(mask, svadd_n_f32_x(mask, value, 0.5f)), svdup_n_u32(0xFF));
-            sum = svadd_u32_m(mask, sum, sum, encoded);
+            sum = svadd_u32_m(mask, sum, encoded);
             sqsum = svmla_u32_m(mask, sqsum, encoded, encoded);
             return encoded;
         }

--- a/src/Simd/SimdSve2DescrIntEnc.cpp
+++ b/src/Simd/SimdSve2DescrIntEnc.cpp
@@ -1,0 +1,174 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdDescrInt.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint32_t Encode32f(const float* src, const svbool_t& mask, const svfloat32_t& scale,
+            const svfloat32_t& min, svuint32_t& sum, svuint32_t& sqsum)
+        {
+            svfloat32_t value = svmul_f32_x(mask, svsub_f32_x(mask, svld1_f32(mask, src), min), scale);
+            svuint32_t encoded = svmin_u32_x(mask, svcvt_u32_f32_x(mask, svadd_n_f32_x(mask, value, 0.5f)), svdup_n_u32(0xFF));
+            sum = svadd_u32_m(mask, sum, sum, encoded);
+            sqsum = svmla_u32_m(mask, sqsum, encoded, encoded);
+            return encoded;
+        }
+
+        SIMD_INLINE void Encode32f8(const float* src, const svbool_t& mask, const svfloat32_t& scale,
+            const svfloat32_t& min, svuint32_t& sum, svuint32_t& sqsum, uint8_t* dst)
+        {
+            svst1b_u32(mask, dst, Encode32f(src, mask, scale, min, sum, sqsum));
+        }
+
+        SIMD_INLINE void Encode32f8(const float* src, const svfloat32_t& scale, const svfloat32_t& min,
+            svuint32_t& sum, svuint32_t& sqsum, uint32_t* dst)
+        {
+            size_t done = 0;
+            do
+            {
+                svbool_t mask = svwhilelt_b32(done, size_t(8));
+                svst1_u32(mask, dst + done, Encode32f(src + done, mask, scale, min, sum, sqsum));
+                done += svcntw();
+            } while (done < 8);
+        }
+
+        static void Encode32f4(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 4)
+            {
+                Encode32f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 4));
+                dst[1] = uint8_t(buf[2] | (buf[3] << 4));
+                dst[2] = uint8_t(buf[4] | (buf[5] << 4));
+                dst[3] = uint8_t(buf[6] | (buf[7] << 4));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode32f5(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 5)
+            {
+                Encode32f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 5));
+                dst[1] = uint8_t((buf[1] >> 3) | (buf[2] << 2) | (buf[3] << 7));
+                dst[2] = uint8_t((buf[3] >> 1) | (buf[4] << 4));
+                dst[3] = uint8_t((buf[4] >> 4) | (buf[5] << 1) | (buf[6] << 6));
+                dst[4] = uint8_t((buf[6] >> 2) | (buf[7] << 3));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode32f6(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 6)
+            {
+                Encode32f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 6));
+                dst[1] = uint8_t((buf[1] >> 2) | (buf[2] << 4));
+                dst[2] = uint8_t((buf[2] >> 4) | (buf[3] << 2));
+                dst[3] = uint8_t(buf[4] | (buf[5] << 6));
+                dst[4] = uint8_t((buf[5] >> 2) | (buf[6] << 4));
+                dst[5] = uint8_t((buf[6] >> 4) | (buf[7] << 2));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode32f7(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 7)
+            {
+                Encode32f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 7));
+                dst[1] = uint8_t((buf[1] >> 1) | (buf[2] << 6));
+                dst[2] = uint8_t((buf[2] >> 2) | (buf[3] << 5));
+                dst[3] = uint8_t((buf[3] >> 3) | (buf[4] << 4));
+                dst[4] = uint8_t((buf[4] >> 4) | (buf[5] << 3));
+                dst[5] = uint8_t((buf[5] >> 5) | (buf[6] << 2));
+                dst[6] = uint8_t((buf[6] >> 6) | (buf[7] << 1));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode32f8(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += svcntw())
+                Encode32f8(src + i, svwhilelt_b32(i, size), _scale, _min, _sum, _sqsum, dst + i);
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        Base::DescrInt::Encode32fPtr GetEncode32f(size_t depth)
+        {
+            switch (depth)
+            {
+            case 4: return Encode32f4;
+            case 5: return Encode32f5;
+            case 6: return Encode32f6;
+            case 7: return Encode32f7;
+            case 8: return Encode32f8;
+            default: return Base::GetEncode32f(depth);
+            }
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -206,6 +206,11 @@ namespace Test
             result = result && DescrIntEncode32fAutoTest(FUNC_DI(Simd::Avx512bw::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntEncode32fAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DescrIntEncode32fAutoTest(FUNC_DI(Simd::Neon::DescrIntInit), FUNC_DI(SimdDescrIntInit));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `DescrIntEncode32f` depth dispatch and encoder kernels for depths 4 through 8.
- Add SVE2 coverage to the descriptor integer encode32f auto-test.
- Add the new SVE2 source to VS2022 project files and document the release note for 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=DescrIntEncode32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2DescrIntEnc.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2DescrInt.cpp`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51c4bbd0-55fc-4f9d-8563-1472b0a50749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51c4bbd0-55fc-4f9d-8563-1472b0a50749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

