### PR TITLE
Add SVE2 optimization for NeuralDerivativeSigmoid

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of function NeuralAddVectorMultipliedByValue.</li>
  <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>
+ <li>SVE2 optimizations of function NeuralDerivativeSigmoid.</li>
  <li>SVE2 optimizations of function NeuralDerivativeRelu.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4141,7 +4141,7 @@ SIMD_API void SimdNeuralDerivativeSigmoid(const float * src, size_t size, const 
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralDerivativeSigmoidPtr) (const float * src, size_t size, const float * slope, float * dst);
-    const static SimdNeuralDerivativeSigmoidPtr simdNeuralDerivativeSigmoid = SIMD_FUNC4(NeuralDerivativeSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralDerivativeSigmoidPtr simdNeuralDerivativeSigmoid = SIMD_FUNC5(NeuralDerivativeSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralDerivativeSigmoid(src, size, slope, dst);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -129,6 +129,8 @@ namespace Simd
 
         void NeuralAddValue(const float* value, float* dst, size_t size);
 
+        void NeuralDerivativeSigmoid(const float* src, size_t size, const float* slope, float* dst);
+
         void NeuralDerivativeRelu(const float* src, size_t size, const float* slope, float* dst);
 
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -157,6 +157,35 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void DerivativeSigmoid(const svbool_t& mask, const svfloat32_t& _1, const svfloat32_t& slope, const float* src, float* dst)
+        {
+            svfloat32_t _src = svld1_f32(mask, src);
+            svfloat32_t _dst = svld1_f32(mask, dst);
+            svst1_f32(mask, dst, svmul_f32_x(mask, svmul_f32_x(mask, _dst, slope), svmul_f32_x(mask, svsub_f32_x(mask, _1, _src), _src)));
+        }
+
+        void NeuralDerivativeSigmoid(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _1 = svdup_n_f32(1.0f);
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
+
+            for (; i + QF <= size; i += QF)
+            {
+                DerivativeSigmoid(body, _1, _slope, src + i + 0 * F, dst + i + 0 * F);
+                DerivativeSigmoid(body, _1, _slope, src + i + 1 * F, dst + i + 1 * F);
+                DerivativeSigmoid(body, _1, _slope, src + i + 2 * F, dst + i + 2 * F);
+                DerivativeSigmoid(body, _1, _slope, src + i + 3 * F, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                DerivativeSigmoid(body, _1, _slope, src + i, dst + i);
+            if (i < size)
+                DerivativeSigmoid(svwhilelt_b32(i, size), _1, _slope, src + i, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void DerivativeRelu(const svbool_t& mask, const svfloat32_t& _1, const svfloat32_t& slope, const float* src, float* dst)
         {
             svfloat32_t _src = svld1_f32(mask, src);

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -673,6 +673,11 @@ namespace Test
             result = result && NeuralActivateDerivativeAutoTest(EPS, true, 3.0f, FUNC_AD(Simd::Avx512bw::NeuralDerivativeSigmoid), FUNC_AD(SimdNeuralDerivativeSigmoid));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralActivateDerivativeAutoTest(EPS, true, 3.0f, FUNC_AD(Simd::Sve2::NeuralDerivativeSigmoid), FUNC_AD(SimdNeuralDerivativeSigmoid));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralActivateDerivativeAutoTest(EPS, true, 3.0f, FUNC_AD(Simd::Neon::NeuralDerivativeSigmoid), FUNC_AD(SimdNeuralDerivativeSigmoid));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `NeuralDerivativeSigmoid` and include it in public dispatch.
- Extend `NeuralDerivativeSigmoidAutoTest` with the SVE2 implementation path.
- Update 7.2.163 release notes for the new SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralDerivativeSigmoid -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -I /workspace/src -std=c++17 -c /workspace/src/Simd/SimdSve2Neural.cpp -o /tmp/SimdSve2Neural.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c47e3b55-5e95-45fb-9e3e-6926411bdc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c47e3b55-5e95-45fb-9e3e-6926411bdc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

