### PR TITLE
Add SVE2 DescrInt 16f encoding

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function DescrIntEncode32f.</li>
+ <li>SVE2 optimizations of function DescrIntEncode16f.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNp.</li>

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -283,6 +283,7 @@ namespace Simd
         //-------------------------------------------------------------------------------------------------
 
         Base::DescrInt::Encode32fPtr GetEncode32f(size_t depth);
+        Base::DescrInt::Encode16fPtr GetEncode16f(size_t depth);
 
         Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth);
         Base::DescrInt::MacroCosineDistancesDirectPtr GetMacroCosineDistancesDirect(size_t depth);

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -38,6 +38,7 @@ namespace Simd
 #endif
         {
             _encode32f = GetEncode32f(_depth);
+            _encode16f = GetEncode16f(_depth);
 
             _cosineDistance = GetCosineDistance(_depth);
             _macroCosineDistancesDirect = GetMacroCosineDistancesDirect(_depth);

--- a/src/Simd/SimdSve2DescrIntEnc.cpp
+++ b/src/Simd/SimdSve2DescrIntEnc.cpp
@@ -31,14 +31,20 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint32_t Encode32f(const float* src, const svbool_t& mask, const svfloat32_t& scale,
+        SIMD_INLINE svuint32_t Encode32f(const svfloat32_t& src, const svbool_t& mask, const svfloat32_t& scale,
             const svfloat32_t& min, svuint32_t& sum, svuint32_t& sqsum)
         {
-            svfloat32_t value = svmul_f32_x(mask, svsub_f32_x(mask, svld1_f32(mask, src), min), scale);
+            svfloat32_t value = svmul_f32_x(mask, svsub_f32_x(mask, src, min), scale);
             svuint32_t encoded = svmin_u32_x(mask, svcvt_u32_f32_x(mask, svadd_n_f32_x(mask, value, 0.5f)), svdup_n_u32(0xFF));
             sum = svadd_u32_m(mask, sum, encoded);
             sqsum = svmla_u32_m(mask, sqsum, encoded, encoded);
             return encoded;
+        }
+
+        SIMD_INLINE svuint32_t Encode32f(const float* src, const svbool_t& mask, const svfloat32_t& scale,
+            const svfloat32_t& min, svuint32_t& sum, svuint32_t& sqsum)
+        {
+            return Encode32f(svld1_f32(mask, src), mask, scale, min, sum, sqsum);
         }
 
         SIMD_INLINE void Encode32f8(const float* src, const svbool_t& mask, const svfloat32_t& scale,
@@ -157,6 +163,133 @@ namespace Simd
             sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
         }
 
+#ifdef SIMD_NEON_FP16_ENABLE
+        SIMD_INLINE void Encode16f8(const uint16_t* src, const svfloat32_t& scale, const svfloat32_t& min,
+            svuint32_t& sum, svuint32_t& sqsum, uint32_t* dst)
+        {
+            const svbool_t mask16 = svwhilelt_b16(size_t(0), size_t(8));
+            const svbool_t mask32 = svwhilelt_b32(size_t(0), size_t(4));
+            svfloat16_t half = svreinterpret_f16_u16(svld1_u16(mask16, src));
+            uint32_t lo[4], hi[4];
+            svst1_u32(mask32, lo, Encode32f(svcvt_f32_f16_x(mask32, half), mask32, scale, min, sum, sqsum));
+            svst1_u32(mask32, hi, Encode32f(svcvtlt_f32_f16_x(mask32, half), mask32, scale, min, sum, sqsum));
+            dst[0] = lo[0], dst[1] = hi[0];
+            dst[2] = lo[1], dst[3] = hi[1];
+            dst[4] = lo[2], dst[5] = hi[2];
+            dst[6] = lo[3], dst[7] = hi[3];
+        }
+
+        static void Encode16f4(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 4)
+            {
+                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 4));
+                dst[1] = uint8_t(buf[2] | (buf[3] << 4));
+                dst[2] = uint8_t(buf[4] | (buf[5] << 4));
+                dst[3] = uint8_t(buf[6] | (buf[7] << 4));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode16f5(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 5)
+            {
+                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 5));
+                dst[1] = uint8_t((buf[1] >> 3) | (buf[2] << 2) | (buf[3] << 7));
+                dst[2] = uint8_t((buf[3] >> 1) | (buf[4] << 4));
+                dst[3] = uint8_t((buf[4] >> 4) | (buf[5] << 1) | (buf[6] << 6));
+                dst[4] = uint8_t((buf[6] >> 2) | (buf[7] << 3));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode16f6(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 6)
+            {
+                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 6));
+                dst[1] = uint8_t((buf[1] >> 2) | (buf[2] << 4));
+                dst[2] = uint8_t((buf[2] >> 4) | (buf[3] << 2));
+                dst[3] = uint8_t(buf[4] | (buf[5] << 6));
+                dst[4] = uint8_t((buf[5] >> 2) | (buf[6] << 4));
+                dst[5] = uint8_t((buf[6] >> 4) | (buf[7] << 2));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode16f7(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 7)
+            {
+                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = uint8_t(buf[0] | (buf[1] << 7));
+                dst[1] = uint8_t((buf[1] >> 1) | (buf[2] << 6));
+                dst[2] = uint8_t((buf[2] >> 2) | (buf[3] << 5));
+                dst[3] = uint8_t((buf[3] >> 3) | (buf[4] << 4));
+                dst[4] = uint8_t((buf[4] >> 4) | (buf[5] << 3));
+                dst[5] = uint8_t((buf[5] >> 5) | (buf[6] << 2));
+                dst[6] = uint8_t((buf[6] >> 6) | (buf[7] << 1));
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+
+        static void Encode16f8(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        {
+            assert(size % 8 == 0);
+            uint32_t buf[8];
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _min = svdup_n_f32(min);
+            svuint32_t _sum = svdup_n_u32(0);
+            svuint32_t _sqsum = svdup_n_u32(0);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 8)
+            {
+                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
+                dst[0] = (uint8_t)buf[0];
+                dst[1] = (uint8_t)buf[1];
+                dst[2] = (uint8_t)buf[2];
+                dst[3] = (uint8_t)buf[3];
+                dst[4] = (uint8_t)buf[4];
+                dst[5] = (uint8_t)buf[5];
+                dst[6] = (uint8_t)buf[6];
+                dst[7] = (uint8_t)buf[7];
+            }
+            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
+            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+        }
+#endif
+
         Base::DescrInt::Encode32fPtr GetEncode32f(size_t depth)
         {
             switch (depth)
@@ -168,6 +301,27 @@ namespace Simd
             case 8: return Encode32f8;
             default: return Base::GetEncode32f(depth);
             }
+        }
+
+        Base::DescrInt::Encode16fPtr GetEncode16f(size_t depth)
+        {
+#ifdef SIMD_NEON_FP16_ENABLE
+            switch (depth)
+            {
+            case 4: return Encode16f4;
+            case 5: return Encode16f5;
+            case 6: return Encode16f6;
+            case 7: return Encode16f7;
+            case 8: return Encode16f8;
+            default: return Base::GetEncode16f(depth);
+            }
+#else
+#ifdef SIMD_NEON_ENABLE
+            return Neon::GetEncode16f(depth);
+#else
+            return Base::GetEncode16f(depth);
+#endif
+#endif
         }
     }
 #endif// SIMD_SVE2_ENABLE

--- a/src/Simd/SimdSve2DescrIntEnc.cpp
+++ b/src/Simd/SimdSve2DescrIntEnc.cpp
@@ -164,126 +164,57 @@ namespace Simd
         }
 
 #ifdef SIMD_NEON_FP16_ENABLE
-        SIMD_INLINE void Encode16f8(const uint16_t* src, const svfloat32_t& scale, const svfloat32_t& min,
-            svuint32_t& sum, svuint32_t& sqsum, uint32_t* dst)
+        SIMD_INLINE void Encode16f(const uint16_t* src, const svbool_t& mask16, const svbool_t& mask32,
+            const svfloat32_t& scale, const svfloat32_t& min, svuint32_t& sum, svuint32_t& sqsum, svuint32_t& even, svuint32_t& odd)
         {
-            const svbool_t mask16 = svwhilelt_b16(size_t(0), size_t(8));
-            const svbool_t mask32 = svwhilelt_b32(size_t(0), size_t(4));
             svfloat16_t half = svreinterpret_f16_u16(svld1_u16(mask16, src));
-            uint32_t lo[4], hi[4];
-            svst1_u32(mask32, lo, Encode32f(svcvt_f32_f16_x(mask32, half), mask32, scale, min, sum, sqsum));
-            svst1_u32(mask32, hi, Encode32f(svcvtlt_f32_f16_x(mask32, half), mask32, scale, min, sum, sqsum));
-            dst[0] = lo[0], dst[1] = hi[0];
-            dst[2] = lo[1], dst[3] = hi[1];
-            dst[4] = lo[2], dst[5] = hi[2];
-            dst[6] = lo[3], dst[7] = hi[3];
+            even = Encode32f(svcvt_f32_f16_x(mask32, half), mask32, scale, min, sum, sqsum);
+            odd = Encode32f(svcvtlt_f32_f16_x(mask32, half), mask32, scale, min, sum, sqsum);
         }
 
         static void Encode16f4(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
             assert(size % 8 == 0);
-            uint32_t buf[8];
+            size_t step = svcntw() * 2, i = 0;
             svfloat32_t _scale = svdup_n_f32(scale);
             svfloat32_t _min = svdup_n_f32(min);
             svuint32_t _sum = svdup_n_u32(0);
             svuint32_t _sqsum = svdup_n_u32(0);
-            for (size_t i = 0; i < size; i += 8, src += 8, dst += 4)
+            svuint32_t even, odd;
+            for (; i < size; i += step, src += step, dst += step / 2)
             {
-                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
-                dst[0] = uint8_t(buf[0] | (buf[1] << 4));
-                dst[1] = uint8_t(buf[2] | (buf[3] << 4));
-                dst[2] = uint8_t(buf[4] | (buf[5] << 4));
-                dst[3] = uint8_t(buf[6] | (buf[7] << 4));
+                size_t tail = Simd::Min(step, size - i);
+                svbool_t mask16 = svwhilelt_b16(size_t(0), tail);
+                svbool_t mask32 = svwhilelt_b32(size_t(0), tail / 2);
+                Encode16f(src, mask16, mask32, _scale, _min, _sum, _sqsum, even, odd);
+                svst1b_u32(mask32, dst, svorr_u32_x(mask32, even, svlsl_n_u32_x(mask32, odd, 4)));
             }
             sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
             sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
         }
 
-        static void Encode16f5(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
+        SIMD_INLINE svuint8_t PackU32ToU8(const svuint32_t& src)
         {
-            assert(size % 8 == 0);
-            uint32_t buf[8];
-            svfloat32_t _scale = svdup_n_f32(scale);
-            svfloat32_t _min = svdup_n_f32(min);
-            svuint32_t _sum = svdup_n_u32(0);
-            svuint32_t _sqsum = svdup_n_u32(0);
-            for (size_t i = 0; i < size; i += 8, src += 8, dst += 5)
-            {
-                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
-                dst[0] = uint8_t(buf[0] | (buf[1] << 5));
-                dst[1] = uint8_t((buf[1] >> 3) | (buf[2] << 2) | (buf[3] << 7));
-                dst[2] = uint8_t((buf[3] >> 1) | (buf[4] << 4));
-                dst[3] = uint8_t((buf[4] >> 4) | (buf[5] << 1) | (buf[6] << 6));
-                dst[4] = uint8_t((buf[6] >> 2) | (buf[7] << 3));
-            }
-            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
-            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
-        }
-
-        static void Encode16f6(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
-        {
-            assert(size % 8 == 0);
-            uint32_t buf[8];
-            svfloat32_t _scale = svdup_n_f32(scale);
-            svfloat32_t _min = svdup_n_f32(min);
-            svuint32_t _sum = svdup_n_u32(0);
-            svuint32_t _sqsum = svdup_n_u32(0);
-            for (size_t i = 0; i < size; i += 8, src += 8, dst += 6)
-            {
-                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
-                dst[0] = uint8_t(buf[0] | (buf[1] << 6));
-                dst[1] = uint8_t((buf[1] >> 2) | (buf[2] << 4));
-                dst[2] = uint8_t((buf[2] >> 4) | (buf[3] << 2));
-                dst[3] = uint8_t(buf[4] | (buf[5] << 6));
-                dst[4] = uint8_t((buf[5] >> 2) | (buf[6] << 4));
-                dst[5] = uint8_t((buf[6] >> 4) | (buf[7] << 2));
-            }
-            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
-            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
-        }
-
-        static void Encode16f7(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
-        {
-            assert(size % 8 == 0);
-            uint32_t buf[8];
-            svfloat32_t _scale = svdup_n_f32(scale);
-            svfloat32_t _min = svdup_n_f32(min);
-            svuint32_t _sum = svdup_n_u32(0);
-            svuint32_t _sqsum = svdup_n_u32(0);
-            for (size_t i = 0; i < size; i += 8, src += 8, dst += 7)
-            {
-                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
-                dst[0] = uint8_t(buf[0] | (buf[1] << 7));
-                dst[1] = uint8_t((buf[1] >> 1) | (buf[2] << 6));
-                dst[2] = uint8_t((buf[2] >> 2) | (buf[3] << 5));
-                dst[3] = uint8_t((buf[3] >> 3) | (buf[4] << 4));
-                dst[4] = uint8_t((buf[4] >> 4) | (buf[5] << 3));
-                dst[5] = uint8_t((buf[5] >> 5) | (buf[6] << 2));
-                dst[6] = uint8_t((buf[6] >> 6) | (buf[7] << 1));
-            }
-            sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
-            sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
+            return svqxtnb_u16(svqxtnb_u32(src));
         }
 
         static void Encode16f8(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
             assert(size % 8 == 0);
-            uint32_t buf[8];
+            size_t step = svcntw() * 2, i = 0;
             svfloat32_t _scale = svdup_n_f32(scale);
             svfloat32_t _min = svdup_n_f32(min);
             svuint32_t _sum = svdup_n_u32(0);
             svuint32_t _sqsum = svdup_n_u32(0);
-            for (size_t i = 0; i < size; i += 8, src += 8, dst += 8)
+            svuint32_t even, odd;
+            for (; i < size; i += step, src += step, dst += step)
             {
-                Encode16f8(src, _scale, _min, _sum, _sqsum, buf);
-                dst[0] = (uint8_t)buf[0];
-                dst[1] = (uint8_t)buf[1];
-                dst[2] = (uint8_t)buf[2];
-                dst[3] = (uint8_t)buf[3];
-                dst[4] = (uint8_t)buf[4];
-                dst[5] = (uint8_t)buf[5];
-                dst[6] = (uint8_t)buf[6];
-                dst[7] = (uint8_t)buf[7];
+                size_t tail = Simd::Min(step, size - i);
+                svbool_t mask16 = svwhilelt_b16(size_t(0), tail);
+                svbool_t mask32 = svwhilelt_b32(size_t(0), tail / 2);
+                svbool_t mask8 = svwhilelt_b8(size_t(0), tail / 2);
+                Encode16f(src, mask16, mask32, _scale, _min, _sum, _sqsum, even, odd);
+                svst2_u8(mask8, dst, svcreate2_u8(PackU32ToU8(even), PackU32ToU8(odd)));
             }
             sum = (int32_t)svaddv_u32(svptrue_b32(), _sum);
             sqsum = (int32_t)svaddv_u32(svptrue_b32(), _sqsum);
@@ -309,9 +240,11 @@ namespace Simd
             switch (depth)
             {
             case 4: return Encode16f4;
-            case 5: return Encode16f5;
-            case 6: return Encode16f6;
-            case 7: return Encode16f7;
+#ifdef SIMD_NEON_ENABLE
+            case 5: return Neon::GetEncode16f(depth);
+            case 6: return Neon::GetEncode16f(depth);
+            case 7: return Neon::GetEncode16f(depth);
+#endif
             case 8: return Encode16f8;
             default: return Base::GetEncode16f(depth);
             }

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -296,6 +296,11 @@ namespace Test
             result = result && DescrIntEncode16fAutoTest(FUNC_DI(Simd::Avx512bw::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntEncode16fAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DescrIntEncode16fAutoTest(FUNC_DI(Simd::Neon::DescrIntInit), FUNC_DI(SimdDescrIntInit));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `DescrIntEncode16f` dispatch.
- Use scalable SVE2 16f encode paths for descriptor depths 4 and 8, avoiding stack-buffer scalar packing.
- Reuse the existing NEON encoder for depths 5 through 7 where the previous SVE2 bit packing was slower.
- Cover SVE2 in `DescrIntEncode16fAutoTest` and document the optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=DescrIntEncode16f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2+fp16 -std=c++14 -fsyntax-only -I src src/Simd/SimdSve2DescrIntEnc.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2+fp16 -std=c++14 -fsyntax-only -I src src/Simd/SimdSve2DescrInt.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2+fp16 -std=c++14 -fsyntax-only -I src -DSIMD_NEON_DISABLE src/Simd/SimdSve2DescrIntEnc.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adbc86ae-c611-4fff-8b1f-f2b7dd799dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adbc86ae-c611-4fff-8b1f-f2b7dd799dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

