### PR TITLE
Add SVE2 Float16ToFloat32 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
+ <li>SVE2 optimizations of function Float16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2721,6 +2721,11 @@ SIMD_API void SimdFloat16ToFloat32(const uint16_t * src, size_t size, float * ds
         Sse41::Float16ToFloat32(src, size, dst);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::Float16ToFloat32(src, size, dst);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && size >= Neon::F)
         Neon::Float16ToFloat32(src, size, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -107,6 +107,8 @@ namespace Simd
 
         void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -30,6 +30,33 @@ namespace Simd
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     namespace Sve2
     {
+        SIMD_INLINE void Float16ToFloat32(const uint16_t* src, const svbool_t& load, const svbool_t& even, const svbool_t& odd,
+            const svbool_t& lo, const svbool_t& hi, float* dst)
+        {
+            size_t F = svlen(svfloat32_t());
+            svfloat16_t _src = svreinterpret_f16_u16(svld1_u16(load, src));
+            svfloat32_t _even = svcvt_f32_f16_x(even, _src);
+            svfloat32_t _odd = svcvtlt_f32_f16_x(odd, _src);
+            svst1_f32(lo, dst + 0, svzip1_f32(_even, _odd));
+            svst1_f32(hi, dst + F, svzip2_f32(_even, _odd));
+        }
+
+        void Float16ToFloat32(const uint16_t* src, size_t size, float* dst)
+        {
+            size_t A = svlen(svuint16_t()), F = svlen(svfloat32_t()), sizeA = AlignLo(size, A), i = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            for (; i < sizeA; i += A)
+                Float16ToFloat32(src + i, body16, body32, body32, body32, body32, dst + i);
+            if (i < size)
+            {
+                size_t tail = size - i;
+                Float16ToFloat32(src + i, svwhilelt_b16(size_t(0), tail),
+                    svwhilelt_b32(size_t(0), (tail + 1) / 2), svwhilelt_b32(size_t(0), tail / 2),
+                    svwhilelt_b32(size_t(0), Simd::Min(tail, F)), svwhilelt_b32(F, tail), dst + i);
+            }
+        }
+
         SIMD_INLINE void CosineDistance16f(const uint16_t* a, const uint16_t* b, const svbool_t& load, const svbool_t& lo, const svbool_t& hi,
             svfloat32_t& aa0, svfloat32_t& aa1, svfloat32_t& ab0, svfloat32_t& ab1, svfloat32_t& bb0, svfloat32_t& bb1)
         {

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -195,6 +195,11 @@ namespace Test
             result = result && Float16ToFloat32AutoTest(FUNC_HS(Simd::Neon::Float16ToFloat32), FUNC_HS(SimdFloat16ToFloat32));
 #endif 
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Float16ToFloat32AutoTest(FUNC_HS(Simd::Sve2::Float16ToFloat32), FUNC_HS(SimdFloat16ToFloat32));
+#endif 
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `Float16ToFloat32` conversion using FP16 widening, zip reordering, and predicated tail stores.
- Route `SimdFloat16ToFloat32` through the SVE2 implementation when available.
- Add SVE2 coverage to `Float16ToFloat32AutoTest` and note the release change.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Float16ToFloat32 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I./src -march=armv9-a+sve2+fp16 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2Float16.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -I./src -march=armv9-a+sve2+fp16 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -I./src -I./src/Test -march=armv9-a+sve2+fp16 -msve-vector-bits=scalable -fsyntax-only src/Test/TestFloat16.cpp`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3caee0b6-bbaf-4c87-847f-479c627996da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3caee0b6-bbaf-4c87-847f-479c627996da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

