### PR TITLE
Add SVE2 NeuralAddConvolution2x2Forward optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -58,6 +58,7 @@
  <li>SVE2 optimizations of function NeuralPow.</li>
  <li>SVE2 optimizations of function NeuralUpdateWeights.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution2x2Forward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Backward.</li>
  <li>SVE2 optimizations of function NeuralPooling1x1Max3x3.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max2x2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4209,6 +4209,11 @@ SIMD_API void SimdNeuralAddConvolution2x2Forward(const float * src, size_t srcSt
         Sse41::NeuralAddConvolution2x2Forward(src, srcStride, width, height, weights, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::NeuralAddConvolution2x2Forward(src, srcStride, width, height, weights, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::NeuralAddConvolution2x2Forward(src, srcStride, width, height, weights, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -143,6 +143,8 @@ namespace Simd
 
         void NeuralAdaptiveGradientUpdate(const float* delta, size_t size, size_t batch, const float* alpha, const float* epsilon, float* gradient, float* weight);
 
+        void NeuralAddConvolution2x2Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
+
         void NeuralAddConvolution2x2Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
         void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -28,6 +28,54 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE svfloat32_t Convolution2x2Forward(const svbool_t& mask, const float* src, size_t stride,
+            const svfloat32_t& weight0, const svfloat32_t& weight1, const svfloat32_t& weight2, const svfloat32_t& weight3)
+        {
+            svfloat32_t sum = svmul_f32_x(mask, svld1_f32(mask, src), weight0);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src + 1), weight1);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src + stride), weight2);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src + stride + 1), weight3);
+            return sum;
+        }
+
+        SIMD_INLINE void AddConvolution2x2Forward(const svbool_t& mask, const float* src, size_t stride,
+            const svfloat32_t& weight0, const svfloat32_t& weight1, const svfloat32_t& weight2, const svfloat32_t& weight3, float* dst)
+        {
+            svfloat32_t sum = Convolution2x2Forward(mask, src, stride, weight0, weight1, weight2, weight3);
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), sum));
+        }
+
+        void NeuralAddConvolution2x2Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t weight0 = svdup_n_f32(weights[0]);
+            const svfloat32_t weight1 = svdup_n_f32(weights[1]);
+            const svfloat32_t weight2 = svdup_n_f32(weights[2]);
+            const svfloat32_t weight3 = svdup_n_f32(weights[3]);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    AddConvolution2x2Forward(body, src + col + 0 * F, srcStride, weight0, weight1, weight2, weight3, dst + col + 0 * F);
+                    AddConvolution2x2Forward(body, src + col + 1 * F, srcStride, weight0, weight1, weight2, weight3, dst + col + 1 * F);
+                    AddConvolution2x2Forward(body, src + col + 2 * F, srcStride, weight0, weight1, weight2, weight3, dst + col + 2 * F);
+                    AddConvolution2x2Forward(body, src + col + 3 * F, srcStride, weight0, weight1, weight2, weight3, dst + col + 3 * F);
+                }
+                for (; col + F <= width; col += F)
+                    AddConvolution2x2Forward(body, src + col, srcStride, weight0, weight1, weight2, weight3, dst + col);
+                if (col < width)
+                    AddConvolution2x2Forward(svwhilelt_b32(col, width), src + col, srcStride, weight0, weight1, weight2, weight3, dst + col);
+
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AddMultiplied(const svbool_t& mask, const float* src, const svfloat32_t& value, float* dst)
         {
             svst1_f32(mask, dst, svmla_f32_m(mask, svld1_f32(mask, dst), svld1_f32(mask, src), value));

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -122,6 +122,11 @@ namespace Test
             result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Avx512bw::NeuralAddConvolution2x2Forward), FUNC_C2(SimdNeuralAddConvolution2x2Forward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Sve2::NeuralAddConvolution2x2Forward), FUNC_C2(SimdNeuralAddConvolution2x2Forward));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Neon::NeuralAddConvolution2x2Forward), FUNC_C2(SimdNeuralAddConvolution2x2Forward));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `NeuralAddConvolution2x2Forward`.
- Add SVE2 auto-test coverage for the 2x2 forward convolution path.
- Update 7.2.163 release notes.

### Notes
- `SimdSve2NeuralConvolution.cpp` is already present in `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` on `dev`.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralAddConvolution2x2Forward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++11 -I src -fsyntax-only src/Simd/SimdSve2NeuralConvolution.cpp`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c919cdb-bea1-401e-87ad-ecb3324d01e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c919cdb-bea1-401e-87ad-ecb3324d01e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

