### PR TITLE
Add SVE2 LaplaceAbs source

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -186,6 +186,7 @@
 <h5>New features</h5>
 <ul>
  <li>Tests for verifying functionality of SVE2 optimizations of functions GetMoments and GetObjectMoments.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function LaplaceAbs.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Laplace.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2LaplaceAbs.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -254,6 +254,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Laplace.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2LaplaceAbs.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdSve2Laplace.cpp
+++ b/src/Simd/SimdSve2Laplace.cpp
@@ -96,13 +96,6 @@ namespace Simd
             Laplace<false>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
         }
 
-        void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
-        {
-            assert(dstStride % sizeof(int16_t) == 0);
-
-            Laplace<true>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
-        }
-
         SIMD_INLINE uint64_t LaplaceAbsSum(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
         {
             svuint16_t laplace = svreinterpret_u16_s16(svabs_s16_z(mask, Laplace(s0, s1, s2, mask)));

--- a/src/Simd/SimdSve2LaplaceAbs.cpp
+++ b/src/Simd/SimdSve2LaplaceAbs.cpp
@@ -1,0 +1,87 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        namespace
+        {
+            SIMD_INLINE int16_t LaplaceAbsScalar(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+            {
+                int value = 8 * s1[x1] - (s0[x0] + s0[x1] + s0[x2] + s1[x0] + s1[x2] + s2[x0] + s2[x1] + s2[x2]);
+                return (int16_t)Simd::Abs(value);
+            }
+
+            SIMD_INLINE svint16_t LaplaceAbsVector(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+            {
+                svint16_t center = svlsl_n_s16_x(mask, svld1ub_s16(mask, s1 + 1), 3);
+                svint16_t sum0 = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0 + 0), svld1ub_s16(mask, s0 + 1)), svld1ub_s16(mask, s0 + 2));
+                svint16_t sum1 = svadd_s16_x(mask, svld1ub_s16(mask, s1 + 0), svld1ub_s16(mask, s1 + 2));
+                svint16_t sum2 = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2 + 0), svld1ub_s16(mask, s2 + 1)), svld1ub_s16(mask, s2 + 2));
+                return svabs_s16_x(mask, svsub_s16_x(mask, center, svadd_s16_x(mask, svadd_s16_x(mask, sum0, sum1), sum2)));
+            }
+
+            SIMD_INLINE void LaplaceAbsVector(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+            {
+                svst1_s16(mask, dst, LaplaceAbsVector(s0, s1, s2, mask));
+            }
+
+            void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
+            {
+                assert(width > 1);
+
+                const size_t A = svcnth();
+                const uint8_t * src0, * src1, * src2;
+                for (size_t row = 0; row < height; ++row)
+                {
+                    src0 = src + srcStride * (row - 1);
+                    src1 = src0 + srcStride;
+                    src2 = src1 + srcStride;
+                    if (row == 0)
+                        src0 = src1;
+                    if (row == height - 1)
+                        src2 = src1;
+
+                    dst[0] = LaplaceAbsScalar(src0, src1, src2, 0, 0, 1);
+                    for (size_t col = 1; col < width - 1; col += A)
+                        LaplaceAbsVector(src0 + col - 1, src1 + col - 1, src2 + col - 1, dst + col, svwhilelt_b16(col, width - 1));
+                    dst[width - 1] = LaplaceAbsScalar(src0, src1, src2, width - 2, width - 1, width - 1);
+
+                    dst += dstStride;
+                }
+            }
+        }
+
+        void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            LaplaceAbs(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -930,7 +930,13 @@ namespace
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcnth();
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::LaplaceAbs), FUNC_G(SimdLaplaceAbs));
+            result = result && GrayFilterAutoTest(2, 3, View::Int16, FUNC_G(Simd::Sve2::LaplaceAbs), FUNC_G(SimdLaplaceAbs));
+            result = result && GrayFilterAutoTest(A + 1, 5, View::Int16, FUNC_G(Simd::Sve2::LaplaceAbs), FUNC_G(SimdLaplaceAbs));
+            result = result && GrayFilterAutoTest(A + 3, 7, View::Int16, FUNC_G(Simd::Sve2::LaplaceAbs), FUNC_G(SimdLaplaceAbs));
+        }
 #endif
 
 #ifdef SIMD_NEON_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Move the exported SVE2 `LaplaceAbs` implementation into `SimdSve2LaplaceAbs.cpp`.
- Add the new SVE2 source to the VS2022 project and filters.
- Extend `LaplaceAbsAutoTest` with SVE2-specific narrow and tail-width cases.
- Update release 7.2.163 notes for the new test coverage.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=LaplaceAbs -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -Isrc -std=c++11 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2LaplaceAbs.cpp`
- `aarch64-linux-gnu-g++ -Isrc -std=c++11 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Test/TestFilter.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58754363-82c1-45ca-97cb-14e1c9ab065a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58754363-82c1-45ca-97cb-14e1c9ab065a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

