### PR TITLE
Add SVE2 DescrIntDecode16f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -50,6 +50,7 @@
  <li>SVE2 optimizations of function DescrIntEncode32f.</li>
  <li>SVE2 optimizations of function DescrIntEncode16f.</li>
  <li>SVE2 optimizations of function DescrIntDecode32f.</li>
+ <li>SVE2 optimizations of function DescrIntDecode16f.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNp.</li>

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -286,6 +286,7 @@ namespace Simd
         Base::DescrInt::Encode16fPtr GetEncode16f(size_t depth);
 
         Base::DescrInt::Decode32fPtr GetDecode32f(size_t depth);
+        Base::DescrInt::Decode16fPtr GetDecode16f(size_t depth);
 
         Base::DescrInt::CosineDistancePtr GetCosineDistance(size_t depth);
         Base::DescrInt::MacroCosineDistancesDirectPtr GetMacroCosineDistancesDirect(size_t depth);

--- a/src/Simd/SimdSve2DescrInt.cpp
+++ b/src/Simd/SimdSve2DescrInt.cpp
@@ -40,6 +40,7 @@ namespace Simd
             _encode32f = GetEncode32f(_depth);
             _encode16f = GetEncode16f(_depth);
             _decode32f = GetDecode32f(_depth);
+            _decode16f = GetDecode16f(_depth);
 
             _cosineDistance = GetCosineDistance(_depth);
             _macroCosineDistancesDirect = GetMacroCosineDistancesDirect(_depth);

--- a/src/Simd/SimdSve2DescrIntDec.cpp
+++ b/src/Simd/SimdSve2DescrIntDec.cpp
@@ -37,6 +37,11 @@ namespace Simd
             return svmla_f32_x(mask, shift, scale, svcvt_f32_u32_x(mask, value));
         }
 
+        SIMD_INLINE void Store16f(const svbool_t& mask32, const svbool_t& mask16, uint16_t* dst, const svfloat32_t& value)
+        {
+            svst1_u16(mask16, dst, svreinterpret_u16_f16(svcvt_f16_f32_x(mask32, value)));
+        }
+
         template<int bits> static void Decode32fN(const uint8_t* src, float scale, float shift, size_t size, float* dst)
         {
             assert(size % 8 == 0);
@@ -55,6 +60,25 @@ namespace Simd
             }
         }
 
+        template<int bits> static void Decode16fN(const uint8_t* src, float scale, float shift, size_t size, uint16_t* dst)
+        {
+            assert(size % 8 == 0);
+            const uint32_t valueMask = (1 << bits) - 1;
+            const int hiOffset = bits == 4 ? 0 : bits - 4;
+            const int hiShift = bits == 4 ? 16 : 4 * bits - hiOffset * 8;
+            svbool_t mask32 = svwhilelt_b32(size_t(0), size_t(4));
+            svbool_t mask16 = svwhilelt_b16(size_t(0), size_t(4));
+            svuint32_t loShifts = svindex_u32(0, bits);
+            svuint32_t hiShifts = svindex_u32(hiShift, bits);
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _shift = svdup_n_f32(shift);
+            for (size_t i = 0; i < size; i += 8, src += bits, dst += 8)
+            {
+                Store16f(mask32, mask16, dst + 0, Decode32f(*(uint32_t*)(src + 0), mask32, loShifts, valueMask, _scale, _shift));
+                Store16f(mask32, mask16, dst + 4, Decode32f(*(uint32_t*)(src + hiOffset), mask32, hiShifts, valueMask, _scale, _shift));
+            }
+        }
+
         static void Decode32f8(const uint8_t* src, float scale, float shift, size_t size, float* dst)
         {
             svfloat32_t _scale = svdup_n_f32(scale);
@@ -64,6 +88,22 @@ namespace Simd
                 svbool_t mask = svwhilelt_b32(i, size);
                 svuint32_t value = svld1ub_u32(mask, src + i);
                 svst1_f32(mask, dst + i, svmla_f32_x(mask, _shift, _scale, svcvt_f32_u32_x(mask, value)));
+            }
+        }
+
+        static void Decode16f8(const uint8_t* src, float scale, float shift, size_t size, uint16_t* dst)
+        {
+            assert(size % 8 == 0);
+            svbool_t mask32 = svwhilelt_b32(size_t(0), size_t(4));
+            svbool_t mask16 = svwhilelt_b16(size_t(0), size_t(4));
+            svfloat32_t _scale = svdup_n_f32(scale);
+            svfloat32_t _shift = svdup_n_f32(shift);
+            for (size_t i = 0; i < size; i += 8, src += 8, dst += 8)
+            {
+                svuint32_t lo = svld1ub_u32(mask32, src + 0);
+                svuint32_t hi = svld1ub_u32(mask32, src + 4);
+                Store16f(mask32, mask16, dst + 0, svmla_f32_x(mask32, _shift, _scale, svcvt_f32_u32_x(mask32, lo)));
+                Store16f(mask32, mask16, dst + 4, svmla_f32_x(mask32, _shift, _scale, svcvt_f32_u32_x(mask32, hi)));
             }
         }
 
@@ -79,6 +119,19 @@ namespace Simd
             case 7: return Decode32fN<7>;
             case 8: return Decode32f8;
             default: return Base::GetDecode32f(depth);
+            }
+        }
+
+        Base::DescrInt::Decode16fPtr GetDecode16f(size_t depth)
+        {
+            switch (depth)
+            {
+            case 4: return Decode16fN<4>;
+            case 5: return Decode16fN<5>;
+            case 6: return Decode16fN<6>;
+            case 7: return Decode16fN<7>;
+            case 8: return Decode16f8;
+            default: return Base::GetDecode16f(depth);
             }
         }
     }

--- a/src/Simd/SimdSve2DescrIntDec.cpp
+++ b/src/Simd/SimdSve2DescrIntDec.cpp
@@ -39,7 +39,8 @@ namespace Simd
 
         SIMD_INLINE void Store16f(const svbool_t& mask32, const svbool_t& mask16, uint16_t* dst, const svfloat32_t& value)
         {
-            svst1_u16(mask16, dst, svreinterpret_u16_f16(svcvt_f16_f32_x(mask32, value)));
+            svuint16_t half = svreinterpret_u16_f16(svcvt_f16_f32_x(mask32, value));
+            svst1_u16(mask16, dst, svuzp1_u16(half, half));
         }
 
         template<int bits> static void Decode32fN(const uint8_t* src, float scale, float shift, size_t size, float* dst)

--- a/src/Test/TestDescrInt.cpp
+++ b/src/Test/TestDescrInt.cpp
@@ -481,6 +481,11 @@ namespace Test
             result = result && DescrIntDecode16fAutoTest(FUNC_DI(Simd::Avx512bw::DescrIntInit), FUNC_DI(SimdDescrIntInit));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DescrIntDecode16fAutoTest(FUNC_DI(Simd::Sve2::DescrIntInit), FUNC_DI(SimdDescrIntInit));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DescrIntDecode16fAutoTest(FUNC_DI(Simd::Neon::DescrIntInit), FUNC_DI(SimdDescrIntInit));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `DescrIntDecode16f` decode kernels for descriptor depths 4 through 8.
- Wire the SVE2 descriptor context and auto-test coverage for `DescrIntDecode16f`.
- Document the optimization in release 7.2.163 notes.
- Fix SVE half-lane packing so converted fp16 values are stored contiguously.

### Testing
- `git diff --check`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=DescrIntDecode16f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -fsyntax-only -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdSve2DescrIntDec.cpp`
- `aarch64-linux-gnu-g++ -std=c++11 -fsyntax-only -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdSve2DescrInt.cpp src/Test/TestDescrInt.cpp`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -S -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdSve2DescrIntDec.cpp -o /tmp/SimdSve2DescrIntDec_fixed.s`
- Verified generated SVE2 assembly contains `fcvt`, `uzp1`, and `st1h` in `Decode16f` kernels.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81d334fa-b70c-4ef3-900b-a1b3d4605858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81d334fa-b70c-4ef3-900b-a1b3d4605858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

