### PR TITLE
Add SVE2 MinFilterSquare5x5 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -114,6 +114,7 @@
  <li>SVE2 optimizations of function AbsSecondDerivativeHistogram.</li>
  <li>SVE2 optimizations of function HistogramMasked.</li>
  <li>SVE2 optimizations of function HistogramConditional.</li>
+ <li>SVE2 optimizations of function MinFilterSquare5x5.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3840,6 +3840,11 @@ SIMD_API void SimdMinFilterSquare5x5(const uint8_t * src, size_t srcStride, size
         Sse41::MinFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride, threshold);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 4 && (width - 4)*channelCount >= svcntb())
+        Sve2::MinFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride, threshold);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 2)*channelCount >= Neon::A)
         Neon::MinFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride, threshold);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -155,6 +155,9 @@ namespace Simd
         void MinFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
 
+        void MinFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
+
         void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2MinFilter.cpp
+++ b/src/Simd/SimdSve2MinFilter.cpp
@@ -154,6 +154,191 @@ namespace Simd
             case 4: MinFilterSquare3x3<4>(src, srcStride, width, height, dst, dstStride, threshold); break;
             }
         }
+
+        SIMD_INLINE uint8_t Min25(const uint8_t* y[5], size_t x[5], int threshold)
+        {
+            uint8_t a[25];
+            a[0] = y[0][x[0]]; a[1] = y[0][x[1]]; a[2] = y[0][x[2]]; a[3] = y[0][x[3]]; a[4] = y[0][x[4]];
+            a[5] = y[1][x[0]]; a[6] = y[1][x[1]]; a[7] = y[1][x[2]]; a[8] = y[1][x[3]]; a[9] = y[1][x[4]];
+            a[10] = y[2][x[0]]; a[11] = y[2][x[1]]; a[12] = y[2][x[2]]; a[13] = y[2][x[3]]; a[14] = y[2][x[4]];
+            a[15] = y[3][x[0]]; a[16] = y[3][x[1]]; a[17] = y[3][x[2]]; a[18] = y[3][x[3]]; a[19] = y[3][x[4]];
+            a[20] = y[4][x[0]]; a[21] = y[4][x[1]]; a[22] = y[4][x[2]]; a[23] = y[4][x[3]]; a[24] = y[4][x[4]];
+
+            uint8_t min = a[0];
+            for (int i = 1; i < 25; ++i)
+                min = min < a[i] ? min : a[i];
+
+            if (1 >= threshold)
+                return min;
+
+            int num = 0;
+            for (int i = 0; i < 25; ++i)
+            {
+                if (a[i] == min)
+                    ++num;
+            }
+            return num >= threshold ? min : a[12];
+        }
+
+        SIMD_INLINE void UpdateMin(const svuint8_t& value, svuint8_t& min, const svbool_t& mask)
+        {
+            min = svmin_u8_x(mask, min, value);
+        }
+
+        SIMD_INLINE void UpdateCount(const svuint8_t& value, const svuint8_t& min, svuint8_t& count, const svuint8_t& one, const svuint8_t& zero, const svbool_t& mask)
+        {
+            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, value), one, zero));
+        }
+
+        template <size_t step> SIMD_INLINE svuint8_t Min25(const uint8_t* y[5], size_t offset, int threshold, const svbool_t& mask)
+        {
+            svuint8_t a00 = svld1_u8(mask, y[0] + offset - 2 * step);
+            svuint8_t a01 = svld1_u8(mask, y[0] + offset - step);
+            svuint8_t a02 = svld1_u8(mask, y[0] + offset);
+            svuint8_t a03 = svld1_u8(mask, y[0] + offset + step);
+            svuint8_t a04 = svld1_u8(mask, y[0] + offset + 2 * step);
+            svuint8_t a10 = svld1_u8(mask, y[1] + offset - 2 * step);
+            svuint8_t a11 = svld1_u8(mask, y[1] + offset - step);
+            svuint8_t a12 = svld1_u8(mask, y[1] + offset);
+            svuint8_t a13 = svld1_u8(mask, y[1] + offset + step);
+            svuint8_t a14 = svld1_u8(mask, y[1] + offset + 2 * step);
+            svuint8_t a20 = svld1_u8(mask, y[2] + offset - 2 * step);
+            svuint8_t a21 = svld1_u8(mask, y[2] + offset - step);
+            svuint8_t a22 = svld1_u8(mask, y[2] + offset);
+            svuint8_t a23 = svld1_u8(mask, y[2] + offset + step);
+            svuint8_t a24 = svld1_u8(mask, y[2] + offset + 2 * step);
+            svuint8_t a30 = svld1_u8(mask, y[3] + offset - 2 * step);
+            svuint8_t a31 = svld1_u8(mask, y[3] + offset - step);
+            svuint8_t a32 = svld1_u8(mask, y[3] + offset);
+            svuint8_t a33 = svld1_u8(mask, y[3] + offset + step);
+            svuint8_t a34 = svld1_u8(mask, y[3] + offset + 2 * step);
+            svuint8_t a40 = svld1_u8(mask, y[4] + offset - 2 * step);
+            svuint8_t a41 = svld1_u8(mask, y[4] + offset - step);
+            svuint8_t a42 = svld1_u8(mask, y[4] + offset);
+            svuint8_t a43 = svld1_u8(mask, y[4] + offset + step);
+            svuint8_t a44 = svld1_u8(mask, y[4] + offset + 2 * step);
+            svuint8_t min = a00;
+            UpdateMin(a01, min, mask);
+            UpdateMin(a02, min, mask);
+            UpdateMin(a03, min, mask);
+            UpdateMin(a04, min, mask);
+            UpdateMin(a10, min, mask);
+            UpdateMin(a11, min, mask);
+            UpdateMin(a12, min, mask);
+            UpdateMin(a13, min, mask);
+            UpdateMin(a14, min, mask);
+            UpdateMin(a20, min, mask);
+            UpdateMin(a21, min, mask);
+            UpdateMin(a22, min, mask);
+            UpdateMin(a23, min, mask);
+            UpdateMin(a24, min, mask);
+            UpdateMin(a30, min, mask);
+            UpdateMin(a31, min, mask);
+            UpdateMin(a32, min, mask);
+            UpdateMin(a33, min, mask);
+            UpdateMin(a34, min, mask);
+            UpdateMin(a40, min, mask);
+            UpdateMin(a41, min, mask);
+            UpdateMin(a42, min, mask);
+            UpdateMin(a43, min, mask);
+            UpdateMin(a44, min, mask);
+
+            if (1 >= threshold)
+                return min;
+
+            svuint8_t count = svdup_n_u8(0);
+            const svuint8_t one = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+            UpdateCount(a00, min, count, one, zero, mask);
+            UpdateCount(a01, min, count, one, zero, mask);
+            UpdateCount(a02, min, count, one, zero, mask);
+            UpdateCount(a03, min, count, one, zero, mask);
+            UpdateCount(a04, min, count, one, zero, mask);
+            UpdateCount(a10, min, count, one, zero, mask);
+            UpdateCount(a11, min, count, one, zero, mask);
+            UpdateCount(a12, min, count, one, zero, mask);
+            UpdateCount(a13, min, count, one, zero, mask);
+            UpdateCount(a14, min, count, one, zero, mask);
+            UpdateCount(a20, min, count, one, zero, mask);
+            UpdateCount(a21, min, count, one, zero, mask);
+            UpdateCount(a22, min, count, one, zero, mask);
+            UpdateCount(a23, min, count, one, zero, mask);
+            UpdateCount(a24, min, count, one, zero, mask);
+            UpdateCount(a30, min, count, one, zero, mask);
+            UpdateCount(a31, min, count, one, zero, mask);
+            UpdateCount(a32, min, count, one, zero, mask);
+            UpdateCount(a33, min, count, one, zero, mask);
+            UpdateCount(a34, min, count, one, zero, mask);
+            UpdateCount(a40, min, count, one, zero, mask);
+            UpdateCount(a41, min, count, one, zero, mask);
+            UpdateCount(a42, min, count, one, zero, mask);
+            UpdateCount(a43, min, count, one, zero, mask);
+            UpdateCount(a44, min, count, one, zero, mask);
+
+            return svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), min, a22);
+        }
+
+        template <size_t step> void MinFilterSquare5x5(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, int threshold)
+        {
+            assert(width > 4 && step * (width - 4) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t body = 2 * step;
+            const size_t end = size - 2 * step;
+            const uint8_t* y[5];
+            size_t x[5];
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[2] = src + srcStride * row;
+                y[1] = row ? y[2] - srcStride : y[2];
+                y[0] = row > 1 ? y[2] - 2 * srcStride : y[1];
+                y[3] = row + 1 < height ? y[2] + srcStride : y[2];
+                y[4] = row + 2 < height ? y[2] + 2 * srcStride : y[3];
+
+                for (size_t col = 0; col < body; ++col)
+                {
+                    x[0] = col < step ? col : col - step;
+                    x[1] = x[0];
+                    x[2] = col;
+                    x[3] = col + step;
+                    x[4] = col + 2 * step;
+                    dst[col] = Min25(y, x, threshold);
+                }
+
+                for (size_t col = body; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    svst1_u8(mask, dst + col, Min25<step>(y, col, threshold, mask));
+                }
+
+                for (size_t col = end; col < size; ++col)
+                {
+                    x[0] = col - 2 * step;
+                    x[1] = col - step;
+                    x[2] = col;
+                    x[3] = col + step < size ? col + step : col;
+                    x[4] = col + 2 * step < size ? col + 2 * step : x[3];
+                    dst[col] = Min25(y, x, threshold);
+                }
+            }
+        }
+
+        void MinFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride, int threshold)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MinFilterSquare5x5<1>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 2: MinFilterSquare5x5<2>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 3: MinFilterSquare5x5<3>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            case 4: MinFilterSquare5x5<4>(src, srcStride, width, height, dst, dstStride, threshold); break;
+            }
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSve2MinFilter.cpp
+++ b/src/Simd/SimdSve2MinFilter.cpp
@@ -298,30 +298,31 @@ namespace Simd
                 y[3] = row + 1 < height ? y[2] + srcStride : y[2];
                 y[4] = row + 2 < height ? y[2] + 2 * srcStride : y[3];
 
-                for (size_t col = 0; col < body; ++col)
+                for (size_t col = 0; col < 2 * body; ++col)
                 {
-                    x[0] = col < step ? col : col - step;
-                    x[1] = x[0];
-                    x[2] = col;
-                    x[3] = col + step;
-                    x[4] = col + 2 * step;
-                    dst[col] = Min25(y, x, threshold);
+                    if (col < body)
+                    {
+                        x[0] = col < step ? col : col - step;
+                        x[1] = x[0];
+                        x[2] = col;
+                        x[3] = x[2] + step;
+                        x[4] = x[3] + step;
+                    }
+                    else
+                    {
+                        x[0] = size - 6 * step + col;
+                        x[1] = x[0] + step;
+                        x[2] = x[1] + step;
+                        x[3] = col < 3 * step ? x[2] + step : x[2];
+                        x[4] = x[3];
+                    }
+                    dst[x[2]] = Min25(y, x, threshold);
                 }
 
                 for (size_t col = body; col < end; col += A)
                 {
                     svbool_t mask = svwhilelt_b8(col, end);
                     svst1_u8(mask, dst + col, Min25<step>(y, col, threshold, mask));
-                }
-
-                for (size_t col = end; col < size; ++col)
-                {
-                    x[0] = col - 2 * step;
-                    x[1] = col - step;
-                    x[2] = col;
-                    x[3] = col + step < size ? col + step : col;
-                    x[4] = col + 2 * step < size ? col + 2 * step : x[3];
-                    dst[col] = Min25(y, x, threshold);
                 }
             }
         }

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -277,6 +277,11 @@ namespace Test
             result = result && LimitFilterAutoTest(FUNC_LM(Simd::Avx512bw::MinFilterSquare5x5), FUNC_LM(SimdMinFilterSquare5x5));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 4)
+            result = result && LimitFilterAutoTest(FUNC_LM(Simd::Sve2::MinFilterSquare5x5), FUNC_LM(SimdMinFilterSquare5x5));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 2 >= Simd::Neon::A)
             result = result && LimitFilterAutoTest(FUNC_LM(Simd::Neon::MinFilterSquare5x5), FUNC_LM(SimdMinFilterSquare5x5));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Added SVE2 implementation and dispatch for `SimdMinFilterSquare5x5`.
* Added SVE2 auto-test coverage for `MinFilterSquare5x5`.
* Updated 7.2.163 release notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=MinFilterSquare5x5 -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ ... -march=armv9-a+sve2 ... -c src/Simd/SimdSve2MinFilter.cpp`
* `aarch64-linux-gnu-g++ ... -march=armv9-a+sve2 ... -c src/Simd/SimdLib.cpp && ... src/Test/TestFilter.cpp`
* QEMU AArch64 comparison of `Base::MinFilterSquare5x5` vs `Sve2::MinFilterSquare5x5` over channel counts 1..4, widths 70/73/128, heights 5/17, thresholds 1/2/3/5/9.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d9905a9-bcad-4436-b1f8-5d8206607748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d9905a9-bcad-4436-b1f8-5d8206607748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

