### PR TITLE
Add SVE2 GaussianBlur3x3 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function Float32ToUint8.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
+ <li>SVE2 optimizations of function GaussianBlur3x3.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Fill.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -227,6 +227,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur3x3.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2995,6 +2995,11 @@ SIMD_API void SimdGaussianBlur3x3(const uint8_t * src, size_t srcStride, size_t 
         Sse41::GaussianBlur3x3(src, srcStride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GaussianBlur3x3(src, srcStride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 1)*channelCount >= Neon::A)
         Neon::GaussianBlur3x3(src, srcStride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -115,6 +115,9 @@ namespace Simd
 
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2GaussianBlur3x3.cpp
+++ b/src/Simd/SimdSve2GaussianBlur3x3.cpp
@@ -56,13 +56,13 @@ namespace Simd
         SIMD_INLINE svuint16_t BinomialSumLo(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            return svadd_u16_x(mask, svadd_u16_x(mask, svmovlb_u16(left), svlsl_n_u16_x(mask, svmovlb_u16(center), 1)), svmovlb_u16(right));
+            return svadd_u16_x(mask, svadd_u16_x(mask, svunpklo_u16(left), svlsl_n_u16_x(mask, svunpklo_u16(center), 1)), svunpklo_u16(right));
         }
 
         SIMD_INLINE svuint16_t BinomialSumHi(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            return svadd_u16_x(mask, svadd_u16_x(mask, svmovlt_u16(left), svlsl_n_u16_x(mask, svmovlt_u16(center), 1)), svmovlt_u16(right));
+            return svadd_u16_x(mask, svadd_u16_x(mask, svunpkhi_u16(left), svlsl_n_u16_x(mask, svunpkhi_u16(center), 1)), svunpkhi_u16(right));
         }
 
         SIMD_INLINE void BlurRow(const uint8_t* src, size_t step, uint16_t* dst, size_t half,
@@ -111,12 +111,17 @@ namespace Simd
             return DivideBy16(svadd_u16_x(mask, svadd_u16_x(mask, svld1_u16(mask, src0), svlsl_n_u16_x(mask, svld1_u16(mask, src1), 1)), svld1_u16(mask, src2)));
         }
 
+        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        {
+            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+        }
+
         SIMD_INLINE void BlurCol(const Buffer& buffer, size_t offset, size_t half, uint8_t* dst,
             const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi)
         {
             svuint16_t lo = BlurCol(buffer.src0 + offset, buffer.src1 + offset, buffer.src2 + offset, maskLo);
             svuint16_t hi = BlurCol(buffer.src0 + offset + half, buffer.src1 + offset + half, buffer.src2 + offset + half, maskHi);
-            svst1_u8(mask8, dst + offset, svqxtnt_u16(svqxtnb_u16(lo), hi));
+            svst1_u8(mask8, dst + offset, PackU16ToU8(lo, hi));
         }
 
         SIMD_INLINE void BlurCols(const Buffer& buffer, size_t size, uint8_t* dst)

--- a/src/Simd/SimdSve2GaussianBlur3x3.cpp
+++ b/src/Simd/SimdSve2GaussianBlur3x3.cpp
@@ -1,0 +1,169 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        namespace
+        {
+            struct Buffer
+            {
+                Buffer(size_t width)
+                {
+                    _p = Allocate(sizeof(uint16_t) * 3 * width);
+                    src0 = (uint16_t*)_p;
+                    src1 = src0 + width;
+                    src2 = src1 + width;
+                }
+
+                ~Buffer()
+                {
+                    Free(_p);
+                }
+
+                uint16_t* src0;
+                uint16_t* src1;
+                uint16_t* src2;
+            private:
+                void* _p;
+            };
+        }
+
+        SIMD_INLINE svuint16_t BinomialSumLo(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svadd_u16_x(mask, svmovlb_u16(left), svlsl_n_u16_x(mask, svmovlb_u16(center), 1)), svmovlb_u16(right));
+        }
+
+        SIMD_INLINE svuint16_t BinomialSumHi(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svadd_u16_x(mask, svmovlt_u16(left), svlsl_n_u16_x(mask, svmovlt_u16(center), 1)), svmovlt_u16(right));
+        }
+
+        SIMD_INLINE void BlurRow(const uint8_t* src, size_t step, uint16_t* dst, size_t half,
+            const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi)
+        {
+            svuint8_t left = svld1_u8(mask8, src - step);
+            svuint8_t center = svld1_u8(mask8, src);
+            svuint8_t right = svld1_u8(mask8, src + step);
+            svst1_u16(maskLo, dst, BinomialSumLo(left, center, right));
+            svst1_u16(maskHi, dst + half, BinomialSumHi(left, center, right));
+        }
+
+        template <size_t step> void BlurRow(const uint8_t* src, size_t width, uint16_t* dst)
+        {
+            size_t size = width * step;
+            if (width == 1)
+            {
+                for (size_t col = 0; col < size; ++col)
+                    dst[col] = uint16_t(src[col]) << 2;
+                return;
+            }
+
+            for (size_t col = 0; col < step; ++col)
+                dst[col] = uint16_t(src[col]) * 3 + src[col + step];
+
+            const size_t A = svcntb(), HA = svcnth(), end = size - step;
+            const svbool_t body8 = svptrue_b8(), body16 = svptrue_b16();
+            size_t col = step;
+            for (; col + A <= end; col += A)
+                BlurRow(src + col, step, dst + col, HA, body8, body16, body16);
+            if (col < end)
+                BlurRow(src + col, step, dst + col, HA, svwhilelt_b8(col, end), svwhilelt_b16(col, end), svwhilelt_b16(col + HA, end));
+
+            for (size_t col = end; col < size; ++col)
+                dst[col] = src[col - step] + uint16_t(src[col]) * 3;
+        }
+
+        SIMD_INLINE svuint16_t DivideBy16(const svuint16_t& value)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 8), 4);
+        }
+
+        SIMD_INLINE svuint16_t BlurCol(const uint16_t* src0, const uint16_t* src1, const uint16_t* src2, const svbool_t& mask)
+        {
+            return DivideBy16(svadd_u16_x(mask, svadd_u16_x(mask, svld1_u16(mask, src0), svlsl_n_u16_x(mask, svld1_u16(mask, src1), 1)), svld1_u16(mask, src2)));
+        }
+
+        SIMD_INLINE void BlurCol(const Buffer& buffer, size_t offset, size_t half, uint8_t* dst,
+            const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi)
+        {
+            svuint16_t lo = BlurCol(buffer.src0 + offset, buffer.src1 + offset, buffer.src2 + offset, maskLo);
+            svuint16_t hi = BlurCol(buffer.src0 + offset + half, buffer.src1 + offset + half, buffer.src2 + offset + half, maskHi);
+            svst1_u8(mask8, dst + offset, svqxtnt_u16(svqxtnb_u16(lo), hi));
+        }
+
+        SIMD_INLINE void BlurCols(const Buffer& buffer, size_t size, uint8_t* dst)
+        {
+            const size_t A = svcntb(), HA = svcnth();
+            const svbool_t body8 = svptrue_b8(), body16 = svptrue_b16();
+            size_t col = 0;
+            for (; col + A <= size; col += A)
+                BlurCol(buffer, col, HA, dst, body8, body16, body16);
+            if (col < size)
+                BlurCol(buffer, col, HA, dst, svwhilelt_b8(col, size), svwhilelt_b16(col, size), svwhilelt_b16(col + HA, size));
+        }
+
+        template <size_t step> void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            size_t size = width * step;
+            Buffer buffer(size);
+
+            BlurRow<step>(src, width, buffer.src0);
+            memcpy(buffer.src1, buffer.src0, sizeof(uint16_t) * size);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                const uint8_t* src2 = src + srcStride * (row + 1 < height ? row + 1 : height - 1);
+                BlurRow<step>(src2, width, buffer.src2);
+
+                BlurCols(buffer, size, dst);
+
+                Swap(buffer.src0, buffer.src2);
+                Swap(buffer.src0, buffer.src1);
+                dst += dstStride;
+            }
+        }
+
+        void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: GaussianBlur3x3<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: GaussianBlur3x3<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: GaussianBlur3x3<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: GaussianBlur3x3<4>(src, srcStride, width, height, dst, dstStride); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -558,6 +558,11 @@ namespace
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Avx512bw::GaussianBlur3x3), FUNC_C(SimdGaussianBlur3x3));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ColorFilterAutoTest(FUNC_C(Simd::Sve2::GaussianBlur3x3), FUNC_C(SimdGaussianBlur3x3));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Neon::GaussianBlur3x3), FUNC_C(SimdGaussianBlur3x3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdGaussianBlur3x3`.
- Extend `GaussianBlur3x3AutoTest` to cover SVE2.
- Register `SimdSve2GaussianBlur3x3.cpp` in the VS2022 SVE2 project and update the 7.2.163 release notes.
- Fix SVE2 lane packing so horizontal buffers and packed output stay in contiguous byte order.

### Testing
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Simd/SimdSve2GaussianBlur3x3.cpp`
- `git diff --check`
- `cmake ./prj/cmake -B build-aarch64-sve2-gcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN=aarch64-linux-gnu-g++ -DSIMD_TARGET=aarch64 -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_SHARED=OFF -DSIMD_PYTHON=OFF -DSIMD_TEST_FLAGS="-march=armv8.6-a+sve2"`
- `cmake --build build-aarch64-sve2-gcc --parallel$(nproc)`
- `QEMU_CPU=max qemu-aarch64 -L /usr/aarch64-linux-gnu ./Test "-r=.." -fi=GaussianBlur3x3 -tt=1 -ts=1 -w=640 -h=480`
- `QEMU_CPU=max qemu-aarch64 -L /usr/aarch64-linux-gnu ./Test "-r=.." -fi=GaussianBlur3x3 -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-add2177f-50ad-4b39-bd21-0a3de05179f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-add2177f-50ad-4b39-bd21-0a3de05179f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

