### PR TITLE
Add SVE2 HogFilterSeparable optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -115,6 +115,7 @@
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>
+ <li>SVE2 optimizations of function HogFilterSeparable.</li>
  <li>SVE2 optimizations of function AddFeatureDifference.</li>
  <li>SVE2 optimizations of function AlphaBlending.</li>
  <li>SVE2 optimizations of function AlphaBlending2x.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3387,22 +3387,27 @@ SIMD_API void SimdHogFilterSeparable(const float * src, size_t srcStride, size_t
 {
     SIMD_EMPTY();
 #ifdef SIMD_AVX512BW_ENABLE
-    if (Avx512bw::Enable && width >= Avx512bw::F + colSize - 1)
+    if (Avx512bw::Enable && width >= Avx512bw::F + rowSize - 1)
         Avx512bw::HogFilterSeparable(src, srcStride, width, height, rowFilter, rowSize, colFilter, colSize, dst, dstStride, add);
     else
 #endif
 #ifdef SIMD_AVX2_ENABLE
-    if (Avx2::Enable && width >= Avx2::F + colSize - 1)
+    if (Avx2::Enable && width >= Avx2::F + rowSize - 1)
         Avx2::HogFilterSeparable(src, srcStride, width, height, rowFilter, rowSize, colFilter, colSize, dst, dstStride, add);
     else
 #endif
 #ifdef SIMD_SSE41_ENABLE
-    if (Sse41::Enable && width >= Sse41::F + colSize - 1)
+    if (Sse41::Enable && width >= Sse41::F + rowSize - 1)
         Sse41::HogFilterSeparable(src, srcStride, width, height, rowFilter, rowSize, colFilter, colSize, dst, dstStride, add);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw() + rowSize - 1)
+        Sve2::HogFilterSeparable(src, srcStride, width, height, rowFilter, rowSize, colFilter, colSize, dst, dstStride, add);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
-    if (Neon::Enable && width >= Neon::F + colSize - 1)
+    if (Neon::Enable && width >= Neon::F + rowSize - 1)
         Neon::HogFilterSeparable(src, srcStride, width, height, rowFilter, rowSize, colFilter, colSize, dst, dstStride, add);
     else
 #endif

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -131,6 +131,9 @@ namespace Simd
 
         void HogDeinterleave(const float* src, size_t srcStride, size_t width, size_t height, size_t count, float** dst, size_t dstStride);
 
+        void HogFilterSeparable(const float* src, size_t srcStride, size_t width, size_t height,
+            const float* rowFilter, size_t rowSize, const float* colFilter, size_t colSize, float* dst, size_t dstStride, int add);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2Hog.cpp
+++ b/src/Simd/SimdSve2Hog.cpp
@@ -446,6 +446,100 @@ namespace Simd
                 src += srcStride;
             }
         }
+
+        //-----------------------------------------------------------------------------------------
+
+        namespace HogSeparableFilter_Detail
+        {
+            template <int add> SIMD_INLINE void Set(float* dst, const svfloat32_t& value, const svbool_t& mask)
+            {
+                svst1_f32(mask, dst, value);
+            }
+
+            template <> SIMD_INLINE void Set<1>(float* dst, const svfloat32_t& value, const svbool_t& mask)
+            {
+                svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), value));
+            }
+        }
+
+        class HogSeparableFilter
+        {
+            typedef Array<float> Array32f;
+
+            size_t _w, _h, _s;
+            Array32f _buffer;
+
+            void Init(size_t w, size_t h, size_t rs, size_t cs)
+            {
+                _w = w - rs + 1;
+                _s = AlignHiAny(_w, svcntw());
+                _h = h - cs + 1;
+                _buffer.Resize(_s * h);
+            }
+
+            SIMD_INLINE void FilterRows(const float* src, const float* filter, size_t size, float* dst, const svbool_t& mask)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t i = 0; i < size; ++i)
+                    sum = svmla_f32_x(mask, sum, svld1_f32(mask, src + i), svdup_n_f32(filter[i]));
+                svst1_f32(mask, dst, sum);
+            }
+
+            void FilterRows(const float* src, size_t srcStride, size_t width, size_t height, const float* filter, size_t size, float* dst, size_t dstStride)
+            {
+                size_t F = svcntw();
+                for (size_t row = 0; row < height; ++row)
+                {
+                    for (size_t col = 0; col < width; col += F)
+                        FilterRows(src + col, filter, size, dst + col, svwhilelt_b32(col, width));
+                    src += srcStride;
+                    dst += dstStride;
+                }
+            }
+
+            template <int add> SIMD_INLINE void FilterCols(const float* src, size_t stride, const float* filter, size_t size, float* dst, const svbool_t& mask)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                for (size_t i = 0; i < size; ++i, src += stride)
+                    sum = svmla_f32_x(mask, sum, svld1_f32(mask, src), svdup_n_f32(filter[i]));
+                HogSeparableFilter_Detail::Set<add>(dst, sum, mask);
+            }
+
+            template <int add> void FilterCols(const float* src, size_t srcStride, size_t width, size_t height, const float* filter, size_t size, float* dst, size_t dstStride)
+            {
+                size_t F = svcntw();
+                for (size_t row = 0; row < height; ++row)
+                {
+                    for (size_t col = 0; col < width; col += F)
+                        FilterCols<add>(src + col, srcStride, filter, size, dst + col, svwhilelt_b32(col, width));
+                    src += srcStride;
+                    dst += dstStride;
+                }
+            }
+
+        public:
+            void Run(const float* src, size_t srcStride, size_t width, size_t height,
+                const float* rowFilter, size_t rowSize, const float* colFilter, size_t colSize, float* dst, size_t dstStride, int add)
+            {
+                Init(width, height, rowSize, colSize);
+
+                FilterRows(src, srcStride, _w, height, rowFilter, rowSize, _buffer.data, _s);
+
+                if (add)
+                    FilterCols<1>(_buffer.data, _s, _w, _h, colFilter, colSize, dst, dstStride);
+                else
+                    FilterCols<0>(_buffer.data, _s, _w, _h, colFilter, colSize, dst, dstStride);
+            }
+        };
+
+        void HogFilterSeparable(const float* src, size_t srcStride, size_t width, size_t height,
+            const float* rowFilter, size_t rowSize, const float* colFilter, size_t colSize, float* dst, size_t dstStride, int add)
+        {
+            assert(width >= rowSize - 1 && height >= colSize - 1);
+
+            HogSeparableFilter filter;
+            filter.Run(src, srcStride, width, height, rowFilter, rowSize, colFilter, colSize, dst, dstStride, add);
+        }
     }
 #endif
 }

--- a/src/Test/TestHog.cpp
+++ b/src/Test/TestHog.cpp
@@ -404,6 +404,11 @@ namespace Test
             result = result && HogFilterSeparableAutoTest(FUNC_HSF(Simd::Neon::HogFilterSeparable), FUNC_HSF(SimdHogFilterSeparable));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && HogFilterSeparableAutoTest(FUNC_HSF(Simd::Sve2::HogFilterSeparable), FUNC_HSF(SimdHogFilterSeparable));
+#endif 
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `HogFilterSeparable`.
- Dispatch `SimdHogFilterSeparable` to SVE2 and align existing SIMD width gates with the row filter size.
- Add SVE2 auto-test coverage and document the optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=HogFilterSeparable -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -fsyntax-only -I./src -march=armv8.5-a+sve2 src/Simd/SimdSve2Hog.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41981881-45b1-46ff-a1e3-9d71275ec3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41981881-45b1-46ff-a1e3-9d71275ec3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

