### PR TITLE
Add SVE2 GrayToBgra optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -78,6 +78,7 @@
  <li>SVE2 optimizations of function BgrToHsv.</li>
  <li>SVE2 optimizations of function BgrToLab.</li>
  <li>SVE2 optimizations of function GrayToBgr.</li>
+ <li>SVE2 optimizations of function GrayToBgra.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv444pV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgr.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -254,5 +254,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgr.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgra.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3090,6 +3090,11 @@ SIMD_API void SimdGrayToBgra(const uint8_t * gray, size_t width, size_t height, 
         Sse41::GrayToBgra(gray, width, height, grayStride, bgra, bgraStride, alpha);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GrayToBgra(gray, width, height, grayStride, bgra, bgraStride, alpha);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::GrayToBgra(gray, width, height, grayStride, bgra, bgraStride, alpha);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -154,6 +154,8 @@ namespace Simd
 
         void GrayToBgr(const uint8_t* gray, size_t width, size_t height, size_t grayStride, uint8_t* bgr, size_t bgrStride);
 
+        void GrayToBgra(const uint8_t* gray, size_t width, size_t height, size_t grayStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
+
         void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
 
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);

--- a/src/Simd/SimdSve2GrayToBgra.cpp
+++ b/src/Simd/SimdSve2GrayToBgra.cpp
@@ -1,0 +1,91 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE bool InitGrayToBgraIndex(uint8_t index[4][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t k = 0; k < 4; ++k)
+            {
+                size_t offset = k * A;
+                for (size_t i = 0; i < A; ++i)
+                    index[k][i] = (uint8_t)((offset + i) / 4);
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t GRAY_TO_BGRA_INDEX[4][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool GRAY_TO_BGRA_INDEX_INITED = InitGrayToBgraIndex(GRAY_TO_BGRA_INDEX);
+
+        SIMD_INLINE void GrayToBgra(const uint8_t* gray, uint8_t* bgra, size_t A, const svuint8_t& alpha,
+            const svuint8_t& index0, const svuint8_t& index1, const svuint8_t& index2, const svuint8_t& index3,
+            const svbool_t& alphaMask, const svbool_t& mask)
+        {
+            svuint8_t _gray = svld1_u8(mask, gray);
+            svst1_u8(mask, bgra + 0 * A, svsel_u8(alphaMask, alpha, svtbl_u8(_gray, index0)));
+            svst1_u8(mask, bgra + 1 * A, svsel_u8(alphaMask, alpha, svtbl_u8(_gray, index1)));
+            svst1_u8(mask, bgra + 2 * A, svsel_u8(alphaMask, alpha, svtbl_u8(_gray, index2)));
+            svst1_u8(mask, bgra + 3 * A, svsel_u8(alphaMask, alpha, svtbl_u8(_gray, index3)));
+        }
+
+        SIMD_INLINE void GrayToBgraTail(const uint8_t* gray, uint8_t* bgra, const svuint8_t& alpha, const svbool_t& mask)
+        {
+            svuint8_t _gray = svld1_u8(mask, gray);
+            svst4_u8(mask, bgra, svcreate4_u8(_gray, _gray, _gray, alpha));
+        }
+
+        void GrayToBgra(const uint8_t* gray, size_t width, size_t height, size_t grayStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha)
+        {
+            size_t A = svlen(svuint8_t()), A4 = A * 4;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            assert((A & 3) == 0);
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _alpha = svdup_n_u8(alpha);
+            const svbool_t alphaMask = svcmpeq_n_u8(body, svand_n_u8_x(body, svindex_u8(0, 1), 3), 3);
+            const svuint8_t index0 = svld1_u8(body, GRAY_TO_BGRA_INDEX[0]);
+            const svuint8_t index1 = svld1_u8(body, GRAY_TO_BGRA_INDEX[1]);
+            const svuint8_t index2 = svld1_u8(body, GRAY_TO_BGRA_INDEX[2]);
+            const svuint8_t index3 = svld1_u8(body, GRAY_TO_BGRA_INDEX[3]);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A4)
+                    GrayToBgra(gray + col, bgra + offset, A, _alpha, index0, index1, index2, index3, alphaMask, body);
+                if (widthA < width)
+                    GrayToBgraTail(gray + col, bgra + offset, _alpha, tail);
+                gray += grayStride;
+                bgra += bgraStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToBgra.cpp
+++ b/src/Test/TestAnyToBgra.cpp
@@ -138,6 +138,11 @@ namespace Test
             result = result && AnyToBgraAutoTest(View::Gray8, FUNC(Simd::Avx512bw::GrayToBgra), FUNC(SimdGrayToBgra));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToBgraAutoTest(View::Gray8, FUNC(Simd::Sve2::GrayToBgra), FUNC(SimdGrayToBgra));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToBgraAutoTest(View::Gray8, FUNC(Simd::Neon::GrayToBgra), FUNC(SimdGrayToBgra));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdGrayToBgra`.
- Wire SVE2 dispatch and auto-test coverage for `GrayToBgra`.
- Add the new source to VS2022 SVE2 project files and release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GrayToBgra -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -O2 -I./src -DSIMD_ARM_ENABLE -fsyntax-only src/Simd/SimdSve2GrayToBgra.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -O2 -I./src -DSIMD_ARM_ENABLE build/sve2_gray_to_bgra_test.cpp src/Simd/SimdSve2GrayToBgra.cpp -o build/sve2_gray_to_bgra_test`
- `qemu-aarch64 -cpu max -L /usr/aarch64-linux-gnu ./build/sve2_gray_to_bgra_test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd1a0028-1484-4e22-a2a6-6f2d4b61183d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd1a0028-1484-4e22-a2a6-6f2d4b61183d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

