### PR TITLE
Add SVE2 MaxFilterSquare5x5 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -144,6 +144,7 @@
  <li>SVE2 optimizations of function LaplaceAbsSum.</li>
  <li>SVE2 optimizations of function LbpEstimate.</li>
  <li>SVE2 optimizations of function MaxFilterSquare3x3.</li>
+ <li>SVE2 optimizations of function MaxFilterSquare5x5.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
@@ -191,6 +192,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function LaplaceAbs.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function LbpEstimate.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare3x3.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare5x5.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3778,6 +3778,11 @@ SIMD_API void SimdMaxFilterSquare5x5(const uint8_t * src, size_t srcStride, size
         Sse41::MaxFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride, threshold);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 4 && (width - 4)*channelCount >= svcntb())
+        Sve2::MaxFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride, threshold);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 2)*channelCount >= Neon::A)
         Neon::MaxFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride, threshold);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -149,6 +149,9 @@ namespace Simd
         void MaxFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
 
+        void MaxFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2MaxFilter.cpp
+++ b/src/Simd/SimdSve2MaxFilter.cpp
@@ -180,40 +180,68 @@ namespace Simd
             return num >= threshold ? max : a[12];
         }
 
-        template <size_t step> SIMD_INLINE void LoadSquare5x5(const uint8_t* y[5], size_t offset, svuint8_t a[25], const svbool_t& mask)
+        SIMD_INLINE void UpdateMax(const svuint8_t& value, svuint8_t& max, const svbool_t& mask)
         {
-            a[0] = svld1_u8(mask, y[0] + offset - 2 * step);
-            a[1] = svld1_u8(mask, y[0] + offset - step);
-            a[2] = svld1_u8(mask, y[0] + offset);
-            a[3] = svld1_u8(mask, y[0] + offset + step);
-            a[4] = svld1_u8(mask, y[0] + offset + 2 * step);
-            a[5] = svld1_u8(mask, y[1] + offset - 2 * step);
-            a[6] = svld1_u8(mask, y[1] + offset - step);
-            a[7] = svld1_u8(mask, y[1] + offset);
-            a[8] = svld1_u8(mask, y[1] + offset + step);
-            a[9] = svld1_u8(mask, y[1] + offset + 2 * step);
-            a[10] = svld1_u8(mask, y[2] + offset - 2 * step);
-            a[11] = svld1_u8(mask, y[2] + offset - step);
-            a[12] = svld1_u8(mask, y[2] + offset);
-            a[13] = svld1_u8(mask, y[2] + offset + step);
-            a[14] = svld1_u8(mask, y[2] + offset + 2 * step);
-            a[15] = svld1_u8(mask, y[3] + offset - 2 * step);
-            a[16] = svld1_u8(mask, y[3] + offset - step);
-            a[17] = svld1_u8(mask, y[3] + offset);
-            a[18] = svld1_u8(mask, y[3] + offset + step);
-            a[19] = svld1_u8(mask, y[3] + offset + 2 * step);
-            a[20] = svld1_u8(mask, y[4] + offset - 2 * step);
-            a[21] = svld1_u8(mask, y[4] + offset - step);
-            a[22] = svld1_u8(mask, y[4] + offset);
-            a[23] = svld1_u8(mask, y[4] + offset + step);
-            a[24] = svld1_u8(mask, y[4] + offset + 2 * step);
+            max = svmax_u8_x(mask, max, value);
         }
 
-        SIMD_INLINE svuint8_t Max25(svuint8_t a[25], int threshold, const svbool_t& mask)
+        SIMD_INLINE void UpdateCount(const svuint8_t& value, const svuint8_t& max, svuint8_t& count, const svuint8_t& one, const svuint8_t& zero, const svbool_t& mask)
         {
-            svuint8_t max = a[0];
-            for (int i = 1; i < 25; ++i)
-                max = svmax_u8_x(mask, max, a[i]);
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, max, value), one, zero));
+        }
+
+        template <size_t step> SIMD_INLINE svuint8_t Max25(const uint8_t* y[5], size_t offset, int threshold, const svbool_t& mask)
+        {
+            svuint8_t a00 = svld1_u8(mask, y[0] + offset - 2 * step);
+            svuint8_t a01 = svld1_u8(mask, y[0] + offset - step);
+            svuint8_t a02 = svld1_u8(mask, y[0] + offset);
+            svuint8_t a03 = svld1_u8(mask, y[0] + offset + step);
+            svuint8_t a04 = svld1_u8(mask, y[0] + offset + 2 * step);
+            svuint8_t a10 = svld1_u8(mask, y[1] + offset - 2 * step);
+            svuint8_t a11 = svld1_u8(mask, y[1] + offset - step);
+            svuint8_t a12 = svld1_u8(mask, y[1] + offset);
+            svuint8_t a13 = svld1_u8(mask, y[1] + offset + step);
+            svuint8_t a14 = svld1_u8(mask, y[1] + offset + 2 * step);
+            svuint8_t a20 = svld1_u8(mask, y[2] + offset - 2 * step);
+            svuint8_t a21 = svld1_u8(mask, y[2] + offset - step);
+            svuint8_t a22 = svld1_u8(mask, y[2] + offset);
+            svuint8_t a23 = svld1_u8(mask, y[2] + offset + step);
+            svuint8_t a24 = svld1_u8(mask, y[2] + offset + 2 * step);
+            svuint8_t a30 = svld1_u8(mask, y[3] + offset - 2 * step);
+            svuint8_t a31 = svld1_u8(mask, y[3] + offset - step);
+            svuint8_t a32 = svld1_u8(mask, y[3] + offset);
+            svuint8_t a33 = svld1_u8(mask, y[3] + offset + step);
+            svuint8_t a34 = svld1_u8(mask, y[3] + offset + 2 * step);
+            svuint8_t a40 = svld1_u8(mask, y[4] + offset - 2 * step);
+            svuint8_t a41 = svld1_u8(mask, y[4] + offset - step);
+            svuint8_t a42 = svld1_u8(mask, y[4] + offset);
+            svuint8_t a43 = svld1_u8(mask, y[4] + offset + step);
+            svuint8_t a44 = svld1_u8(mask, y[4] + offset + 2 * step);
+            svuint8_t max = a00;
+            UpdateMax(a01, max, mask);
+            UpdateMax(a02, max, mask);
+            UpdateMax(a03, max, mask);
+            UpdateMax(a04, max, mask);
+            UpdateMax(a10, max, mask);
+            UpdateMax(a11, max, mask);
+            UpdateMax(a12, max, mask);
+            UpdateMax(a13, max, mask);
+            UpdateMax(a14, max, mask);
+            UpdateMax(a20, max, mask);
+            UpdateMax(a21, max, mask);
+            UpdateMax(a22, max, mask);
+            UpdateMax(a23, max, mask);
+            UpdateMax(a24, max, mask);
+            UpdateMax(a30, max, mask);
+            UpdateMax(a31, max, mask);
+            UpdateMax(a32, max, mask);
+            UpdateMax(a33, max, mask);
+            UpdateMax(a34, max, mask);
+            UpdateMax(a40, max, mask);
+            UpdateMax(a41, max, mask);
+            UpdateMax(a42, max, mask);
+            UpdateMax(a43, max, mask);
+            UpdateMax(a44, max, mask);
 
             if (1 >= threshold)
                 return max;
@@ -221,10 +249,33 @@ namespace Simd
             svuint8_t count = svdup_n_u8(0);
             const svuint8_t one = svdup_n_u8(1);
             const svuint8_t zero = svdup_n_u8(0);
-            for (int i = 0; i < 25; ++i)
-                count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, max, a[i]), one, zero));
+            UpdateCount(a00, max, count, one, zero, mask);
+            UpdateCount(a01, max, count, one, zero, mask);
+            UpdateCount(a02, max, count, one, zero, mask);
+            UpdateCount(a03, max, count, one, zero, mask);
+            UpdateCount(a04, max, count, one, zero, mask);
+            UpdateCount(a10, max, count, one, zero, mask);
+            UpdateCount(a11, max, count, one, zero, mask);
+            UpdateCount(a12, max, count, one, zero, mask);
+            UpdateCount(a13, max, count, one, zero, mask);
+            UpdateCount(a14, max, count, one, zero, mask);
+            UpdateCount(a20, max, count, one, zero, mask);
+            UpdateCount(a21, max, count, one, zero, mask);
+            UpdateCount(a22, max, count, one, zero, mask);
+            UpdateCount(a23, max, count, one, zero, mask);
+            UpdateCount(a24, max, count, one, zero, mask);
+            UpdateCount(a30, max, count, one, zero, mask);
+            UpdateCount(a31, max, count, one, zero, mask);
+            UpdateCount(a32, max, count, one, zero, mask);
+            UpdateCount(a33, max, count, one, zero, mask);
+            UpdateCount(a34, max, count, one, zero, mask);
+            UpdateCount(a40, max, count, one, zero, mask);
+            UpdateCount(a41, max, count, one, zero, mask);
+            UpdateCount(a42, max, count, one, zero, mask);
+            UpdateCount(a43, max, count, one, zero, mask);
+            UpdateCount(a44, max, count, one, zero, mask);
 
-            return svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), max, a[12]);
+            return svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), max, a22);
         }
 
         template <size_t step> void MaxFilterSquare5x5(
@@ -238,7 +289,6 @@ namespace Simd
             const size_t end = size - 2 * step;
             const uint8_t* y[5];
             size_t x[5];
-            svuint8_t a[25];
 
             for (size_t row = 0; row < height; ++row, dst += dstStride)
             {
@@ -261,8 +311,7 @@ namespace Simd
                 for (size_t col = body; col < end; col += A)
                 {
                     svbool_t mask = svwhilelt_b8(col, end);
-                    LoadSquare5x5<step>(y, col, a, mask);
-                    svst1_u8(mask, dst + col, Max25(a, threshold, mask));
+                    svst1_u8(mask, dst + col, Max25<step>(y, col, threshold, mask));
                 }
 
                 for (size_t col = end; col < size; ++col)

--- a/src/Simd/SimdSve2MaxFilter.cpp
+++ b/src/Simd/SimdSve2MaxFilter.cpp
@@ -154,6 +154,142 @@ namespace Simd
             case 4: MaxFilterSquare3x3<4>(src, srcStride, width, height, dst, dstStride, threshold); break;
             }
         }
+
+        SIMD_INLINE uint8_t Max25(const uint8_t* y[5], size_t x[5], int threshold)
+        {
+            uint8_t a[25];
+            a[0] = y[0][x[0]]; a[1] = y[0][x[1]]; a[2] = y[0][x[2]]; a[3] = y[0][x[3]]; a[4] = y[0][x[4]];
+            a[5] = y[1][x[0]]; a[6] = y[1][x[1]]; a[7] = y[1][x[2]]; a[8] = y[1][x[3]]; a[9] = y[1][x[4]];
+            a[10] = y[2][x[0]]; a[11] = y[2][x[1]]; a[12] = y[2][x[2]]; a[13] = y[2][x[3]]; a[14] = y[2][x[4]];
+            a[15] = y[3][x[0]]; a[16] = y[3][x[1]]; a[17] = y[3][x[2]]; a[18] = y[3][x[3]]; a[19] = y[3][x[4]];
+            a[20] = y[4][x[0]]; a[21] = y[4][x[1]]; a[22] = y[4][x[2]]; a[23] = y[4][x[3]]; a[24] = y[4][x[4]];
+
+            uint8_t max = a[0];
+            for (int i = 1; i < 25; ++i)
+                max = max > a[i] ? max : a[i];
+
+            if (1 >= threshold)
+                return max;
+
+            int num = 0;
+            for (int i = 0; i < 25; ++i)
+            {
+                if (a[i] == max)
+                    ++num;
+            }
+            return num >= threshold ? max : a[12];
+        }
+
+        template <size_t step> SIMD_INLINE void LoadSquare5x5(const uint8_t* y[5], size_t offset, svuint8_t a[25], const svbool_t& mask)
+        {
+            a[0] = svld1_u8(mask, y[0] + offset - 2 * step);
+            a[1] = svld1_u8(mask, y[0] + offset - step);
+            a[2] = svld1_u8(mask, y[0] + offset);
+            a[3] = svld1_u8(mask, y[0] + offset + step);
+            a[4] = svld1_u8(mask, y[0] + offset + 2 * step);
+            a[5] = svld1_u8(mask, y[1] + offset - 2 * step);
+            a[6] = svld1_u8(mask, y[1] + offset - step);
+            a[7] = svld1_u8(mask, y[1] + offset);
+            a[8] = svld1_u8(mask, y[1] + offset + step);
+            a[9] = svld1_u8(mask, y[1] + offset + 2 * step);
+            a[10] = svld1_u8(mask, y[2] + offset - 2 * step);
+            a[11] = svld1_u8(mask, y[2] + offset - step);
+            a[12] = svld1_u8(mask, y[2] + offset);
+            a[13] = svld1_u8(mask, y[2] + offset + step);
+            a[14] = svld1_u8(mask, y[2] + offset + 2 * step);
+            a[15] = svld1_u8(mask, y[3] + offset - 2 * step);
+            a[16] = svld1_u8(mask, y[3] + offset - step);
+            a[17] = svld1_u8(mask, y[3] + offset);
+            a[18] = svld1_u8(mask, y[3] + offset + step);
+            a[19] = svld1_u8(mask, y[3] + offset + 2 * step);
+            a[20] = svld1_u8(mask, y[4] + offset - 2 * step);
+            a[21] = svld1_u8(mask, y[4] + offset - step);
+            a[22] = svld1_u8(mask, y[4] + offset);
+            a[23] = svld1_u8(mask, y[4] + offset + step);
+            a[24] = svld1_u8(mask, y[4] + offset + 2 * step);
+        }
+
+        SIMD_INLINE svuint8_t Max25(svuint8_t a[25], int threshold, const svbool_t& mask)
+        {
+            svuint8_t max = a[0];
+            for (int i = 1; i < 25; ++i)
+                max = svmax_u8_x(mask, max, a[i]);
+
+            if (1 >= threshold)
+                return max;
+
+            svuint8_t count = svdup_n_u8(0);
+            const svuint8_t one = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+            for (int i = 0; i < 25; ++i)
+                count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, max, a[i]), one, zero));
+
+            return svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), max, a[12]);
+        }
+
+        template <size_t step> void MaxFilterSquare5x5(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, int threshold)
+        {
+            assert(width > 4 && step * (width - 4) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t body = 2 * step;
+            const size_t end = size - 2 * step;
+            const uint8_t* y[5];
+            size_t x[5];
+            svuint8_t a[25];
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[2] = src + srcStride * row;
+                y[1] = row ? y[2] - srcStride : y[2];
+                y[0] = row > 1 ? y[2] - 2 * srcStride : y[1];
+                y[3] = row + 1 < height ? y[2] + srcStride : y[2];
+                y[4] = row + 2 < height ? y[2] + 2 * srcStride : y[3];
+
+                for (size_t col = 0; col < body; ++col)
+                {
+                    x[0] = col < step ? col : col - step;
+                    x[1] = x[0];
+                    x[2] = col;
+                    x[3] = col + step;
+                    x[4] = col + 2 * step;
+                    dst[col] = Max25(y, x, threshold);
+                }
+
+                for (size_t col = body; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    LoadSquare5x5<step>(y, col, a, mask);
+                    svst1_u8(mask, dst + col, Max25(a, threshold, mask));
+                }
+
+                for (size_t col = end; col < size; ++col)
+                {
+                    x[0] = col - 2 * step;
+                    x[1] = col - step;
+                    x[2] = col;
+                    x[3] = col + step < size ? col + step : col;
+                    x[4] = col + 2 * step < size ? col + 2 * step : x[3];
+                    dst[col] = Max25(y, x, threshold);
+                }
+            }
+        }
+
+        void MaxFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride, int threshold)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MaxFilterSquare5x5<1>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 2: MaxFilterSquare5x5<2>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 3: MaxFilterSquare5x5<3>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 4: MaxFilterSquare5x5<4>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -202,6 +202,11 @@ namespace Test
             result = result && LimitFilterAutoTest(FUNC_LM(Simd::Avx512bw::MaxFilterSquare5x5), FUNC_LM(SimdMaxFilterSquare5x5));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 4)
+            result = result && LimitFilterAutoTest(FUNC_LM(Simd::Sve2::MaxFilterSquare5x5), FUNC_LM(SimdMaxFilterSquare5x5));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 2 >= Simd::Neon::A)
             result = result && LimitFilterAutoTest(FUNC_LM(Simd::Neon::MaxFilterSquare5x5), FUNC_LM(SimdMaxFilterSquare5x5));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `MaxFilterSquare5x5`.
- Extend SVE2 autotest coverage for `MaxFilterSquare5x5`.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `./Test "-r=.." -fi=MaxFilterSquare5x5 -tt=1 -ts=1` from `build/`
- `aarch64-linux-gnu-g++ -I src -fPIC -std=c++11 -O3 -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2MaxFilter.cpp -o /tmp/SimdSve2MaxFilter.o`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DSIMD_TARGET=aarch64 -DSIMD_SVE=ON -DSIMD_SVE2=ON -DSIMD_SHARED=OFF -DSIMD_PYTHON=OFF -DSIMD_INSTALL=OFF && cmake --build build-aarch64-sve2 --parallel$(nproc)`
- `QEMU_CPU=max qemu-aarch64 -L /usr/aarch64-linux-gnu ./Test "-r=.." -fi=MaxFilterSquare5x5 -tt=1 -ts=1` from `build-aarch64-sve2/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4975e28b-0ed2-4518-9e2c-c980ae8ee5fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4975e28b-0ed2-4518-9e2c-c980ae8ee5fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

