### PR TITLE
validate lbp maxCatCount before subset indexing

### DIFF
--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -209,6 +209,15 @@ namespace Simd
                 int subsetSize = (data->ncategories + 31) / 32;
                 int nodeStep = 3 + (data->ncategories > 0 ? subsetSize : 1);
 
+                // The LBP predictor indexes each node's subset bitmask with the 8-bit LBP
+                // code (subset[c >> 5], c in 0..255), and the SIMD back-ends load eight ints
+                // per node regardless of c. That requires subsetSize >= 8. maxCatCount is read
+                // straight from the cascade and drives subsetSize, so a value below 256 (or a
+                // negative one, which wraps to a huge size_t at runtime) leaves the subset
+                // array short and the predictor reads past it. Reject such cascades here.
+                if (data->featureType == SimdDetectionInfoFeatureLbp && subsetSize < 8)
+                    SIMD_EX("Invalid LBP cascade: maxCatCount out of range!");
+
                 Xml::Node * stages = cascade->FirstNode(Names::stages);
                 if (stages == NULL)
                     SIMD_EX("Invalid stages count!");


### PR DESCRIPTION
**Out-of-bounds read from an unchecked LBP maxCatCount**

The cascade loader takes `maxCatCount` from the XML and turns it into `subsetSize = (maxCatCount + 31)/32`, the number of ints stored per node in the LBP subset bitmask. At detection time the predictor indexes `subset[c >> 5]` with the 8-bit LBP code `c` (0..255), and the vector back-ends load eight ints per node regardless of `c`, so the bitmask must hold at least eight ints (real cascades use `maxCatCount` 256). A cascade declaring a small `maxCatCount` (e.g. 32, giving subsetSize 1), or a negative one that widens to a huge `size_t` at runtime, passes loading and leaves the subset array short, so the predictor reads past it. ASan flags a heap-buffer-overflow read in `Neon::Detect` eleven bytes past a four-byte subset allocation.

The cascade is otherwise well formed, so the check belongs in the shared loader next to the existing rect and feature-index validation rather than at each back-end. Reject LBP cascades whose subset cannot span the 8-bit code range.