### PR TITLE
Add SVE2 GaussianBlurInit optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function Float32ToUint8.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
+ <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Fill.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -227,6 +227,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur3x3.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>

--- a/src/Simd/SimdGaussianBlur.h
+++ b/src/Simd/SimdGaussianBlur.h
@@ -144,5 +144,22 @@ namespace Simd
         void* GaussianBlurInit(size_t width, size_t height, size_t channels, const float* sigma, const float* epsilon);
     }
 #endif //SIMD_NEON_ENABLE
+
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+#ifdef SIMD_NEON_ENABLE
+        class GaussianBlurDefault : public Neon::GaussianBlurDefault
+#else
+        class GaussianBlurDefault : public Base::GaussianBlurDefault
+#endif
+        {
+        public:
+            GaussianBlurDefault(const BlurParam& param);
+        };
+
+        void* GaussianBlurInit(size_t width, size_t height, size_t channels, const float* sigma, const float* epsilon);
+    }
+#endif //SIMD_SVE2_ENABLE
 }
 #endif//__SimdGaussianBlur_h__

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3012,7 +3012,7 @@ SIMD_API void* SimdGaussianBlurInit(size_t width, size_t height, size_t channels
 {
     SIMD_EMPTY();
     typedef void* (*SimdGaussianBlurInitPtr) (size_t width, size_t height, size_t channels, const float* sigma, const float* epsilon);
-    const static SimdGaussianBlurInitPtr simdGaussianBlurInit = SIMD_FUNC4(GaussianBlurInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdGaussianBlurInitPtr simdGaussianBlurInit = SIMD_FUNC5(GaussianBlurInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdGaussianBlurInit(width, height, channels, sigma, epsilon);
 }

--- a/src/Simd/SimdSve2GaussianBlur.cpp
+++ b/src/Simd/SimdSve2GaussianBlur.cpp
@@ -1,0 +1,347 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdGaussianBlur.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        SIMD_INLINE svfloat32_t LoadAs32f(const uint8_t* src, const svbool_t& mask)
+        {
+            return svcvt_f32_u32_x(mask, svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE void BlurColsAny(const uint8_t* src, size_t size, size_t channels, const float* weight, size_t kernel, float* dst)
+        {
+            size_t F = svcntw(), sizeF = AlignLoAny(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(body, sum, svdup_n_f32(weight[k]), LoadAs32f(src + i + k * channels, body));
+                svst1_f32(body, dst + i, sum);
+            }
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(tail, sum, svdup_n_f32(weight[k]), LoadAs32f(src + i + k * channels, tail));
+                svst1_f32(tail, dst + i, sum);
+            }
+        }
+
+        SIMD_INLINE void StoreAs8u(uint8_t* dst, const svfloat32_t& src, const svbool_t& mask)
+        {
+            svfloat32_t value = svmin_n_f32_x(mask, svadd_n_f32_x(mask, src, 0.5f), 255.0f);
+            svst1b_u32(mask, dst, svcvt_u32_f32_x(mask, value));
+        }
+
+        SIMD_INLINE void BlurRowsAny(const float* src, size_t size, size_t stride, const float* weight, size_t kernel, uint8_t* dst)
+        {
+            size_t F = svcntw(), A = 4 * F, sizeA = AlignLoAny(size, A), sizeF = AlignLoAny(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i < sizeA; i += A)
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f);
+                svfloat32_t sum1 = svdup_n_f32(0.0f);
+                svfloat32_t sum2 = svdup_n_f32(0.0f);
+                svfloat32_t sum3 = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                {
+                    svfloat32_t w = svdup_n_f32(weight[k]);
+                    const float* ps = src + i + k * stride;
+                    sum0 = svmla_f32_m(body, sum0, w, svld1_f32(body, ps + 0 * F));
+                    sum1 = svmla_f32_m(body, sum1, w, svld1_f32(body, ps + 1 * F));
+                    sum2 = svmla_f32_m(body, sum2, w, svld1_f32(body, ps + 2 * F));
+                    sum3 = svmla_f32_m(body, sum3, w, svld1_f32(body, ps + 3 * F));
+                }
+                StoreAs8u(dst + i + 0 * F, sum0, body);
+                StoreAs8u(dst + i + 1 * F, sum1, body);
+                StoreAs8u(dst + i + 2 * F, sum2, body);
+                StoreAs8u(dst + i + 3 * F, sum3, body);
+            }
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(body, sum, svdup_n_f32(weight[k]), svld1_f32(body, src + i + k * stride));
+                StoreAs8u(dst + i, sum, body);
+            }
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(tail, sum, svdup_n_f32(weight[k]), svld1_f32(tail, src + i + k * stride));
+                StoreAs8u(dst + i, sum, tail);
+            }
+        }
+
+        template<int channels> void BlurImageAny(const BlurParam& p, const Base::AlgDefault& a, const uint8_t* src, size_t srcStride, uint8_t* cols, float* rows, uint8_t* dst, size_t dstStride)
+        {
+            Base::PadCols<channels>(src, a.half, a.size, cols), src += srcStride;
+            BlurColsAny(cols, a.size, p.channels, a.weight.data, a.kernel, rows + a.half * a.stride);
+            for (size_t row = 0; row < a.half; ++row)
+                memcpy(rows + row * a.stride, rows + a.half * a.stride, a.size * sizeof(float));
+            for (size_t row = 1; row < a.nose; ++row)
+            {
+                Base::PadCols<channels>(src, a.half, a.size, cols), src += srcStride;
+                BlurColsAny(cols, a.size, p.channels, a.weight.data, a.kernel, rows + (a.half + row) * a.stride);
+            }
+            for (size_t row = a.nose; row <= a.half; ++row)
+                memcpy(rows + (a.half + row) * a.stride, rows + (a.half + a.nose - 1) * a.stride, a.size * sizeof(float));
+            BlurRowsAny(rows, a.size, a.stride, a.weight.data, a.kernel, dst), dst += dstStride;
+
+            for (size_t row = 1, b = row % a.kernel + 2 * a.half, w = a.kernel - row % a.kernel; row < a.body; ++row, ++b, --w)
+            {
+                if (b >= a.kernel)
+                    b -= a.kernel;
+                if (w == 0)
+                    w += a.kernel;
+                Base::PadCols<channels>(src, a.half, a.size, cols), src += srcStride;
+                BlurColsAny(cols, a.size, p.channels, a.weight.data, a.kernel, rows + b * a.stride);
+                BlurRowsAny(rows, a.size, a.stride, a.weight.data + w, a.kernel, dst), dst += dstStride;
+            }
+
+            size_t last = (a.body + 2 * a.half - 1) % a.kernel;
+            for (size_t row = a.body, b = row % a.kernel + 2 * a.half, w = a.kernel - row % a.kernel; row < p.height; ++row, ++b, --w)
+            {
+                if (b >= a.kernel)
+                    b -= a.kernel;
+                if (w == 0)
+                    w += a.kernel;
+                memcpy(rows + b * a.stride, rows + last * a.stride, a.size * sizeof(float));
+                BlurRowsAny(rows, a.size, a.stride, a.weight.data + w, a.kernel, dst), dst += dstStride;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<int kernel> SIMD_INLINE void BlurCols(const uint8_t* src, size_t size, size_t channels, const float* weight, float* dst)
+        {
+            svfloat32_t w[kernel];
+            for (size_t k = 0; k < kernel; ++k)
+                w[k] = svdup_n_f32(weight[k]);
+            size_t F = svcntw(), sizeF = AlignLoAny(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(body, sum, w[k], LoadAs32f(src + i + k * channels, body));
+                svst1_f32(body, dst + i, sum);
+            }
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(tail, sum, w[k], LoadAs32f(src + i + k * channels, tail));
+                svst1_f32(tail, dst + i, sum);
+            }
+        }
+
+        template<> SIMD_INLINE void BlurCols<3>(const uint8_t* src, size_t size, size_t channels, const float* weight, float* dst)
+        {
+            svfloat32_t w0 = svdup_n_f32(weight[0]);
+            svfloat32_t w1 = svdup_n_f32(weight[1]);
+            svfloat32_t w2 = svdup_n_f32(weight[2]);
+            size_t F = svcntw(), sizeF = AlignLoAny(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t sum = svmul_f32_x(body, w0, LoadAs32f(src + i + 0 * channels, body));
+                sum = svmla_f32_m(body, sum, w1, LoadAs32f(src + i + 1 * channels, body));
+                sum = svmla_f32_m(body, sum, w2, LoadAs32f(src + i + 2 * channels, body));
+                svst1_f32(body, dst + i, sum);
+            }
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t sum = svmul_f32_x(tail, w0, LoadAs32f(src + i + 0 * channels, tail));
+                sum = svmla_f32_m(tail, sum, w1, LoadAs32f(src + i + 1 * channels, tail));
+                sum = svmla_f32_m(tail, sum, w2, LoadAs32f(src + i + 2 * channels, tail));
+                svst1_f32(tail, dst + i, sum);
+            }
+        }
+
+        template<> SIMD_INLINE void BlurCols<5>(const uint8_t* src, size_t size, size_t channels, const float* weight, float* dst)
+        {
+            svfloat32_t w0 = svdup_n_f32(weight[0]);
+            svfloat32_t w1 = svdup_n_f32(weight[1]);
+            svfloat32_t w2 = svdup_n_f32(weight[2]);
+            svfloat32_t w3 = svdup_n_f32(weight[3]);
+            svfloat32_t w4 = svdup_n_f32(weight[4]);
+            size_t F = svcntw(), sizeF = AlignLoAny(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t sum0 = svmul_f32_x(body, w0, LoadAs32f(src + i + 0 * channels, body));
+                svfloat32_t sum1 = svmul_f32_x(body, w1, LoadAs32f(src + i + 1 * channels, body));
+                sum0 = svmla_f32_m(body, sum0, w2, LoadAs32f(src + i + 2 * channels, body));
+                sum1 = svmla_f32_m(body, sum1, w3, LoadAs32f(src + i + 3 * channels, body));
+                sum0 = svmla_f32_m(body, sum0, w4, LoadAs32f(src + i + 4 * channels, body));
+                svst1_f32(body, dst + i, svadd_f32_x(body, sum0, sum1));
+            }
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t sum0 = svmul_f32_x(tail, w0, LoadAs32f(src + i + 0 * channels, tail));
+                svfloat32_t sum1 = svmul_f32_x(tail, w1, LoadAs32f(src + i + 1 * channels, tail));
+                sum0 = svmla_f32_m(tail, sum0, w2, LoadAs32f(src + i + 2 * channels, tail));
+                sum1 = svmla_f32_m(tail, sum1, w3, LoadAs32f(src + i + 3 * channels, tail));
+                sum0 = svmla_f32_m(tail, sum0, w4, LoadAs32f(src + i + 4 * channels, tail));
+                svst1_f32(tail, dst + i, svadd_f32_x(tail, sum0, sum1));
+            }
+        }
+
+        template<int kernel> SIMD_INLINE void BlurRows(const float* src, size_t size, size_t stride, const float* weight, uint8_t* dst)
+        {
+            svfloat32_t w[kernel];
+            for (size_t k = 0; k < kernel; ++k)
+                w[k] = svdup_n_f32(weight[k]);
+            size_t F = svcntw(), A = 4 * F, sizeA = AlignLoAny(size, A), sizeF = AlignLoAny(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i < sizeA; i += A)
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f);
+                svfloat32_t sum1 = svdup_n_f32(0.0f);
+                svfloat32_t sum2 = svdup_n_f32(0.0f);
+                svfloat32_t sum3 = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                {
+                    const float* ps = src + i + k * stride;
+                    sum0 = svmla_f32_m(body, sum0, w[k], svld1_f32(body, ps + 0 * F));
+                    sum1 = svmla_f32_m(body, sum1, w[k], svld1_f32(body, ps + 1 * F));
+                    sum2 = svmla_f32_m(body, sum2, w[k], svld1_f32(body, ps + 2 * F));
+                    sum3 = svmla_f32_m(body, sum3, w[k], svld1_f32(body, ps + 3 * F));
+                }
+                StoreAs8u(dst + i + 0 * F, sum0, body);
+                StoreAs8u(dst + i + 1 * F, sum1, body);
+                StoreAs8u(dst + i + 2 * F, sum2, body);
+                StoreAs8u(dst + i + 3 * F, sum3, body);
+            }
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(body, sum, w[k], svld1_f32(body, src + i + k * stride));
+                StoreAs8u(dst + i, sum, body);
+            }
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t k = 0; k < kernel; ++k)
+                    sum = svmla_f32_m(tail, sum, w[k], svld1_f32(tail, src + i + k * stride));
+                StoreAs8u(dst + i, sum, tail);
+            }
+        }
+
+        template<int channels, int kernel> void BlurImage(const BlurParam& p, const Base::AlgDefault& a, const uint8_t* src, size_t srcStride, uint8_t* cols, float* rows, uint8_t* dst, size_t dstStride)
+        {
+            Base::PadCols<channels>(src, a.half, a.size, cols), src += srcStride;
+            BlurCols<kernel>(cols, a.size, p.channels, a.weight.data, rows + a.half * a.stride);
+            for (size_t row = 0; row < a.half; ++row)
+                memcpy(rows + row * a.stride, rows + a.half * a.stride, a.size * sizeof(float));
+            for (size_t row = 1; row < a.nose; ++row)
+            {
+                Base::PadCols<channels>(src, a.half, a.size, cols), src += srcStride;
+                BlurCols<kernel>(cols, a.size, p.channels, a.weight.data, rows + (a.half + row) * a.stride);
+            }
+            for (size_t row = a.nose; row <= a.half; ++row)
+                memcpy(rows + (a.half + row) * a.stride, rows + (a.half + a.nose - 1) * a.stride, a.size * sizeof(float));
+            BlurRows<kernel>(rows, a.size, a.stride, a.weight.data, dst), dst += dstStride;
+
+            for (size_t row = 1, b = row % a.kernel + 2 * a.half, w = kernel - row % kernel; row < a.body; ++row, ++b, --w)
+            {
+                if (b >= kernel)
+                    b -= kernel;
+                if (w == 0)
+                    w += kernel;
+                Base::PadCols<channels>(src, a.half, a.size, cols), src += srcStride;
+                BlurCols<kernel>(cols, a.size, p.channels, a.weight.data, rows + b * a.stride);
+                BlurRows<kernel>(rows, a.size, a.stride, a.weight.data + w, dst), dst += dstStride;
+            }
+
+            size_t last = (a.body + 2 * a.half - 1) % kernel;
+            for (size_t row = a.body, b = row % kernel + 2 * a.half, w = kernel - row % kernel; row < p.height; ++row, ++b, --w)
+            {
+                if (b >= kernel)
+                    b -= kernel;
+                if (w == 0)
+                    w += kernel;
+                memcpy(rows + b * a.stride, rows + last * a.stride, a.size * sizeof(float));
+                BlurRows<kernel>(rows, a.size, a.stride, a.weight.data + w, dst), dst += dstStride;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<int channels> Base::BlurDefaultPtr GetBlurDefaultPtr(const BlurParam& p, const Base::AlgDefault& a)
+        {
+            switch (a.kernel)
+            {
+            case 3: return BlurImage<channels, 3>;
+            case 5: return BlurImage<channels, 5>;
+            case 7: return BlurImage<channels, 7>;
+            case 9: return BlurImage<channels, 9>;
+            default: return BlurImageAny<channels>;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        GaussianBlurDefault::GaussianBlurDefault(const BlurParam& param)
+#ifdef SIMD_NEON_ENABLE
+            : Neon::GaussianBlurDefault(param)
+#else
+            : Base::GaussianBlurDefault(param)
+#endif
+        {
+            switch (_param.channels)
+            {
+            case 1: _blur = GetBlurDefaultPtr<1>(_param, _alg); break;
+            case 2: _blur = GetBlurDefaultPtr<2>(_param, _alg); break;
+            case 3: _blur = GetBlurDefaultPtr<3>(_param, _alg); break;
+            case 4: _blur = GetBlurDefaultPtr<4>(_param, _alg); break;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        void* GaussianBlurInit(size_t width, size_t height, size_t channels, const float* sigma, const float* epsilon)
+        {
+            BlurParam param(width, height, channels, sigma, epsilon, SIMD_ALIGN);
+            if (!param.Valid())
+                return NULL;
+            return new GaussianBlurDefault(param);
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Simd/SimdSve2GaussianBlur.cpp
+++ b/src/Simd/SimdSve2GaussianBlur.cpp
@@ -144,16 +144,13 @@ namespace Simd
 
         template<int kernel> SIMD_INLINE void BlurCols(const uint8_t* src, size_t size, size_t channels, const float* weight, float* dst)
         {
-            svfloat32_t w[kernel];
-            for (size_t k = 0; k < kernel; ++k)
-                w[k] = svdup_n_f32(weight[k]);
             size_t F = svcntw(), sizeF = AlignLoAny(size, F), i = 0;
             const svbool_t body = svptrue_b32();
             for (; i < sizeF; i += F)
             {
                 svfloat32_t sum = svdup_n_f32(0.0f);
                 for (size_t k = 0; k < kernel; ++k)
-                    sum = svmla_f32_m(body, sum, w[k], LoadAs32f(src + i + k * channels, body));
+                    sum = svmla_f32_m(body, sum, svdup_n_f32(weight[k]), LoadAs32f(src + i + k * channels, body));
                 svst1_f32(body, dst + i, sum);
             }
             if (i < size)
@@ -161,7 +158,7 @@ namespace Simd
                 svbool_t tail = svwhilelt_b32(i, size);
                 svfloat32_t sum = svdup_n_f32(0.0f);
                 for (size_t k = 0; k < kernel; ++k)
-                    sum = svmla_f32_m(tail, sum, w[k], LoadAs32f(src + i + k * channels, tail));
+                    sum = svmla_f32_m(tail, sum, svdup_n_f32(weight[k]), LoadAs32f(src + i + k * channels, tail));
                 svst1_f32(tail, dst + i, sum);
             }
         }
@@ -222,9 +219,6 @@ namespace Simd
 
         template<int kernel> SIMD_INLINE void BlurRows(const float* src, size_t size, size_t stride, const float* weight, uint8_t* dst)
         {
-            svfloat32_t w[kernel];
-            for (size_t k = 0; k < kernel; ++k)
-                w[k] = svdup_n_f32(weight[k]);
             size_t F = svcntw(), A = 4 * F, sizeA = AlignLoAny(size, A), sizeF = AlignLoAny(size, F), i = 0;
             const svbool_t body = svptrue_b32();
             for (; i < sizeA; i += A)
@@ -235,11 +229,12 @@ namespace Simd
                 svfloat32_t sum3 = svdup_n_f32(0.0f);
                 for (size_t k = 0; k < kernel; ++k)
                 {
+                    svfloat32_t w = svdup_n_f32(weight[k]);
                     const float* ps = src + i + k * stride;
-                    sum0 = svmla_f32_m(body, sum0, w[k], svld1_f32(body, ps + 0 * F));
-                    sum1 = svmla_f32_m(body, sum1, w[k], svld1_f32(body, ps + 1 * F));
-                    sum2 = svmla_f32_m(body, sum2, w[k], svld1_f32(body, ps + 2 * F));
-                    sum3 = svmla_f32_m(body, sum3, w[k], svld1_f32(body, ps + 3 * F));
+                    sum0 = svmla_f32_m(body, sum0, w, svld1_f32(body, ps + 0 * F));
+                    sum1 = svmla_f32_m(body, sum1, w, svld1_f32(body, ps + 1 * F));
+                    sum2 = svmla_f32_m(body, sum2, w, svld1_f32(body, ps + 2 * F));
+                    sum3 = svmla_f32_m(body, sum3, w, svld1_f32(body, ps + 3 * F));
                 }
                 StoreAs8u(dst + i + 0 * F, sum0, body);
                 StoreAs8u(dst + i + 1 * F, sum1, body);
@@ -250,7 +245,7 @@ namespace Simd
             {
                 svfloat32_t sum = svdup_n_f32(0.0f);
                 for (size_t k = 0; k < kernel; ++k)
-                    sum = svmla_f32_m(body, sum, w[k], svld1_f32(body, src + i + k * stride));
+                    sum = svmla_f32_m(body, sum, svdup_n_f32(weight[k]), svld1_f32(body, src + i + k * stride));
                 StoreAs8u(dst + i, sum, body);
             }
             if (i < size)
@@ -258,7 +253,7 @@ namespace Simd
                 svbool_t tail = svwhilelt_b32(i, size);
                 svfloat32_t sum = svdup_n_f32(0.0f);
                 for (size_t k = 0; k < kernel; ++k)
-                    sum = svmla_f32_m(tail, sum, w[k], svld1_f32(tail, src + i + k * stride));
+                    sum = svmla_f32_m(tail, sum, svdup_n_f32(weight[k]), svld1_f32(tail, src + i + k * stride));
                 StoreAs8u(dst + i, sum, tail);
             }
         }

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -1020,8 +1020,8 @@ namespace
         for (int channels = 1; channels <= 4; channels++)
         {
             result = result && GaussianBlurAutoTest(channels, 0.3f, f1, f2);
-            //result = result && GaussianBlurAutoTest(channels, 1.0f, f1, f2);
-            //result = result && GaussianBlurAutoTest(channels, 3.0f, f1, f2);
+            result = result && GaussianBlurAutoTest(channels, 1.0f, f1, f2);
+            result = result && GaussianBlurAutoTest(channels, 3.0f, f1, f2);
         }
 
         return result;
@@ -1048,6 +1048,11 @@ namespace
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Avx512bw::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Sve2::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+#endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add an SVE2 implementation of `GaussianBlurInit` with scalable predicated column and row blur kernels.
* Wire SVE2 dispatch and auto-test coverage for `GaussianBlurInit`, including larger sigma values that exercise non-copy blur paths.
* Register the new source in the VS2022 SVE2 project and document the release note.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=GaussianBlur -tt=1 -ts=1`
* `cmake ./prj/cmake -B build-aarch64-gcc -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="aarch64-linux-gnu-g++" -DSIMD_TARGET="aarch64" -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_TEST=OFF && cmake --build build-aarch64-gcc --parallel$(nproc)`
* `cmake ./prj/cmake -B build-aarch64-test -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="aarch64-linux-gnu-g++" -DSIMD_TARGET="aarch64" -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_TEST=ON -DSIMD_PYTHON=OFF && cmake --build build-aarch64-test --parallel$(nproc)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99a3d3a8-ab06-4b98-8510-e7e077e0ef17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99a3d3a8-ab06-4b98-8510-e7e077e0ef17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

