### PR TITLE
validate cascade node feature index before init

### DIFF
--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -316,6 +316,15 @@ namespace Simd
                         data->lbpFeatures.push_back(feature);
                     }
                 }
+
+                size_t featureCount = data->featureType == SimdDetectionInfoFeatureHaar
+                    ? data->haarFeatures.size() : data->lbpFeatures.size();
+                for (size_t i = 0; i < data->nodes.size(); ++i)
+                {
+                    int featureIdx = data->nodes[i].featureIdx;
+                    if (featureIdx < 0 || (size_t)featureIdx >= featureCount)
+                        SIMD_EX("Invalid cascade node: feature index out of range!");
+                }
             }
             catch (...)
             {


### PR DESCRIPTION
**Out-of-bounds feature index in cascade nodes**

`DetectionLoadStringXml` parses untrusted cascade XML and stores each weak-classifier node`s `featureIdx` straight from the `internalNodes` text, with no range check. That index is later used to look a feature up: `CreateHidHaar` reads `data.haarFeatures[node.featureIdx]` during init, and the LBP predictor indexes `hid.features[node->featureIdx]`. A cascade whose node points past the parsed feature list (or a negative value) therefore reads off the end of the vector. With ASan a node index of `999999` against a single feature faults at `SimdBaseDetection.cpp:393` in `CreateHidHaar`.

The recently merged rect checks guarded the per-rect value vectors but not this node-to-feature reference, so it was still reachable. Validating the index once in the loader keeps the rejection at the parse boundary and covers both the HAAR and LBP paths. I have kept it to a range check raising the existing `SIMD_EX`; valid cascades are unaffected.