### PR TITLE
Add SVE2 median rhomb 5x5 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -115,6 +115,7 @@
  <li>SVE2 optimizations of function HistogramMasked.</li>
  <li>SVE2 optimizations of function HistogramConditional.</li>
  <li>SVE2 optimizations of function MedianFilterRhomb3x3.</li>
+ <li>SVE2 optimizations of function MedianFilterRhomb5x5.</li>
  <li>SVE2 optimizations of function MinFilterSquare5x5.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
@@ -200,6 +201,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MaxFilterSquare5x5.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MinFilterSquare3x3.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function MedianFilterRhomb5x5.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3933,6 +3933,11 @@ SIMD_API void SimdMedianFilterRhomb5x5(const uint8_t * src, size_t srcStride, si
         Sse41::MedianFilterRhomb5x5(src, srcStride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 4 && (width - 4)*channelCount >= svcntb())
+        Sve2::MedianFilterRhomb5x5(src, srcStride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 2)*channelCount >= Neon::A)
         Neon::MedianFilterRhomb5x5(src, srcStride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -155,6 +155,9 @@ namespace Simd
         void MedianFilterRhomb3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void MedianFilterRhomb5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void MinFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
 

--- a/src/Simd/SimdSve2MedianFilter.cpp
+++ b/src/Simd/SimdSve2MedianFilter.cpp
@@ -121,6 +121,152 @@ namespace Simd
             case 4: MedianFilterRhomb3x3<4>(src, srcStride, width, height, dst, dstStride); break;
             }
         }
+
+        SIMD_INLINE uint8_t Median13(const uint8_t* y[5], size_t x[5])
+        {
+            int a[13];
+            a[0] = y[0][x[2]];
+            a[1] = y[1][x[1]]; a[2] = y[1][x[2]]; a[3] = y[1][x[3]];
+            a[4] = y[2][x[0]]; a[5] = y[2][x[1]]; a[6] = y[2][x[2]]; a[7] = y[2][x[3]]; a[8] = y[2][x[4]];
+            a[9] = y[3][x[1]]; a[10] = y[3][x[2]]; a[11] = y[3][x[3]];
+            a[12] = y[4][x[2]];
+
+            Base::SortU8(a[0], a[1]); Base::SortU8(a[3], a[4]); Base::SortU8(a[2], a[4]);
+            Base::SortU8(a[2], a[3]); Base::SortU8(a[6], a[7]); Base::SortU8(a[5], a[7]);
+            Base::SortU8(a[5], a[6]); Base::SortU8(a[9], a[10]); Base::SortU8(a[8], a[10]);
+            Base::SortU8(a[8], a[9]); Base::SortU8(a[11], a[12]); Base::SortU8(a[5], a[8]);
+            Base::SortU8(a[2], a[8]); Base::SortU8(a[2], a[5]); Base::SortU8(a[6], a[9]);
+            Base::SortU8(a[3], a[9]); Base::SortU8(a[3], a[6]); Base::SortU8(a[7], a[10]);
+            Base::SortU8(a[4], a[10]); Base::SortU8(a[4], a[7]); Base::SortU8(a[3], a[12]);
+            Base::SortU8(a[0], a[9]);
+            a[1] = Base::MinU8(a[1], a[10]);
+            a[1] = Base::MinU8(a[1], a[7]);
+            a[1] = Base::MinU8(a[1], a[9]);
+            a[11] = Base::MaxU8(a[5], a[11]);
+            a[11] = Base::MaxU8(a[3], a[11]);
+            a[11] = Base::MaxU8(a[2], a[11]);
+            Base::SortU8(a[0], a[6]); Base::SortU8(a[1], a[8]); Base::SortU8(a[6], a[8]);
+            a[4] = Base::MinU8(a[4], a[8]);
+            Base::SortU8(a[0], a[1]); Base::SortU8(a[4], a[6]); Base::SortU8(a[0], a[4]);
+            a[11] = Base::MaxU8(a[0], a[11]);
+            Base::SortU8(a[6], a[11]);
+            a[1] = Base::MinU8(a[1], a[11]);
+            Base::SortU8(a[1], a[4]); Base::SortU8(a[6], a[12]);
+            a[6] = Base::MaxU8(a[1], a[6]);
+            a[4] = Base::MinU8(a[4], a[12]);
+            a[6] = Base::MaxU8(a[4], a[6]);
+
+            return (uint8_t)a[6];
+        }
+
+        SIMD_INLINE svuint8_t Median13(svuint8_t a0, svuint8_t a1, svuint8_t a2, svuint8_t a3, svuint8_t a4, svuint8_t a5, svuint8_t a6,
+            svuint8_t a7, svuint8_t a8, svuint8_t a9, svuint8_t a10, svuint8_t a11, svuint8_t a12, const svbool_t& mask)
+        {
+            SortU8(a0, a1, mask); SortU8(a3, a4, mask); SortU8(a2, a4, mask);
+            SortU8(a2, a3, mask); SortU8(a6, a7, mask); SortU8(a5, a7, mask);
+            SortU8(a5, a6, mask); SortU8(a9, a10, mask); SortU8(a8, a10, mask);
+            SortU8(a8, a9, mask); SortU8(a11, a12, mask); SortU8(a5, a8, mask);
+            SortU8(a2, a8, mask); SortU8(a2, a5, mask); SortU8(a6, a9, mask);
+            SortU8(a3, a9, mask); SortU8(a3, a6, mask); SortU8(a7, a10, mask);
+            SortU8(a4, a10, mask); SortU8(a4, a7, mask); SortU8(a3, a12, mask);
+            SortU8(a0, a9, mask);
+            a1 = svmin_u8_x(mask, a1, a10);
+            a1 = svmin_u8_x(mask, a1, a7);
+            a1 = svmin_u8_x(mask, a1, a9);
+            a11 = svmax_u8_x(mask, a5, a11);
+            a11 = svmax_u8_x(mask, a3, a11);
+            a11 = svmax_u8_x(mask, a2, a11);
+            SortU8(a0, a6, mask); SortU8(a1, a8, mask); SortU8(a6, a8, mask);
+            a4 = svmin_u8_x(mask, a4, a8);
+            SortU8(a0, a1, mask); SortU8(a4, a6, mask); SortU8(a0, a4, mask);
+            a11 = svmax_u8_x(mask, a0, a11);
+            SortU8(a6, a11, mask);
+            a1 = svmin_u8_x(mask, a1, a11);
+            SortU8(a1, a4, mask); SortU8(a6, a12, mask);
+            a6 = svmax_u8_x(mask, a1, a6);
+            a4 = svmin_u8_x(mask, a4, a12);
+            return svmax_u8_x(mask, a4, a6);
+        }
+
+        template <size_t step> SIMD_INLINE svuint8_t MedianFilterRhomb5x5(const uint8_t* y[5], size_t offset, const svbool_t& mask)
+        {
+            svuint8_t a0 = svld1_u8(mask, y[0] + offset);
+            svuint8_t a1 = svld1_u8(mask, y[1] + offset - step);
+            svuint8_t a2 = svld1_u8(mask, y[1] + offset);
+            svuint8_t a3 = svld1_u8(mask, y[1] + offset + step);
+            svuint8_t a4 = svld1_u8(mask, y[2] + offset - 2 * step);
+            svuint8_t a5 = svld1_u8(mask, y[2] + offset - step);
+            svuint8_t a6 = svld1_u8(mask, y[2] + offset);
+            svuint8_t a7 = svld1_u8(mask, y[2] + offset + step);
+            svuint8_t a8 = svld1_u8(mask, y[2] + offset + 2 * step);
+            svuint8_t a9 = svld1_u8(mask, y[3] + offset - step);
+            svuint8_t a10 = svld1_u8(mask, y[3] + offset);
+            svuint8_t a11 = svld1_u8(mask, y[3] + offset + step);
+            svuint8_t a12 = svld1_u8(mask, y[4] + offset);
+            return Median13(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, mask);
+        }
+
+        template <size_t step> void MedianFilterRhomb5x5(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > 4 && step * (width - 4) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t body = 2 * step;
+            const size_t end = size - body;
+            const uint8_t* y[5];
+            size_t x[5];
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[2] = src + srcStride * row;
+                y[1] = row ? y[2] - srcStride : y[2];
+                y[0] = row > 1 ? y[2] - 2 * srcStride : y[1];
+                y[3] = row + 1 < height ? y[2] + srcStride : y[2];
+                y[4] = row + 2 < height ? y[2] + 2 * srcStride : y[3];
+
+                for (size_t col = 0; col < body; ++col)
+                {
+                    x[0] = col < step ? col : col - step;
+                    x[1] = x[0];
+                    x[2] = col;
+                    x[3] = col + step;
+                    x[4] = col + 2 * step;
+                    dst[col] = Median13(y, x);
+                }
+
+                for (size_t col = body; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    svst1_u8(mask, dst + col, MedianFilterRhomb5x5<step>(y, col, mask));
+                }
+
+                for (size_t col = end; col < size; ++col)
+                {
+                    x[0] = col - 2 * step;
+                    x[1] = col - step;
+                    x[2] = col;
+                    x[3] = col + step < size ? col + step : col;
+                    x[4] = col + 2 * step < size ? col + 2 * step : x[3];
+                    dst[col] = Median13(y, x);
+                }
+            }
+        }
+
+        void MedianFilterRhomb5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MedianFilterRhomb5x5<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: MedianFilterRhomb5x5<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: MedianFilterRhomb5x5<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: MedianFilterRhomb5x5<4>(src, srcStride, width, height, dst, dstStride); break;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -443,6 +443,11 @@ namespace
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Avx512bw::MedianFilterRhomb5x5), FUNC_C(SimdMedianFilterRhomb5x5));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W >= svcntb() + 4)
+            result = result && ColorFilterAutoTest(FUNC_C(Simd::Sve2::MedianFilterRhomb5x5), FUNC_C(SimdMedianFilterRhomb5x5));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 2 >= Simd::Neon::A)
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Neon::MedianFilterRhomb5x5), FUNC_C(SimdMedianFilterRhomb5x5));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation and dispatch for `SimdMedianFilterRhomb5x5`.
* Add SVE2 coverage to `MedianFilterRhomb5x5AutoTest`.
* Document the SVE2 optimization and test coverage in release 7.2.163.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" ./build/Test "-r=." -fi=MedianFilterRhomb5x5 -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2MedianFilter.cpp`
* `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check origin/dev...HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c43d3036-6a35-46a4-b10d-33ee0f0cca93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c43d3036-6a35-46a4-b10d-33ee0f0cca93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

