### PR TITLE
Add SVE2 row sums optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -92,6 +92,7 @@
  <li>SVE2 optimizations of function BgrToBayer.</li>
  <li>SVE2 optimizations of function Base64Decode.</li>
  <li>SVE2 optimizations of function Base64Encode.</li>
+ <li>SVE2 optimizations of function GetRowSums.</li>
  <li>SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GetAbsDyRowSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5459,6 +5459,11 @@ SIMD_API void SimdGetRowSums(const uint8_t * src, size_t stride, size_t width, s
         Sse41::GetRowSums(src, stride, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GetRowSums(src, stride, width, height, sums);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::GetRowSums(src, stride, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -239,6 +239,8 @@ namespace Simd
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);
 
+        void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
+
         void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 
         void GetAbsDyRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -73,6 +73,34 @@ namespace Simd
             svst1_u32(hi32, dst + col + half, svadd_u32_x(hi32, svld1_u32(hi32, dst + col + half), svunpkhi_u32(sums16)));
         }
 
+        SIMD_INLINE void GetRowSums(const uint8_t* src, svbool_t mask, svuint8_t _1, svuint32_t& sum)
+        {
+            svuint8_t val = svld1_u8(mask, src);
+            sum = svdot_u32(sum, val, _1);
+        }
+
+        void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _1 = svdup_n_u8(1);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                svuint32_t sum = svdup_n_u32(0);
+                for (; col < widthA; col += A)
+                    GetRowSums(src + col, body, _1, sum);
+                if (widthA < width)
+                    GetRowSums(src + col, tail, _1, sum);
+                sums[row] = svaddv_u32(svptrue_b32(), sum);
+                src += stride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
         {
             const size_t HA = svlen(svuint16_t());

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -432,6 +432,11 @@ namespace Test
             result = result && GetSumsAutoTest(FUNC3(Simd::Avx512bw::GetRowSums), FUNC3(SimdGetRowSums), true);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GetSumsAutoTest(FUNC3(Simd::Sve2::GetRowSums), FUNC3(SimdGetRowSums), true);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && GetSumsAutoTest(FUNC3(Simd::Neon::GetRowSums), FUNC3(SimdGetRowSums), true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdGetRowSums`.
- Extend `GetRowSumsAutoTest` to cover the SVE2 implementation.
- Document the SVE2 `GetRowSums` optimization in the 7.2.163 release notes.

### Testing
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Statistic.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -O2 -I src -c src/Simd/SimdSve2Statistic.cpp -o /tmp/SimdSve2Statistic.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GetRowSums -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b3d7c2e-7720-4144-9f5c-a1b62e62bdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b3d7c2e-7720-4144-9f5c-a1b62e62bdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

