### PR TITLE
validate weak classifier leaf and node count before init

### DIFF
--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -234,8 +234,8 @@ namespace Simd
 
                         Data::DTree tree;
                         tree.nodeCount = (int)internalNodes.size() / nodeStep;
-                        if (tree.nodeCount > 1)
-                            data->isStumpBased = false;
+                        if (tree.nodeCount != 1 || leafValues.size() != 2)
+                            SIMD_EX("Invalid cascade: a weak classifier must be a stump with one node and two leaf values!");
                         data->classifiers.push_back(tree);
 
                         data->nodes.reserve(data->nodes.size() + tree.nodeCount);


### PR DESCRIPTION
**Out-of-bounds leaves in cascade weak classifiers**

`DetectionLoadStringXml` trusts the per-classifier `leafValues` and `internalNodes` counts from the cascade XML, yet `CreateHidHaar`/`CreateHidLbp`, `InitLbp` and the predictors all treat every weak classifier as a stump and index `leaves[2*tree + {0,1}]` and `nodes[tree]`, so a classifier carrying fewer than two leaves leaves `data.leaves` shorter than `2*trees` and `CreateHidHaar` runs off the vector during `SimdDetectionInit` (ASan flags a heap-buffer-overflow at `CreateHidHaar` for a HAAR cascade whose `leafValues` holds a single number). The recently merged rect and feature-index guards do not cover this count, so I have rejected any non-stump weak classifier at the parse boundary, which keeps both the HAAR and LBP init and runtime paths safe in one spot.
