### PR TITLE
Add SVE2 optimization for DetectionLbpDetect16ip

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -120,6 +120,7 @@
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fi.</li>
+ <li>SVE2 optimizations of function DetectionLbpDetect16ip.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2469,6 +2469,11 @@ SIMD_API void SimdDetectionLbpDetect16ip(const void * hid, const uint8_t * mask,
         Sse41::DetectionLbpDetect16ip(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::DetectionLbpDetect16ip(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::DetectionLbpDetect16ip(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -198,6 +198,9 @@ namespace Simd
         void DetectionLbpDetect32fi(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 
+        void DetectionLbpDetect16ip(const void* hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
+
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
 
         void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Detection.cpp
+++ b/src/Simd/SimdSve2Detection.cpp
@@ -431,6 +431,136 @@ namespace Simd
                 Rect(left, top, right, bottom),
                 Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
         }
+
+        SIMD_INLINE svuint32_t IntegralSum16i(const svuint32_t& s0, const svuint32_t& s1, const svuint32_t& s2, const svuint32_t& s3, const svbool_t& mask)
+        {
+            return svsub_u32_x(mask, svsub_u32_x(mask, s0, s1), svsub_u32_x(mask, s2, s3));
+        }
+
+        template<int i> SIMD_INLINE svuint32_t Load16i(const HidLbpFeature<uint16_t>& feature, ptrdiff_t offset, const svbool_t& mask)
+        {
+            return svld1uh_u32(mask, feature.p[i] + offset);
+        }
+
+        SIMD_INLINE svuint32_t Calculate(const HidLbpFeature<uint16_t>& feature, ptrdiff_t offset, const svbool_t& mask)
+        {
+            svuint32_t a5 = Load16i<5>(feature, offset, mask);
+            svuint32_t a6 = Load16i<6>(feature, offset, mask);
+            svuint32_t a9 = Load16i<9>(feature, offset, mask);
+            svuint32_t a10 = Load16i<10>(feature, offset, mask);
+            svuint32_t central = IntegralSum16i(a5, a6, a9, a10, mask);
+
+            svuint32_t a0 = Load16i<0>(feature, offset, mask);
+            svuint32_t a1 = Load16i<1>(feature, offset, mask);
+            svuint32_t a4 = Load16i<4>(feature, offset, mask);
+            svuint32_t value = AddLbpBit(svdup_n_u32(0), IntegralSum16i(a0, a1, a4, a5, mask), central, 128, mask);
+
+            svuint32_t a2 = Load16i<2>(feature, offset, mask);
+            value = AddLbpBit(value, IntegralSum16i(a1, a2, a5, a6, mask), central, 64, mask);
+            svuint32_t a3 = Load16i<3>(feature, offset, mask);
+            svuint32_t a7 = Load16i<7>(feature, offset, mask);
+            value = AddLbpBit(value, IntegralSum16i(a2, a3, a6, a7, mask), central, 32, mask);
+            svuint32_t a11 = Load16i<11>(feature, offset, mask);
+            value = AddLbpBit(value, IntegralSum16i(a6, a7, a10, a11, mask), central, 16, mask);
+            svuint32_t a14 = Load16i<14>(feature, offset, mask);
+            svuint32_t a15 = Load16i<15>(feature, offset, mask);
+            value = AddLbpBit(value, IntegralSum16i(a10, a11, a14, a15, mask), central, 8, mask);
+            svuint32_t a13 = Load16i<13>(feature, offset, mask);
+            value = AddLbpBit(value, IntegralSum16i(a9, a10, a13, a14, mask), central, 4, mask);
+            svuint32_t a12 = Load16i<12>(feature, offset, mask);
+            svuint32_t a8 = Load16i<8>(feature, offset, mask);
+            value = AddLbpBit(value, IntegralSum16i(a8, a9, a12, a13, mask), central, 2, mask);
+            return AddLbpBit(value, IntegralSum16i(a4, a5, a8, a9, mask), central, 1, mask);
+        }
+
+        SIMD_INLINE svbool_t LeafMask(const HidLbpFeature<uint16_t>& feature, ptrdiff_t offset, const int* subset, const svbool_t& mask)
+        {
+            svuint32_t value = Calculate(feature, offset, mask);
+            svuint32_t index = svlsr_n_u32_x(mask, value, 5);
+            svuint32_t bit = svlsl_u32_x(mask, svdup_n_u32(1), svand_n_u32_x(mask, value, 31));
+            svuint32_t leaf = svld1_gather_u32index_u32(mask, (const uint32_t*)subset, index);
+            return svcmpne_n_u32(mask, svand_u32_x(mask, leaf, bit), 0);
+        }
+
+        svbool_t Detect(const HidLbpCascade<int, uint16_t>& hid, size_t offset, int startStage, svbool_t result, const svbool_t& mask)
+        {
+            typedef HidLbpCascade<int, uint16_t> Hid;
+
+            size_t subsetSize = (hid.ncategories + 31) / 32;
+            const int* subsets = hid.subsets.data();
+            const Hid::Leave* leaves = hid.leaves.data();
+            const Hid::Node* nodes = hid.nodes.data();
+            const Hid::Stage* stages = hid.stages.data();
+            if (startStage >= (int)hid.stages.size())
+                return result;
+            int nodeOffset = stages[startStage].first;
+            int leafOffset = 2 * nodeOffset;
+            for (int i_stage = startStage, n_stages = (int)hid.stages.size(); i_stage < n_stages; i_stage++)
+            {
+                const Hid::Stage& stage = stages[i_stage];
+                svint32_t sum = svdup_n_s32(0);
+                for (int i_tree = 0, n_trees = stage.ntrees; i_tree < n_trees; i_tree++)
+                {
+                    const Hid::Feature& feature = hid.features[nodes[nodeOffset].featureIdx];
+                    const int* subset = subsets + nodeOffset * subsetSize;
+                    svbool_t leaf = LeafMask(feature, offset, subset, result);
+                    sum = svadd_s32_x(result, sum, svsel_s32(leaf, svdup_n_s32(leaves[leafOffset + 0]), svdup_n_s32(leaves[leafOffset + 1])));
+                    nodeOffset++;
+                    leafOffset += 2;
+                }
+                result = svcmpge_n_s32(result, sum, stage.threshold);
+                size_t resultCount = svcntp_b32(mask, result);
+                if (resultCount == 0)
+                    return result;
+                else if (resultCount == 1)
+                {
+                    const size_t F = svcntw();
+                    for (size_t j = 0; j < F; ++j)
+                    {
+                        svbool_t lane = svcmpeq_n_u32(mask, svindex_u32(0, 1), (uint32_t)j);
+                        if (svcntp_b32(lane, result))
+                            return Base::Detect(hid, offset + j, i_stage + 1) > 0 ? lane : svpfalse_b();
+                    }
+                }
+            }
+            return result;
+        }
+
+        void DetectionLbpDetect16ip(const HidLbpCascade<int, uint16_t>& hid, const Image& mask, const Rect& rect, Image& dst)
+        {
+            size_t width = rect.Width();
+            const svuint32_t zero = svdup_n_u32(0);
+            const svuint32_t one = svdup_n_u32(1);
+            for (ptrdiff_t row = rect.top; row < rect.bottom; row += 1)
+            {
+                size_t col = 0;
+                size_t offset = row * hid.isum.stride / sizeof(uint16_t) + rect.left;
+                const uint8_t* maskRow = mask.data + row * mask.stride + rect.left;
+                uint8_t* dstRow = dst.data + row * dst.stride + rect.left;
+                for (; col < width; col += svcntw())
+                {
+                    svbool_t pg = svwhilelt_b32(col, width);
+                    svbool_t result = svcmpne_n_u32(pg, svld1ub_u32(pg, maskRow + col), 0);
+                    if (svcntp_b32(pg, result))
+                    {
+                        result = Detect(hid, offset + col, 0, result, pg);
+                        svst1b_u32(pg, dstRow + col, svsel_u32(result, one, zero));
+                    }
+                    else
+                        svst1b_u32(pg, dstRow + col, zero);
+                }
+            }
+        }
+
+        void DetectionLbpDetect16ip(const void* _hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride)
+        {
+            const HidLbpCascade<int, uint16_t>& hid = *(HidLbpCascade<int, uint16_t>*)_hid;
+            return DetectionLbpDetect16ip(hid,
+                Image(hid.sum.width - 1, hid.sum.height - 1, maskStride, Image::Gray8, (uint8_t*)mask),
+                Rect(left, top, right, bottom),
+                Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSve2Detection.cpp
+++ b/src/Simd/SimdSve2Detection.cpp
@@ -434,7 +434,7 @@ namespace Simd
 
         SIMD_INLINE svuint32_t IntegralSum16i(const svuint32_t& s0, const svuint32_t& s1, const svuint32_t& s2, const svuint32_t& s3, const svbool_t& mask)
         {
-            return svsub_u32_x(mask, svsub_u32_x(mask, s0, s1), svsub_u32_x(mask, s2, s3));
+            return svand_n_u32_x(mask, svsub_u32_x(mask, svsub_u32_x(mask, s0, s1), svsub_u32_x(mask, s2, s3)), 0xFFFF);
         }
 
         template<int i> SIMD_INLINE svuint32_t Load16i(const HidLbpFeature<uint16_t>& feature, ptrdiff_t offset, const svbool_t& mask)

--- a/src/Test/TestDetection.cpp
+++ b/src/Test/TestDetection.cpp
@@ -420,6 +420,11 @@ namespace Test
             result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Neon::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Sve2::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatcher wiring for `SimdDetectionLbpDetect16ip`.
- Preserve 16-bit integral-sum wraparound in the SVE2 LBP comparisons to match Base/x86/NEON semantics.
- Add SVE2 auto-test coverage for `DetectionLbpDetect16ip`.
- Update release notes for version 7.2.163.

### Testing
- `git diff --check`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2Detection.cpp -o /tmp/SimdSve2Detection.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -fPIC -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdLib.cpp -o /tmp/SimdLib.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I./src -I./src/Test -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Test/TestDetection.cpp -o /tmp/TestDetection.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && cd build && ./Test "-r=.." -fi=DetectionLbpDetect16ip -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-271b6670-11d7-4d7a-bc3a-840b31cb8d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-271b6670-11d7-4d7a-bc3a-840b31cb8d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

