### PR TITLE
Add SVE2 FillPixel optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -125,6 +125,7 @@
  <li>SVE2 optimizations of function Fill32f.</li>
  <li>SVE2 optimizations of function FillBgr.</li>
  <li>SVE2 optimizations of function FillBgra.</li>
+ <li>SVE2 optimizations of function FillPixel.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2625,6 +2625,11 @@ SIMD_API void SimdFillPixel(uint8_t * dst, size_t stride, size_t width, size_t h
         Sse41::FillPixel(dst, stride, width, height, pixel, pixelSize);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::FillPixel(dst, stride, width, height, pixel, pixelSize);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::FillPixel(dst, stride, width, height, pixel, pixelSize);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -208,6 +208,8 @@ namespace Simd
 
         void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha);
 
+        void FillPixel(uint8_t* dst, size_t stride, size_t width, size_t height, const uint8_t* pixel, size_t pixelSize);
+
         void Fill32f(float* dst, size_t size, const float* value);
 
         void Reorder16bit(const uint8_t* src, size_t size, uint8_t* dst);

--- a/src/Simd/SimdSve2Fill.cpp
+++ b/src/Simd/SimdSve2Fill.cpp
@@ -116,6 +116,79 @@ namespace Simd
             }
         }
 
+        void FillPixel8u(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t pixel)
+        {
+            size_t A = svcntb(), QA = 4 * A;
+            const svbool_t body = svptrue_b8();
+            const svuint8_t _pixel = svdup_n_u8(pixel);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QA <= width; col += QA)
+                {
+                    svst1_u8(body, dst + col + 0 * A, _pixel);
+                    svst1_u8(body, dst + col + 1 * A, _pixel);
+                    svst1_u8(body, dst + col + 2 * A, _pixel);
+                    svst1_u8(body, dst + col + 3 * A, _pixel);
+                }
+                for (; col + A <= width; col += A)
+                    svst1_u8(body, dst + col, _pixel);
+                if (col < width)
+                    svst1_u8(svwhilelt_b8(col, width), dst + col, _pixel);
+                dst += stride;
+            }
+        }
+
+        void FillPixel16u(uint8_t* dst, size_t stride, size_t width, size_t height, const uint8_t* pixel)
+        {
+#ifdef SIMD_BIG_ENDIAN
+            uint16_t uv = uint16_t(pixel[1]) | (uint16_t(pixel[0]) << 8);
+#else
+            uint16_t uv = uint16_t(pixel[0]) | (uint16_t(pixel[1]) << 8);
+#endif
+            size_t F = svcnth(), QF = 4 * F;
+            const svbool_t body = svptrue_b16();
+            const svuint16_t _pixel = svdup_n_u16(uv);
+            for (size_t row = 0; row < height; ++row)
+            {
+                uint16_t* d = (uint16_t*)dst;
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    svst1_u16(body, d + col + 0 * F, _pixel);
+                    svst1_u16(body, d + col + 1 * F, _pixel);
+                    svst1_u16(body, d + col + 2 * F, _pixel);
+                    svst1_u16(body, d + col + 3 * F, _pixel);
+                }
+                for (; col + F <= width; col += F)
+                    svst1_u16(body, d + col, _pixel);
+                if (col < width)
+                    svst1_u16(svwhilelt_b16(col, width), d + col, _pixel);
+                dst += stride;
+            }
+        }
+
+        void FillPixel(uint8_t* dst, size_t stride, size_t width, size_t height, const uint8_t* pixel, size_t pixelSize)
+        {
+            switch (pixelSize)
+            {
+            case 1:
+                FillPixel8u(dst, stride, width, height, pixel[0]);
+                break;
+            case 2:
+                FillPixel16u(dst, stride, width, height, pixel);
+                break;
+            case 3:
+                FillBgr(dst, stride, width, height, pixel[0], pixel[1], pixel[2]);
+                break;
+            case 4:
+                FillBgra(dst, stride, width, height, pixel[0], pixel[1], pixel[2], pixel[3]);
+                break;
+            default:
+                assert(0);
+            }
+        }
+
         //-------------------------------------------------------------------------------------------------
 
         void Fill32f(float* dst, size_t size, const float* value)

--- a/src/Test/TestFill.cpp
+++ b/src/Test/TestFill.cpp
@@ -451,6 +451,11 @@ namespace Test
             result = result && FillPixelAutoTest(FUNC_FP(Simd::Avx512bw::FillPixel), FUNC_FP(SimdFillPixel));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && FillPixelAutoTest(FUNC_FP(Simd::Sve2::FillPixel), FUNC_FP(SimdFillPixel));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && FillPixelAutoTest(FUNC_FP(Simd::Neon::FillPixel), FUNC_FP(SimdFillPixel));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation of `FillPixel` with vectorized 8-bit and 16-bit pixel fills and delegation to existing BGR/BGRA paths.
* Wire SVE2 `FillPixel` into runtime dispatch and auto-tests.
* Document the SVE2 `FillPixel` optimization in release 7.2.163.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=FillPixel -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -I./src -fsyntax-only ./src/Simd/SimdSve2Fill.cpp`
* `git diff --check && git status --short --branch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98855519-6667-4a55-8a62-b7eb4dbdc4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98855519-6667-4a55-8a62-b7eb4dbdc4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

