### PR TITLE
Add SVE2 midpoint square5x5 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -149,6 +149,7 @@
  <li>SVE2 optimizations of function MinFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MeanFilter3x3.</li>
  <li>SVE2 optimizations of function MidpointFilterSquare3x3.</li>
+ <li>SVE2 optimizations of function MidpointFilterSquare5x5.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fp.</li>
  <li>SVE2 optimizations of function DetectionHaarDetect32fi.</li>
  <li>SVE2 optimizations of function DetectionLbpDetect32fp.</li>
@@ -200,6 +201,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MinFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4037,6 +4037,11 @@ SIMD_API void SimdMidpointFilterSquare5x5(const uint8_t * src, size_t srcStride,
         Sse41::MidpointFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 4 && (width - 4)*channelCount >= svcntb())
+        Sve2::MidpointFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 2)*channelCount >= Neon::A)
         Neon::MidpointFilterSquare5x5(src, srcStride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -164,6 +164,9 @@ namespace Simd
         void MidpointFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void MidpointFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void CosineDistance16f(const uint16_t* a, const uint16_t* b, size_t size, float* distance);
 
         void CosineDistancesMxNa16f(size_t M, size_t N, size_t K, const uint16_t* const* A, const uint16_t* const* B, float* distances);

--- a/src/Simd/SimdSve2MidpointFilter.cpp
+++ b/src/Simd/SimdSve2MidpointFilter.cpp
@@ -138,6 +138,148 @@ namespace Simd
             case 4: MidpointFilterSquare3x3<4>(src, srcStride, width, height, dst, dstStride); break;
             }
         }
+
+        SIMD_INLINE uint8_t Midpoint25(const uint8_t* y[5], size_t x[5])
+        {
+            uint8_t a[25];
+            a[0] = y[0][x[0]]; a[1] = y[0][x[1]]; a[2] = y[0][x[2]]; a[3] = y[0][x[3]]; a[4] = y[0][x[4]];
+            a[5] = y[1][x[0]]; a[6] = y[1][x[1]]; a[7] = y[1][x[2]]; a[8] = y[1][x[3]]; a[9] = y[1][x[4]];
+            a[10] = y[2][x[0]]; a[11] = y[2][x[1]]; a[12] = y[2][x[2]]; a[13] = y[2][x[3]]; a[14] = y[2][x[4]];
+            a[15] = y[3][x[0]]; a[16] = y[3][x[1]]; a[17] = y[3][x[2]]; a[18] = y[3][x[3]]; a[19] = y[3][x[4]];
+            a[20] = y[4][x[0]]; a[21] = y[4][x[1]]; a[22] = y[4][x[2]]; a[23] = y[4][x[3]]; a[24] = y[4][x[4]];
+
+            uint8_t min = a[0], max = a[0];
+            for (int i = 1; i < 25; ++i)
+            {
+                min = min < a[i] ? min : a[i];
+                max = max > a[i] ? max : a[i];
+            }
+            return uint8_t((min + max + 1) >> 1);
+        }
+
+        SIMD_INLINE void UpdateMinMax(const svuint8_t& value, svuint8_t& min, svuint8_t& max, const svbool_t& mask)
+        {
+            min = svmin_u8_x(mask, min, value);
+            max = svmax_u8_x(mask, max, value);
+        }
+
+        template <size_t step> SIMD_INLINE svuint8_t Midpoint25(const uint8_t* y[5], size_t offset, const svbool_t& mask)
+        {
+            svuint8_t a00 = svld1_u8(mask, y[0] + offset - 2 * step);
+            svuint8_t a01 = svld1_u8(mask, y[0] + offset - step);
+            svuint8_t a02 = svld1_u8(mask, y[0] + offset);
+            svuint8_t a03 = svld1_u8(mask, y[0] + offset + step);
+            svuint8_t a04 = svld1_u8(mask, y[0] + offset + 2 * step);
+            svuint8_t a10 = svld1_u8(mask, y[1] + offset - 2 * step);
+            svuint8_t a11 = svld1_u8(mask, y[1] + offset - step);
+            svuint8_t a12 = svld1_u8(mask, y[1] + offset);
+            svuint8_t a13 = svld1_u8(mask, y[1] + offset + step);
+            svuint8_t a14 = svld1_u8(mask, y[1] + offset + 2 * step);
+            svuint8_t a20 = svld1_u8(mask, y[2] + offset - 2 * step);
+            svuint8_t a21 = svld1_u8(mask, y[2] + offset - step);
+            svuint8_t a22 = svld1_u8(mask, y[2] + offset);
+            svuint8_t a23 = svld1_u8(mask, y[2] + offset + step);
+            svuint8_t a24 = svld1_u8(mask, y[2] + offset + 2 * step);
+            svuint8_t a30 = svld1_u8(mask, y[3] + offset - 2 * step);
+            svuint8_t a31 = svld1_u8(mask, y[3] + offset - step);
+            svuint8_t a32 = svld1_u8(mask, y[3] + offset);
+            svuint8_t a33 = svld1_u8(mask, y[3] + offset + step);
+            svuint8_t a34 = svld1_u8(mask, y[3] + offset + 2 * step);
+            svuint8_t a40 = svld1_u8(mask, y[4] + offset - 2 * step);
+            svuint8_t a41 = svld1_u8(mask, y[4] + offset - step);
+            svuint8_t a42 = svld1_u8(mask, y[4] + offset);
+            svuint8_t a43 = svld1_u8(mask, y[4] + offset + step);
+            svuint8_t a44 = svld1_u8(mask, y[4] + offset + 2 * step);
+            svuint8_t min = a00, max = a00;
+            UpdateMinMax(a01, min, max, mask);
+            UpdateMinMax(a02, min, max, mask);
+            UpdateMinMax(a03, min, max, mask);
+            UpdateMinMax(a04, min, max, mask);
+            UpdateMinMax(a10, min, max, mask);
+            UpdateMinMax(a11, min, max, mask);
+            UpdateMinMax(a12, min, max, mask);
+            UpdateMinMax(a13, min, max, mask);
+            UpdateMinMax(a14, min, max, mask);
+            UpdateMinMax(a20, min, max, mask);
+            UpdateMinMax(a21, min, max, mask);
+            UpdateMinMax(a22, min, max, mask);
+            UpdateMinMax(a23, min, max, mask);
+            UpdateMinMax(a24, min, max, mask);
+            UpdateMinMax(a30, min, max, mask);
+            UpdateMinMax(a31, min, max, mask);
+            UpdateMinMax(a32, min, max, mask);
+            UpdateMinMax(a33, min, max, mask);
+            UpdateMinMax(a34, min, max, mask);
+            UpdateMinMax(a40, min, max, mask);
+            UpdateMinMax(a41, min, max, mask);
+            UpdateMinMax(a42, min, max, mask);
+            UpdateMinMax(a43, min, max, mask);
+            UpdateMinMax(a44, min, max, mask);
+            return svrhadd_u8_x(mask, min, max);
+        }
+
+        template <size_t step> void MidpointFilterSquare5x5(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > 4 && step * (width - 4) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t body = 2 * step;
+            const size_t end = size - body;
+            const uint8_t* y[5];
+            size_t x[5];
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[2] = src + srcStride * row;
+                y[1] = row ? y[2] - srcStride : y[2];
+                y[0] = row > 1 ? y[2] - 2 * srcStride : y[1];
+                y[3] = row + 1 < height ? y[2] + srcStride : y[2];
+                y[4] = row + 2 < height ? y[2] + 2 * srcStride : y[3];
+
+                for (size_t col = 0; col < 2 * body; ++col)
+                {
+                    if (col < body)
+                    {
+                        x[0] = col < step ? col : col - step;
+                        x[1] = x[0];
+                        x[2] = col;
+                        x[3] = x[2] + step;
+                        x[4] = x[3] + step;
+                    }
+                    else
+                    {
+                        x[0] = size - 6 * step + col;
+                        x[1] = x[0] + step;
+                        x[2] = x[1] + step;
+                        x[3] = col < 3 * step ? x[2] + step : x[2];
+                        x[4] = x[3];
+                    }
+                    dst[x[2]] = Midpoint25(y, x);
+                }
+
+                for (size_t col = body; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    svst1_u8(mask, dst + col, Midpoint25<step>(y, col, mask));
+                }
+            }
+        }
+
+        void MidpointFilterSquare5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MidpointFilterSquare5x5<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: MidpointFilterSquare5x5<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: MidpointFilterSquare5x5<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: MidpointFilterSquare5x5<4>(src, srcStride, width, height, dst, dstStride); break;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -563,6 +563,11 @@ namespace
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Avx512bw::MidpointFilterSquare5x5), FUNC_C(SimdMidpointFilterSquare5x5));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 4)
+            result = result && ColorFilterAutoTest(FUNC_C(Simd::Sve2::MidpointFilterSquare5x5), FUNC_C(SimdMidpointFilterSquare5x5));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 2 >= Simd::Neon::A)
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Neon::MidpointFilterSquare5x5), FUNC_C(SimdMidpointFilterSquare5x5));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 optimization and dispatch for `SimdMidpointFilterSquare5x5`.
- Register SVE2 Square5x5 midpoint auto-test coverage.
- Document the SVE2 optimization and tests in release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=MidpointFilterSquare5x5 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -I"/workspace/src" -c "/workspace/src/Simd/SimdSve2MidpointFilter.cpp" -o "/tmp/SimdSve2MidpointFilter.o"`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -I"/workspace/src" -c "/workspace/src/Simd/SimdLib.cpp" -o "/tmp/SimdLib.aarch64.o"`
- AArch64 SVE2 QEMU harness comparing `Simd::Sve2::MidpointFilterSquare5x5` to Base across widths, heights, and channel counts: passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb68ef0e-947f-448a-b629-9c632c199ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb68ef0e-947f-448a-b629-9c632c199ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

