### PR TITLE
Add SVE2 NeuralConvert optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function Float32ToUint8.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
+ <li>SVE2 optimizations of function NeuralConvert.</li>
  <li>SVE2 optimizations of function NeuralAddVectorMultipliedByValue.</li>
  <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>
@@ -211,6 +212,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvert.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>
 </ul>
 <h5>Bug fixing</h5>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4088,6 +4088,11 @@ SIMD_API void SimdNeuralConvert(const uint8_t * src, size_t srcStride, size_t wi
         Sse41::NeuralConvert(src, srcStride, width, height, dst, dstStride, inversion);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntb())
+        Sve2::NeuralConvert(src, srcStride, width, height, dst, dstStride, inversion);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::NeuralConvert(src, srcStride, width, height, dst, dstStride, inversion);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -121,6 +121,8 @@ namespace Simd
 
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void NeuralConvert(const uint8_t* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride, int inversion);
+
         void NeuralAddVectorMultipliedByValue(const float* src, size_t size, const float* value, float* dst);
 
         void NeuralAddVector(const float* src, size_t size, float* dst);

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -46,22 +46,17 @@ namespace Simd
         }
 
         template <bool inversion> SIMD_INLINE void Convert(const uint8_t* src, const svfloat32_t& scale, float* dst, size_t F,
-            const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+            const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
         {
-            svuint8_t _src = svld1_u8(mask8, src);
-            svuint16_t lo = svmovlb_u16(_src);
-            svuint16_t hi = svmovlt_u16(_src);
-
-            Convert<inversion>(mask0, svmovlb_u32(lo), scale, dst + 0 * F);
-            Convert<inversion>(mask1, svmovlt_u32(lo), scale, dst + 1 * F);
-            Convert<inversion>(mask2, svmovlb_u32(hi), scale, dst + 2 * F);
-            Convert<inversion>(mask3, svmovlt_u32(hi), scale, dst + 3 * F);
+            Convert<inversion>(mask0, svld1ub_u32(mask0, src + 0 * F), scale, dst + 0 * F);
+            Convert<inversion>(mask1, svld1ub_u32(mask1, src + 1 * F), scale, dst + 1 * F);
+            Convert<inversion>(mask2, svld1ub_u32(mask2, src + 2 * F), scale, dst + 2 * F);
+            Convert<inversion>(mask3, svld1ub_u32(mask3, src + 3 * F), scale, dst + 3 * F);
         }
 
         template <bool inversion> void NeuralConvert(const uint8_t* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
         {
             size_t F = svcntw(), A = svcntb();
-            const svbool_t body8 = svptrue_b8();
             const svbool_t body32 = svptrue_b32();
             const svfloat32_t scale = svdup_n_f32(1.0f / 255.0f);
 
@@ -69,9 +64,9 @@ namespace Simd
             {
                 size_t col = 0;
                 for (; col + A <= width; col += A)
-                    Convert<inversion>(src + col, scale, dst + col, F, body8, body32, body32, body32, body32);
+                    Convert<inversion>(src + col, scale, dst + col, F, body32, body32, body32, body32);
                 if (col < width)
-                    Convert<inversion>(src + col, scale, dst + col, F, svwhilelt_b8(col, width),
+                    Convert<inversion>(src + col, scale, dst + col, F,
                         svwhilelt_b32(col + 0 * F, width), svwhilelt_b32(col + 1 * F, width),
                         svwhilelt_b32(col + 2 * F, width), svwhilelt_b32(col + 3 * F, width));
                 src += srcStride;

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -28,6 +28,67 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        template <bool inversion> SIMD_INLINE svuint32_t Invert(const svbool_t& mask, const svuint32_t& value);
+
+        template <> SIMD_INLINE svuint32_t Invert<true>(const svbool_t& mask, const svuint32_t& value)
+        {
+            return svsub_u32_x(mask, svdup_n_u32(0xFF), value);
+        }
+
+        template <> SIMD_INLINE svuint32_t Invert<false>(const svbool_t& mask, const svuint32_t& value)
+        {
+            return value;
+        }
+
+        template <bool inversion> SIMD_INLINE void Convert(const svbool_t& mask, const svuint32_t& src, const svfloat32_t& scale, float* dst)
+        {
+            svst1_f32(mask, dst, svmul_f32_x(mask, svcvt_f32_u32_x(mask, Invert<inversion>(mask, src)), scale));
+        }
+
+        template <bool inversion> SIMD_INLINE void Convert(const uint8_t* src, const svfloat32_t& scale, float* dst, size_t F,
+            const svbool_t& mask8, const svbool_t& mask0, const svbool_t& mask1, const svbool_t& mask2, const svbool_t& mask3)
+        {
+            svuint8_t _src = svld1_u8(mask8, src);
+            svuint16_t lo = svmovlb_u16(_src);
+            svuint16_t hi = svmovlt_u16(_src);
+
+            Convert<inversion>(mask0, svmovlb_u32(lo), scale, dst + 0 * F);
+            Convert<inversion>(mask1, svmovlt_u32(lo), scale, dst + 1 * F);
+            Convert<inversion>(mask2, svmovlb_u32(hi), scale, dst + 2 * F);
+            Convert<inversion>(mask3, svmovlt_u32(hi), scale, dst + 3 * F);
+        }
+
+        template <bool inversion> void NeuralConvert(const uint8_t* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            size_t F = svcntw(), A = svcntb();
+            const svbool_t body8 = svptrue_b8();
+            const svbool_t body32 = svptrue_b32();
+            const svfloat32_t scale = svdup_n_f32(1.0f / 255.0f);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + A <= width; col += A)
+                    Convert<inversion>(src + col, scale, dst + col, F, body8, body32, body32, body32, body32);
+                if (col < width)
+                    Convert<inversion>(src + col, scale, dst + col, F, svwhilelt_b8(col, width),
+                        svwhilelt_b32(col + 0 * F, width), svwhilelt_b32(col + 1 * F, width),
+                        svwhilelt_b32(col + 2 * F, width), svwhilelt_b32(col + 3 * F, width));
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        void NeuralConvert(const uint8_t* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride, int inversion)
+        {
+            if (inversion)
+                NeuralConvert<true>(src, srcStride, width, height, dst, dstStride);
+            else
+                NeuralConvert<false>(src, srcStride, width, height, dst, dstStride);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AddMultiplied(const svbool_t& mask, const svfloat32_t& value, const float* src, float* dst)
         {
             svst1_f32(mask, dst, svmla_f32_m(mask, svld1_f32(mask, dst), svld1_f32(mask, src), value));

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -121,6 +121,14 @@ namespace Test
         }
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            result = result && NeuralConvertAutoTest(EPS, FUNC_C1(Simd::Sve2::NeuralConvert, true), FUNC_C1(SimdNeuralConvert, true));
+            result = result && NeuralConvertAutoTest(EPS, FUNC_C1(Simd::Sve2::NeuralConvert, false), FUNC_C1(SimdNeuralConvert, false));
+        }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdNeuralConvert`.
- Register SVE2 coverage in `NeuralConvertAutoTest`.
- Fix SVE2 output ordering by loading ordered byte chunks directly into 32-bit lanes.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- From `build/`: `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralConvert -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Simd/SimdSve2Neural.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -std=c++17 -fsyntax-only src/Test/TestNeural.cpp`
- Temporary AArch64 runtime check under QEMU: `aarch64-linux-gnu-g++ -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -I . -I src -std=c++17 sve2_neural_convert_check.cpp -o build/sve2_neural_convert_check && qemu-aarch64 -cpu max -L /usr/aarch64-linux-gnu build/sve2_neural_convert_check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f05b3ce2-38ee-46b5-aed0-a7a3f9d3a60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f05b3ce2-38ee-46b5-aed0-a7a3f9d3a60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

