### PR TITLE
Add SVE2 Laplace optimizations

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -139,6 +139,9 @@
  <li>SVE2 optimizations of function ContourMetrics.</li>
  <li>SVE2 optimizations of function ContourMetricsMasked.</li>
  <li>SVE2 optimizations of function ContourAnchors.</li>
+ <li>SVE2 optimizations of function Laplace.</li>
+ <li>SVE2 optimizations of function LaplaceAbs.</li>
+ <li>SVE2 optimizations of function LaplaceAbsSum.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToY.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Laplace.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -251,6 +251,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp">
       <Filter>Sve2\Legacy</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Laplace.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3623,6 +3623,11 @@ SIMD_API void SimdLaplace(const uint8_t * src, size_t srcStride, size_t width, s
         Sse41::Laplace(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Laplace(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::Laplace(src, srcStride, width, height, dst, dstStride);
@@ -3649,6 +3654,11 @@ SIMD_API void SimdLaplaceAbs(const uint8_t * src, size_t srcStride, size_t width
         Sse41::LaplaceAbs(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::LaplaceAbs(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::LaplaceAbs(src, srcStride, width, height, dst, dstStride);
@@ -3673,6 +3683,11 @@ SIMD_API void SimdLaplaceAbsSum(const uint8_t * src, size_t stride, size_t width
 #ifdef SIMD_SSE41_ENABLE
     if(Sse41::Enable && width > Sse41::A)
         Sse41::LaplaceAbsSum(src, stride, width, height, sum);
+    else
+#endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::LaplaceAbsSum(src, stride, width, height, sum);
     else
 #endif
 #ifdef SIMD_NEON_ENABLE

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -138,6 +138,12 @@ namespace Simd
         void HogFilterSeparable(const float* src, size_t srcStride, size_t width, size_t height,
             const float* rowFilter, size_t rowSize, const float* colFilter, size_t colSize, float* dst, size_t dstStride, int add);
 
+        void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
+        void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
+        void LaplaceAbsSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2Laplace.cpp
+++ b/src/Simd/SimdSve2Laplace.cpp
@@ -1,0 +1,140 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template <bool abs> SIMD_INLINE int16_t Laplace(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2);
+
+        template <> SIMD_INLINE int16_t Laplace<false>(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+        {
+            return 8 * s1[x1] - (s0[x0] + s0[x1] + s0[x2] + s1[x0] + s1[x2] + s2[x0] + s2[x1] + s2[x2]);
+        }
+
+        template <> SIMD_INLINE int16_t Laplace<true>(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+        {
+            return (int16_t)Simd::Abs(Laplace<false>(s0, s1, s2, x0, x1, x2));
+        }
+
+        SIMD_INLINE svint16_t Laplace(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+        {
+            svint16_t center = svlsl_n_s16_x(mask, svld1ub_s16(mask, s1 + 1), 3);
+            svint16_t sum0 = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0 + 0), svld1ub_s16(mask, s0 + 1)), svld1ub_s16(mask, s0 + 2));
+            svint16_t sum1 = svadd_s16_x(mask, svld1ub_s16(mask, s1 + 0), svld1ub_s16(mask, s1 + 2));
+            svint16_t sum2 = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2 + 0), svld1ub_s16(mask, s2 + 1)), svld1ub_s16(mask, s2 + 2));
+            return svsub_s16_x(mask, center, svadd_s16_x(mask, svadd_s16_x(mask, sum0, sum1), sum2));
+        }
+
+        template <bool abs> SIMD_INLINE svint16_t ConditionalAbs(const svint16_t& value, const svbool_t& mask)
+        {
+            return value;
+        }
+
+        template <> SIMD_INLINE svint16_t ConditionalAbs<true>(const svint16_t& value, const svbool_t& mask)
+        {
+            return svabs_s16_x(mask, value);
+        }
+
+        template <bool abs> SIMD_INLINE void Laplace(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        {
+            svst1_s16(mask, dst, ConditionalAbs<abs>(Laplace(s0, s1, s2, mask), mask));
+        }
+
+        template <bool abs> void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t * src0, * src1, * src2;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + srcStride * (row - 1);
+                src1 = src0 + srcStride;
+                src2 = src1 + srcStride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                dst[0] = Laplace<abs>(src0, src1, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    Laplace<abs>(src0 + col - 1, src1 + col - 1, src2 + col - 1, dst + col, svwhilelt_b16(col, width - 1));
+                dst[width - 1] = Laplace<abs>(src0, src1, src2, width - 2, width - 1, width - 1);
+
+                dst += dstStride;
+            }
+        }
+
+        void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            Laplace<false>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
+        void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            Laplace<true>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
+        SIMD_INLINE uint64_t LaplaceAbsSum(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+        {
+            svuint16_t laplace = svreinterpret_u16_s16(svabs_s16_z(mask, Laplace(s0, s1, s2, mask)));
+            return svaddv_u32(svptrue_b32(), svunpklo_u32(laplace)) + svaddv_u32(svptrue_b32(), svunpkhi_u32(laplace));
+        }
+
+        void LaplaceAbsSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t * src0, * src1, * src2;
+            uint64_t fullSum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + stride * (row - 1);
+                src1 = src0 + stride;
+                src2 = src1 + stride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                uint64_t rowSum = Laplace<true>(src0, src1, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    rowSum += LaplaceAbsSum(src0 + col - 1, src1 + col - 1, src2 + col - 1, svwhilelt_b16(col, width - 1));
+                rowSum += Laplace<true>(src0, src1, src2, width - 2, width - 1, width - 1);
+
+                fullSum += rowSum;
+            }
+            *sum = fullSum;
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -893,6 +893,11 @@ namespace
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::Laplace), FUNC_G(SimdLaplace));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::Laplace), FUNC_G(SimdLaplace));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Neon::Laplace), FUNC_G(SimdLaplace));
@@ -922,6 +927,11 @@ namespace
         if (Simd::Avx512bw::Enable && TestAvx512bw(options) && W - 1 >= Simd::Avx512bw::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::LaplaceAbs), FUNC_G(SimdLaplaceAbs));
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::LaplaceAbs), FUNC_G(SimdLaplaceAbs));
+#endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -826,6 +826,11 @@ namespace Test
             result = result && SumAutoTest(FUNC4(Simd::Avx512bw::LaplaceAbsSum), FUNC4(SimdLaplaceAbsSum));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SumAutoTest(FUNC4(Simd::Sve2::LaplaceAbsSum), FUNC4(SimdLaplaceAbsSum));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SumAutoTest(FUNC4(Simd::Neon::LaplaceAbsSum), FUNC4(SimdLaplaceAbsSum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementations and dispatch for `Laplace`, `LaplaceAbs`, and `LaplaceAbsSum`.
* Extend SVE2 coverage in filter/statistic auto tests.
* Register the new SVE2 source in VS2022 project files and release notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=Laplace -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2Laplace.cpp -o /tmp/SimdSve2Laplace.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92e0dae3-cf98-405f-8908-8101041805e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92e0dae3-cf98-405f-8908-8101041805e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

