### PR TITLE
Add SVE2 NeuralAddVector optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function Float32ToUint8.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
+ <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4118,7 +4118,7 @@ SIMD_API void SimdNeuralAddVector(const float * src, size_t size, float * dst)
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralAddVectorPtr) (const float * src, size_t size, float * dst);
-    const static SimdNeuralAddVectorPtr simdNeuralAddVector = SIMD_FUNC4(NeuralAddVector, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralAddVectorPtr simdNeuralAddVector = SIMD_FUNC5(NeuralAddVector, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralAddVector(src, size, dst);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -121,6 +121,8 @@ namespace Simd
 
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void NeuralAddVector(const float* src, size_t size, float* dst);
+
         void NeuralAddValue(const float* value, float* dst, size_t size);
 
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -28,6 +28,29 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE void AddVector(const svbool_t& mask, const float* src, float* dst)
+        {
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), svld1_f32(mask, src)));
+        }
+
+        void NeuralAddVector(const float* src, size_t size, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+
+            for (; i + QF <= size; i += QF)
+            {
+                AddVector(body, src + i + 0 * F, dst + i + 0 * F);
+                AddVector(body, src + i + 1 * F, dst + i + 1 * F);
+                AddVector(body, src + i + 2 * F, dst + i + 2 * F);
+                AddVector(body, src + i + 3 * F, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                AddVector(body, src + i, dst + i);
+            if (i < size)
+                AddVector(svwhilelt_b32(i, size), src + i, dst + i);
+        }
+
         SIMD_INLINE void AddValue(const svbool_t& mask, const svfloat32_t& value, float* dst)
         {
             svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), value));

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -382,6 +382,11 @@ namespace Test
             result = result && NeuralAddVectorAutoTest(EPS, FUNC_ADDVEC(Simd::Avx512bw::NeuralAddVector), FUNC_ADDVEC(SimdNeuralAddVector));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddVectorAutoTest(EPS, FUNC_ADDVEC(Simd::Sve2::NeuralAddVector), FUNC_ADDVEC(SimdNeuralAddVector));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddVectorAutoTest(EPS, FUNC_ADDVEC(Simd::Neon::NeuralAddVector), FUNC_ADDVEC(SimdNeuralAddVector));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation and declaration for `NeuralAddVector`.
* Include SVE2 in `SimdNeuralAddVector` runtime dispatch and `NeuralAddVectorAutoTest`.
* Document the release note for version 7.2.163.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralAddVector -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.2-a+sve2 -I./src src/Simd/SimdSve2Neural.cpp`
* `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.2-a+sve2 -I./src src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-420b6b24-2fa1-4249-946a-2a980651dcda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-420b6b24-2fa1-4249-946a-2a980651dcda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

