### PR TITLE
Add SVE2 NeuralPow optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -54,6 +54,7 @@
  <li>SVE2 optimizations of function NeuralDerivativeSigmoid.</li>
  <li>SVE2 optimizations of function NeuralDerivativeTanh.</li>
  <li>SVE2 optimizations of function NeuralDerivativeRelu.</li>
+ <li>SVE2 optimizations of function NeuralPow.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="..\..\src\Simd\SimdMemory.h" />
     <ClInclude Include="..\..\src\Simd\SimdNeon.h" />
     <ClInclude Include="..\..\src\Simd\SimdPack.h" />
+    <ClInclude Include="..\..\src\Simd\SimdPow.h" />
     <ClInclude Include="..\..\src\Simd\SimdReorder.h" />
     <ClInclude Include="..\..\src\Simd\SimdSet.h" />
     <ClInclude Include="..\..\src\Simd\SimdStore.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="..\..\src\Simd\SimdPack.h">
       <Filter>Inc</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Simd\SimdPow.h">
+      <Filter>Inc</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdCast.h">
       <Filter>Inc</Filter>
     </ClInclude>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4168,7 +4168,7 @@ SIMD_API void SimdNeuralPow(const float * src, size_t size, const float * expone
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralPowPtr) (const float * src, size_t size, const float * exponent, float * dst);
-    const static SimdNeuralPowPtr simdNeuralPow = SIMD_FUNC4(NeuralPow, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralPowPtr simdNeuralPow = SIMD_FUNC5(NeuralPow, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralPow(src, size, exponent, dst);
 }

--- a/src/Simd/SimdPow.h
+++ b/src/Simd/SimdPow.h
@@ -206,9 +206,6 @@ namespace Simd
     {
         class Pow
         {
-            svuint32_t _exponent, _mantissa;
-            svfloat32_t _one;
-
             SIMD_INLINE svfloat32_t Poly5(const svbool_t& mask, const svfloat32_t& x, float a, float b, float c, float d, float e, float f) const
             {
                 svfloat32_t p = svdup_n_f32(f);
@@ -233,21 +230,17 @@ namespace Simd
             SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, const svfloat32_t& x) const
             {
                 svuint32_t i = svreinterpret_u32_f32(x);
-                svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_u32_x(mask, i, _exponent), 23)), 127);
+                svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
                 svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-                svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_u32_x(mask, i, _mantissa), svreinterpret_u32_f32(_one)));
+                svfloat32_t one = svdup_n_f32(1.0f);
+                svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
                 svfloat32_t p = Poly5(mask, m, 3.1157899f, -3.3241990f, 2.5988452f, -1.2315303f, 3.1821337e-1f, -3.4436006e-2f);
-                return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, _one));
+                return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
             }
 
         public:
 
-            SIMD_INLINE Pow()
-            {
-                _exponent = svdup_n_u32(0x7F800000);
-                _mantissa = svdup_n_u32(0x007FFFFF);
-                _one = svdup_n_f32(1.0f);
-            }
+            SIMD_INLINE Pow() {}
 
             SIMD_INLINE svfloat32_t operator() (const svbool_t& mask, const svfloat32_t& basis, const svfloat32_t& exponent) const
             {

--- a/src/Simd/SimdPow.h
+++ b/src/Simd/SimdPow.h
@@ -201,6 +201,62 @@ namespace Simd
     }
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class Pow
+        {
+            svuint32_t _exponent, _mantissa;
+            svfloat32_t _one;
+
+            SIMD_INLINE svfloat32_t Poly5(const svbool_t& mask, const svfloat32_t& x, float a, float b, float c, float d, float e, float f) const
+            {
+                svfloat32_t p = svdup_n_f32(f);
+                p = svmla_f32_x(mask, svdup_n_f32(e), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(d), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(c), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(b), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(a), x, p);
+                return p;
+            }
+
+            SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, const svfloat32_t& x) const
+            {
+                svfloat32_t _x = svmax_n_f32_x(mask, svmin_n_f32_x(mask, x, 129.00000f), -126.99999f);
+                svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, _x, 0.5f));
+                svfloat32_t fpart = svsub_f32_x(mask, _x, svcvt_f32_s32_x(mask, ipart));
+                svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+                svfloat32_t expfpart = Poly5(mask, fpart, 9.9999994e-1f, 6.9315308e-1f, 2.4015361e-1f, 5.5826318e-2f, 8.9893397e-3f, 1.8775767e-3f);
+                return svmul_f32_x(mask, expipart, expfpart);
+            }
+
+            SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, const svfloat32_t& x) const
+            {
+                svuint32_t i = svreinterpret_u32_f32(x);
+                svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_u32_x(mask, i, _exponent), 23)), 127);
+                svfloat32_t e = svcvt_f32_s32_x(mask, e32);
+                svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_u32_x(mask, i, _mantissa), svreinterpret_u32_f32(_one)));
+                svfloat32_t p = Poly5(mask, m, 3.1157899f, -3.3241990f, 2.5988452f, -1.2315303f, 3.1821337e-1f, -3.4436006e-2f);
+                return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, _one));
+            }
+
+        public:
+
+            SIMD_INLINE Pow()
+            {
+                _exponent = svdup_n_u32(0x7F800000);
+                _mantissa = svdup_n_u32(0x007FFFFF);
+                _one = svdup_n_f32(1.0f);
+            }
+
+            SIMD_INLINE svfloat32_t operator() (const svbool_t& mask, const svfloat32_t& basis, const svfloat32_t& exponent) const
+            {
+                return Exp2(mask, svmul_f32_x(mask, Log2(mask, basis), exponent));
+            }
+        };
+    }
+#endif //SIMD_SVE2_ENABLE
+
 #ifdef SIMD_NEON_ENABLE    
     namespace Neon
     {

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -135,6 +135,8 @@ namespace Simd
 
         void NeuralDerivativeRelu(const float* src, size_t size, const float* slope, float* dst);
 
+        void NeuralPow(const float* src, size_t size, const float* exponent, float* dst);
+
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);
 
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -22,6 +22,7 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
+#include "Simd/SimdPow.h"
 
 namespace Simd
 {
@@ -241,6 +242,33 @@ namespace Simd
                 DerivativeRelu(body, _1, _slope, src + i, dst + i);
             if (i < size)
                 DerivativeRelu(svwhilelt_b32(i, size), _1, _slope, src + i, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void NeuralPow(const svbool_t& mask, const Pow& pow, const svfloat32_t& exponent, const float* src, float* dst)
+        {
+            svst1_f32(mask, dst, pow(mask, svld1_f32(mask, src), exponent));
+        }
+
+        void NeuralPow(const float* src, size_t size, const float* exponent, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _exponent = svdup_n_f32(exponent[0]);
+            Pow pow;
+
+            for (; i + QF <= size; i += QF)
+            {
+                NeuralPow(body, pow, _exponent, src + i + 0 * F, dst + i + 0 * F);
+                NeuralPow(body, pow, _exponent, src + i + 1 * F, dst + i + 1 * F);
+                NeuralPow(body, pow, _exponent, src + i + 2 * F, dst + i + 2 * F);
+                NeuralPow(body, pow, _exponent, src + i + 3 * F, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                NeuralPow(body, pow, _exponent, src + i, dst + i);
+            if (i < size)
+                NeuralPow(svwhilelt_b32(i, size), pow, _exponent, src + i, dst + i);
         }
 
         //-------------------------------------------------------------------------------------------------

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -587,6 +587,11 @@ namespace Test
             result = result && NeuralPowAutoTest(EPS, false, FUNC_AF(Simd::Avx512bw::NeuralPow), FUNC_AF(SimdNeuralPow));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralPowAutoTest(EPS, false, FUNC_AF(Simd::Sve2::NeuralPow), FUNC_AF(SimdNeuralPow));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralPowAutoTest(EPS, false, FUNC_AF(Simd::Neon::NeuralPow), FUNC_AF(SimdNeuralPow));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add a predicated SVE2 vector Pow helper and `Sve2::NeuralPow` implementation.
* Route `SimdNeuralPow` through SVE2 before NEON when available.
* Add SVE2 NeuralPow auto-test coverage, VS2022 project metadata, and release note entry.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `./build/Test "-r=." -fi=NeuralPow -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Neural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0173560c-5f75-4927-82f5-51fe65f8bdcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0173560c-5f75-4927-82f5-51fe65f8bdcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

