### PR TITLE
Add SVE2 optimization for DetectionLbpDetect16ii

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -121,6 +121,7 @@
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect16ip.</li>
+ <li>SVE2 optimizations of function DetectionLbpDetect16ii.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2502,6 +2502,11 @@ SIMD_API void SimdDetectionLbpDetect16ii(const void * hid, const uint8_t * mask,
         Sse41::DetectionLbpDetect16ii(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= 2 * svcntw())
+        Sve2::DetectionLbpDetect16ii(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::DetectionLbpDetect16ii(hid, mask, maskStride, left, top, right, bottom, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -201,6 +201,9 @@ namespace Simd
         void DetectionLbpDetect16ip(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 
+        void DetectionLbpDetect16ii(const void* hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
+
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
 
         void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Detection.cpp
+++ b/src/Simd/SimdSve2Detection.cpp
@@ -561,6 +561,56 @@ namespace Simd
                 Rect(left, top, right, bottom),
                 Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
         }
+
+        void DetectionLbpDetect16ii(const HidLbpCascade<int, uint16_t>& hid, const Image& mask, const Rect& rect, Image& dst)
+        {
+            const size_t step = 2;
+            const size_t F = svcntw();
+            size_t width = rect.Width();
+            size_t evenWidth = Simd::AlignLo(width, 2);
+            svbool_t mask32 = svptrue_b32();
+            svbool_t mask8 = svwhilelt_b8(size_t(0), 2 * F);
+            svuint8_t even = svindex_u8(0, 2);
+            svuint32_t zero32 = svdup_n_u32(0);
+            svuint32_t one32 = svdup_n_u32(1);
+            svuint8_t zero8 = svdup_n_u8(0);
+            for (ptrdiff_t row = rect.top; row < rect.bottom; row += step)
+            {
+                size_t col = 0;
+                size_t offset = row * hid.isum.stride / sizeof(uint16_t) + rect.left / 2;
+                const uint8_t* maskRow = mask.data + row * mask.stride + rect.left;
+                uint8_t* dstRow = dst.data + row * dst.stride + rect.left;
+                for (; col + 2 * F <= evenWidth; col += 2 * F)
+                {
+                    svbool_t result = svcmpne_n_u32(mask32, LoadMask32fi(maskRow + col, mask8, even), 0);
+                    if (svcntp_b32(mask32, result))
+                    {
+                        result = Detect(hid, offset + col / 2, 0, result, mask32);
+                        svuint8_t value = PackU32ToU8(svsel_u32(result, one32, zero32));
+                        svst1_u8(mask8, dstRow + col, svzip1_u8(value, zero8));
+                    }
+                    else
+                        svst1_u8(mask8, dstRow + col, zero8);
+                }
+                for (; col < width; col += step)
+                {
+                    if (maskRow[col] == 0)
+                        continue;
+                    if (Base::Detect(hid, offset + col / 2, 0) > 0)
+                        dstRow[col] = 1;
+                }
+            }
+        }
+
+        void DetectionLbpDetect16ii(const void* _hid, const uint8_t* mask, size_t maskStride,
+            ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride)
+        {
+            const HidLbpCascade<int, uint16_t>& hid = *(HidLbpCascade<int, uint16_t>*)_hid;
+            return DetectionLbpDetect16ii(hid,
+                Image(hid.sum.width - 1, hid.sum.height - 1, maskStride, Image::Gray8, (uint8_t*)mask),
+                Rect(left, top, right, bottom),
+                Image(hid.sum.width - 1, hid.sum.height - 1, dstStride, Image::Gray8, dst).Ref());
+        }
     }
 #endif
 }

--- a/src/Test/TestDetection.cpp
+++ b/src/Test/TestDetection.cpp
@@ -455,6 +455,11 @@ namespace Test
             result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Neon::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Sve2::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdDetectionLbpDetect16ii`.
- Extend the detection auto-test matrix with SVE2 coverage.
- Document the new SVE2 optimization in release 7.2.163.
- Merge latest `dev`, including the upstream Synet compilation fix.

### Testing
- Passed: recommended shared x86 build with AVX-512VNNI and AMX-BF16 enabled.
- Passed: `./Test "-r=.." -fi=DetectionLbpDetect16ii -tt=1 -ts=1` from the shared build.
- Passed: ARM64 SVE2 static library cross-build with `SIMD_SVE2=ON`; `SimdSve2Detection.cpp` compiled and `libSimd.a` linked.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b5385ad-5901-4ae2-8e6b-92c48cd0c4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b5385ad-5901-4ae2-8e6b-92c48cd0c4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

