### PR TITLE
Add SVE2 HOG direction histogram optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -112,6 +112,7 @@
  <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
  <li>SVE2 optimizations of function HistogramMasked.</li>
  <li>SVE2 optimizations of function HistogramConditional.</li>
+ <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3307,6 +3307,11 @@ SIMD_API void SimdHogDirectionHistograms(const uint8_t * src, size_t stride, siz
         Sse41::HogDirectionHistograms(src, stride, width, height, cellX, cellY, quantization, histograms);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= 3)
+        Sve2::HogDirectionHistograms(src, stride, width, height, cellX, cellY, quantization, histograms);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A + 2)
         Neon::HogDirectionHistograms(src, stride, width, height, cellX, cellY, quantization, histograms);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -124,6 +124,9 @@ namespace Simd
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void HogDirectionHistograms(const uint8_t* src, size_t stride, size_t width, size_t height,
+            size_t cellX, size_t cellY, size_t quantization, float* histograms);
+
         void HogDeinterleave(const float* src, size_t srcStride, size_t width, size_t height, size_t count, float** dst, size_t dstStride);
 
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);

--- a/src/Simd/SimdSve2Hog.cpp
+++ b/src/Simd/SimdSve2Hog.cpp
@@ -64,7 +64,13 @@ namespace Simd
             };
         }
 
-        SIMD_INLINE void HogDirectionHistograms32(const svint32_t& dx, const svint32_t& dy, Buffer& buffer, size_t col, const svbool_t& mask)
+        SIMD_INLINE svbool_t HogTailMask(size_t col, size_t end, const svuint32_t& offsets)
+        {
+            const svbool_t mask = svptrue_b32();
+            return svcmplt_n_u32(mask, svadd_n_u32_x(mask, offsets, (uint32_t)col), (uint32_t)end);
+        }
+
+        SIMD_INLINE void HogDirectionHistograms32(const svint32_t& dx, const svint32_t& dy, Buffer& buffer, size_t col, const svuint32_t& offsets, const svbool_t& mask)
         {
             svfloat32_t _dx = svcvt_f32_s32_x(mask, dx);
             svfloat32_t _dy = svcvt_f32_s32_x(mask, dy);
@@ -82,15 +88,14 @@ namespace Simd
                 bestDot = svmax_f32_x(mask, dot, bestDot);
                 bestIndex = svsel_s32(negative, svdup_n_s32(buffer.size + i), bestIndex);
             }
-            svst1_s32(mask, buffer.index + col, bestIndex);
-            svst1_f32(mask, buffer.value + col, svsqrt_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, _dx, _dx), _dy, _dy)));
+            svst1_scatter_u32index_s32(mask, buffer.index + col, offsets, bestIndex);
+            svst1_scatter_u32index_f32(mask, buffer.value + col, offsets, svsqrt_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, _dx, _dx), _dy, _dy)));
         }
 
-        SIMD_INLINE void HogDirectionHistograms16(const svint16_t& dx, const svint16_t& dy, Buffer& buffer, size_t col, const svbool_t& maskLo, const svbool_t& maskHi)
+        SIMD_INLINE void HogDirectionHistograms16(const svint16_t& dx, const svint16_t& dy, Buffer& buffer, size_t col, const svuint32_t& loOffsets, const svuint32_t& hiOffsets, const svbool_t& maskLo, const svbool_t& maskHi)
         {
-            size_t F = svcntw();
-            HogDirectionHistograms32(svmovlb_s32(dx), svmovlb_s32(dy), buffer, col + 0, maskLo);
-            HogDirectionHistograms32(svmovlt_s32(dx), svmovlt_s32(dy), buffer, col + F, maskHi);
+            HogDirectionHistograms32(svmovlb_s32(dx), svmovlb_s32(dy), buffer, col, loOffsets, maskLo);
+            HogDirectionHistograms32(svmovlt_s32(dx), svmovlt_s32(dy), buffer, col, hiOffsets, maskHi);
         }
 
         SIMD_INLINE svint16_t HogDifferenceLo(const svuint8_t& a, const svuint8_t& b)
@@ -108,14 +113,17 @@ namespace Simd
         SIMD_INLINE void HogDirectionHistograms(const uint8_t* src, size_t stride, Buffer& buffer, size_t col, size_t end)
         {
             const uint8_t* s = src + col;
-            size_t F = svcntw();
             svbool_t mask = svwhilelt_b8(col, end);
+            const svuint32_t offsets0 = svindex_u32(0, 4);
+            const svuint32_t offsets1 = svindex_u32(2, 4);
+            const svuint32_t offsets2 = svindex_u32(1, 4);
+            const svuint32_t offsets3 = svindex_u32(3, 4);
             svuint8_t t = svld1_u8(mask, s - stride);
             svuint8_t l = svld1_u8(mask, s - 1);
             svuint8_t r = svld1_u8(mask, s + 1);
             svuint8_t b = svld1_u8(mask, s + stride);
-            HogDirectionHistograms16(HogDifferenceLo(r, l), HogDifferenceLo(b, t), buffer, col + 0 * F, svwhilelt_b32(col + 0 * F, end), svwhilelt_b32(col + 1 * F, end));
-            HogDirectionHistograms16(HogDifferenceHi(r, l), HogDifferenceHi(b, t), buffer, col + 2 * F, svwhilelt_b32(col + 2 * F, end), svwhilelt_b32(col + 3 * F, end));
+            HogDirectionHistograms16(HogDifferenceLo(r, l), HogDifferenceLo(b, t), buffer, col, offsets0, offsets1, HogTailMask(col, end, offsets0), HogTailMask(col, end, offsets1));
+            HogDirectionHistograms16(HogDifferenceHi(r, l), HogDifferenceHi(b, t), buffer, col, offsets2, offsets3, HogTailMask(col, end, offsets2), HogTailMask(col, end, offsets3));
         }
 
         void HogDirectionHistograms(const uint8_t* src, size_t stride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Hog.cpp
+++ b/src/Simd/SimdSve2Hog.cpp
@@ -22,12 +22,121 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
+#include "Simd/SimdBase.h"
 
 namespace Simd
 {
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        namespace
+        {
+            struct Buffer
+            {
+                const int size;
+                float* cos;
+                float* sin;
+                int* index;
+                float* value;
+
+                Buffer(size_t width, size_t quantization)
+                    : size((int)quantization / 2)
+                {
+                    _p = Allocate(width * (sizeof(int) + sizeof(float)) + sizeof(float) * 2 * size);
+                    index = (int*)_p;
+                    value = (float*)index + width;
+                    cos = value + width;
+                    sin = cos + size;
+                    for (int i = 0; i < size; ++i)
+                    {
+                        cos[i] = (float)::cos(i * M_PI / size);
+                        sin[i] = (float)::sin(i * M_PI / size);
+                    }
+                }
+
+                ~Buffer()
+                {
+                    Free(_p);
+                }
+
+            private:
+                void* _p;
+            };
+        }
+
+        SIMD_INLINE void HogDirectionHistograms32(const svint32_t& dx, const svint32_t& dy, Buffer& buffer, size_t col, const svbool_t& mask)
+        {
+            svfloat32_t _dx = svcvt_f32_s32_x(mask, dx);
+            svfloat32_t _dy = svcvt_f32_s32_x(mask, dy);
+            svfloat32_t bestDot = svdup_n_f32(0.0f);
+            svint32_t bestIndex = svdup_n_s32(0);
+            for (int i = 0; i < buffer.size; ++i)
+            {
+                svfloat32_t dot = svmla_f32_x(mask, svmul_n_f32_x(mask, _dx, buffer.cos[i]), _dy, svdup_n_f32(buffer.sin[i]));
+                svbool_t positive = svcmpgt_f32(mask, dot, bestDot);
+                bestDot = svmax_f32_x(mask, dot, bestDot);
+                bestIndex = svsel_s32(positive, svdup_n_s32(i), bestIndex);
+
+                dot = svneg_f32_x(mask, dot);
+                svbool_t negative = svcmpgt_f32(mask, dot, bestDot);
+                bestDot = svmax_f32_x(mask, dot, bestDot);
+                bestIndex = svsel_s32(negative, svdup_n_s32(buffer.size + i), bestIndex);
+            }
+            svst1_s32(mask, buffer.index + col, bestIndex);
+            svst1_f32(mask, buffer.value + col, svsqrt_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, _dx, _dx), _dy, _dy)));
+        }
+
+        SIMD_INLINE void HogDirectionHistograms16(const svint16_t& dx, const svint16_t& dy, Buffer& buffer, size_t col, const svbool_t& maskLo, const svbool_t& maskHi)
+        {
+            size_t F = svcntw();
+            HogDirectionHistograms32(svmovlb_s32(dx), svmovlb_s32(dy), buffer, col + 0, maskLo);
+            HogDirectionHistograms32(svmovlt_s32(dx), svmovlt_s32(dy), buffer, col + F, maskHi);
+        }
+
+        SIMD_INLINE svint16_t HogDifferenceLo(const svuint8_t& a, const svuint8_t& b)
+        {
+            svbool_t mask = svptrue_b16();
+            return svsub_s16_x(mask, svreinterpret_s16_u16(svmovlb_u16(a)), svreinterpret_s16_u16(svmovlb_u16(b)));
+        }
+
+        SIMD_INLINE svint16_t HogDifferenceHi(const svuint8_t& a, const svuint8_t& b)
+        {
+            svbool_t mask = svptrue_b16();
+            return svsub_s16_x(mask, svreinterpret_s16_u16(svmovlt_u16(a)), svreinterpret_s16_u16(svmovlt_u16(b)));
+        }
+
+        SIMD_INLINE void HogDirectionHistograms(const uint8_t* src, size_t stride, Buffer& buffer, size_t col, size_t end)
+        {
+            const uint8_t* s = src + col;
+            size_t F = svcntw();
+            svbool_t mask = svwhilelt_b8(col, end);
+            svuint8_t t = svld1_u8(mask, s - stride);
+            svuint8_t l = svld1_u8(mask, s - 1);
+            svuint8_t r = svld1_u8(mask, s + 1);
+            svuint8_t b = svld1_u8(mask, s + stride);
+            HogDirectionHistograms16(HogDifferenceLo(r, l), HogDifferenceLo(b, t), buffer, col + 0 * F, svwhilelt_b32(col + 0 * F, end), svwhilelt_b32(col + 1 * F, end));
+            HogDirectionHistograms16(HogDifferenceHi(r, l), HogDifferenceHi(b, t), buffer, col + 2 * F, svwhilelt_b32(col + 2 * F, end), svwhilelt_b32(col + 3 * F, end));
+        }
+
+        void HogDirectionHistograms(const uint8_t* src, size_t stride, size_t width, size_t height,
+            size_t cellX, size_t cellY, size_t quantization, float* histograms)
+        {
+            assert(width % cellX == 0 && height % cellY == 0 && quantization % 2 == 0);
+
+            Buffer buffer(width, quantization);
+
+            memset(histograms, 0, quantization * (width / cellX) * (height / cellY) * sizeof(float));
+
+            size_t A = svcntb(), end = width - 1;
+            for (size_t row = 1; row < height - 1; ++row)
+            {
+                const uint8_t* s = src + stride * row;
+                for (size_t col = 1; col < end; col += A)
+                    HogDirectionHistograms(s, stride, buffer, col, end);
+                Base::AddRowToHistograms(buffer.index, buffer.value, row, width, height, cellX, cellY, quantization, histograms);
+            }
+        }
+
         SIMD_INLINE void HogDeinterleave(const float* src, const svuint32_t& offsets, const svbool_t& mask, float* dst)
         {
             svst1_f32(mask, dst, svld1_gather_u32index_f32(mask, src, offsets));

--- a/src/Test/TestHog.cpp
+++ b/src/Test/TestHog.cpp
@@ -107,6 +107,11 @@ namespace Test
             result = result && HogDirectionHistogramsAutoTest(FUNC_HDH(Simd::Avx512bw::HogDirectionHistograms), FUNC_HDH(SimdHogDirectionHistograms));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 2)
+            result = result && HogDirectionHistogramsAutoTest(FUNC_HDH(Simd::Sve2::HogDirectionHistograms), FUNC_HDH(SimdHogDirectionHistograms));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A + 2)
             result = result && HogDirectionHistogramsAutoTest(FUNC_HDH(Simd::Neon::HogDirectionHistograms), FUNC_HDH(SimdHogDirectionHistograms));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation of `HogDirectionHistograms` and route public dispatch to it on SVE2-capable ARM builds.
* Fix SVE2 widened-lane storage with scatter stores so Base and SVE2 histograms use the same source-column order.
* Extend HOG auto-tests to cover the direct SVE2 implementation.
* Document the new optimization in release `7.2.163`.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `cmake --build build --parallel$(nproc) && export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=HogDirectionHistograms -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -std=c++17 -O2 -static -march=armv8.5-a+sve2 -msve-vector-bits=128 -I. -Isrc tmp_sve2_hog_compare.cpp -o /tmp/tmp_sve2_hog_compare && qemu-aarch64 -cpu max /tmp/tmp_sve2_hog_compare` (`maxDiff=0 mismatches=0` before temporary harness cleanup)
* `aarch64-linux-gnu-g++ -std=c++17 -O2 -static -march=armv8.5-a+sve2 -I. -Isrc tmp_sve2_hog_compare.cpp -o /tmp/tmp_sve2_hog_compare_scalable && qemu-aarch64 -cpu max,sve-max-vq=4 /tmp/tmp_sve2_hog_compare_scalable` (`maxDiff=0 mismatches=0` before temporary harness cleanup)
* `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv9-a+sve2 -I src src/Simd/SimdSve2Hog.cpp && aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv9-a+sve2 -I src src/Simd/SimdLib.cpp && aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv9-a+sve2 -I src src/Test/TestHog.cpp`
* `git diff --check && git status --short`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-824cd864-69ad-4e26-921f-50bca0d7b0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-824cd864-69ad-4e26-921f-50bca0d7b0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

