### PR TITLE
Add SVE2 NeuralProductSum optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
  <li>SVE2 optimizations of function NeuralConvert.</li>
+ <li>SVE2 optimizations of function NeuralProductSum.</li>
  <li>SVE2 optimizations of function NeuralAddVectorMultipliedByValue.</li>
  <li>SVE2 optimizations of function NeuralAddVector.</li>
  <li>SVE2 optimizations of function NeuralAddValue.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4105,7 +4105,7 @@ SIMD_API void SimdNeuralProductSum(const float * a, const float * b, size_t size
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralProductSumPtr) (const float * a, const float * b, size_t size, float * sum);
-    const static SimdNeuralProductSumPtr simdNeuralProductSum = SIMD_FUNC4(NeuralProductSum, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralProductSumPtr simdNeuralProductSum = SIMD_FUNC5(NeuralProductSum, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralProductSum(a, b, size, sum);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -123,6 +123,8 @@ namespace Simd
 
         void NeuralConvert(const uint8_t* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride, int inversion);
 
+        void NeuralProductSum(const float* a, const float* b, size_t size, float* sum);
+
         void NeuralAddVectorMultipliedByValue(const float* src, size_t size, const float* value, float* dst);
 
         void NeuralAddVector(const float* src, size_t size, float* dst);

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -94,23 +94,26 @@ namespace Simd
         {
             size_t F = svcntw(), QF = 4 * F, i = 0;
             const svbool_t body = svptrue_b32();
-            svfloat32_t sums[4] = { svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f) };
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            svfloat32_t sum2 = svdup_n_f32(0.0f);
+            svfloat32_t sum3 = svdup_n_f32(0.0f);
 
             for (; i + QF <= size; i += QF)
             {
-                ProductSum(body, a + i + 0 * F, b + i + 0 * F, sums[0]);
-                ProductSum(body, a + i + 1 * F, b + i + 1 * F, sums[1]);
-                ProductSum(body, a + i + 2 * F, b + i + 2 * F, sums[2]);
-                ProductSum(body, a + i + 3 * F, b + i + 3 * F, sums[3]);
+                ProductSum(body, a + i + 0 * F, b + i + 0 * F, sum0);
+                ProductSum(body, a + i + 1 * F, b + i + 1 * F, sum1);
+                ProductSum(body, a + i + 2 * F, b + i + 2 * F, sum2);
+                ProductSum(body, a + i + 3 * F, b + i + 3 * F, sum3);
             }
             for (; i + F <= size; i += F)
-                ProductSum(body, a + i, b + i, sums[0]);
+                ProductSum(body, a + i, b + i, sum0);
             if (i < size)
-                ProductSum(svwhilelt_b32(i, size), a + i, b + i, sums[0]);
+                ProductSum(svwhilelt_b32(i, size), a + i, b + i, sum0);
 
-            sums[0] = svadd_f32_x(body, sums[0], sums[1]);
-            sums[2] = svadd_f32_x(body, sums[2], sums[3]);
-            *sum = svaddv_f32(body, svadd_f32_x(body, sums[0], sums[2]));
+            sum0 = svadd_f32_x(body, sum0, sum1);
+            sum2 = svadd_f32_x(body, sum2, sum3);
+            *sum = svaddv_f32(body, svadd_f32_x(body, sum0, sum2));
         }
 
         //-------------------------------------------------------------------------------------------------

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -85,6 +85,36 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void ProductSum(const svbool_t& mask, const float* a, const float* b, svfloat32_t& sum)
+        {
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, a), svld1_f32(mask, b));
+        }
+
+        void NeuralProductSum(const float* a, const float* b, size_t size, float* sum)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sums[4] = { svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f) };
+
+            for (; i + QF <= size; i += QF)
+            {
+                ProductSum(body, a + i + 0 * F, b + i + 0 * F, sums[0]);
+                ProductSum(body, a + i + 1 * F, b + i + 1 * F, sums[1]);
+                ProductSum(body, a + i + 2 * F, b + i + 2 * F, sums[2]);
+                ProductSum(body, a + i + 3 * F, b + i + 3 * F, sums[3]);
+            }
+            for (; i + F <= size; i += F)
+                ProductSum(body, a + i, b + i, sums[0]);
+            if (i < size)
+                ProductSum(svwhilelt_b32(i, size), a + i, b + i, sums[0]);
+
+            sums[0] = svadd_f32_x(body, sums[0], sums[1]);
+            sums[2] = svadd_f32_x(body, sums[2], sums[3]);
+            *sum = svaddv_f32(body, svadd_f32_x(body, sums[0], sums[2]));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AddMultiplied(const svbool_t& mask, const svfloat32_t& value, const float* src, float* dst)
         {
             svst1_f32(mask, dst, svmla_f32_m(mask, svld1_f32(mask, dst), svld1_f32(mask, src), value));

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -216,6 +216,11 @@ namespace Test
             result = result && NeuralProductSumAutoTest(EPS, FUNC_PS(Simd::Avx512bw::NeuralProductSum), FUNC_PS(SimdNeuralProductSum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralProductSumAutoTest(EPS, FUNC_PS(Simd::Sve2::NeuralProductSum), FUNC_PS(SimdNeuralProductSum));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralProductSumAutoTest(EPS, FUNC_PS(Simd::Neon::NeuralProductSum), FUNC_PS(SimdNeuralProductSum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch wiring for `SimdNeuralProductSum`.
- Add SVE2 NeuralProductSum autotest coverage.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=NeuralProductSum -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I./src -fsyntax-only ./src/Simd/SimdSve2Neural.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I./src -fsyntax-only ./src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I./src -I./src/Test -fsyntax-only ./src/Test/TestNeural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a5ea22e-ca80-4899-a52c-0ed459c914e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a5ea22e-ca80-4899-a52c-0ed459c914e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

