### PR TITLE
guard isspace against signed char in cascade xml value trim

### DIFF
--- a/src/Simd/SimdBaseDetection.cpp
+++ b/src/Simd/SimdBaseDetection.cpp
@@ -61,7 +61,7 @@ namespace Simd
             {
                 while (first != last)
                 {
-                    if (!isspace(*first))
+                    if (!isspace(static_cast<unsigned char>(*first)))
                         return first;
                     ++first;
                 }


### PR DESCRIPTION
The cascade loader trims whitespace from XML element values through Xml::FindNotSpace, which passes the dereferenced char straight to isspace. That text comes from the cascade file, so a value byte with the high bit set, say a Latin-1 non-breaking space (0xA0), is sign-extended to a negative int on the usual platforms where char is signed. Such an argument falls outside the range isspace is defined for (a value representable as unsigned char, or EOF), and on a libc whose classification table is not padded for negative indices it reads out of bounds; elsewhere the result is at best implementation-defined. I came across it while tracing how the stageType and featureType values reach the trim helper, and the parser in SimdXml.hpp already casts to unsigned char for precisely this reason in its Compare table lookups. Casting before the isspace call brings this helper in line with that convention and keeps the behaviour well defined regardless of the platform's char signedness. As far as I can tell it is the only unguarded ctype call left in the library, so nothing else needs the same treatment.