### PR TITLE
Add SVE2 GetAbsDyRowSums optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -92,6 +92,7 @@
  <li>SVE2 optimizations of function BgrToBayer.</li>
  <li>SVE2 optimizations of function Base64Decode.</li>
  <li>SVE2 optimizations of function Base64Encode.</li>
+ <li>SVE2 optimizations of function GetAbsDyRowSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5521,6 +5521,11 @@ SIMD_API void SimdGetAbsDyRowSums(const uint8_t * src, size_t stride, size_t wid
         Sse41::GetAbsDyRowSums(src, stride, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GetAbsDyRowSums(src, stride, width, height, sums);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::GetAbsDyRowSums(src, stride, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -239,6 +239,8 @@ namespace Simd
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);
 
+        void GetAbsDyRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
+
         void GetAbsDxColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 
         void SquareSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum);

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -117,6 +117,39 @@ namespace Simd
             sums[width] = 0;
         }
 
+        SIMD_INLINE void GetAbsDyRowSums(const uint8_t* src0, const uint8_t* src1, svbool_t mask, svuint8_t _1, svuint8_t zero, svuint32_t& sum)
+        {
+            svuint8_t diff = svabd_u8_x(mask, svld1_u8(mask, src0), svld1_u8(mask, src1));
+            sum = svdot_u32(sum, svsel_u8(mask, diff, zero), _1);
+        }
+
+        void GetAbsDyRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
+        {
+            const size_t A = svlen(svuint8_t());
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _1 = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+
+            const uint8_t* src0 = src;
+            const uint8_t* src1 = src + stride;
+            height--;
+            sums[height] = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                svuint32_t sum = svdup_n_u32(0);
+                for (; col < widthA; col += A)
+                    GetAbsDyRowSums(src0 + col, src1 + col, body, _1, zero, sum);
+                if (col < width)
+                    GetAbsDyRowSums(src0 + col, src1 + col, tail, _1, zero, sum);
+                sums[row] = svaddv_u32(svptrue_b32(), sum);
+                src0 += stride;
+                src1 += stride;
+            }
+        }
+
         //-------------------------------------------------------------------------------------------------
 
         SIMD_INLINE void ValueSum(const uint8_t* src, svbool_t mask, svuint8_t _1, svuint32_t& sum)

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -516,6 +516,11 @@ namespace Test
             result = result && GetSumsAutoTest(FUNC3(Simd::Neon::GetAbsDyRowSums), FUNC3(SimdGetAbsDyRowSums), true);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GetSumsAutoTest(FUNC3(Simd::Sve2::GetAbsDyRowSums), FUNC3(SimdGetAbsDyRowSums), true);
+#endif
+
 #ifdef SIMD_HVX_ENABLE
         if (Simd::Hvx::Enable && TestHvx(options) && W >= Simd::Hvx::A)
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdGetAbsDyRowSums`.
- Extend `GetAbsDyRowSumsAutoTest` with SVE2 coverage.
- Document the optimization in release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GetAbsDyRowSums -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Simd/SimdSve2Statistic.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-633875cf-ae90-4978-8b00-d110d53247a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-633875cf-ae90-4978-8b00-d110d53247a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

