### PR TITLE
Add SVE2 optimization for HistogramMasked

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -110,6 +110,7 @@
  <li>SVE2 optimizations of function ConditionalSquareGradientSum.</li>
  <li>SVE2 optimizations of function ConditionalFill.</li>
  <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
+ <li>SVE2 optimizations of function HistogramMasked.</li>
  <li>SVE2 optimizations of function HistogramConditional.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3195,6 +3195,11 @@ SIMD_API void SimdHistogramMasked(const uint8_t *src, size_t srcStride, size_t w
         Sse41::HistogramMasked(src, srcStride, width, height, mask, maskStride, index, histogram);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::HistogramMasked(src, srcStride, width, height, mask, maskStride, index, histogram);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::HistogramMasked(src, srcStride, width, height, mask, maskStride, index, histogram);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -70,6 +70,9 @@ namespace Simd
         void AbsSecondDerivativeHistogram(const uint8_t* src, size_t width, size_t height, size_t stride,
             size_t step, size_t indent, uint32_t* histogram);
 
+        void HistogramMasked(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t index, uint32_t* histogram);
+
         void HistogramConditional(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             const uint8_t* mask, size_t maskStride, uint8_t value, SimdCompareType compareType, uint32_t* histogram);
 

--- a/src/Simd/SimdSve2Histogram.cpp
+++ b/src/Simd/SimdSve2Histogram.cpp
@@ -169,6 +169,12 @@ namespace Simd
             SumHistograms(buffer.h[0], 4, histogram);
         }
 
+        void HistogramMasked(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* mask, size_t maskStride, uint8_t index, uint32_t* histogram)
+        {
+            HistogramConditional<SimdCompareEqual>(src, srcStride, width, height, mask, maskStride, index, histogram);
+        }
+
         void HistogramConditional(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             const uint8_t* mask, size_t maskStride, uint8_t value, SimdCompareType compareType, uint32_t* histogram)
         {

--- a/src/Test/TestHistogram.cpp
+++ b/src/Test/TestHistogram.cpp
@@ -189,6 +189,11 @@ namespace Test
             result = result && HistogramMaskedAutoTest(FUNC_HM(Simd::Avx512bw::HistogramMasked), FUNC_HM(SimdHistogramMasked));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && HistogramMaskedAutoTest(FUNC_HM(Simd::Sve2::HistogramMasked), FUNC_HM(SimdHistogramMasked));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && HistogramMaskedAutoTest(FUNC_HM(Simd::Neon::HistogramMasked), FUNC_HM(SimdHistogramMasked));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Added SVE2 `HistogramMasked` entry point and public dispatch wiring.
- Added SVE2 coverage to `HistogramMaskedAutoTest`.
- Updated release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build_fast -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_SYNET=OFF -DSIMD_AVX512=OFF -DSIMD_AVX512VNNI=OFF -DSIMD_AMXBF16=OFF -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build_fast --parallel4`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=HistogramMasked -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -DSIMD_SYNET_DISABLE -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2Histogram.cpp -o /tmp/SimdSve2Histogram.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719e6c31-62dc-43cf-a80b-de1c29b9e64d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719e6c31-62dc-43cf-a80b-de1c29b9e64d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

