### PR TITLE
Add SVE2 neural adaptive gradient update

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of function NeuralAddVectorMultipliedByValue.</li>
  <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>
+ <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4186,7 +4186,7 @@ SIMD_API void SimdNeuralAdaptiveGradientUpdate(const float * delta, size_t size,
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralAdaptiveGradientUpdatePtr) (const float * delta, size_t size, size_t batch, const float * alpha, const float * epsilon, float * gradient, float * weight);
-    const static SimdNeuralAdaptiveGradientUpdatePtr simdNeuralAdaptiveGradientUpdate = SIMD_FUNC4(NeuralAdaptiveGradientUpdate, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralAdaptiveGradientUpdatePtr simdNeuralAdaptiveGradientUpdate = SIMD_FUNC5(NeuralAdaptiveGradientUpdate, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralAdaptiveGradientUpdate(delta, size, batch, alpha, epsilon, gradient, weight);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -129,6 +129,8 @@ namespace Simd
 
         void NeuralAddValue(const float* value, float* dst, size_t size);
 
+        void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);
+
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -154,6 +154,38 @@ namespace Simd
             if (i < size)
                 AddValue(svwhilelt_b32(i, size), _value, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void AdaptiveGradientUpdate(const svbool_t& mask, const svfloat32_t& norm, const svfloat32_t& alpha, const svfloat32_t& epsilon, const float* delta, float* gradient, float* weight)
+        {
+            svfloat32_t d = svmul_f32_x(mask, svld1_f32(mask, delta), norm);
+            svfloat32_t _gradient = svmla_f32_m(mask, svld1_f32(mask, gradient), d, d);
+            svst1_f32(mask, gradient, _gradient);
+            svst1_f32(mask, weight, svsub_f32_x(mask, svld1_f32(mask, weight),
+                svdiv_f32_x(mask, svmul_f32_x(mask, alpha, d), svsqrt_f32_x(mask, svadd_f32_x(mask, _gradient, epsilon)))));
+        }
+
+        void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _norm = svdup_n_f32((float)(1.0 / batch));
+            const svfloat32_t _alpha = svdup_n_f32(alpha[0]);
+            const svfloat32_t _epsilon = svdup_n_f32(epsilon[0]);
+
+            for (; i + QF <= size; i += QF)
+            {
+                AdaptiveGradientUpdate(body, _norm, _alpha, _epsilon, delta + i + 0 * F, gradient + i + 0 * F, weight + i + 0 * F);
+                AdaptiveGradientUpdate(body, _norm, _alpha, _epsilon, delta + i + 1 * F, gradient + i + 1 * F, weight + i + 1 * F);
+                AdaptiveGradientUpdate(body, _norm, _alpha, _epsilon, delta + i + 2 * F, gradient + i + 2 * F, weight + i + 2 * F);
+                AdaptiveGradientUpdate(body, _norm, _alpha, _epsilon, delta + i + 3 * F, gradient + i + 3 * F, weight + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                AdaptiveGradientUpdate(body, _norm, _alpha, _epsilon, delta + i, gradient + i, weight + i);
+            if (i < size)
+                AdaptiveGradientUpdate(svwhilelt_b32(i, size), _norm, _alpha, _epsilon, delta + i, gradient + i, weight + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -920,6 +920,11 @@ namespace Test
             result = result && NeuralAdaptiveGradientUpdateAutoTest(EPS, false, FUNC_AGU(Simd::Avx512bw::NeuralAdaptiveGradientUpdate), FUNC_AGU(SimdNeuralAdaptiveGradientUpdate));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAdaptiveGradientUpdateAutoTest(EPS, false, FUNC_AGU(Simd::Sve2::NeuralAdaptiveGradientUpdate), FUNC_AGU(SimdNeuralAdaptiveGradientUpdate));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAdaptiveGradientUpdateAutoTest(EPS, false, FUNC_AGU(Simd::Neon::NeuralAdaptiveGradientUpdate), FUNC_AGU(SimdNeuralAdaptiveGradientUpdate));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `NeuralAdaptiveGradientUpdate` and wire it into public dispatch.
- Extend `NeuralAdaptiveGradientUpdateAutoTest` coverage for SVE2.
- Document the new SVE2 optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralAdaptiveGradientUpdate -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I src -std=c++11 -fsyntax-only src/Simd/SimdSve2Neural.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I src -std=c++11 -fsyntax-only src/Simd/SimdLib.cpp && aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I src -I src/Test -std=c++11 -fsyntax-only src/Test/TestNeural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fde43b0a-22aa-4de7-a280-0682bccc5b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fde43b0a-22aa-4de7-a280-0682bccc5b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

