### PR TITLE
Add SVE2 NeuralAddValue optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function Float32ToUint8.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
+ <li>SVE2 optimizations of function NeuralAddValue.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>
@@ -208,6 +209,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -68,6 +68,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MedianFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MidpointFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Neural.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -272,6 +272,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Neural.cpp">
+      <Filter>Sve2\Legacy</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4109,7 +4109,7 @@ SIMD_API void SimdNeuralAddValue(const float * value, float * dst, size_t size)
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralAddValuePtr) (const float * value, float * dst, size_t size);
-    const static SimdNeuralAddValuePtr simdNeuralAddValue = SIMD_FUNC4(NeuralAddValue, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralAddValuePtr simdNeuralAddValue = SIMD_FUNC5(NeuralAddValue, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralAddValue(value, dst, size);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -121,6 +121,8 @@ namespace Simd
 
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void NeuralAddValue(const float* value, float* dst, size_t size);
+
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -1,0 +1,56 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void AddValue(const svbool_t& mask, const svfloat32_t& value, float* dst)
+        {
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), value));
+        }
+
+        void NeuralAddValue(const float* value, float* dst, size_t size)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _value = svdup_n_f32(value[0]);
+
+            for (; i + QF <= size; i += QF)
+            {
+                AddValue(body, _value, dst + i + 0 * F);
+                AddValue(body, _value, dst + i + 1 * F);
+                AddValue(body, _value, dst + i + 2 * F);
+                AddValue(body, _value, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                AddValue(body, _value, dst + i);
+            if (i < size)
+                AddValue(svwhilelt_b32(i, size), _value, dst + i);
+        }
+    }
+#endif
+}

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -467,6 +467,11 @@ namespace Test
             result = result && NeuralAddValueAutoTest(EPS, FUNC_ADDVAL(Simd::Avx512bw::NeuralAddValue), FUNC_ADDVAL(SimdNeuralAddValue));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddValueAutoTest(EPS, FUNC_ADDVAL(Simd::Sve2::NeuralAddValue), FUNC_ADDVAL(SimdNeuralAddValue));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddValueAutoTest(EPS, FUNC_ADDVAL(Simd::Neon::NeuralAddValue), FUNC_ADDVAL(SimdNeuralAddValue));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `NeuralAddValue` with predicated tail handling.
- Wire SVE2 dispatch and auto-test coverage for `SimdNeuralAddValue`.
- Add the new source to VS2022 SVE2 project files and update release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralAddValue -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I./src -c src/Simd/SimdSve2Neural.cpp -o /tmp/SimdSve2Neural.o`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I./src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib_sve2.o`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I./src -c src/Test/TestNeural.cpp -o /tmp/TestNeural_sve2.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d22b102-ab0b-4bb3-8958-1cf6285ea571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d22b102-ab0b-4bb3-8958-1cf6285ea571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

