### PR TITLE
Add SVE2 FillBgra optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -124,6 +124,7 @@
  <li>SVE2 optimizations of function DetectionLbpDetect16ii.</li>
  <li>SVE2 optimizations of function Fill32f.</li>
  <li>SVE2 optimizations of function FillBgr.</li>
+ <li>SVE2 optimizations of function FillBgra.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2589,6 +2589,11 @@ SIMD_API void SimdFillBgra(uint8_t * dst, size_t stride, size_t width, size_t he
         Sse41::FillBgra(dst, stride, width, height, blue, green, red, alpha);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::FillBgra(dst, stride, width, height, blue, green, red, alpha);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::FillBgra(dst, stride, width, height, blue, green, red, alpha);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -206,6 +206,8 @@ namespace Simd
 
         void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red);
 
+        void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha);
+
         void Fill32f(float* dst, size_t size, const float* value);
 
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Fill.cpp
+++ b/src/Simd/SimdSve2Fill.cpp
@@ -87,6 +87,35 @@ namespace Simd
             }
         }
 
+        void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha)
+        {
+#ifdef SIMD_BIG_ENDIAN
+            uint32_t bgra = uint32_t(alpha) | (uint32_t(red) << 8) | (uint32_t(green) << 16) | (uint32_t(blue) << 24);
+#else
+            uint32_t bgra = uint32_t(blue) | (uint32_t(green) << 8) | (uint32_t(red) << 16) | (uint32_t(alpha) << 24);
+#endif
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const svuint32_t _bgra = svdup_n_u32(bgra);
+            for (size_t row = 0; row < height; ++row)
+            {
+                uint32_t* d = (uint32_t*)dst;
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    svst1_u32(body, d + col + 0 * F, _bgra);
+                    svst1_u32(body, d + col + 1 * F, _bgra);
+                    svst1_u32(body, d + col + 2 * F, _bgra);
+                    svst1_u32(body, d + col + 3 * F, _bgra);
+                }
+                for (; col + F <= width; col += F)
+                    svst1_u32(body, d + col, _bgra);
+                if (col < width)
+                    svst1_u32(svwhilelt_b32(col, width), d + col, _bgra);
+                dst += stride;
+            }
+        }
+
         //-------------------------------------------------------------------------------------------------
 
         void Fill32f(float* dst, size_t size, const float* value)

--- a/src/Test/TestFill.cpp
+++ b/src/Test/TestFill.cpp
@@ -258,6 +258,11 @@ namespace Test
             result = result && FillBgraAutoTest(FUNC_BGRA(Simd::Avx512bw::FillBgra), FUNC_BGRA(SimdFillBgra));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && FillBgraAutoTest(FUNC_BGRA(Simd::Sve2::FillBgra), FUNC_BGRA(SimdFillBgra));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::F)
             result = result && FillBgraAutoTest(FUNC_BGRA(Simd::Neon::FillBgra), FUNC_BGRA(SimdFillBgra));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `FillBgra` using vector-length agnostic 32-bit stores.
- Route `SimdFillBgra` through SVE2 when available and add SVE2 coverage to `FillBgraAutoTest`.
- Document the new SVE2 `FillBgra` optimization in the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./Test "-r=.." -fi=FillBgra -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2Fill.cpp`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TARGET="aarch64" -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_SHARED=OFF -DSIMD_PYTHON=OFF -DSIMD_GET_VERSION=OFF && cmake --build build-aarch64-sve2 --parallel$(nproc)`
- `qemu-aarch64 -cpu max -L /usr/aarch64-linux-gnu ./Test "-r=.." -fi=FillBgra -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa35360d-9df2-43f0-aadf-af407a38e21f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa35360d-9df2-43f0-aadf-af407a38e21f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

