### PR TITLE
Add SVE2 Float32ToFloat16 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
+ <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2695,6 +2695,11 @@ SIMD_API void SimdFloat32ToFloat16(const float * src, size_t size, uint16_t * ds
         Sse41::Float32ToFloat16(src, size, dst);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::Float32ToFloat16(src, size, dst);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && size >= Neon::F)
         Neon::Float32ToFloat16(src, size, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -107,6 +107,8 @@ namespace Simd
 
         void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void Float32ToFloat16(const float* src, size_t size, uint16_t* dst);
+
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -30,6 +30,29 @@ namespace Simd
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     namespace Sve2
     {
+        SIMD_INLINE void Float32ToFloat16(const float* src, const svbool_t& lo, const svbool_t& hi, const svbool_t& store, uint16_t* dst)
+        {
+            size_t F = svlen(svfloat32_t());
+            svuint16_t _lo = svreinterpret_u16_f16(svcvt_f16_f32_x(lo, svld1_f32(lo, src + 0)));
+            svuint16_t _hi = svreinterpret_u16_f16(svcvt_f16_f32_x(hi, svld1_f32(hi, src + F)));
+            svst1_u16(store, dst, svuzp1_u16(_lo, _hi));
+        }
+
+        void Float32ToFloat16(const float* src, size_t size, uint16_t* dst)
+        {
+            size_t A = svlen(svuint16_t()), F = svlen(svfloat32_t()), sizeA = AlignLo(size, A), i = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            for (; i < sizeA; i += A)
+                Float32ToFloat16(src + i, body32, body32, body16, dst + i);
+            if (i < size)
+            {
+                size_t tail = size - i;
+                Float32ToFloat16(src + i, svwhilelt_b32(size_t(0), Simd::Min(tail, F)),
+                    svwhilelt_b32(F, tail), svwhilelt_b16(size_t(0), tail), dst + i);
+            }
+        }
+
         SIMD_INLINE void Float16ToFloat32(const uint16_t* src, const svbool_t& load, const svbool_t& even, const svbool_t& odd,
             const svbool_t& lo, const svbool_t& hi, float* dst)
         {

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -109,6 +109,11 @@ namespace Test
             result = result && Float32ToFloat16AutoTest(FUNC_SH(Simd::Neon::Float32ToFloat16), FUNC_SH(SimdFloat32ToFloat16));
 #endif 
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Float32ToFloat16AutoTest(FUNC_SH(Simd::Sve2::Float32ToFloat16), FUNC_SH(SimdFloat32ToFloat16));
+#endif 
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `Float32ToFloat16` conversion using predicated SVE loads/converts/stores.
- Wire SVE2 dispatch and auto-test coverage for `SimdFloat32ToFloat16`.
- Update 7.2.163 release notes for the new SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=Float32ToFloat16 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv9-a+sve2+fp16 -msve-vector-bits=scalable -I./src src/Simd/SimdSve2Float16.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2d801cf-1e6f-480c-a106-732f47d94a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d801cf-1e6f-480c-a106-732f47d94a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

