### PR TITLE
Add SVE2 BFloat16ToFloat32 tail handling

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,7 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
- <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
+ <li>SVE2 optimizations of function BFloat16ToFloat32 for ARM/ARM64 platform.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>

--- a/src/Simd/SimdSve2BFloat16.cpp
+++ b/src/Simd/SimdSve2BFloat16.cpp
@@ -29,12 +29,13 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE void BFloat16ToFloat32(const uint16_t* src, const svbool_t& mask, float* dst)
+        SIMD_INLINE void BFloat16ToFloat32(const uint16_t* src, const svbool_t& load, const svbool_t& lo, const svbool_t& hi, float* dst)
         {
+            size_t A = svlen(svuint16_t());
             svuint16_t zero = svdup_n_u16(0);
-            svuint16_t _src = svld1_u16(mask, src);
-            svst1_u16(mask, (uint16_t*)dst + 0 * svlen(svuint16_t()), svzip1_u16(zero, _src));
-            svst1_u16(mask, (uint16_t*)dst + 1 * svlen(svuint16_t()), svzip2_u16(zero, _src));
+            svuint16_t _src = svld1_u16(load, src);
+            svst1_u16(lo, (uint16_t*)dst + 0 * A, svzip1_u16(zero, _src));
+            svst1_u16(hi, (uint16_t*)dst + 1 * A, svzip2_u16(zero, _src));
         }
 
         void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst)
@@ -43,9 +44,13 @@ namespace Simd
             const svbool_t body = svptrue_b16();
             size_t i = 0;
             for (; i < sizeA; i += A)
-                BFloat16ToFloat32(src + i, body, dst + i);
-            for (; i < size; ++i)
-                dst[i] = Base::BFloat16ToFloat32(src[i]);
+                BFloat16ToFloat32(src + i, body, body, body, dst + i);
+            if (i < size)
+            {
+                size_t tail = size - i, half = 2 * tail;
+                BFloat16ToFloat32(src + i, svwhilelt_b16(size_t(0), tail),
+                    svwhilelt_b16(size_t(0), Simd::Min(half, A)), svwhilelt_b16(A, half), dst + i);
+            }
         }
     }
 #endif

--- a/src/Test/TestBFloat16.cpp
+++ b/src/Test/TestBFloat16.cpp
@@ -170,6 +170,8 @@ namespace Test
     {
         bool result = true;
 
+        result = result && BFloat16ToFloat32AutoTest(1, f1, f2);
+        result = result && BFloat16ToFloat32AutoTest(E * O + 1, f1, f2);
         result = result && BFloat16ToFloat32AutoTest(W * H, f1, f2);
         result = result && BFloat16ToFloat32AutoTest(W * H - 1, f1, f2);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add masked SVE2 tail handling for `BFloat16ToFloat32`.
- Extend `BFloat16ToFloat32AutoTest` with tail-only sizes.
- Update the 7.2.163 release note for the SVE2 conversion optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BFloat16ToFloat32 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -DNDEBUG -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2BFloat16.cpp -o /tmp/SimdSve2BFloat16.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc330991-3385-4b76-99a2-3130bd7250ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc330991-3385-4b76-99a2-3130bd7250ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

