### PR TITLE
cap decoded buffer size in png CreateImage

### DIFF
--- a/src/Simd/SimdBaseImageLoadPng.cpp
+++ b/src/Simd/SimdBaseImageLoadPng.cpp
@@ -1056,6 +1056,15 @@ namespace Simd
             SIMD_PERF_FUNC();
 
             int outS = _outN * (_depth == 16 ? 2 : 1);
+            // The IHDR check in ReadHeader bounds _width * _height * _channels, but the
+            // decoded buffer is sized from outS = _outN * (depth == 16 ? 2 : 1), which is up
+            // to four times _channels for a 16-bit grayscale image with a tRNS chunk (_outN
+            // becomes _channels + 1). _width * _height * outS is evaluated in 32-bit and wraps
+            // for such an image once _width * _height reaches 2^30, leaving a near-empty buffer
+            // that the de-filter and interlace loops below overrun. Cap the decoded size the
+            // way the JPEG loader already does (see JpegProcessFrameHeader).
+            if ((uint64_t)_width * _height * outS > INT_MAX)
+                return static_cast<bool>(PngLoadError("too large", "Image too large to decode"));
             if (!_interlace)
                 return CreateImageRaw(data, (int)size, _width, _height);
             Array8u buf(_width * _height * outS);


### PR DESCRIPTION
The PNG loader's de-filter and interlace buffers in CreateImage are sized from _width * _height * outS in 32-bit arithmetic, where outS already folds in the extra alpha channel and the 16-bit sample width. The IHDR sanity check in ReadHeader only bounds _width * _height * _channels under 2^30, so it does not account for that larger factor: a 16-bit greyscale image carrying a tRNS chunk ends up with outS four times _channels, and at the 2^30 boundary (for instance 32768x32768) the size computation wraps to zero while the value the header check validated stays in range. The buffer is then allocated near-empty and the row loops below write well past it. I noticed it because the zlib output buffer a few lines up already casts to size_t whereas these did not. Promoting the product to uint64_t and rejecting anything above INT_MAX keeps the guard in one place and matches the limit the JPEG path already applies in JpegProcessFrameHeader. It only rejects images whose decoded buffer could not be addressed safely, so smaller inputs are unaffected.