### PR TITLE
Add SVE2 DetectionLbpDetect32fi optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -119,6 +119,7 @@
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
+ <li>SVE2 optimizations of function DetectionLbpDetect32fi.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2436,6 +2436,11 @@ SIMD_API void SimdDetectionLbpDetect32fi(const void * hid, const uint8_t * mask,
         Sse41::DetectionLbpDetect32fi(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= 2 * svcntw())
+        Sve2::DetectionLbpDetect32fi(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::DetectionLbpDetect32fi(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -195,6 +195,9 @@ namespace Simd
         void DetectionLbpDetect32fp(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 
+        void DetectionLbpDetect32fi(const void* hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
+
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
 
         void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Detection.cpp
+++ b/src/Simd/SimdSve2Detection.cpp
@@ -381,6 +381,56 @@ namespace Simd
                 Rect(left, top, right, bottom),
                 Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
         }
+
+        void DetectionLbpDetect32fi(const HidLbpCascade<float, uint32_t>& hid, const Image& mask, const Rect& rect, Image& dst)
+        {
+            const size_t step = 2;
+            const size_t F = svcntw();
+            size_t width = rect.Width();
+            size_t evenWidth = Simd::AlignLo(width, 2);
+            svbool_t mask32 = svptrue_b32();
+            svbool_t mask8 = svwhilelt_b8(size_t(0), 2 * F);
+            svuint8_t even = svindex_u8(0, 2);
+            svuint32_t zero32 = svdup_n_u32(0);
+            svuint32_t one32 = svdup_n_u32(1);
+            svuint8_t zero8 = svdup_n_u8(0);
+            for (ptrdiff_t row = rect.top; row < rect.bottom; row += step)
+            {
+                size_t col = 0;
+                size_t offset = row * hid.isum.stride / sizeof(uint32_t) + rect.left / 2;
+                const uint8_t* maskRow = mask.data + row * mask.stride + rect.left;
+                uint8_t* dstRow = dst.data + row * dst.stride + rect.left;
+                for (; col + 2 * F <= evenWidth; col += 2 * F)
+                {
+                    svbool_t result = svcmpne_n_u32(mask32, LoadMask32fi(maskRow + col, mask8, even), 0);
+                    if (svcntp_b32(mask32, result))
+                    {
+                        result = Detect(hid, offset + col / 2, 0, result, mask32);
+                        svuint8_t value = PackU32ToU8(svsel_u32(result, one32, zero32));
+                        svst1_u8(mask8, dstRow + col, svzip1_u8(value, zero8));
+                    }
+                    else
+                        svst1_u8(mask8, dstRow + col, zero8);
+                }
+                for (; col < width; col += step)
+                {
+                    if (maskRow[col] == 0)
+                        continue;
+                    if (Base::Detect(hid, offset + col / 2, 0) > 0)
+                        dstRow[col] = 1;
+                }
+            }
+        }
+
+        void DetectionLbpDetect32fi(const void* _hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride)
+        {
+            const HidLbpCascade<float, uint32_t>& hid = *(HidLbpCascade<float, uint32_t>*)_hid;
+            return DetectionLbpDetect32fi(hid,
+                Image(hid.sum.width - 1, hid.sum.height - 1, maskStride, Image::Gray8, (uint8_t*)mask),
+                Rect(left, top, right, bottom),
+                Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
+        }
     }
 #endif
 }

--- a/src/Test/TestDetection.cpp
+++ b/src/Test/TestDetection.cpp
@@ -385,6 +385,11 @@ namespace Test
             result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Neon::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Sve2::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatcher/test coverage for `SimdDetectionLbpDetect32fi`.
- Document the new SVE2 optimization in release 7.2.163 notes.

### Testing
- Built AArch64 SVE2 configuration with explicit `aarch64-linux-gnu-g++`/`gcc` compilers.
- Ran focused `DetectionLbpDetect32fi` test under `qemu-aarch64` with `QEMU_CPU=max`; the test framework reported `SIMD: NEON SVE(512) SVE2` and finished successfully.
- Built native x86_64 Release configuration with `g++` and ran the same focused test successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b043e38e-8790-4e20-af5f-0332d7350d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b043e38e-8790-4e20-af5f-0332d7350d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

