### PR TITLE
Add SVE2 FillBgr optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -123,6 +123,7 @@
  <li>SVE2 optimizations of function DetectionLbpDetect16ip.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect16ii.</li>
  <li>SVE2 optimizations of function Fill32f.</li>
+ <li>SVE2 optimizations of function FillBgr.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2558,6 +2558,11 @@ SIMD_API void SimdFillBgr(uint8_t * dst, size_t stride, size_t width, size_t hei
         Sse41::FillBgr(dst, stride, width, height, blue, green, red);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::FillBgr(dst, stride, width, height, blue, green, red);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::FillBgr(dst, stride, width, height, blue, green, red);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -204,6 +204,8 @@ namespace Simd
         void DetectionLbpDetect16ii(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 
+        void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red);
+
         void Fill32f(float* dst, size_t size, const float* value);
 
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Fill.cpp
+++ b/src/Simd/SimdSve2Fill.cpp
@@ -28,6 +28,67 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE bool InitFillBgrIndex(uint8_t index[3][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t k = 0; k < 3; ++k)
+            {
+                size_t offset = k * A;
+                for (size_t i = 0; i < A; ++i)
+                    index[k][i] = (uint8_t)((offset + i) % 3);
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t FILL_BGR_INDEX[3][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool FILL_BGR_INDEX_INITED = InitFillBgrIndex(FILL_BGR_INDEX);
+
+        SIMD_INLINE svuint8_t FillBgr(const svuint8_t& index, const svuint8_t& blue, const svuint8_t& green, const svuint8_t& red, const svbool_t& mask)
+        {
+            return svsel_u8(svcmpeq_n_u8(mask, index, 0), blue, svsel_u8(svcmpeq_n_u8(mask, index, 1), green, red));
+        }
+
+        SIMD_INLINE void FillBgr(uint8_t* dst, size_t A, const svuint8_t& bgr0, const svuint8_t& bgr1, const svuint8_t& bgr2,
+            const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2)
+        {
+            svst1_u8(mask0, dst + 0 * A, bgr0);
+            svst1_u8(mask1, dst + 1 * A, bgr1);
+            svst1_u8(mask2, dst + 2 * A, bgr2);
+        }
+
+        void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red)
+        {
+            size_t A = svlen(svuint8_t()), A3 = A * 3;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t widthA = AlignLo(width, A);
+            size_t tail = (width - widthA) * 3;
+            const svbool_t body = svptrue_b8();
+            const svuint8_t _blue = svdup_n_u8(blue);
+            const svuint8_t _green = svdup_n_u8(green);
+            const svuint8_t _red = svdup_n_u8(red);
+            const svuint8_t index0 = svld1_u8(body, FILL_BGR_INDEX[0]);
+            const svuint8_t index1 = svld1_u8(body, FILL_BGR_INDEX[1]);
+            const svuint8_t index2 = svld1_u8(body, FILL_BGR_INDEX[2]);
+            const svuint8_t bgr0 = FillBgr(index0, _blue, _green, _red, body);
+            const svuint8_t bgr1 = FillBgr(index1, _blue, _green, _red, body);
+            const svuint8_t bgr2 = FillBgr(index2, _blue, _green, _red, body);
+            const svbool_t tail0 = svwhilelt_b8(size_t(0 * A), tail);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1 * A), tail);
+            const svbool_t tail2 = svwhilelt_b8(size_t(2 * A), tail);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    FillBgr(dst + offset, A, bgr0, bgr1, bgr2, body, body, body);
+                if (tail)
+                    FillBgr(dst + offset, A, bgr0, bgr1, bgr2, tail0, tail1, tail2);
+                dst += stride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         void Fill32f(float* dst, size_t size, const float* value)
         {
             if (value == 0 || value[0] == 0)

--- a/src/Test/TestFill.cpp
+++ b/src/Test/TestFill.cpp
@@ -349,6 +349,11 @@ namespace Test
             result = result && FillBgrAutoTest(FUNC_BGR(Simd::Avx512bw::FillBgr), FUNC_BGR(SimdFillBgr));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && FillBgrAutoTest(FUNC_BGR(Simd::Sve2::FillBgr), FUNC_BGR(SimdFillBgr));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && FillBgrAutoTest(FUNC_BGR(Simd::Neon::FillBgr), FUNC_BGR(SimdFillBgr));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `FillBgr` implementation using contiguous byte stores with vector-length-aware tail masks.
- Wire `SimdFillBgr` dispatch and SVE2 auto-test coverage.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=FillBgr -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -fsyntax-only -march=armv8.6-a+sve2 -I src src/Simd/SimdSve2Fill.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1f1a928-19f3-4fa2-877a-e336f985c033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1f1a928-19f3-4fa2-877a-e336f985c033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

