### PR TITLE
Add SVE2 MeanFilter3x3 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -145,6 +145,7 @@
  <li>SVE2 optimizations of function LbpEstimate.</li>
  <li>SVE2 optimizations of function MaxFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MaxFilterSquare5x5.</li>
+ <li>SVE2 optimizations of function MeanFilter3x3.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
@@ -193,6 +194,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function LbpEstimate.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare5x5.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -64,6 +64,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Laplace.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Lbp.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MaxFilter.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2MeanFilter3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -260,6 +260,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MaxFilter.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2MeanFilter3x3.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3861,6 +3861,11 @@ SIMD_API void SimdMeanFilter3x3(const uint8_t * src, size_t srcStride, size_t wi
         Sse41::MeanFilter3x3(src, srcStride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::MeanFilter3x3(src, srcStride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 1)*channelCount >= Neon::A)
         Neon::MeanFilter3x3(src, srcStride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -152,6 +152,9 @@ namespace Simd
         void MaxFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
 
+        void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2MeanFilter3x3.cpp
+++ b/src/Simd/SimdSve2MeanFilter3x3.cpp
@@ -1,0 +1,133 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdConst.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE uint8_t DivideBy9(size_t value)
+        {
+            return uint8_t(((value + 5) * Base::DIVISION_BY_9_FACTOR) >> Base::DIVISION_BY_9_SHIFT);
+        }
+
+        SIMD_INLINE svuint16_t DivideBy9(const svuint16_t& value)
+        {
+            const svbool_t mask = svptrue_b32();
+            svuint16_t value5 = svadd_n_u16_x(svptrue_b16(), value, 5);
+            svuint32_t lo = svlsr_n_u32_x(mask, svmul_n_u32_x(mask, svunpklo_u32(value5),
+                Base::DIVISION_BY_9_FACTOR), Base::DIVISION_BY_9_SHIFT);
+            svuint32_t hi = svlsr_n_u32_x(mask, svmul_n_u32_x(mask, svunpkhi_u32(value5),
+                Base::DIVISION_BY_9_FACTOR), Base::DIVISION_BY_9_SHIFT);
+            return svuzp1_u16(svreinterpret_u16_u32(lo), svreinterpret_u16_u32(hi));
+        }
+
+        SIMD_INLINE svuint16_t RowSumLo(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svadd_u16_x(mask, svunpklo_u16(left), svunpklo_u16(center)), svunpklo_u16(right));
+        }
+
+        SIMD_INLINE svuint16_t RowSumHi(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
+        {
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svadd_u16_x(mask, svunpkhi_u16(left), svunpkhi_u16(center)), svunpkhi_u16(right));
+        }
+
+        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        {
+            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+        }
+
+        SIMD_INLINE void MeanFilter3x3(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            size_t step, uint8_t* dst, const svbool_t& mask8)
+        {
+            const svbool_t mask16 = svptrue_b16();
+            svuint8_t left0 = svld1_u8(mask8, src0 - step);
+            svuint8_t center0 = svld1_u8(mask8, src0);
+            svuint8_t right0 = svld1_u8(mask8, src0 + step);
+            svuint8_t left1 = svld1_u8(mask8, src1 - step);
+            svuint8_t center1 = svld1_u8(mask8, src1);
+            svuint8_t right1 = svld1_u8(mask8, src1 + step);
+            svuint8_t left2 = svld1_u8(mask8, src2 - step);
+            svuint8_t center2 = svld1_u8(mask8, src2);
+            svuint8_t right2 = svld1_u8(mask8, src2 + step);
+            svuint16_t lo = svadd_u16_x(mask16, svadd_u16_x(mask16, RowSumLo(left0, center0, right0),
+                RowSumLo(left1, center1, right1)), RowSumLo(left2, center2, right2));
+            svuint16_t hi = svadd_u16_x(mask16, svadd_u16_x(mask16, RowSumHi(left0, center0, right0),
+                RowSumHi(left1, center1, right1)), RowSumHi(left2, center2, right2));
+            svst1_u8(mask8, dst, PackU16ToU8(DivideBy9(lo), DivideBy9(hi)));
+        }
+
+        template <size_t step> void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            size_t size = width * step;
+            for (size_t row = 0; row < height; ++row)
+            {
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = row + 1 < height ? src1 + srcStride : src1;
+                if (width == 1)
+                {
+                    for (size_t col = 0; col < step; ++col)
+                        dst[col] = DivideBy9((src0[col] + src1[col] + src2[col]) * 3);
+                }
+                else
+                {
+                    for (size_t col = 0; col < step; ++col)
+                        dst[col] = DivideBy9(src0[col] + src0[col] + src0[col + step] +
+                            src1[col] + src1[col] + src1[col + step] +
+                            src2[col] + src2[col] + src2[col + step]);
+
+                    const size_t end = size - step, A = svcntb();
+                    size_t col = step;
+                    for (; col < end; col += A)
+                        MeanFilter3x3(src0 + col, src1 + col, src2 + col, step, dst + col, svwhilelt_b8(col, end));
+
+                    for (col = end; col < size; ++col)
+                        dst[col] = DivideBy9(src0[col - step] + src0[col] + src0[col] +
+                            src1[col - step] + src1[col] + src1[col] +
+                            src2[col - step] + src2[col] + src2[col]);
+                }
+                dst += dstStride;
+            }
+        }
+
+        void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MeanFilter3x3<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: MeanFilter3x3<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: MeanFilter3x3<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: MeanFilter3x3<4>(src, srcStride, width, height, dst, dstStride); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -358,6 +358,11 @@ namespace
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Avx512bw::MeanFilter3x3), FUNC_C(SimdMeanFilter3x3));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ColorFilterAutoTest(FUNC_C(Simd::Sve2::MeanFilter3x3), FUNC_C(SimdMeanFilter3x3));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Neon::MeanFilter3x3), FUNC_C(SimdMeanFilter3x3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdMeanFilter3x3` and dispatch it from the public API.
- Add SVE2 coverage to `MeanFilter3x3AutoTest`.
- Register the new source in VS2022 SVE2 project files and update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=MeanFilter3x3 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -fsyntax-only -I./src ./src/Simd/SimdSve2MeanFilter3x3.cpp`
- `clang++ --target=aarch64-linux-gnu -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -fsyntax-only -I./src ./src/Simd/SimdSve2MeanFilter3x3.cpp && aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -c -I./src ./src/Simd/SimdSve2MeanFilter3x3.cpp -o /tmp/SimdSve2MeanFilter3x3.o`
- Temporary QEMU harness: `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -O2 -static -I./src ./build-aarch64-sve2/mean_filter_sve2_harness.cpp ./src/Simd/SimdSve2MeanFilter3x3.cpp -o ./build-aarch64-sve2/mean_filter_sve2_harness && qemu-aarch64 -cpu max ./build-aarch64-sve2/mean_filter_sve2_harness`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f0e3f17-47bc-4e08-9bd7-8732514781ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f0e3f17-47bc-4e08-9bd7-8732514781ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

