### PR TITLE
Add SVE2 Float32ToUint8 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -44,6 +44,7 @@
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
  <li>SVE2 optimizations of function Float32ToBFloat16 for ARM/ARM64 platform.</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32 for ARM/ARM64 platform.</li>
+ <li>SVE2 optimizations of function Float32ToUint8 for ARM/ARM64 platform.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2898,6 +2898,11 @@ SIMD_API void SimdFloat32ToUint8(const float * src, size_t size, const float * l
         Sse41::Float32ToUint8(src, size, lower, upper, dst);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Float32ToUint8(src, size, lower, upper, dst);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && size >= Neon::A)
         Neon::Float32ToUint8(src, size, lower, upper, dst);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -109,6 +109,8 @@ namespace Simd
 
         void BFloat16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void Float32ToUint8(const float* src, size_t size, const float* lower, const float* upper, uint8_t* dst);
+
         void Float32ToFloat16(const float* src, size_t size, uint16_t* dst);
 
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);

--- a/src/Simd/SimdSve2Float32.cpp
+++ b/src/Simd/SimdSve2Float32.cpp
@@ -28,6 +28,39 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE svuint32_t Float32ToUint8(const float* src, const svbool_t& mask, const svfloat32_t& lower, const svfloat32_t& upper, const svfloat32_t& boost)
+        {
+            svfloat32_t value = svld1_f32(mask, src);
+            value = svmul_f32_x(mask, svsub_f32_x(mask, svmin_f32_x(mask, svmax_f32_x(mask, value, lower), upper), lower), boost);
+            return svcvt_u32_f32_x(mask, value);
+        }
+
+        void Float32ToUint8(const float* src, size_t size, const float* lower, const float* upper, uint8_t* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _lower = svdup_n_f32(lower[0]);
+            const svfloat32_t _upper = svdup_n_f32(upper[0]);
+            const svfloat32_t boost = svdup_n_f32(255.0f / (upper[0] - lower[0]));
+
+            for (; i + QF <= size; i += QF)
+            {
+                svst1b_u32(body, dst + i + 0 * F, Float32ToUint8(src + i + 0 * F, body, _lower, _upper, boost));
+                svst1b_u32(body, dst + i + 1 * F, Float32ToUint8(src + i + 1 * F, body, _lower, _upper, boost));
+                svst1b_u32(body, dst + i + 2 * F, Float32ToUint8(src + i + 2 * F, body, _lower, _upper, boost));
+                svst1b_u32(body, dst + i + 3 * F, Float32ToUint8(src + i + 3 * F, body, _lower, _upper, boost));
+            }
+            for (; i + F <= size; i += F)
+                svst1b_u32(body, dst + i, Float32ToUint8(src + i, body, _lower, _upper, boost));
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svst1b_u32(tail, dst + i, Float32ToUint8(src + i, tail, _lower, _upper, boost));
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void CosineDistance32f(const float* a, const float* b, const svbool_t& mask,
             svfloat32_t& aa, svfloat32_t& ab, svfloat32_t& bb)
         {

--- a/src/Test/TestFloat32.cpp
+++ b/src/Test/TestFloat32.cpp
@@ -103,6 +103,11 @@ namespace Test
             result = result && Float32ToUint8AutoTest(FUNC_FB(Simd::Avx512bw::Float32ToUint8), FUNC_FB(SimdFloat32ToUint8));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Float32ToUint8AutoTest(FUNC_FB(Simd::Sve2::Float32ToUint8), FUNC_FB(SimdFloat32ToUint8));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && Float32ToUint8AutoTest(FUNC_FB(Simd::Neon::Float32ToUint8), FUNC_FB(SimdFloat32ToUint8));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdFloat32ToUint8`.
- Extend `Float32ToUint8AutoTest` to cover `Simd::Sve2::Float32ToUint8`.
- Document the SVE2 optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Float32ToUint8 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2Float32.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e12c7a-82e4-464e-8cf0-7d57a52278ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e12c7a-82e4-464e-8cf0-7d57a52278ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

