### PR TITLE
Add SVE2 GrayToY optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -79,6 +79,7 @@
  <li>SVE2 optimizations of function BgrToLab.</li>
  <li>SVE2 optimizations of function GrayToBgr.</li>
  <li>SVE2 optimizations of function GrayToBgra.</li>
+ <li>SVE2 optimizations of function GrayToY.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv444pV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgra.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2GrayToY.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -257,5 +257,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgra.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2GrayToY.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdGrayToY.h
+++ b/src/Simd/SimdGrayToY.h
@@ -166,6 +166,26 @@ namespace Simd
     }
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint8_t GrayToY(const svuint8_t& g)
+        {
+            const svbool_t mask16 = svptrue_b16();
+            const svuint16_t G2Y_SCALE = svdup_n_u16(Base::G2Y_SCALE);
+            const svuint16_t G2Y_ROUND = svdup_n_u16(Base::G2Y_ROUND);
+            const svuint8_t G2Y_LO = svdup_n_u8(Base::G2Y_LO);
+            const svuint8_t G2Y_HI = svdup_n_u8(Base::G2Y_HI);
+            svuint16_t g0 = svmovlb_u16(g);
+            svuint16_t g1 = svmovlt_u16(g);
+            svuint16_t y0 = svlsr_n_u16_x(mask16, svadd_u16_x(mask16, svmul_u16_x(mask16, g0, G2Y_SCALE), G2Y_ROUND), Base::G2Y_SHIFT);
+            svuint16_t y1 = svlsr_n_u16_x(mask16, svadd_u16_x(mask16, svmul_u16_x(mask16, g1, G2Y_SCALE), G2Y_ROUND), Base::G2Y_SHIFT);
+            svuint8_t y = svqxtnt_u16(svqxtnb_u16(y0), y1);
+            return svmin_u8_x(svptrue_b8(), svqadd_u8(y, G2Y_LO), G2Y_HI);
+        }
+    }
+#endif
+
 #ifdef SIMD_AVX512BW_ENABLE    
     namespace Avx512bw
     {

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3121,6 +3121,11 @@ SIMD_API void SimdGrayToY(const uint8_t * gray, size_t grayStride, size_t width,
         Sse41::GrayToY(gray, grayStride, width, height, y, yStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GrayToY(gray, grayStride, width, height, y, yStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::GrayToY(gray, grayStride, width, height, y, yStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -156,6 +156,8 @@ namespace Simd
 
         void GrayToBgra(const uint8_t* gray, size_t width, size_t height, size_t grayStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
 
+        void GrayToY(const uint8_t* gray, size_t grayStride, size_t width, size_t height, uint8_t* y, size_t yStride);
+
         void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
 
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);

--- a/src/Simd/SimdSve2GrayToY.cpp
+++ b/src/Simd/SimdSve2GrayToY.cpp
@@ -1,0 +1,50 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdGrayToY.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void GrayToY(const uint8_t* gray, size_t grayStride, size_t width, size_t height, uint8_t* y, size_t yStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    svst1_u8(body, y + col, GrayToY(svld1_u8(body, gray + col)));
+                if (col < width)
+                    svst1_u8(tail, y + col, GrayToY(svld1_u8(tail, gray + col)));
+                gray += grayStride;
+                y += yStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToAny.cpp
+++ b/src/Test/TestAnyToAny.cpp
@@ -491,6 +491,11 @@ namespace Test
             result = result && AnyToAnyAutoTest(View::Gray8, View::Gray8, FUNC_N(Simd::Avx512bw::GrayToY), FUNC_N(SimdGrayToY));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToAnyAutoTest(View::Gray8, View::Gray8, FUNC_N(Simd::Sve2::GrayToY), FUNC_N(SimdGrayToY));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToAnyAutoTest(View::Gray8, View::Gray8, FUNC_N(Simd::Neon::GrayToY), FUNC_N(SimdGrayToY));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add vector-length agnostic SVE2 implementation of `GrayToY`.
- Dispatch `SimdGrayToY` to SVE2 and cover it in `GrayToYAutoTest`.
- Register the new SVE2 source in VS2022 project files and release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GrayToY -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -fsyntax-only src/Simd/SimdSve2GrayToY.cpp`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD^`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac1994f8-186c-4961-bef3-2ffa7a19cc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac1994f8-186c-4961-bef3-2ffa7a19cc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

