### PR TITLE
Add SVE2 optimization for NeuralPooling1x1Max3x3

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -58,6 +58,7 @@
  <li>SVE2 optimizations of function NeuralPow.</li>
  <li>SVE2 optimizations of function NeuralUpdateWeights.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
+ <li>SVE2 optimizations of function NeuralPooling1x1Max3x3.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
  <li>SVE2 optimizations of function CosineDistance16f.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4453,6 +4453,11 @@ SIMD_API void SimdNeuralPooling1x1Max3x3(const float * src, size_t srcStride, si
         Sse41::NeuralPooling1x1Max3x3(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > svcntw())
+        Sve2::NeuralPooling1x1Max3x3(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::F)
         Neon::NeuralPooling1x1Max3x3(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -143,6 +143,8 @@ namespace Simd
 
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);
 
+        void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
+
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             size_t channelCount, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -364,6 +364,90 @@ namespace Simd
             if (i < size)
                 AdaptiveGradientUpdate(svwhilelt_b32(i, size), _norm, _alpha, _epsilon, delta + i, gradient + i, weight + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE float Max2(const float* src)
+        {
+            return Simd::Max(src[0], src[1]);
+        }
+
+        SIMD_INLINE float Max2x2(const float* src, size_t stride)
+        {
+            return Simd::Max(Max2(src), Max2(src + stride));
+        }
+
+        SIMD_INLINE float Max2x3(const float* src, size_t stride)
+        {
+            return Simd::Max(Max2(src), Simd::Max(Max2(src + stride), Max2(src + 2 * stride)));
+        }
+
+        SIMD_INLINE svfloat32_t Pooling1x1Max3x1(const svbool_t& mask, const float* src)
+        {
+            svfloat32_t src0 = svld1_f32(mask, src + 0);
+            svfloat32_t src1 = svld1_f32(mask, src + 1);
+            svfloat32_t src2 = svld1_f32(mask, src + 2);
+            return svmax_f32_x(mask, svmax_f32_x(mask, src0, src1), src2);
+        }
+
+        SIMD_INLINE svfloat32_t Pooling1x1Max3x2(const svbool_t& mask, const float* src, size_t stride)
+        {
+            svfloat32_t src0 = Pooling1x1Max3x1(mask, src);
+            svfloat32_t src1 = Pooling1x1Max3x1(mask, src + stride);
+            return svmax_f32_x(mask, src0, src1);
+        }
+
+        SIMD_INLINE svfloat32_t Pooling1x1Max3x3(const svbool_t& mask, const float* src, size_t stride)
+        {
+            svfloat32_t src0 = Pooling1x1Max3x1(mask, src);
+            svfloat32_t src1 = Pooling1x1Max3x1(mask, src + stride);
+            svfloat32_t src2 = Pooling1x1Max3x1(mask, src + 2 * stride);
+            return svmax_f32_x(mask, svmax_f32_x(mask, src0, src1), src2);
+        }
+
+        SIMD_INLINE void Pooling1x1Max3x2(const float* src, size_t stride, size_t width, float* dst)
+        {
+            size_t F = svcntw(), bodyWidth = width - 1;
+            for (size_t col = 1; col < bodyWidth; col += F)
+            {
+                svbool_t mask = svwhilelt_b32(col, bodyWidth);
+                svst1_f32(mask, dst + col, Pooling1x1Max3x2(mask, src + col - 1, stride));
+            }
+        }
+
+        SIMD_INLINE void Pooling1x1Max3x3(const float* src, size_t stride, size_t width, float* dst)
+        {
+            size_t F = svcntw(), bodyWidth = width - 1;
+            for (size_t col = 1; col < bodyWidth; col += F)
+            {
+                svbool_t mask = svwhilelt_b32(col, bodyWidth);
+                svst1_f32(mask, dst + col, Pooling1x1Max3x3(mask, src + col - 1, stride));
+            }
+        }
+
+        void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            assert(width > 1 && height > 1);
+
+            dst[0] = Max2x2(src, srcStride);
+            Pooling1x1Max3x2(src, srcStride, width, dst);
+            dst[width - 1] = Max2x2(src + width - 2, srcStride);
+            dst += dstStride;
+
+            for (size_t row = 1; row < height - 1; ++row)
+            {
+                const float* s = src + (row - 1) * srcStride;
+                dst[0] = Max2x3(s, srcStride);
+                Pooling1x1Max3x3(s, srcStride, width, dst);
+                dst[width - 1] = Max2x3(s + width - 2, srcStride);
+                dst += dstStride;
+            }
+
+            src += (height - 2) * srcStride;
+            dst[0] = Max2x2(src, srcStride);
+            Pooling1x1Max3x2(src, srcStride, width, dst);
+            dst[width - 1] = Max2x2(src + width - 2, srcStride);
+        }
     }
 #endif
 }

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -1038,6 +1038,11 @@ namespace Test
             result = result && NeuralPoolingMaxAutoTest(stride, pooling, pad, EPS, FUNC_M(Simd::Avx512bw::NeuralPooling1x1Max3x3), FUNC_M(SimdNeuralPooling1x1Max3x3));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralPoolingMaxAutoTest(stride, pooling, pad, EPS, FUNC_M(Simd::Sve2::NeuralPooling1x1Max3x3), FUNC_M(SimdNeuralPooling1x1Max3x3));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralPoolingMaxAutoTest(stride, pooling, pad, EPS, FUNC_M(Simd::Neon::NeuralPooling1x1Max3x3), FUNC_M(SimdNeuralPooling1x1Max3x3));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdNeuralPooling1x1Max3x3`.
- Extend `NeuralPooling1x1Max3x3AutoTest` with SVE2 coverage.
- Document the SVE2 optimization in release 7.2.163 notes.

### Testing
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2Neural.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -I src -fsyntax-only src/Simd/SimdLib.cpp`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralPooling1x1Max3x3 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -I src -I . -fsyntax-only src/Test/TestNeural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c882ab4e-fc6e-4713-a27d-26ed05f96264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c882ab4e-fc6e-4713-a27d-26ed05f96264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

