### PR TITLE
Add SVE2 Haar detection optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -116,6 +116,7 @@
  <li>SVE2 optimizations of function ContourMetrics.</li>
  <li>SVE2 optimizations of function ContourMetricsMasked.</li>
  <li>SVE2 optimizations of function ContourAnchors.</li>
+ <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToYuvV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Detection.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrInt.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp" />
@@ -69,6 +70,7 @@
     <ClInclude Include="..\..\src\Simd\SimdConversion.h" />
     <ClInclude Include="..\..\src\Simd\SimdCpu.h" />
     <ClInclude Include="..\..\src\Simd\SimdDefs.h" />
+    <ClInclude Include="..\..\src\Simd\SimdDetection.h" />
     <ClInclude Include="..\..\src\Simd\SimdDescrInt.h" />
     <ClInclude Include="..\..\src\Simd\SimdDescrIntCommon.h" />
     <ClInclude Include="..\..\src\Simd\SimdEnable.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -34,6 +34,9 @@
     <Filter Include="Sve2\Descriptors">
       <UniqueIdentifier>{337a78ee-4aa8-4208-8ce2-6333e5dd214a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sve2\Legacy">
+      <UniqueIdentifier>{8fe9db43-ed1c-4ea6-9f51-4f4092bd6ef7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdSve2.h">
@@ -76,6 +79,9 @@
       <Filter>Inc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdDefs.h">
+      <Filter>Inc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Simd\SimdDetection.h">
       <Filter>Inc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdDescrInt.h">
@@ -145,6 +151,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Cpu.cpp">
       <Filter>Sve2\System</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Detection.cpp">
+      <Filter>Sve2\Legacy</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2BgrToGray.cpp">
       <Filter>Sve2\Convert</Filter>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2337,6 +2337,11 @@ SIMD_API void SimdDetectionHaarDetect32fp(const void * hid, const uint8_t * mask
         Sse41::DetectionHaarDetect32fp(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::DetectionHaarDetect32fp(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::DetectionHaarDetect32fp(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -186,6 +186,9 @@ namespace Simd
 
         void CorrelationSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum);
 
+        void DetectionHaarDetect32fp(const void* hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
+
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
 
         void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Detection.cpp
+++ b/src/Simd/SimdSve2Detection.cpp
@@ -1,0 +1,168 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdDetection.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        using namespace Simd::Detection;
+
+        SIMD_INLINE svuint32_t Sum32ip(uint32_t* const ptr[4], size_t offset, const svbool_t& mask)
+        {
+            svuint32_t s0 = svld1_u32(mask, ptr[0] + offset);
+            svuint32_t s1 = svld1_u32(mask, ptr[1] + offset);
+            svuint32_t s2 = svld1_u32(mask, ptr[2] + offset);
+            svuint32_t s3 = svld1_u32(mask, ptr[3] + offset);
+            return svsub_u32_x(mask, svsub_u32_x(mask, s0, s1), svsub_u32_x(mask, s2, s3));
+        }
+
+        SIMD_INLINE svfloat32_t ValidSqrt(const svfloat32_t& value, const svbool_t& mask)
+        {
+            svbool_t positive = svcmpgt_n_f32(mask, value, 0.0f);
+            return svsqrt_f32_x(mask, svsel_f32(positive, value, svdup_n_f32(1.0f)));
+        }
+
+        SIMD_INLINE svfloat32_t Norm32fp(const HidHaarCascade& hid, size_t offset, const svbool_t& mask)
+        {
+            svfloat32_t area = svdup_n_f32(hid.windowArea);
+            svfloat32_t sum = svcvt_f32_u32_x(mask, Sum32ip(hid.p, offset, mask));
+            svfloat32_t sqsum = svcvt_f32_u32_x(mask, Sum32ip(hid.pq, offset, mask));
+            return ValidSqrt(svsub_f32_x(mask, svmul_f32_x(mask, sqsum, area), svmul_f32_x(mask, sum, sum)), mask);
+        }
+
+        SIMD_INLINE svfloat32_t WeightedSum32f(const WeightedRect& rect, size_t offset, const svbool_t& mask)
+        {
+            svuint32_t s0 = svld1_u32(mask, rect.p0 + offset);
+            svuint32_t s1 = svld1_u32(mask, rect.p1 + offset);
+            svuint32_t s2 = svld1_u32(mask, rect.p2 + offset);
+            svuint32_t s3 = svld1_u32(mask, rect.p3 + offset);
+            svuint32_t sum = svsub_u32_x(mask, svsub_u32_x(mask, s0, s1), svsub_u32_x(mask, s2, s3));
+            return svmul_f32_x(mask, svcvt_f32_u32_x(mask, sum), svdup_n_f32(rect.weight));
+        }
+
+        SIMD_INLINE void StageSum32f(const float* leaves, float threshold, const svfloat32_t& sum, const svfloat32_t& norm,
+            svfloat32_t& stageSum, const svbool_t& mask)
+        {
+            svbool_t select = svcmpge_f32(mask, sum, svmul_n_f32_x(mask, norm, threshold));
+            stageSum = svadd_f32_x(mask, stageSum, svsel_f32(select, svdup_n_f32(leaves[1]), svdup_n_f32(leaves[0])));
+        }
+
+        svbool_t Detect32f(const HidHaarCascade& hid, size_t offset, const svfloat32_t& norm, svbool_t result, const svbool_t& mask)
+        {
+            typedef HidHaarCascade Hid;
+            const float* leaves = hid.leaves.data();
+            const Hid::Node* node = hid.nodes.data();
+            const Hid::Stage* stages = hid.stages.data();
+            for (int i = 0, n = (int)hid.stages.size(); i < n; ++i)
+            {
+                const Hid::Stage& stage = stages[i];
+                if (stage.canSkip)
+                    continue;
+                const Hid::Node* end = node + stage.ntrees;
+                svfloat32_t stageSum = svdup_n_f32(0.0f);
+                if (stage.hasThree)
+                {
+                    for (; node < end; ++node, leaves += 2)
+                    {
+                        const Hid::Feature& feature = hid.features[node->featureIdx];
+                        svfloat32_t sum = svadd_f32_x(result, WeightedSum32f(feature.rect[0], offset, result), WeightedSum32f(feature.rect[1], offset, result));
+                        if (feature.rect[2].p0)
+                            sum = svadd_f32_x(result, sum, WeightedSum32f(feature.rect[2], offset, result));
+                        StageSum32f(leaves, node->threshold, sum, norm, stageSum, result);
+                    }
+                }
+                else
+                {
+                    for (; node < end; ++node, leaves += 2)
+                    {
+                        const Hid::Feature& feature = hid.features[node->featureIdx];
+                        svfloat32_t sum = svadd_f32_x(result, WeightedSum32f(feature.rect[0], offset, result), WeightedSum32f(feature.rect[1], offset, result));
+                        StageSum32f(leaves, node->threshold, sum, norm, stageSum, result);
+                    }
+                }
+                result = svcmpge_n_f32(result, stageSum, stage.threshold);
+                size_t resultCount = svcntp_b32(mask, result);
+                if (resultCount == 0)
+                {
+                    return result;
+                }
+                else if (resultCount == 1)
+                {
+                    const size_t F = svcntw();
+                    Buffer<float> buffer(F);
+                    svst1_f32(mask, buffer.m, norm);
+                    for (size_t j = 0; j < F; ++j)
+                    {
+                        svbool_t lane = svcmpeq_n_u32(mask, svindex_u32(0, 1), (uint32_t)j);
+                        if (svcntp_b32(lane, result))
+                            return Base::Detect32f(hid, offset + j, i + 1, buffer.m[j]) > 0 ? lane : svpfalse_b();
+                    }
+                }
+            }
+            return result;
+        }
+
+        void DetectionHaarDetect32fp(const HidHaarCascade& hid, const Image& mask, const Rect& rect, Image& dst)
+        {
+            size_t width = rect.Width();
+            const svuint32_t zero = svdup_n_u32(0);
+            const svuint32_t one = svdup_n_u32(1);
+            for (ptrdiff_t row = rect.top; row < rect.bottom; row += 1)
+            {
+                size_t col = 0;
+                size_t p_offset = row * hid.sum.stride / sizeof(uint32_t) + rect.left;
+                size_t pq_offset = row * hid.sqsum.stride / sizeof(uint32_t) + rect.left;
+                const uint8_t* maskRow = mask.data + row * mask.stride + rect.left;
+                uint8_t* dstRow = dst.data + row * dst.stride + rect.left;
+                for (; col < width; col += svcntw())
+                {
+                    svbool_t pg = svwhilelt_b32(col, width);
+                    svbool_t result = svcmpne_n_u32(pg, svld1ub_u32(pg, maskRow + col), 0);
+                    if (svcntp_b32(pg, result))
+                    {
+                        svfloat32_t norm = Norm32fp(hid, pq_offset + col, pg);
+                        result = Detect32f(hid, p_offset + col, norm, result, pg);
+                        svst1b_u32(pg, dstRow + col, svsel_u32(result, one, zero));
+                    }
+                    else
+                        svst1b_u32(pg, dstRow + col, zero);
+                }
+            }
+        }
+
+        void DetectionHaarDetect32fp(const void* _hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride)
+        {
+            const HidHaarCascade& hid = *(HidHaarCascade*)_hid;
+            return DetectionHaarDetect32fp(hid,
+                Image(hid.sum.width - 1, hid.sum.height - 1, maskStride, Image::Gray8, (uint8_t*)mask),
+                Rect(left, top, right, bottom),
+                Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
+        }
+    }
+#endif
+}

--- a/src/Test/TestDetection.cpp
+++ b/src/Test/TestDetection.cpp
@@ -280,6 +280,11 @@ namespace Test
             result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Neon::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Sve2::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdDetectionHaarDetect32fp`.
- Dispatch the public Haar 32fp detector to SVE2 on capable ARM/ARM64 builds.
- Add SVE2 coverage to `DetectionHaarDetect32fpAutoTest` and update Visual Studio SVE2 project files.
- Document the new optimization in release 7.2.163 notes.

### Verification
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -I./src -fsyntax-only src/Simd/SimdSve2Detection.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -I./src -fsyntax-only src/Simd/SimdLib.cpp`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=DetectionHaarDetect32fp -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12daf41d-ac84-44a7-85d9-213c475c7746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12daf41d-ac84-44a7-85d9-213c475c7746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

