### PR TITLE
Add SVE2 MedianFilterSquare3x3 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -116,6 +116,7 @@
  <li>SVE2 optimizations of function HistogramConditional.</li>
  <li>SVE2 optimizations of function MedianFilterRhomb3x3.</li>
  <li>SVE2 optimizations of function MedianFilterRhomb5x5.</li>
+ <li>SVE2 optimizations of function MedianFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MinFilterSquare5x5.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3964,6 +3964,11 @@ SIMD_API void SimdMedianFilterSquare3x3(const uint8_t * src, size_t srcStride, s
         Sse41::MedianFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > 1 && (width - 1)*channelCount >= svcntb())
+        Sve2::MedianFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && (width - 1)*channelCount >= Neon::A)
         Neon::MedianFilterSquare3x3(src, srcStride, width, height, channelCount, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -158,6 +158,9 @@ namespace Simd
         void MedianFilterRhomb5x5(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 
+        void MedianFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride);
+
         void MinFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride, int threshold);
 

--- a/src/Simd/SimdSve2MedianFilter.cpp
+++ b/src/Simd/SimdSve2MedianFilter.cpp
@@ -122,6 +122,106 @@ namespace Simd
             }
         }
 
+        SIMD_INLINE uint8_t Median9(const uint8_t* y[3], size_t x0, size_t x1, size_t x2)
+        {
+            int a[9];
+            a[0] = y[0][x0]; a[1] = y[0][x1]; a[2] = y[0][x2];
+            a[3] = y[1][x0]; a[4] = y[1][x1]; a[5] = y[1][x2];
+            a[6] = y[2][x0]; a[7] = y[2][x1]; a[8] = y[2][x2];
+
+            Base::SortU8(a[1], a[2]); Base::SortU8(a[4], a[5]); Base::SortU8(a[7], a[8]);
+            Base::SortU8(a[0], a[1]); Base::SortU8(a[3], a[4]); Base::SortU8(a[6], a[7]);
+            Base::SortU8(a[1], a[2]); Base::SortU8(a[4], a[5]); Base::SortU8(a[7], a[8]);
+            a[3] = Base::MaxU8(a[0], a[3]);
+            a[5] = Base::MinU8(a[5], a[8]);
+            Base::SortU8(a[4], a[7]);
+            a[6] = Base::MaxU8(a[3], a[6]);
+            a[4] = Base::MaxU8(a[1], a[4]);
+            a[2] = Base::MinU8(a[2], a[5]);
+            a[4] = Base::MinU8(a[4], a[7]);
+            Base::SortU8(a[4], a[2]);
+            a[4] = Base::MaxU8(a[6], a[4]);
+            a[4] = Base::MinU8(a[4], a[2]);
+
+            return (uint8_t)a[4];
+        }
+
+        SIMD_INLINE svuint8_t Median9(svuint8_t a0, svuint8_t a1, svuint8_t a2, svuint8_t a3, svuint8_t a4,
+            svuint8_t a5, svuint8_t a6, svuint8_t a7, svuint8_t a8, const svbool_t& mask)
+        {
+            SortU8(a1, a2, mask); SortU8(a4, a5, mask); SortU8(a7, a8, mask);
+            SortU8(a0, a1, mask); SortU8(a3, a4, mask); SortU8(a6, a7, mask);
+            SortU8(a1, a2, mask); SortU8(a4, a5, mask); SortU8(a7, a8, mask);
+            a3 = svmax_u8_x(mask, a0, a3);
+            a5 = svmin_u8_x(mask, a5, a8);
+            SortU8(a4, a7, mask);
+            a6 = svmax_u8_x(mask, a3, a6);
+            a4 = svmax_u8_x(mask, a1, a4);
+            a2 = svmin_u8_x(mask, a2, a5);
+            a4 = svmin_u8_x(mask, a4, a7);
+            SortU8(a4, a2, mask);
+            a4 = svmax_u8_x(mask, a6, a4);
+            return svmin_u8_x(mask, a4, a2);
+        }
+
+        template <size_t step> SIMD_INLINE svuint8_t MedianFilterSquare3x3(const uint8_t* y[3], size_t offset, const svbool_t& mask)
+        {
+            svuint8_t a0 = svld1_u8(mask, y[0] + offset - step);
+            svuint8_t a1 = svld1_u8(mask, y[0] + offset);
+            svuint8_t a2 = svld1_u8(mask, y[0] + offset + step);
+            svuint8_t a3 = svld1_u8(mask, y[1] + offset - step);
+            svuint8_t a4 = svld1_u8(mask, y[1] + offset);
+            svuint8_t a5 = svld1_u8(mask, y[1] + offset + step);
+            svuint8_t a6 = svld1_u8(mask, y[2] + offset - step);
+            svuint8_t a7 = svld1_u8(mask, y[2] + offset);
+            svuint8_t a8 = svld1_u8(mask, y[2] + offset + step);
+            return Median9(a0, a1, a2, a3, a4, a5, a6, a7, a8, mask);
+        }
+
+        template <size_t step> void MedianFilterSquare3x3(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(width > 1 && step * (width - 1) >= svcntb());
+
+            const size_t A = svcntb();
+            const size_t size = step * width;
+            const size_t end = size - step;
+            const uint8_t* y[3];
+
+            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            {
+                y[1] = src + srcStride * row;
+                y[0] = row ? y[1] - srcStride : y[1];
+                y[2] = row + 1 < height ? y[1] + srcStride : y[1];
+
+                for (size_t col = 0; col < step; ++col)
+                    dst[col] = Median9(y, col, col, col + step);
+
+                for (size_t col = step; col < end; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, end);
+                    svst1_u8(mask, dst + col, MedianFilterSquare3x3<step>(y, col, mask));
+                }
+
+                for (size_t col = end; col < size; ++col)
+                    dst[col] = Median9(y, col - step, col, col);
+            }
+        }
+
+        void MedianFilterSquare3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            assert(channelCount > 0 && channelCount <= 4);
+
+            switch (channelCount)
+            {
+            case 1: MedianFilterSquare3x3<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: MedianFilterSquare3x3<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: MedianFilterSquare3x3<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: MedianFilterSquare3x3<4>(src, srcStride, width, height, dst, dstStride); break;
+            }
+        }
+
         SIMD_INLINE uint8_t Median13(const uint8_t* y[5], size_t x[5])
         {
             int a[13];

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -478,6 +478,11 @@ namespace
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Avx512bw::MedianFilterSquare3x3), FUNC_C(SimdMedianFilterSquare3x3));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W - 1 >= svcntb())
+            result = result && ColorFilterAutoTest(FUNC_C(Simd::Sve2::MedianFilterSquare3x3), FUNC_C(SimdMedianFilterSquare3x3));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && ColorFilterAutoTest(FUNC_C(Simd::Neon::MedianFilterSquare3x3), FUNC_C(SimdMedianFilterSquare3x3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `MedianFilterSquare3x3` with scalar border handling and predicated vector body.
- Wire SVE2 declaration, runtime dispatch, and auto-test coverage.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel2`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=MedianFilterSquare3x3 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -O2 -DNDEBUG -I src -c src/Simd/SimdSve2MedianFilter.cpp -o build/SimdSve2MedianFilter.o`
- Temporary aarch64/QEMU harness: `QEMU_CPU=max qemu-aarch64 -L /usr/aarch64-linux-gnu build/test_sve2_median` -> `SVE2 MedianFilterSquare3x3 matches Base, A=64`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54d86e00-93c5-44ab-b04e-f6ffc52a0477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54d86e00-93c5-44ab-b04e-f6ffc52a0477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

