### PR TITLE
Add SVE2 optimization for NeuralDerivativeTanh

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -52,6 +52,7 @@
  <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>
  <li>SVE2 optimizations of function NeuralDerivativeSigmoid.</li>
+ <li>SVE2 optimizations of function NeuralDerivativeTanh.</li>
  <li>SVE2 optimizations of function NeuralDerivativeRelu.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4150,7 +4150,7 @@ SIMD_API void SimdNeuralDerivativeTanh(const float * src, size_t size, const flo
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralDerivativeTanhPtr) (const float * src, size_t size, const float * slope, float * dst);
-    const static SimdNeuralDerivativeTanhPtr simdNeuralDerivativeTanh = SIMD_FUNC4(NeuralDerivativeTanh, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralDerivativeTanhPtr simdNeuralDerivativeTanh = SIMD_FUNC5(NeuralDerivativeTanh, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralDerivativeTanh(src, size, slope, dst);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -131,6 +131,8 @@ namespace Simd
 
         void NeuralDerivativeSigmoid(const float* src, size_t size, const float* slope, float* dst);
 
+        void NeuralDerivativeTanh(const float* src, size_t size, const float* slope, float* dst);
+
         void NeuralDerivativeRelu(const float* src, size_t size, const float* slope, float* dst);
 
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -186,6 +186,35 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void DerivativeTanh(const svbool_t& mask, const svfloat32_t& _1, const svfloat32_t& slope, const float* src, float* dst)
+        {
+            svfloat32_t _src = svld1_f32(mask, src);
+            svfloat32_t _dst = svld1_f32(mask, dst);
+            svst1_f32(mask, dst, svmul_f32_x(mask, svmul_f32_x(mask, _dst, slope), svsub_f32_x(mask, _1, svmul_f32_x(mask, _src, _src))));
+        }
+
+        void NeuralDerivativeTanh(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _1 = svdup_n_f32(1.0f);
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
+
+            for (; i + QF <= size; i += QF)
+            {
+                DerivativeTanh(body, _1, _slope, src + i + 0 * F, dst + i + 0 * F);
+                DerivativeTanh(body, _1, _slope, src + i + 1 * F, dst + i + 1 * F);
+                DerivativeTanh(body, _1, _slope, src + i + 2 * F, dst + i + 2 * F);
+                DerivativeTanh(body, _1, _slope, src + i + 3 * F, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                DerivativeTanh(body, _1, _slope, src + i, dst + i);
+            if (i < size)
+                DerivativeTanh(svwhilelt_b32(i, size), _1, _slope, src + i, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void DerivativeRelu(const svbool_t& mask, const svfloat32_t& _1, const svfloat32_t& slope, const float* src, float* dst)
         {
             svfloat32_t _src = svld1_f32(mask, src);

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -708,6 +708,11 @@ namespace Test
             result = result && NeuralActivateDerivativeAutoTest(EPS, true, 3.0f, FUNC_AD(Simd::Avx512bw::NeuralDerivativeTanh), FUNC_AD(SimdNeuralDerivativeTanh));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralActivateDerivativeAutoTest(EPS, true, 3.0f, FUNC_AD(Simd::Sve2::NeuralDerivativeTanh), FUNC_AD(SimdNeuralDerivativeTanh));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralActivateDerivativeAutoTest(EPS, true, 3.0f, FUNC_AD(Simd::Neon::NeuralDerivativeTanh), FUNC_AD(SimdNeuralDerivativeTanh));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `NeuralDerivativeTanh`.
- Dispatch `SimdNeuralDerivativeTanh` through the SVE2 path when enabled.
- Add SVE2 coverage to `NeuralDerivativeTanhAutoTest` and update the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralDerivativeTanh -tt=1 -ts=1`
- `cmake ./prj/cmake -B build-aarch64-sve2-clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DSIMD_TOOLCHAIN="clang" -DSIMD_TARGET="" -DSIMD_SVE2=ON -DSIMD_TEST=OFF -DSIMD_SHARED=OFF && cmake --build build-aarch64-sve2-clang --parallel$(nproc)`

Note: `aarch64-linux-gnu-g++` was also tried, but this package rejected the repository's `-msve-vector-bits=scalable` flag before source compilation; Clang 18 completed the SVE2 cross-build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11734da5-697e-4e92-9190-59afab78dc53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11734da5-697e-4e92-9190-59afab78dc53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

