### PR TITLE
fix stack buffer overflow reading weights in Neural::Network::Load

### DIFF
--- a/src/Simd/SimdNeural.hpp
+++ b/src/Simd/SimdNeural.hpp
@@ -1907,9 +1907,7 @@ namespace Simd
 
             static SIMD_INLINE void Load(std::istream & is, float & value)
             {
-                char buffer[64];
-                is >> buffer;
-                value = (float)::atof(buffer);
+                is >> value;
             }
 
             const Vector & Forward(const Vector & src, size_t thread, Layer::Method method)


### PR DESCRIPTION
Network::Load deserialises the saved weights by reading each value as a whitespace-delimited token, and the per-value helper reads that token into a fixed char[64] with operator>> before handing it to atof. With libc++ that operator>> binds the unbounded basic_istream& operator>>(istream&, char*) form, which copies characters until the next space with no length cap, so a single token longer than 63 bytes walks off the end of the stack buffer. The tokens come straight from the model file or stream passed to Load, so a corrupt or hostile file overflows the stack rather than simply failing to parse. I noticed it while building the Neural test under -std=c++11 with AddressSanitizer, which flags a stack-buffer-overflow write on the 64-byte frame for an over-long token. Reading the float directly with is >> value removes the intermediate buffer and the atof call, mirrors the operator<< used on the save side so valid files round-trip unchanged, and keeps parsing on the stream own locale instead of quietly falling back to the C locale. I have kept the change to that one helper.