### PR TITLE
Add SVE2 MinFilterSquare3x3 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -145,6 +145,7 @@
  <li>SVE2 optimizations of function LbpEstimate.</li>
  <li>SVE2 optimizations of function MaxFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MaxFilterSquare5x5.</li>
+ <li>SVE2 optimizations of function MinFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MeanFilter3x3.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
@@ -194,6 +195,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function LbpEstimate.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare5x5.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function MinFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
 </ul>
 <h5>Bug fixing</h5>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Lbp.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MaxFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MeanFilter3x3.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -263,6 +263,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MeanFilter3x3.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3809,6 +3809,11 @@ SIMD_API void SimdMinFilterSquare3x3(const uint8_t * src, size_t srcStride, size
         Sse41::MinFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride, threshold);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 2 && (width - 2)*channelCount >= svcntb())
+        Sve2::MinFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride, threshold);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 1)*channelCount >= Neon::A)
         Neon::MinFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride, threshold);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -152,6 +152,9 @@ namespace Simd
         void MaxFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
 
+        void MinFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
+
         void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2MinFilter.cpp
+++ b/src/Simd/SimdSve2MinFilter.cpp
@@ -1,0 +1,159 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE uint8_t Min9(const uint8_t* y[3], size_t x[3], int threshold)
+        {
+            uint8_t a[9];
+            a[0] = y[0][x[0]]; a[1] = y[0][x[1]]; a[2] = y[0][x[2]];
+            a[3] = y[1][x[0]]; a[4] = y[1][x[1]]; a[5] = y[1][x[2]];
+            a[6] = y[2][x[0]]; a[7] = y[2][x[1]]; a[8] = y[2][x[2]];
+
+            uint8_t min = a[0];
+            for (int i = 1; i < 9; ++i)
+                min = min < a[i] ? min : a[i];
+
+            if (1 >= threshold)
+                return min;
+
+            int num = 0;
+            for (int i = 0; i < 9; ++i)
+            {
+                if (a[i] == min)
+                    ++num;
+            }
+            return num >= threshold ? min : a[4];
+        }
+
+        template <size_t step> SIMD_INLINE void LoadMinSquare3x3(const uint8_t* y[3], size_t offset,
+            svuint8_t& a0, svuint8_t& a1, svuint8_t& a2, svuint8_t& a3, svuint8_t& a4, svuint8_t& a5, svuint8_t& a6, svuint8_t& a7, svuint8_t& a8,
+            const svbool_t& mask)
+        {
+            a0 = svld1_u8(mask, y[0] + offset - step);
+            a1 = svld1_u8(mask, y[0] + offset);
+            a2 = svld1_u8(mask, y[0] + offset + step);
+            a3 = svld1_u8(mask, y[1] + offset - step);
+            a4 = svld1_u8(mask, y[1] + offset);
+            a5 = svld1_u8(mask, y[1] + offset + step);
+            a6 = svld1_u8(mask, y[2] + offset - step);
+            a7 = svld1_u8(mask, y[2] + offset);
+            a8 = svld1_u8(mask, y[2] + offset + step);
+        }
+
+        SIMD_INLINE svuint8_t Min9(const svuint8_t& a0, const svuint8_t& a1, const svuint8_t& a2, const svuint8_t& a3, const svuint8_t& a4,
+            const svuint8_t& a5, const svuint8_t& a6, const svuint8_t& a7, const svuint8_t& a8, int threshold, const svbool_t& mask)
+        {
+            svuint8_t min = a0;
+            min = svmin_u8_x(mask, min, a1);
+            min = svmin_u8_x(mask, min, a2);
+            min = svmin_u8_x(mask, min, a3);
+            min = svmin_u8_x(mask, min, a4);
+            min = svmin_u8_x(mask, min, a5);
+            min = svmin_u8_x(mask, min, a6);
+            min = svmin_u8_x(mask, min, a7);
+            min = svmin_u8_x(mask, min, a8);
+
+            if (1 >= threshold)
+                return min;
+
+            svuint8_t count = svdup_n_u8(0);
+            const svuint8_t one = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a0), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a1), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a2), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a3), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a4), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a5), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a6), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a7), one, zero));
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, a8), one, zero));
+
+            return svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), min, a4);
+        }
+
+        template <size_t step> void MinFilterSquare3x3(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, int threshold)
+        {
+            assert(width > 2 && step * (width - 2) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t end = size - step;
+            const uint8_t* y[3];
+            size_t x[3];
+            svuint8_t a0, a1, a2, a3, a4, a5, a6, a7, a8;
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[1] = src + srcStride * row;
+                y[0] = row ? y[1] - srcStride : y[1];
+                y[2] = row + 1 < height ? y[1] + srcStride : y[1];
+
+                for (size_t col = 0; col < step; ++col)
+                {
+                    x[0] = col;
+                    x[1] = col;
+                    x[2] = col + step;
+                    dst[col] = Min9(y, x, threshold);
+                }
+
+                for (size_t col = step; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    LoadMinSquare3x3<step>(y, col, a0, a1, a2, a3, a4, a5, a6, a7, a8, mask);
+                    svst1_u8(mask, dst + col, Min9(a0, a1, a2, a3, a4, a5, a6, a7, a8, threshold, mask));
+                }
+
+                for (size_t col = end; col < size; ++col)
+                {
+                    x[0] = col - step;
+                    x[1] = col;
+                    x[2] = col;
+                    dst[col] = Min9(y, x, threshold);
+                }
+            }
+        }
+
+        void MinFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride, int threshold)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MinFilterSquare3x3<1>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 2: MinFilterSquare3x3<2>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 3: MinFilterSquare3x3<3>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 4: MinFilterSquare3x3<4>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -242,6 +242,11 @@ namespace Test
             result = result && LimitFilterAutoTest(FUNC_LM(Simd::Avx512bw::MinFilterSquare3x3), FUNC_LM(SimdMinFilterSquare3x3));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 2)
+            result = result && LimitFilterAutoTest(FUNC_LM(Simd::Sve2::MinFilterSquare3x3), FUNC_LM(SimdMinFilterSquare3x3));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && LimitFilterAutoTest(FUNC_LM(Simd::Neon::MinFilterSquare3x3), FUNC_LM(SimdMinFilterSquare3x3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `MinFilterSquare3x3` with scalar border handling and masked scalable-vector body processing.
- Route `SimdMinFilterSquare3x3` through the SVE2 implementation when available.
- Add SVE2 auto-test coverage and update VS2022 SVE2 project files and 7.2.163 release notes.

### Testing
- `cmake --build build --target Simd --parallel2`
- `cmake --build build --target Test --parallel2`
- `./build/Test "-r=." -fi=MinFilterSquare3x3 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src -std=c++11 -fsyntax-only src/Simd/SimdSve2MinFilter.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src -std=c++11 -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src -std=c++11 -D_GLIBCXX_USE_NANOSLEEP -fsyntax-only src/Test/TestFilter.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1799a4c8-8521-4a41-9aad-8c7080664abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1799a4c8-8521-4a41-9aad-8c7080664abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

