### PR TITLE
Add SVE2 optimization for Fill32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -122,6 +122,7 @@
  <li>SVE2 optimizations of function DetectionLbpDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect16ip.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect16ii.</li>
+ <li>SVE2 optimizations of function Fill32f.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -48,6 +48,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntCdu.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntDec.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntEnc.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Fill.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -218,6 +218,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2DescrIntEnc.cpp">
       <Filter>Sve2\Descriptors</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Fill.cpp">
+      <Filter>Sve2\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2632,7 +2632,7 @@ SIMD_API void SimdFill32f(float * dst, size_t size, const float * value)
 {
     SIMD_EMPTY();
     typedef void(*SimdFill32fPtr) (float * dst, size_t size, const float * value);
-    const static SimdFill32fPtr simdFill32f = SIMD_FUNC4(Fill32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdFill32fPtr simdFill32f = SIMD_FUNC5(Fill32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdFill32f(dst, size, value);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -204,6 +204,8 @@ namespace Simd
         void DetectionLbpDetect16ii(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 
+        void Fill32f(float* dst, size_t size, const float* value);
+
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);
 
         void Reorder32bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Fill.cpp
+++ b/src/Simd/SimdSve2Fill.cpp
@@ -1,0 +1,56 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void Fill32f(float* dst, size_t size, const float* value)
+        {
+            if (value == 0 || value[0] == 0)
+                memset(dst, 0, size * sizeof(float));
+            else
+            {
+                size_t F = svcntw(), QF = 4 * F, i = 0;
+                const svbool_t body = svptrue_b32();
+                const svfloat32_t _value = svdup_n_f32(value[0]);
+
+                for (; i + QF <= size; i += QF)
+                {
+                    svst1_f32(body, dst + i + 0 * F, _value);
+                    svst1_f32(body, dst + i + 1 * F, _value);
+                    svst1_f32(body, dst + i + 2 * F, _value);
+                    svst1_f32(body, dst + i + 3 * F, _value);
+                }
+                for (; i + F <= size; i += F)
+                    svst1_f32(body, dst + i, _value);
+                if (i < size)
+                    svst1_f32(svwhilelt_b32(i, size), dst + i, _value);
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestFill.cpp
+++ b/src/Test/TestFill.cpp
@@ -529,6 +529,11 @@ namespace Test
             result = result && Fill32fAutoTest(FUNC_32F(Simd::Avx512bw::Fill32f), FUNC_32F(SimdFill32f));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Fill32fAutoTest(FUNC_32F(Simd::Sve2::Fill32f), FUNC_32F(SimdFill32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && Fill32fAutoTest(FUNC_32F(Simd::Neon::Fill32f), FUNC_32F(SimdFill32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Simd::Sve2::Fill32f` using SVE2/SVE predicated stores for aligned body and tail handling.
- Route `SimdFill32f` through SVE2 before NEON when available.
- Extend `Fill32fAutoTest` for SVE2 and register the new source in VS2022 SVE2 project files.
- Document the SVE2 `Fill32f` optimization in the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Fill32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -DSIMD_STATIC -I./src -c src/Simd/SimdSve2Fill.cpp -o /tmp/SimdSve2Fill.o`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -DSIMD_STATIC -I./src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib.o`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src -D_GLIBCXX_USE_NANOSLEEP -c src/Test/TestFill.cpp -o /tmp/TestFill.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60915b59-8fbf-4b02-a215-fb4204ab3226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60915b59-8fbf-4b02-a215-fb4204ab3226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

