### PR TITLE
Add SVE2 GetColSums optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -92,6 +92,7 @@
  <li>SVE2 optimizations of function BgrToBayer.</li>
  <li>SVE2 optimizations of function Base64Decode.</li>
  <li>SVE2 optimizations of function Base64Encode.</li>
+ <li>SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GetAbsDyRowSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>
  <li>SVE2 optimizations of function ValueSum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5490,6 +5490,11 @@ SIMD_API void SimdGetColSums(const uint8_t * src, size_t stride, size_t width, s
         Sse41::GetColSums(src, stride, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GetColSums(src, stride, width, height, sums);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::GetColSums(src, stride, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -239,6 +239,8 @@ namespace Simd
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);
 
+        void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
+
         void GetAbsDyRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 
         void GetAbsDxColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -73,20 +73,10 @@ namespace Simd
             svst1_u32(hi32, dst + col + half, svadd_u32_x(hi32, svld1_u32(hi32, dst + col + half), svunpkhi_u32(sums16)));
         }
 
-        SIMD_INLINE void GetColSums(const uint8_t* src, const svbool_t& mask8, const svbool_t& lo16, const svbool_t& hi16, size_t half, uint16_t* sums)
-        {
-            svuint8_t value = svld1_u8(mask8, src);
-            svst1_u16(lo16, sums, svadd_u16_x(lo16, svld1_u16(lo16, sums), svunpklo_u16(value)));
-            svst1_u16(hi16, sums + half, svadd_u16_x(hi16, svld1_u16(hi16, sums + half), svunpkhi_u16(value)));
-        }
-
         void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
         {
-            const size_t A = svlen(svuint8_t()), HA = svlen(svuint16_t());
-            const size_t widthA = AlignLo(width, A);
-            const size_t widthB = AlignHi(width, A);
-            const svbool_t body8 = svptrue_b8();
-            const svbool_t body16 = svptrue_b16();
+            const size_t HA = svlen(svuint16_t());
+            const size_t widthB = AlignHi(width, HA);
             const size_t stepSize = SCHAR_MAX + 1;
             const size_t stepCount = (height + SCHAR_MAX) / stepSize;
 
@@ -98,15 +88,32 @@ namespace Simd
                 const size_t rowEnd = Min(rowStart + stepSize, height);
 
                 memset(buffer.sums16, 0, sizeof(uint16_t) * widthB);
-                const uint8_t* rowSrc = src + rowStart * stride;
-                for (size_t row = rowStart; row < rowEnd; ++row)
+                size_t row = rowStart;
+                for (; row + 4 <= rowEnd; row += 4)
                 {
-                    size_t col = 0;
-                    for (; col < widthA; col += A)
-                        GetColSums(rowSrc + col, body8, body16, body16, HA, buffer.sums16 + col);
-                    if (col < width)
-                        GetColSums(rowSrc + col, svwhilelt_b8(col, width), svwhilelt_b16(col, width), svwhilelt_b16(col + HA, width), HA, buffer.sums16 + col);
-                    rowSrc += stride;
+                    const uint8_t* src0 = src + row * stride;
+                    const uint8_t* src1 = src0 + stride;
+                    const uint8_t* src2 = src1 + stride;
+                    const uint8_t* src3 = src2 + stride;
+                    for (size_t col = 0; col < width; col += HA)
+                    {
+                        svbool_t mask = svwhilelt_b16(col, width);
+                        svuint16_t sum = svld1_u16(mask, buffer.sums16 + col);
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src0 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src1 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src2 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src3 + col));
+                        svst1_u16(mask, buffer.sums16 + col, sum);
+                    }
+                }
+                for (; row < rowEnd; ++row)
+                {
+                    const uint8_t* rowSrc = src + row * stride;
+                    for (size_t col = 0; col < width; col += HA)
+                    {
+                        svbool_t mask = svwhilelt_b16(col, width);
+                        svst1_u16(mask, buffer.sums16 + col, svadd_u16_x(mask, svld1_u16(mask, buffer.sums16 + col), svld1ub_u16(mask, rowSrc + col)));
+                    }
                 }
 
                 for (size_t col = 0; col < width; col += svcntw() * 2)

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -87,17 +87,41 @@ namespace Simd
                 const size_t rowStart = step * stepSize;
                 const size_t rowEnd = Min(rowStart + stepSize, height);
 
-                for (size_t col = 0; col < width; col += HA)
+                memset(buffer.sums16, 0, sizeof(uint16_t) * widthB);
+                size_t row = rowStart;
+                for (; row + 8 <= rowEnd; row += 8)
                 {
-                    svbool_t mask = svwhilelt_b16(col, width);
-                    svuint16_t sum = svdup_n_u16(0);
-                    const uint8_t* rowSrc = src + rowStart * stride + col;
-                    for (size_t row = rowStart; row < rowEnd; ++row)
+                    const uint8_t* src0 = src + row * stride;
+                    const uint8_t* src1 = src0 + stride;
+                    const uint8_t* src2 = src1 + stride;
+                    const uint8_t* src3 = src2 + stride;
+                    const uint8_t* src4 = src3 + stride;
+                    const uint8_t* src5 = src4 + stride;
+                    const uint8_t* src6 = src5 + stride;
+                    const uint8_t* src7 = src6 + stride;
+                    for (size_t col = 0; col < width; col += HA)
                     {
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, rowSrc));
-                        rowSrc += stride;
+                        svbool_t mask = svwhilelt_b16(col, width);
+                        svuint16_t sum = svld1_u16(mask, buffer.sums16 + col);
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src0 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src1 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src2 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src3 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src4 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src5 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src6 + col));
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src7 + col));
+                        svst1_u16(mask, buffer.sums16 + col, sum);
                     }
-                    svst1_u16(mask, buffer.sums16 + col, sum);
+                }
+                for (; row < rowEnd; ++row)
+                {
+                    const uint8_t* rowSrc = src + row * stride;
+                    for (size_t col = 0; col < width; col += HA)
+                    {
+                        svbool_t mask = svwhilelt_b16(col, width);
+                        svst1_u16(mask, buffer.sums16 + col, svadd_u16_x(mask, svld1_u16(mask, buffer.sums16 + col), svld1ub_u16(mask, rowSrc + col)));
+                    }
                 }
 
                 for (size_t col = 0; col < width; col += svcntw() * 2)

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -73,6 +73,48 @@ namespace Simd
             svst1_u32(hi32, dst + col + half, svadd_u32_x(hi32, svld1_u32(hi32, dst + col + half), svunpkhi_u32(sums16)));
         }
 
+        SIMD_INLINE void GetColSums(const uint8_t* src, const svbool_t& mask8, const svbool_t& lo16, const svbool_t& hi16, size_t half, uint16_t* sums)
+        {
+            svuint8_t value = svld1_u8(mask8, src);
+            svst1_u16(lo16, sums, svadd_u16_x(lo16, svld1_u16(lo16, sums), svunpklo_u16(value)));
+            svst1_u16(hi16, sums + half, svadd_u16_x(hi16, svld1_u16(hi16, sums + half), svunpkhi_u16(value)));
+        }
+
+        void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
+        {
+            const size_t A = svlen(svuint8_t()), HA = svlen(svuint16_t());
+            const size_t widthA = AlignLo(width, A);
+            const size_t widthB = AlignHi(width, A);
+            const svbool_t body8 = svptrue_b8();
+            const svbool_t body16 = svptrue_b16();
+            const size_t stepSize = SCHAR_MAX + 1;
+            const size_t stepCount = (height + SCHAR_MAX) / stepSize;
+
+            Buffer buffer(widthB);
+            memset(buffer.sums32, 0, sizeof(uint32_t) * widthB);
+            for (size_t step = 0; step < stepCount; ++step)
+            {
+                const size_t rowStart = step * stepSize;
+                const size_t rowEnd = Min(rowStart + stepSize, height);
+
+                memset(buffer.sums16, 0, sizeof(uint16_t) * widthB);
+                const uint8_t* rowSrc = src + rowStart * stride;
+                for (size_t row = rowStart; row < rowEnd; ++row)
+                {
+                    size_t col = 0;
+                    for (; col < widthA; col += A)
+                        GetColSums(rowSrc + col, body8, body16, body16, HA, buffer.sums16 + col);
+                    if (col < width)
+                        GetColSums(rowSrc + col, svwhilelt_b8(col, width), svwhilelt_b16(col, width), svwhilelt_b16(col + HA, width), HA, buffer.sums16 + col);
+                    rowSrc += stride;
+                }
+
+                for (size_t col = 0; col < width; col += svcntw() * 2)
+                    AddSums16To32(buffer.sums16, buffer.sums32, col, width, svcntw());
+            }
+            memcpy(sums, buffer.sums32, sizeof(uint32_t) * width);
+        }
+
         void GetAbsDxColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
         {
             if (width < 2)

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -87,33 +87,17 @@ namespace Simd
                 const size_t rowStart = step * stepSize;
                 const size_t rowEnd = Min(rowStart + stepSize, height);
 
-                memset(buffer.sums16, 0, sizeof(uint16_t) * widthB);
-                size_t row = rowStart;
-                for (; row + 4 <= rowEnd; row += 4)
+                for (size_t col = 0; col < width; col += HA)
                 {
-                    const uint8_t* src0 = src + row * stride;
-                    const uint8_t* src1 = src0 + stride;
-                    const uint8_t* src2 = src1 + stride;
-                    const uint8_t* src3 = src2 + stride;
-                    for (size_t col = 0; col < width; col += HA)
+                    svbool_t mask = svwhilelt_b16(col, width);
+                    svuint16_t sum = svdup_n_u16(0);
+                    const uint8_t* rowSrc = src + rowStart * stride + col;
+                    for (size_t row = rowStart; row < rowEnd; ++row)
                     {
-                        svbool_t mask = svwhilelt_b16(col, width);
-                        svuint16_t sum = svld1_u16(mask, buffer.sums16 + col);
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src0 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src1 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src2 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src3 + col));
-                        svst1_u16(mask, buffer.sums16 + col, sum);
+                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, rowSrc));
+                        rowSrc += stride;
                     }
-                }
-                for (; row < rowEnd; ++row)
-                {
-                    const uint8_t* rowSrc = src + row * stride;
-                    for (size_t col = 0; col < width; col += HA)
-                    {
-                        svbool_t mask = svwhilelt_b16(col, width);
-                        svst1_u16(mask, buffer.sums16 + col, svadd_u16_x(mask, svld1_u16(mask, buffer.sums16 + col), svld1ub_u16(mask, rowSrc + col)));
-                    }
+                    svst1_u16(mask, buffer.sums16 + col, sum);
                 }
 
                 for (size_t col = 0; col < width; col += svcntw() * 2)

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -476,6 +476,11 @@ namespace Test
             result = result && GetSumsAutoTest(FUNC3(Simd::Neon::GetColSums), FUNC3(SimdGetColSums), false);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GetSumsAutoTest(FUNC3(Simd::Sve2::GetColSums), FUNC3(SimdGetColSums), false);
+#endif
+
 #ifdef SIMD_HVX_ENABLE
         if (Simd::Hvx::Enable && TestHvx(options) && W >= Simd::Hvx::A)
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `GetColSums` using row-blocked 16-bit accumulation widened into 32-bit column sums.
- Route `SimdGetColSums` through SVE2 when available and add SVE2 auto-test coverage.
- Document the release note for version 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=GetColSums -tt=1 -ts=1`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="" -DSIMD_TARGET=aarch64 -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_TEST_FLAGS="" -DSIMD_SHARED=OFF -DSIMD_PYTHON=OFF -DSIMD_AVX512=OFF -DSIMD_AVX512VNNI=OFF -DSIMD_AMXBF16=OFF`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -I ../src -march=armv9-a+sve2 -msve-vector-bits=scalable ../src/Simd/SimdSve2Statistic.cpp && cmake --build . --parallel$(nproc) && qemu-aarch64 -L /usr/aarch64-linux-gnu -cpu max ./Test "-r=.." -fi=GetColSums -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2546c058-388c-4d44-ae88-d06ba8542e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2546c058-388c-4d44-ae88-d06ba8542e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

