### PR TITLE
Add SVE2 optimization for descriptor Decode32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -49,6 +49,7 @@
  <li>SVE2 optimizations of function CosineDistance32f.</li>
  <li>SVE2 optimizations of function DescrIntEncode32f.</li>
  <li>SVE2 optimizations of function DescrIntEncode16f.</li>
+ <li>SVE2 optimizations of function DescrIntDecode32f.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNp.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrInt.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntDec.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntEnc.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp">
       <Filter>Sve2\Descriptors</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntDec.cpp">
+      <Filter>Sve2\Descriptors</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntEnc.cpp">
       <Filter>Sve2\Descriptors</Filter>
     </ClCompile>

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -285,6 +285,8 @@ namespace Simd
         Base::DescrInt::Encode32fPtr GetEncode32f(size_t depth);
         Base::DescrInt::Encode16fPtr GetEncode16f(size_t depth);
 
+        Base::DescrInt::Decode32fPtr GetDecode32f(size_t depth);
+
         Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth);
         Base::DescrInt::MacroCosineDistancesDirectPtr GetMacroCosineDistancesDirect(size_t depth);
 

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -39,6 +39,7 @@ namespace Simd
         {
             _encode32f = GetEncode32f(_depth);
             _encode16f = GetEncode16f(_depth);
+            _decode32f = GetDecode32f(_depth);
 
             _cosineDistance = GetCosineDistance(_depth);
             _macroCosineDistancesDirect = GetMacroCosineDistancesDirect(_depth);

--- a/src/Simd/SimdSve2DescrIntDec.cpp
+++ b/src/Simd/SimdSve2DescrIntDec.cpp
@@ -1,0 +1,86 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdDescrInt.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svfloat32_t Decode32f(uint32_t src, const svbool_t& mask, const svuint32_t& shifts,
+            uint32_t valueMask, const svfloat32_t& scale, const svfloat32_t& shift)
+        {
+            svuint32_t value = svand_n_u32_x(mask, svlsr_u32_x(mask, svdup_n_u32(src), shifts), valueMask);
+            return svmla_f32_x(mask, shift, scale, svcvt_f32_u32_x(mask, value));
+        }
+
+        template<int bits> static void Decode32fN(const uint8_t* src, float scale, float shift, size_t size, float* dst)
+        {
+            assert(size % 8 == 0);
+            const uint32_t valueMask = (1 << bits) - 1;
+            const int hiOffset = bits == 4 ? 0 : bits - 4;
+            const int hiShift = bits == 4 ? 16 : 4 * bits - hiOffset * 8;
+            svbool_t mask = svwhilelt_b32(size_t(0), size_t(4));
+            svuint32_t loShifts = svindex_u32(0, bits);
+            svuint32_t hiShifts = svindex_u32(hiShift, bits);
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _shift = svdup_n_f32(shift);
+            for (size_t i = 0; i < size; i += 8, src += bits, dst += 8)
+            {
+                svst1_f32(mask, dst + 0, Decode32f(*(uint32_t*)(src + 0), mask, loShifts, valueMask, _scale, _shift));
+                svst1_f32(mask, dst + 4, Decode32f(*(uint32_t*)(src + hiOffset), mask, hiShifts, valueMask, _scale, _shift));
+            }
+        }
+
+        static void Decode32f8(const uint8_t* src, float scale, float shift, size_t size, float* dst)
+        {
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _shift = svdup_n_f32(shift);
+            for (size_t i = 0; i < size; i += svcntw())
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                svuint32_t value = svld1ub_u32(mask, src + i);
+                svst1_f32(mask, dst + i, svmla_f32_x(mask, _shift, _scale, svcvt_f32_u32_x(mask, value)));
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        Base::DescrInt::Decode32fPtr GetDecode32f(size_t depth)
+        {
+            switch (depth)
+            {
+            case 4: return Decode32fN<4>;
+            case 5: return Decode32fN<5>;
+            case 6: return Decode32fN<6>;
+            case 7: return Decode32fN<7>;
+            case 8: return Decode32f8;
+            default: return Base::GetDecode32f(depth);
+            }
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -386,6 +386,11 @@ namespace Test
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && DescrIntDecode32fAutoTest(FUNC_DI(Simd::Avx512bw::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntDecode32fAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
         
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 `DescrIntDecode32f` dispatch and implementation for depths 4 through 8.
* Extend descriptor decode autotests to include SVE2.
* Register the new SVE2 decode source in Visual Studio project files and document the release note.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=DescrIntDecode32f -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2DescrIntDec.cpp -o /tmp/SimdSve2DescrIntDec.o`
* `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2DescrInt.cpp -o /tmp/SimdSve2DescrInt.o`
* `python3` packed-depth extraction formula check for depths 4 through 7.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9435239c-7959-433c-92b8-8a6bba8795a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9435239c-7959-433c-92b8-8a6bba8795a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

