### PR TITLE
Add SVE2 HistogramConditional optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -110,6 +110,7 @@
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
  <li>SVE2 optimizations of function ConditionalFill.</li>
  <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
+ <li>SVE2 optimizations of function HistogramConditional.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function AlphaBlending2x.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3227,6 +3227,11 @@ SIMD_API void SimdHistogramConditional(const uint8_t * src, size_t srcStride, si
         Sse41::HistogramConditional(src, srcStride, width, height, mask, maskStride, value, compareType, histogram);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::HistogramConditional(src, srcStride, width, height, mask, maskStride, value, compareType, histogram);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::HistogramConditional(src, srcStride, width, height, mask, maskStride, value, compareType, histogram);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -70,6 +70,9 @@ namespace Simd
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 
+        void HistogramConditional(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t value, SimdCompareType compareType, uint32_t* histogram);
+
         void BackgroundGrowRangeSlow(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             uint8_t* lo, size_t loStride, uint8_t* hi, size_t hiStride);
 

--- a/src/Simd/SimdSve2Histogram.cpp
+++ b/src/Simd/SimdSve2Histogram.cpp
@@ -22,6 +22,7 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
+#include "Simd/SimdCompare.h"
 
 namespace Simd
 {
@@ -117,6 +118,77 @@ namespace Simd
             }
 
             SumHistograms(buffer.h[0], 0, histogram);
+        }
+
+        template <SimdCompareType compareType> SIMD_INLINE
+        void ConditionalSrc(const uint8_t* src, const uint8_t* mask, const svbool_t& mask8,
+            const svuint8_t& value, uint16_t* dst, const svbool_t& lo16, const svbool_t& hi16)
+        {
+            svuint8_t _src = svld1_u8(mask8, src);
+            svuint8_t _mask = svld1_u8(mask8, mask);
+            svuint8_t enable = svand_u8_z(Compare8u<compareType>(mask8, _mask, value), svdup_n_u8(1), svdup_n_u8(1));
+            svst1_u16(lo16, dst, svmul_u16_x(lo16, svadd_n_u16_x(lo16, svunpklo_u16(_src), 4), svunpklo_u16(enable)));
+            svst1_u16(hi16, dst + svlen(svuint16_t()), svmul_u16_x(hi16, svadd_n_u16_x(hi16, svunpkhi_u16(_src), 4), svunpkhi_u16(enable)));
+        }
+
+        template <SimdCompareType compareType>
+        void HistogramConditional(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t value, uint32_t* histogram)
+        {
+            size_t A = svlen(svuint8_t()), HA = svlen(svuint16_t());
+            Buffer<uint16_t> buffer(AlignHiAny(width, A), HISTOGRAM_SIZE + 4);
+            size_t widthA = AlignLoAny(width, A);
+            size_t alignedWidth4 = Simd::AlignLo(width, 4);
+            const svbool_t body8 = svptrue_b8(), body16 = svptrue_b16();
+            const svbool_t tail8 = svwhilelt_b8(widthA, width);
+            const svbool_t tailLo16 = svwhilelt_b16(widthA, width);
+            const svbool_t tailHi16 = svwhilelt_b16(widthA + HA, width);
+            const svuint8_t _value = svdup_n_u8(value);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    ConditionalSrc<compareType>(src + col, mask + col, body8, _value, buffer.v + col, body16, body16);
+                if (widthA < width)
+                    ConditionalSrc<compareType>(src + col, mask + col, tail8, _value, buffer.v + col, tailLo16, tailHi16);
+
+                for (col = 0; col < alignedWidth4; col += 4)
+                {
+                    ++buffer.h[0][buffer.v[col + 0]];
+                    ++buffer.h[1][buffer.v[col + 1]];
+                    ++buffer.h[2][buffer.v[col + 2]];
+                    ++buffer.h[3][buffer.v[col + 3]];
+                }
+                for (; col < width; ++col)
+                    ++buffer.h[0][buffer.v[col]];
+
+                src += srcStride;
+                mask += maskStride;
+            }
+
+            SumHistograms(buffer.h[0], 4, histogram);
+        }
+
+        void HistogramConditional(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t value, SimdCompareType compareType, uint32_t* histogram)
+        {
+            switch (compareType)
+            {
+            case SimdCompareEqual:
+                return HistogramConditional<SimdCompareEqual>(src, srcStride, width, height, mask, maskStride, value, histogram);
+            case SimdCompareNotEqual:
+                return HistogramConditional<SimdCompareNotEqual>(src, srcStride, width, height, mask, maskStride, value, histogram);
+            case SimdCompareGreater:
+                return HistogramConditional<SimdCompareGreater>(src, srcStride, width, height, mask, maskStride, value, histogram);
+            case SimdCompareGreaterOrEqual:
+                return HistogramConditional<SimdCompareGreaterOrEqual>(src, srcStride, width, height, mask, maskStride, value, histogram);
+            case SimdCompareLesser:
+                return HistogramConditional<SimdCompareLesser>(src, srcStride, width, height, mask, maskStride, value, histogram);
+            case SimdCompareLesserOrEqual:
+                return HistogramConditional<SimdCompareLesserOrEqual>(src, srcStride, width, height, mask, maskStride, value, histogram);
+            default:
+                assert(0);
+            }
         }
     }
 #endif

--- a/src/Test/TestHistogram.cpp
+++ b/src/Test/TestHistogram.cpp
@@ -440,6 +440,11 @@ namespace Test
             result = result && HistogramConditionalAutoTest(FUNC_HC(Simd::Avx512bw::HistogramConditional), FUNC_HC(SimdHistogramConditional));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && HistogramConditionalAutoTest(FUNC_HC(Simd::Sve2::HistogramConditional), FUNC_HC(SimdHistogramConditional));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && HistogramConditionalAutoTest(FUNC_HC(Simd::Neon::HistogramConditional), FUNC_HC(SimdHistogramConditional));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdHistogramConditional`.
- Extend `HistogramConditionalAutoTest` to cover the SVE2 path.
- Document the new optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=HistogramConditional -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -DSIMD_SVE2_ENABLE -I src -fsyntax-only src/Simd/SimdSve2Histogram.cpp`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="aarch64-linux-gnu-g++" -DSIMD_TARGET="aarch64" -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_SHARED=OFF && cmake --build build-aarch64-sve2 --parallel$(nproc)`
- `cd build-aarch64-sve2 && qemu-aarch64 -cpu max -L /usr/aarch64-linux-gnu ./Test "-r=.." -fi=HistogramConditional -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31c532e1-9e9b-4603-ade4-10ab91a33646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31c532e1-9e9b-4603-ade4-10ab91a33646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

