### PR TITLE
Add SVE2 NeuralUpdateWeights optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -56,6 +56,7 @@
  <li>SVE2 optimizations of function NeuralDerivativeTanh.</li>
  <li>SVE2 optimizations of function NeuralDerivativeRelu.</li>
  <li>SVE2 optimizations of function NeuralPow.</li>
+ <li>SVE2 optimizations of function NeuralUpdateWeights.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
@@ -221,6 +222,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvert.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function NeuralUpdateWeights.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4177,7 +4177,7 @@ SIMD_API void SimdNeuralUpdateWeights(const float * x, size_t size, const float 
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralUpdateWeightsPtr) (const float * x, size_t size, const float * a, const float * b, float * d, float * w);
-    const static SimdNeuralUpdateWeightsPtr simdNeuralUpdateWeights = SIMD_FUNC4(NeuralUpdateWeights, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralUpdateWeightsPtr simdNeuralUpdateWeights = SIMD_FUNC5(NeuralUpdateWeights, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralUpdateWeights(x, size, a, b, d, w);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -139,6 +139,8 @@ namespace Simd
 
         void NeuralPow(const float* src, size_t size, const float* exponent, float* dst);
 
+        void NeuralUpdateWeights(const float* x, size_t size, const float* a, const float* b, float* d, float* w);
+
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);
 
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -306,6 +306,35 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void UpdateWeights(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const float* x, float* d, float* w)
+        {
+            svfloat32_t _d = svmla_f32_m(mask, svmul_f32_x(mask, svld1_f32(mask, x), b), svld1_f32(mask, d), a);
+            svst1_f32(mask, d, _d);
+            svst1_f32(mask, w, svadd_f32_x(mask, svld1_f32(mask, w), _d));
+        }
+
+        void NeuralUpdateWeights(const float* x, size_t size, const float* a, const float* b, float* d, float* w)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _a = svdup_n_f32(a[0]);
+            const svfloat32_t _b = svdup_n_f32(b[0]);
+
+            for (; i + QF <= size; i += QF)
+            {
+                UpdateWeights(body, _a, _b, x + i + 0 * F, d + i + 0 * F, w + i + 0 * F);
+                UpdateWeights(body, _a, _b, x + i + 1 * F, d + i + 1 * F, w + i + 1 * F);
+                UpdateWeights(body, _a, _b, x + i + 2 * F, d + i + 2 * F, w + i + 2 * F);
+                UpdateWeights(body, _a, _b, x + i + 3 * F, d + i + 3 * F, w + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                UpdateWeights(body, _a, _b, x + i, d + i, w + i);
+            if (i < size)
+                UpdateWeights(svwhilelt_b32(i, size), _a, _b, x + i, d + i, w + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AdaptiveGradientUpdate(const svbool_t& mask, const svfloat32_t& norm, const svfloat32_t& alpha, const svfloat32_t& epsilon, const float* delta, float* gradient, float* weight)
         {
             svfloat32_t d = svmul_f32_x(mask, svld1_f32(mask, delta), norm);

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -851,6 +851,11 @@ namespace Test
             result = result && NeuralUpdateWeightsAutoTest(EPS, false, FUNC_UW(Simd::Avx512bw::NeuralUpdateWeights), FUNC_UW(SimdNeuralUpdateWeights));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralUpdateWeightsAutoTest(EPS, false, FUNC_UW(Simd::Sve2::NeuralUpdateWeights), FUNC_UW(SimdNeuralUpdateWeights));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralUpdateWeightsAutoTest(EPS, false, FUNC_UW(Simd::Neon::NeuralUpdateWeights), FUNC_UW(SimdNeuralUpdateWeights));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch wiring for `SimdNeuralUpdateWeights`.
- Add SVE2 coverage to `NeuralUpdateWeightsAutoTest`.
- Update 7.2.163 release notes for the optimization and test coverage.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --target Test --parallel2`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralUpdateWeights -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I./src ./src/Simd/SimdSve2Neural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c160286-bf48-4e25-a56a-6904b10608da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c160286-bf48-4e25-a56a-6904b10608da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

