### PR TITLE
Add SVE2 neural pooling 2x2 max optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -59,6 +59,7 @@
  <li>SVE2 optimizations of function NeuralUpdateWeights.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function NeuralPooling1x1Max3x3.</li>
+ <li>SVE2 optimizations of function NeuralPooling2x2Max2x2.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max3x3.</li>
  <li>SVE2 optimizations of function GaussianBlurInit.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4484,6 +4484,11 @@ SIMD_API void SimdNeuralPooling2x2Max2x2(const float * src, size_t srcStride, si
         Sse41::NeuralPooling2x2Max2x2(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= 2 * svcntw())
+        Sve2::NeuralPooling2x2Max2x2(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DF)
         Neon::NeuralPooling2x2Max2x2(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -145,6 +145,8 @@ namespace Simd
 
         void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
 
+        void NeuralPooling2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
+
         void NeuralPooling2x2Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
 
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2Neural.cpp
+++ b/src/Simd/SimdSve2Neural.cpp
@@ -457,6 +457,20 @@ namespace Simd
             return svmax_f32_x(mask, svmax_f32_x(mask, src0, src1), src2);
         }
 
+        SIMD_INLINE svfloat32_t Pooling2x2Max1x2(const svbool_t& mask, const float* src, const svuint32_t& offsets0, const svuint32_t& offsets1)
+        {
+            svfloat32_t src0 = svld1_gather_u32index_f32(mask, src, offsets0);
+            svfloat32_t src1 = svld1_gather_u32index_f32(mask, src, offsets1);
+            return svmax_f32_x(mask, src0, src1);
+        }
+
+        SIMD_INLINE svfloat32_t Pooling2x2Max2x2(const svbool_t& mask, const float* src, size_t stride, const svuint32_t& offsets0, const svuint32_t& offsets1)
+        {
+            svfloat32_t src0 = Pooling2x2Max1x2(mask, src, offsets0, offsets1);
+            svfloat32_t src1 = Pooling2x2Max1x2(mask, src + stride, offsets0, offsets1);
+            return svmax_f32_x(mask, src0, src1);
+        }
+
         SIMD_INLINE svfloat32_t Pooling2x2Max3x2(const svbool_t& mask, const float* src, size_t stride, const svuint32_t& offsets0, const svuint32_t& offsets1, const svuint32_t& offsets2)
         {
             svfloat32_t src0 = Pooling2x2Max1x3(mask, src, offsets0, offsets1, offsets2);
@@ -470,6 +484,36 @@ namespace Simd
             svfloat32_t src1 = Pooling2x2Max1x3(mask, src + stride, offsets0, offsets1, offsets2);
             svfloat32_t src2 = Pooling2x2Max1x3(mask, src + 2 * stride, offsets0, offsets1, offsets2);
             return svmax_f32_x(mask, svmax_f32_x(mask, src0, src1), src2);
+        }
+
+        void NeuralPooling2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            size_t F = svcntw(), heightEven = Simd::AlignLo(height, 2), widthEven = Simd::AlignLo(width, 2), dstWidthEven = widthEven >> 1;
+            const svuint32_t offsets0 = svindex_u32(0, 2);
+            const svuint32_t offsets1 = svindex_u32(1, 2);
+
+            for (size_t row = 0; row < heightEven; row += 2)
+            {
+                for (size_t col = 0; col < dstWidthEven; col += F)
+                {
+                    svbool_t mask = svwhilelt_b32(col, dstWidthEven);
+                    svst1_f32(mask, dst + col, Pooling2x2Max2x2(mask, src + 2 * col, srcStride, offsets0, offsets1));
+                }
+                if (width - widthEven)
+                    dst[dstWidthEven] = Simd::Max(src[widthEven], src[widthEven + srcStride]);
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+            if (height - heightEven)
+            {
+                for (size_t col = 0; col < dstWidthEven; col += F)
+                {
+                    svbool_t mask = svwhilelt_b32(col, dstWidthEven);
+                    svst1_f32(mask, dst + col, Pooling2x2Max1x2(mask, src + 2 * col, offsets0, offsets1));
+                }
+                if (width - widthEven)
+                    dst[dstWidthEven] = src[widthEven];
+            }
         }
 
         void NeuralPooling2x2Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -1074,6 +1074,11 @@ namespace Test
             result = result && NeuralPoolingMaxAutoTest(stride, pooling, pad, EPS, FUNC_M(Simd::Avx512bw::NeuralPooling2x2Max2x2), FUNC_M(SimdNeuralPooling2x2Max2x2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralPoolingMaxAutoTest(stride, pooling, pad, EPS, FUNC_M(Simd::Sve2::NeuralPooling2x2Max2x2), FUNC_M(SimdNeuralPooling2x2Max2x2));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralPoolingMaxAutoTest(stride, pooling, pad, EPS, FUNC_M(Simd::Neon::NeuralPooling2x2Max2x2), FUNC_M(SimdNeuralPooling2x2Max2x2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `SimdNeuralPooling2x2Max2x2`.
- Route the public dispatcher to SVE2 when available and add SVE2 coverage to `NeuralPooling2x2Max2x2AutoTest`.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralPooling2x2Max2x2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.5-a+sve2 -I./src ./src/Simd/SimdSve2Neural.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf82545b-57d4-412d-bd81-a1ac6d939024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf82545b-57d4-412d-bd81-a1ac6d939024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

