### PR TITLE
Add SVE2 NeuralDerivativeRelu optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of function NeuralAddVectorMultipliedByValue.</li>
  <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>
+ <li>SVE2 optimizations of function NeuralDerivativeRelu.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4159,7 +4159,7 @@ SIMD_API void SimdNeuralDerivativeRelu(const float * src, size_t size, const flo
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralDerivativeReluPtr) (const float * src, size_t size, const float * slope, float * dst);
-    const static SimdNeuralDerivativeReluPtr simdNeuralDerivativeRelu = SIMD_FUNC4(NeuralDerivativeRelu, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralDerivativeReluPtr simdNeuralDerivativeRelu = SIMD_FUNC5(NeuralDerivativeRelu, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralDerivativeRelu(src, size, slope, dst);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -129,6 +129,8 @@ namespace Simd
 
         void NeuralAddValue(const float* value, float* dst, size_t size);
 
+        void NeuralDerivativeRelu(const float* src, size_t size, const float* slope, float* dst);
+
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);
 
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -157,6 +157,36 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void DerivativeRelu(const svbool_t& mask, const svfloat32_t& _1, const svfloat32_t& slope, const float* src, float* dst)
+        {
+            svfloat32_t _src = svld1_f32(mask, src);
+            svfloat32_t _dst = svld1_f32(mask, dst);
+            svbool_t positive = svcmpgt_n_f32(mask, _src, 0.0f);
+            svst1_f32(mask, dst, svmul_f32_x(mask, svsel_f32(positive, _1, slope), _dst));
+        }
+
+        void NeuralDerivativeRelu(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _1 = svdup_n_f32(1.0f);
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
+
+            for (; i + QF <= size; i += QF)
+            {
+                DerivativeRelu(body, _1, _slope, src + i + 0 * F, dst + i + 0 * F);
+                DerivativeRelu(body, _1, _slope, src + i + 1 * F, dst + i + 1 * F);
+                DerivativeRelu(body, _1, _slope, src + i + 2 * F, dst + i + 2 * F);
+                DerivativeRelu(body, _1, _slope, src + i + 3 * F, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                DerivativeRelu(body, _1, _slope, src + i, dst + i);
+            if (i < size)
+                DerivativeRelu(svwhilelt_b32(i, size), _1, _slope, src + i, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AdaptiveGradientUpdate(const svbool_t& mask, const svfloat32_t& norm, const svfloat32_t& alpha, const svfloat32_t& epsilon, const float* delta, float* gradient, float* weight)
         {
             svfloat32_t d = svmul_f32_x(mask, svld1_f32(mask, delta), norm);

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -733,6 +733,11 @@ namespace Test
             result = result && NeuralActivateDerivativeAutoTest(EPS, true, 0.5f, FUNC_AD(Simd::Avx512bw::NeuralDerivativeRelu), FUNC_AD(SimdNeuralDerivativeRelu));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralActivateDerivativeAutoTest(EPS, true, 0.5f, FUNC_AD(Simd::Sve2::NeuralDerivativeRelu), FUNC_AD(SimdNeuralDerivativeRelu));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralActivateDerivativeAutoTest(EPS, true, 0.5f, FUNC_AD(Simd::Neon::NeuralDerivativeRelu), FUNC_AD(SimdNeuralDerivativeRelu));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdNeuralDerivativeRelu`.
- Add SVE2 coverage to `NeuralDerivativeReluAutoTest`.
- Document the new SVE2 optimization in release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralDerivativeRelu -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -fsyntax-only -std=c++17 -march=armv8.5-a+sve2 -I./src ./src/Simd/SimdSve2Neural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f85981b5-ca41-4d50-b269-d7adc703f9a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f85981b5-ca41-4d50-b269-d7adc703f9a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

