### PR TITLE
Add SVE2 GetMoments optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -96,6 +96,8 @@
  <li>SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GetAbsDyRowSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>
+ <li>SVE2 optimizations of function GetMoments.</li>
+ <li>SVE2 optimizations of function GetObjectMoments.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
  <li>SVE2 optimizations of function SquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSum.</li>
@@ -170,6 +172,10 @@
 </ul>
 
 <h4>Test framework</h4>
+<h5>New features</h5>
+<ul>
+ <li>Tests for verifying functionality of SVE2 optimizations of functions GetMoments and GetObjectMoments.</li>
+</ul>
 <h5>Bug fixing</h5>
 <ul>
  <li>Crash in Error in MakeAutoTests.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -200,6 +200,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp">
+      <Filter>Sve2\Statistics</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Conditional.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5406,6 +5406,11 @@ SIMD_API void SimdGetMoments(const uint8_t * mask, size_t stride, size_t width, 
         Sse41::GetMoments(mask, stride, width, height, index, area, x, y, xx, xy, yy);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GetMoments(mask, stride, width, height, index, area, x, y, xx, xy, yy);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A && simd)
         Neon::GetMoments(mask, stride, width, height, index, area, x, y, xx, xy, yy);
@@ -5431,6 +5436,11 @@ SIMD_API void SimdGetObjectMoments(const uint8_t* src, size_t srcStride, size_t 
 #ifdef SIMD_SSE41_ENABLE
     if (Sse41::Enable && width >= Sse41::A)
         Sse41::GetObjectMoments(src, srcStride, width, height, mask, maskStride, index, n, s, sx, sy, sxx, sxy, syy);
+    else
+#endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GetObjectMoments(src, srcStride, width, height, mask, maskStride, index, n, s, sx, sy, sxx, sxy, syy);
     else
 #endif
 #ifdef SIMD_NEON_ENABLE

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -247,6 +247,12 @@ namespace Simd
 
         void GetAbsDxColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 
+        void GetMoments(const uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index,
+            uint64_t* area, uint64_t* x, uint64_t* y, uint64_t* xx, uint64_t* xy, uint64_t* yy);
+
+        void GetObjectMoments(const uint8_t* src, size_t srcStride, size_t width, size_t height, const uint8_t* mask, size_t maskStride, uint8_t index,
+            uint64_t* n, uint64_t* s, uint64_t* sx, uint64_t* sy, uint64_t* sxx, uint64_t* sxy, uint64_t* syy);
+
         void SquareSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum);
 
         void ValueSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum);

--- a/src/Simd/SimdSve2StatisticMoments.cpp
+++ b/src/Simd/SimdSve2StatisticMoments.cpp
@@ -1,0 +1,160 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void GetObjectMoments16(const svuint16_t& src, const svuint16_t& col, size_t offset, size_t end, svuint32_t& sx, svuint32_t& sxx)
+        {
+            const size_t F = svcntw();
+
+            svbool_t lo = svwhilelt_b32(offset, end);
+            svuint32_t srcLo = svunpklo_u32(src);
+            svuint32_t colLo = svunpklo_u32(col);
+            sx = svmla_u32_m(lo, sx, srcLo, colLo);
+            sxx = svmla_u32_m(lo, sxx, srcLo, svmul_u32_x(lo, colLo, colLo));
+
+            svbool_t hi = svwhilelt_b32(offset + F, end);
+            svuint32_t srcHi = svunpkhi_u32(src);
+            svuint32_t colHi = svunpkhi_u32(col);
+            sx = svmla_u32_m(hi, sx, srcHi, colHi);
+            sxx = svmla_u32_m(hi, sxx, srcHi, svmul_u32_x(hi, colHi, colHi));
+        }
+
+        SIMD_INLINE void GetObjectMoments8(const svuint8_t& src, const svuint8_t& count, size_t offset, size_t end, const svuint8_t& one,
+            svuint32_t& n, svuint32_t& s, svuint32_t& sx, svuint32_t& sxx)
+        {
+            const size_t HA = svcnth();
+
+            n = svdot_u32(n, count, one);
+            s = svdot_u32(s, src, one);
+
+            svuint16_t srcLo = svunpklo_u16(src);
+            svuint16_t colLo = svindex_u16((uint16_t)offset, 1);
+            GetObjectMoments16(srcLo, colLo, offset, end, sx, sxx);
+
+            svuint16_t srcHi = svunpkhi_u16(src);
+            svuint16_t colHi = svindex_u16((uint16_t)(offset + HA), 1);
+            GetObjectMoments16(srcHi, colHi, offset + HA, end, sx, sxx);
+        }
+
+        void GetObjectMoments(const uint8_t* src, size_t srcStride, size_t width, size_t height, const uint8_t* mask, size_t maskStride, uint8_t index,
+            uint64_t* n, uint64_t* s, uint64_t* sx, uint64_t* sy, uint64_t* sxx, uint64_t* sxy, uint64_t* syy)
+        {
+            assert(src || mask);
+
+            *n = 0;
+            *s = 0;
+            *sx = 0;
+            *sy = 0;
+            *sxx = 0;
+            *sxy = 0;
+            *syy = 0;
+
+            const size_t A = svcntb();
+            const size_t B = 181;
+            const svuint8_t _index = svdup_n_u8(index);
+            const svuint8_t one = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t colB = 0; colB < width;)
+                {
+                    size_t colE = Simd::Min(colB + B, width);
+                    svuint32_t _n = svdup_n_u32(0);
+                    svuint32_t _s = svdup_n_u32(0);
+                    svuint32_t _sx = svdup_n_u32(0);
+                    svuint32_t _sxx = svdup_n_u32(0);
+
+                    if (mask == NULL)
+                    {
+                        for (size_t col = colB; col < colE; col += A)
+                        {
+                            svbool_t pg = svwhilelt_b8(col, colE);
+                            svuint8_t _src = svld1_u8(pg, src + col);
+                            svuint8_t _count = svand_u8_z(pg, one, one);
+                            GetObjectMoments8(_src, _count, col - colB, colE - colB, one, _n, _s, _sx, _sxx);
+                        }
+                    }
+                    else if (src == NULL)
+                    {
+                        for (size_t col = colB; col < colE; col += A)
+                        {
+                            svbool_t pg = svwhilelt_b8(col, colE);
+                            svbool_t equal = svcmpeq_u8(pg, svld1_u8(pg, mask + col), _index);
+                            svuint8_t _src = svand_u8_z(equal, one, one);
+                            GetObjectMoments8(_src, _src, col - colB, colE - colB, one, _n, _s, _sx, _sxx);
+                        }
+                    }
+                    else
+                    {
+                        for (size_t col = colB; col < colE; col += A)
+                        {
+                            svbool_t pg = svwhilelt_b8(col, colE);
+                            svbool_t equal = svcmpeq_u8(pg, svld1_u8(pg, mask + col), _index);
+                            svuint8_t _src = svsel_u8(equal, svld1_u8(pg, src + col), zero);
+                            svuint8_t _count = svand_u8_z(equal, one, one);
+                            GetObjectMoments8(_src, _count, col - colB, colE - colB, one, _n, _s, _sx, _sxx);
+                        }
+                    }
+
+                    uint64_t _sn = svaddv_u32(svptrue_b32(), _n);
+                    uint64_t _ss = svaddv_u32(svptrue_b32(), _s);
+                    uint64_t _ssx = svaddv_u32(svptrue_b32(), _sx);
+                    uint64_t _ssxx = svaddv_u32(svptrue_b32(), _sxx);
+                    uint64_t _x = colB;
+                    uint64_t _y = row;
+
+                    *n += _sn;
+                    *s += _ss;
+
+                    *sx += _ssx + _ss * _x;
+                    *sy += _ss * _y;
+
+                    *sxx += _ssxx + _ssx * _x * 2 + _ss * _x * _x;
+                    *sxy += _ssx * _y + _ss * _x * _y;
+                    *syy += _ss * _y * _y;
+
+                    colB = colE;
+                }
+                if (src)
+                    src += srcStride;
+                if (mask)
+                    mask += maskStride;
+            }
+        }
+
+        void GetMoments(const uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index,
+            uint64_t* area, uint64_t* x, uint64_t* y, uint64_t* xx, uint64_t* xy, uint64_t* yy)
+        {
+            uint64_t stub;
+            GetObjectMoments(NULL, 0, width, height, mask, stride, index, &stub, area, x, y, xx, xy, yy);
+        }
+    }
+#endif
+}

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -233,6 +233,11 @@ namespace Test
             result = result && GetMomentsAutoTest(FUNC_M(Simd::Avx512bw::GetMoments), FUNC_M(SimdGetMoments));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GetMomentsAutoTest(FUNC_M(Simd::Sve2::GetMoments), FUNC_M(SimdGetMoments));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && GetMomentsAutoTest(FUNC_M(Simd::Neon::GetMoments), FUNC_M(SimdGetMoments));
@@ -345,6 +350,11 @@ namespace Test
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && GetObjectMomentsAutoTest(FUNC_GOM(Simd::Avx512bw::GetObjectMoments), FUNC_GOM(SimdGetObjectMoments));
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GetObjectMomentsAutoTest(FUNC_GOM(Simd::Sve2::GetObjectMoments), FUNC_GOM(SimdGetObjectMoments));
+#endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementations of `GetMoments` and `GetObjectMoments`.
* Wire SVE2 dispatch and auto-test coverage.
* Add the new source to the VS2022 SVE2 project and update 7.2.163 release notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GetMoments -tt=1 -ts=1 && ./Test "-r=.." -fi=GetObjectMoments -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2StatisticMoments.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ff060f7-2709-462a-adcb-c28808261f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ff060f7-2709-462a-adcb-c28808261f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

