### PR TITLE
Add SVE2 optimization for Gemm32fNN

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -53,6 +53,7 @@
  <li>SVE2 optimizations of function CosineDistancesMxNa16f.</li>
  <li>SVE2 optimizations of function CosineDistancesMxNp16f.</li>
  <li>SVE2 optimizations of function CosineDistance32f.</li>
+ <li>SVE2 optimizations of function Gemm32fNN.</li>
  <li>SVE2 optimizations of function Gemm32fNT.</li>
  <li>SVE2 optimizations of function DescrIntEncode32f.</li>
  <li>SVE2 optimizations of function DescrIntEncode16f.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Fill.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Gemm32fNN.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Gemm32fNT.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Gemm32fPack.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GaussianBlur.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -230,6 +230,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Float32.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Gemm32fNN.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Gemm32fNT.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3028,7 +3028,7 @@ typedef void(*SimdGemm32fPtr) (size_t M, size_t N, size_t K, const float * alpha
 SIMD_API void SimdGemm32fNN(size_t M, size_t N, size_t K, const float * alpha, const float * A, size_t lda, const float * B, size_t ldb, const float * beta, float * C, size_t ldc)
 {
     SIMD_EMPTY();
-    const static SimdGemm32fPtr simdGemm32fNN = SIMD_FUNC4(Gemm32fNN, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdGemm32fPtr simdGemm32fNN = SIMD_FUNC5(Gemm32fNN, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdGemm32fNN(M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -124,6 +124,8 @@ namespace Simd
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void Gemm32fNN(size_t M, size_t N, size_t K, const float* alpha, const float* A, size_t lda, const float* B, size_t ldb, const float* beta, float* C, size_t ldc);
+
         void Gemm32fNT(size_t M, size_t N, size_t K, const float* alpha, const float* A, size_t lda, const float* B, size_t ldb, const float* beta, float* C, size_t ldc);
 
         void HogDirectionHistograms(const uint8_t* src, size_t stride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Gemm32fNN.cpp
+++ b/src/Simd/SimdSve2Gemm32fNN.cpp
@@ -1,0 +1,126 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdGemm.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void AddProduct(float* ptr, const svfloat32_t& value, const svfloat32_t& alpha, const svbool_t& mask)
+        {
+            svst1_f32(mask, ptr, svmla_f32_m(mask, svld1_f32(mask, ptr), value, alpha));
+        }
+
+#define SIMD_SVE2_GEMM_INIT(row) \
+        svfloat32_t c##row##0, c##row##1, c##row##2, c##row##3; \
+        if (M > row) c##row##0 = zero, c##row##1 = zero, c##row##2 = zero, c##row##3 = zero;
+
+#define SIMD_SVE2_GEMM_ROW(row) \
+        if (M > row) \
+        { \
+            svfloat32_t a = svdup_n_f32(A[(row) * lda]); \
+            c##row##0 = svmla_f32_m(mask0, c##row##0, b0, a); \
+            c##row##1 = svmla_f32_m(mask1, c##row##1, b1, a); \
+            c##row##2 = svmla_f32_m(mask2, c##row##2, b2, a); \
+            c##row##3 = svmla_f32_m(mask3, c##row##3, b3, a); \
+        }
+
+#define SIMD_SVE2_GEMM_SAVE(row) \
+        if (M > row) \
+        { \
+            AddProduct(C + (row) * ldc + 0 * F, c##row##0, _alpha, mask0); \
+            AddProduct(C + (row) * ldc + 1 * F, c##row##1, _alpha, mask1); \
+            AddProduct(C + (row) * ldc + 2 * F, c##row##2, _alpha, mask2); \
+            AddProduct(C + (row) * ldc + 3 * F, c##row##3, _alpha, mask3); \
+        }
+
+        template<int M> void GemmKernelMx4nn(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, size_t F, float* C, size_t ldc, size_t tail)
+        {
+            const svbool_t mask0 = svwhilelt_b32(0 * F, tail);
+            const svbool_t mask1 = svwhilelt_b32(1 * F, tail);
+            const svbool_t mask2 = svwhilelt_b32(2 * F, tail);
+            const svbool_t mask3 = svwhilelt_b32(3 * F, tail);
+            const svfloat32_t zero = svdup_n_f32(0.0f);
+            SIMD_SVE2_GEMM_INIT(0);
+            SIMD_SVE2_GEMM_INIT(1);
+            SIMD_SVE2_GEMM_INIT(2);
+            SIMD_SVE2_GEMM_INIT(3);
+            SIMD_SVE2_GEMM_INIT(4);
+            SIMD_SVE2_GEMM_INIT(5);
+            for (size_t k = 0; k < K; ++k)
+            {
+                svfloat32_t b0 = svld1_f32(mask0, B + 0 * F);
+                svfloat32_t b1 = svld1_f32(mask1, B + 1 * F);
+                svfloat32_t b2 = svld1_f32(mask2, B + 2 * F);
+                svfloat32_t b3 = svld1_f32(mask3, B + 3 * F);
+                SIMD_SVE2_GEMM_ROW(0);
+                SIMD_SVE2_GEMM_ROW(1);
+                SIMD_SVE2_GEMM_ROW(2);
+                SIMD_SVE2_GEMM_ROW(3);
+                SIMD_SVE2_GEMM_ROW(4);
+                SIMD_SVE2_GEMM_ROW(5);
+                A += 1;
+                B += ldb;
+            }
+            svfloat32_t _alpha = svdup_n_f32(alpha);
+            SIMD_SVE2_GEMM_SAVE(0);
+            SIMD_SVE2_GEMM_SAVE(1);
+            SIMD_SVE2_GEMM_SAVE(2);
+            SIMD_SVE2_GEMM_SAVE(3);
+            SIMD_SVE2_GEMM_SAVE(4);
+            SIMD_SVE2_GEMM_SAVE(5);
+        }
+
+        void Gemm32fNN(size_t M, size_t N, size_t K, const float* alpha, const float* A, size_t lda, const float* B, size_t ldb, const float* beta, float* C, size_t ldc)
+        {
+            const size_t F = svcntw();
+            const size_t microM = 6;
+            const size_t microN = 4 * F;
+            GemmScaleC(M, N, beta[0], C, ldc);
+            for (size_t i = 0; i < M; i += microM)
+            {
+                size_t m = Simd::Min(microM, M - i);
+                for (size_t j = 0; j < N; j += microN)
+                {
+                    size_t tail = Simd::Min(microN, N - j);
+                    switch (m)
+                    {
+                    case 1: GemmKernelMx4nn<1>(K, alpha[0], A + i * lda, lda, B + j, ldb, F, C + i * ldc + j, ldc, tail); break;
+                    case 2: GemmKernelMx4nn<2>(K, alpha[0], A + i * lda, lda, B + j, ldb, F, C + i * ldc + j, ldc, tail); break;
+                    case 3: GemmKernelMx4nn<3>(K, alpha[0], A + i * lda, lda, B + j, ldb, F, C + i * ldc + j, ldc, tail); break;
+                    case 4: GemmKernelMx4nn<4>(K, alpha[0], A + i * lda, lda, B + j, ldb, F, C + i * ldc + j, ldc, tail); break;
+                    case 5: GemmKernelMx4nn<5>(K, alpha[0], A + i * lda, lda, B + j, ldb, F, C + i * ldc + j, ldc, tail); break;
+                    case 6: GemmKernelMx4nn<6>(K, alpha[0], A + i * lda, lda, B + j, ldb, F, C + i * ldc + j, ldc, tail); break;
+                    }
+                }
+            }
+        }
+
+#undef SIMD_SVE2_GEMM_INIT
+#undef SIMD_SVE2_GEMM_ROW
+#undef SIMD_SVE2_GEMM_SAVE
+    }
+#endif
+}

--- a/src/Test/TestGemm.cpp
+++ b/src/Test/TestGemm.cpp
@@ -233,6 +233,11 @@ namespace Test
             result = result && Gemm32fNNAutoTest(FUNC_GEMM32F(Simd::Avx512bw::Gemm32fNN), FUNC_GEMM32F(SimdGemm32fNN));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && Gemm32fNNAutoTest(FUNC_GEMM32F(Simd::Sve2::Gemm32fNN), FUNC_GEMM32F(SimdGemm32fNN));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && Gemm32fNNAutoTest(FUNC_GEMM32F(Simd::Neon::Gemm32fNN), FUNC_GEMM32F(SimdGemm32fNN));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `Gemm32fNN` kernel and runtime dispatch.
- Cover SVE2 NN in `Gemm32fNNAutoTest`.
- Add Visual Studio project entries and 7.2.163 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Gemm32fNN -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2Gemm32fNN.cpp`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8b51666-d45c-4fd8-ac99-057b0ab07d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8b51666-d45c-4fd8-ac99-057b0ab07d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

