### PR TITLE
Add SVE2 optimization for HogDeinterleave

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -112,6 +112,7 @@
  <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
  <li>SVE2 optimizations of function HistogramMasked.</li>
  <li>SVE2 optimizations of function HistogramConditional.</li>
+ <li>SVE2 optimizations of function HogDeinterleave.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function AlphaBlending2x.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToY.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -239,6 +239,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp">
+      <Filter>Sve2\Legacy</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3359,6 +3359,11 @@ SIMD_API void SimdHogDeinterleave(const float * src, size_t srcStride, size_t wi
         Sse41::HogDeinterleave(src, srcStride, width, height, count, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::HogDeinterleave(src, srcStride, width, height, count, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F && count >= Neon::F)
         Neon::HogDeinterleave(src, srcStride, width, height, count, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -124,6 +124,8 @@ namespace Simd
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void HogDeinterleave(const float* src, size_t srcStride, size_t width, size_t height, size_t count, float** dst, size_t dstStride);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2Hog.cpp
+++ b/src/Simd/SimdSve2Hog.cpp
@@ -1,0 +1,67 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void HogDeinterleave(const float* src, const svuint32_t& offsets, const svbool_t& mask, float* dst)
+        {
+            svst1_f32(mask, dst, svld1_gather_u32index_f32(mask, src, offsets));
+        }
+
+        void HogDeinterleave(const float* src, size_t srcStride, size_t width, size_t height, size_t count, float** dst, size_t dstStride)
+        {
+            assert(width >= svcntw());
+
+            size_t F = svcntw(), alignedWidth = AlignLo(width, F);
+            const svbool_t body = svptrue_b32();
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), (uint32_t)count);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t rowOffset = row * dstStride, col = 0;
+                for (; col < alignedWidth; col += F)
+                {
+                    const float* s = src + count * col;
+                    size_t offset = rowOffset + col;
+                    for (size_t i = 0; i < count; ++i)
+                        HogDeinterleave(s + i, offsets, body, dst[i] + offset);
+                }
+                if (col < width)
+                {
+                    const float* s = src + count * col;
+                    size_t offset = rowOffset + col;
+                    svbool_t tail = svwhilelt_b32(col, width);
+                    for (size_t i = 0; i < count; ++i)
+                        HogDeinterleave(s + i, offsets, tail, dst[i] + offset);
+                }
+                src += srcStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestHog.cpp
+++ b/src/Test/TestHog.cpp
@@ -285,6 +285,11 @@ namespace Test
             result = result && HogDeinterleaveAutoTest(FUNC_HD(Simd::Avx512bw::HogDeinterleave), FUNC_HD(SimdHogDeinterleave));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && HogDeinterleaveAutoTest(FUNC_HD(Simd::Sve2::HogDeinterleave), FUNC_HD(SimdHogDeinterleave));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && HogDeinterleaveAutoTest(FUNC_HD(Simd::Neon::HogDeinterleave), FUNC_HD(SimdHogDeinterleave));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add an SVE2 implementation of `HogDeinterleave` and route public dispatch to it on SVE2 targets.
* Extend HOG auto-tests to cover `Simd::Sve2::HogDeinterleave` when SVE2 is available.
* Register `SimdSve2Hog.cpp` in the VS2022 SVE2 project and document the release note for 7.2.163.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=HogDeinterleave -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I./src -fsyntax-only src/Simd/SimdSve2Hog.cpp`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I./src -fsyntax-only src/Simd/SimdLib.cpp`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I./src -fsyntax-only src/Test/TestHog.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42991638-305d-43c3-8a39-5d70ee43fe3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42991638-305d-43c3-8a39-5d70ee43fe3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

