### PR TITLE
Add SVE2 Float32ToBFloat16 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
+ <li>SVE2 optimizations of function Float32ToBFloat16 for ARM/ARM64 platform.</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32 for ARM/ARM64 platform.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2656,7 +2656,7 @@ SIMD_API void SimdFloat32ToBFloat16(const float* src, size_t size, uint16_t* dst
 {
     SIMD_EMPTY();
     typedef void(*SimdFloat32ToBFloat16Ptr) (const float* src, size_t size, uint16_t* dst);
-    const static SimdFloat32ToBFloat16Ptr simdFloat32ToBFloat16 = SIMD_FUNC5(Float32ToBFloat16, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdFloat32ToBFloat16Ptr simdFloat32ToBFloat16 = SIMD_FUNC6(Float32ToBFloat16, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdFloat32ToBFloat16(src, size, dst);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -105,6 +105,8 @@ namespace Simd
 
         void Base64Encode(const uint8_t* src, size_t size, uint8_t* dst);
 
+        void Float32ToBFloat16(const float* src, size_t size, uint16_t* dst);
+
         void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
         void Float32ToFloat16(const float* src, size_t size, uint16_t* dst);

--- a/src/Simd/SimdSve2BFloat16.cpp
+++ b/src/Simd/SimdSve2BFloat16.cpp
@@ -29,6 +29,38 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
+        {
+            svuint32_t bits = svreinterpret_u32_f32(value);
+            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+        }
+
+        SIMD_INLINE void Float32ToBFloat16(const float* src, const svbool_t& lo, const svbool_t& hi, const svbool_t& store, uint16_t* dst)
+        {
+            size_t F = svlen(svfloat32_t());
+            svuint16_t _lo = svreinterpret_u16_u32(Float32ToBFloat16(svld1_f32(lo, src + 0), lo));
+            svuint16_t _hi = svreinterpret_u16_u32(Float32ToBFloat16(svld1_f32(hi, src + F), hi));
+            svst1_u16(store, dst, svuzp1_u16(_lo, _hi));
+        }
+
+        void Float32ToBFloat16(const float* src, size_t size, uint16_t* dst)
+        {
+            size_t A = svlen(svuint16_t()), F = svlen(svfloat32_t()), sizeA = AlignLo(size, A), i = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            for (; i < sizeA; i += A)
+                Float32ToBFloat16(src + i, body32, body32, body16, dst + i);
+            if (i < size)
+            {
+                size_t tail = size - i;
+                Float32ToBFloat16(src + i, svwhilelt_b32(size_t(0), Simd::Min(tail, F)),
+                    svwhilelt_b32(F, tail), svwhilelt_b16(size_t(0), tail), dst + i);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void BFloat16ToFloat32(const uint16_t* src, const svbool_t& load, const svbool_t& lo, const svbool_t& hi, float* dst)
         {
             size_t A = svlen(svuint16_t());

--- a/src/Test/TestBFloat16.cpp
+++ b/src/Test/TestBFloat16.cpp
@@ -112,6 +112,11 @@ namespace Test
             result = result && Float32ToBFloat16AutoTest(FUNC_SB(Simd::AmxBf16::Float32ToBFloat16), FUNC_SB(SimdFloat32ToBFloat16));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Float32ToBFloat16AutoTest(FUNC_SB(Simd::Sve2::Float32ToBFloat16), FUNC_SB(SimdFloat32ToBFloat16));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && Float32ToBFloat16AutoTest(FUNC_SB(Simd::Neon::Float32ToBFloat16), FUNC_SB(SimdFloat32ToBFloat16));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdFloat32ToBFloat16`.
- Extend bfloat16 auto-tests to cover `Simd::Sve2::Float32ToBFloat16`.
- Document the SVE2 optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=BFloat16 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -march=armv8.6-a+sve2 -I/workspace/src -fsyntax-only /workspace/src/Simd/SimdSve2BFloat16.cpp`
- `git diff --check && git status --short --branch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed3d1883-d159-4ab7-8104-7511bb60041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed3d1883-d159-4ab7-8104-7511bb60041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

