### PR TITLE
Add SVE2 midpoint square3x3 filter

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -148,6 +148,7 @@
  <li>SVE2 optimizations of function MaxFilterSquare5x5.</li>
  <li>SVE2 optimizations of function MinFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MeanFilter3x3.</li>
+ <li>SVE2 optimizations of function MidpointFilterSquare3x3.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
@@ -198,6 +199,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare5x5.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MinFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Lbp.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MaxFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MeanFilter3x3.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2MidpointFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -263,6 +263,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MeanFilter3x3.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2MidpointFilter.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4006,6 +4006,11 @@ SIMD_API void SimdMidpointFilterSquare3x3(const uint8_t * src, size_t srcStride,
         Sse41::MidpointFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 2 && (width - 2)*channelCount >= svcntb())
+        Sve2::MidpointFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 1)*channelCount >= Neon::A)
         Neon::MidpointFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -161,6 +161,9 @@ namespace Simd
         void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void MidpointFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2MidpointFilter.cpp
+++ b/src/Simd/SimdSve2MidpointFilter.cpp
@@ -1,0 +1,143 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE uint8_t Midpoint9(const uint8_t* y[3], size_t x[3])
+        {
+            uint8_t a[9];
+            a[0] = y[0][x[0]]; a[1] = y[0][x[1]]; a[2] = y[0][x[2]];
+            a[3] = y[1][x[0]]; a[4] = y[1][x[1]]; a[5] = y[1][x[2]];
+            a[6] = y[2][x[0]]; a[7] = y[2][x[1]]; a[8] = y[2][x[2]];
+
+            uint8_t min = a[0], max = a[0];
+            for (int i = 1; i < 9; ++i)
+            {
+                min = min < a[i] ? min : a[i];
+                max = max > a[i] ? max : a[i];
+            }
+            return uint8_t((min + max + 1) >> 1);
+        }
+
+        template <size_t step> SIMD_INLINE void LoadSquare3x3(const uint8_t* y[3], size_t offset,
+            svuint8_t& a0, svuint8_t& a1, svuint8_t& a2, svuint8_t& a3, svuint8_t& a4, svuint8_t& a5, svuint8_t& a6, svuint8_t& a7, svuint8_t& a8,
+            const svbool_t& mask)
+        {
+            a0 = svld1_u8(mask, y[0] + offset - step);
+            a1 = svld1_u8(mask, y[0] + offset);
+            a2 = svld1_u8(mask, y[0] + offset + step);
+            a3 = svld1_u8(mask, y[1] + offset - step);
+            a4 = svld1_u8(mask, y[1] + offset);
+            a5 = svld1_u8(mask, y[1] + offset + step);
+            a6 = svld1_u8(mask, y[2] + offset - step);
+            a7 = svld1_u8(mask, y[2] + offset);
+            a8 = svld1_u8(mask, y[2] + offset + step);
+        }
+
+        SIMD_INLINE svuint8_t Midpoint9(const svuint8_t& a0, const svuint8_t& a1, const svuint8_t& a2, const svuint8_t& a3, const svuint8_t& a4,
+            const svuint8_t& a5, const svuint8_t& a6, const svuint8_t& a7, const svuint8_t& a8, const svbool_t& mask)
+        {
+            svuint8_t min = a0, max = a0;
+            min = svmin_u8_x(mask, min, a1);
+            max = svmax_u8_x(mask, max, a1);
+            min = svmin_u8_x(mask, min, a2);
+            max = svmax_u8_x(mask, max, a2);
+            min = svmin_u8_x(mask, min, a3);
+            max = svmax_u8_x(mask, max, a3);
+            min = svmin_u8_x(mask, min, a4);
+            max = svmax_u8_x(mask, max, a4);
+            min = svmin_u8_x(mask, min, a5);
+            max = svmax_u8_x(mask, max, a5);
+            min = svmin_u8_x(mask, min, a6);
+            max = svmax_u8_x(mask, max, a6);
+            min = svmin_u8_x(mask, min, a7);
+            max = svmax_u8_x(mask, max, a7);
+            min = svmin_u8_x(mask, min, a8);
+            max = svmax_u8_x(mask, max, a8);
+            return svrhadd_u8_x(mask, min, max);
+        }
+
+        template <size_t step> void MidpointFilterSquare3x3(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > 2 && step * (width - 2) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t end = size - step;
+            const uint8_t* y[3];
+            size_t x[3];
+            svuint8_t a0, a1, a2, a3, a4, a5, a6, a7, a8;
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[1] = src + srcStride * row;
+                y[0] = row ? y[1] - srcStride : y[1];
+                y[2] = row + 1 < height ? y[1] + srcStride : y[1];
+
+                for (size_t col = 0; col < step; ++col)
+                {
+                    x[0] = col;
+                    x[1] = col;
+                    x[2] = col + step;
+                    dst[col] = Midpoint9(y, x);
+                }
+
+                for (size_t col = step; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    LoadSquare3x3<step>(y, col, a0, a1, a2, a3, a4, a5, a6, a7, a8, mask);
+                    svst1_u8(mask, dst + col, Midpoint9(a0, a1, a2, a3, a4, a5, a6, a7, a8, mask));
+                }
+
+                for (size_t col = end; col < size; ++col)
+                {
+                    x[0] = col - step;
+                    x[1] = col;
+                    x[2] = col;
+                    dst[col] = Midpoint9(y, x);
+                }
+            }
+        }
+
+        void MidpointFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MidpointFilterSquare3x3<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: MidpointFilterSquare3x3<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: MidpointFilterSquare3x3<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: MidpointFilterSquare3x3<4>(src, srcStride, width, height, dst, dstStride); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -528,6 +528,11 @@ namespace
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Avx512bw::MidpointFilterSquare3x3), FUNC_C(SimdMidpointFilterSquare3x3));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 2)
+            result = result && ColorFilterAutoTest(FUNC_C(Simd::Sve2::MidpointFilterSquare3x3), FUNC_C(SimdMidpointFilterSquare3x3));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Neon::MidpointFilterSquare3x3), FUNC_C(SimdMidpointFilterSquare3x3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 optimization for `MidpointFilterSquare3x3` and route runtime dispatch to it when available.
- Extend midpoint square3x3 auto-tests to cover SVE2.
- Add the new SVE2 source to VS2022 project files and release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=MidpointFilterSquare3x3 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I/workspace/src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only /workspace/src/Simd/SimdSve2MidpointFilter.cpp`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="aarch64-linux-gnu-g++" -DSIMD_TARGET="aarch64" -DSIMD_SVE2=ON -DSIMD_SHARED=ON`
- `cmake --build build-aarch64-sve2 --target Simd --parallel$(nproc)`

Note: full AArch64 `Test` executable link was not used as a pass criterion because this checkout currently references existing SVE symbols while configuring only SVE2; the `Simd` library target compiled and linked successfully, including the new midpoint SVE2 source.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c44f0b1d-03f0-4b0a-a659-d6539a0c7171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c44f0b1d-03f0-4b0a-a659-d6539a0c7171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

