### PR TITLE
Add SVE2 NeuralAddConvolution2x2Sum optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -60,6 +60,7 @@
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Forward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Backward.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution2x2Sum.</li>
  <li>SVE2 optimizations of function NeuralPooling1x1Max3x3.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max2x2.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max3x3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4354,6 +4354,11 @@ SIMD_API void SimdNeuralAddConvolution2x2Sum(const float * src, size_t srcStride
         Sse41::NeuralAddConvolution2x2Sum(src, srcStride, dst, dstStride, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::NeuralAddConvolution2x2Sum(src, srcStride, dst, dstStride, width, height, sums);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::NeuralAddConvolution2x2Sum(src, srcStride, dst, dstStride, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -147,6 +147,8 @@ namespace Simd
 
         void NeuralAddConvolution2x2Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
+        void NeuralAddConvolution2x2Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);
+
         void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
 
         void NeuralPooling2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -123,50 +123,50 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        SIMD_INLINE void AddConvolution2x2Sum(const svbool_t& mask, const float* src, size_t stride, const svfloat32_t& dst, svfloat32_t sums[4])
+        SIMD_INLINE void AddConvolution2x2Sum(const svbool_t& mask, const float* src, size_t stride, const svfloat32_t& dst,
+            svfloat32_t& sum0, svfloat32_t& sum1, svfloat32_t& sum2, svfloat32_t& sum3)
         {
-            sums[0] = svmla_f32_m(mask, sums[0], svld1_f32(mask, src), dst);
-            sums[1] = svmla_f32_m(mask, sums[1], svld1_f32(mask, src + 1), dst);
-            sums[2] = svmla_f32_m(mask, sums[2], svld1_f32(mask, src + stride), dst);
-            sums[3] = svmla_f32_m(mask, sums[3], svld1_f32(mask, src + stride + 1), dst);
+            sum0 = svmla_f32_m(mask, sum0, svld1_f32(mask, src), dst);
+            sum1 = svmla_f32_m(mask, sum1, svld1_f32(mask, src + 1), dst);
+            sum2 = svmla_f32_m(mask, sum2, svld1_f32(mask, src + stride), dst);
+            sum3 = svmla_f32_m(mask, sum3, svld1_f32(mask, src + stride + 1), dst);
         }
 
         void NeuralAddConvolution2x2Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums)
         {
             size_t F = svcntw(), QF = 4 * F;
             const svbool_t body = svptrue_b32();
-            svfloat32_t _sums[4];
-            _sums[0] = svdup_n_f32(0.0f);
-            _sums[1] = svdup_n_f32(0.0f);
-            _sums[2] = svdup_n_f32(0.0f);
-            _sums[3] = svdup_n_f32(0.0f);
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            svfloat32_t sum2 = svdup_n_f32(0.0f);
+            svfloat32_t sum3 = svdup_n_f32(0.0f);
 
             for (size_t row = 0; row < height; ++row)
             {
                 size_t col = 0;
                 for (; col + QF <= width; col += QF)
                 {
-                    AddConvolution2x2Sum(body, src + col + 0 * F, srcStride, svld1_f32(body, dst + col + 0 * F), _sums);
-                    AddConvolution2x2Sum(body, src + col + 1 * F, srcStride, svld1_f32(body, dst + col + 1 * F), _sums);
-                    AddConvolution2x2Sum(body, src + col + 2 * F, srcStride, svld1_f32(body, dst + col + 2 * F), _sums);
-                    AddConvolution2x2Sum(body, src + col + 3 * F, srcStride, svld1_f32(body, dst + col + 3 * F), _sums);
+                    AddConvolution2x2Sum(body, src + col + 0 * F, srcStride, svld1_f32(body, dst + col + 0 * F), sum0, sum1, sum2, sum3);
+                    AddConvolution2x2Sum(body, src + col + 1 * F, srcStride, svld1_f32(body, dst + col + 1 * F), sum0, sum1, sum2, sum3);
+                    AddConvolution2x2Sum(body, src + col + 2 * F, srcStride, svld1_f32(body, dst + col + 2 * F), sum0, sum1, sum2, sum3);
+                    AddConvolution2x2Sum(body, src + col + 3 * F, srcStride, svld1_f32(body, dst + col + 3 * F), sum0, sum1, sum2, sum3);
                 }
                 for (; col + F <= width; col += F)
-                    AddConvolution2x2Sum(body, src + col, srcStride, svld1_f32(body, dst + col), _sums);
+                    AddConvolution2x2Sum(body, src + col, srcStride, svld1_f32(body, dst + col), sum0, sum1, sum2, sum3);
                 if (col < width)
                 {
                     svbool_t tail = svwhilelt_b32(col, width);
-                    AddConvolution2x2Sum(tail, src + col, srcStride, svld1_f32(tail, dst + col), _sums);
+                    AddConvolution2x2Sum(tail, src + col, srcStride, svld1_f32(tail, dst + col), sum0, sum1, sum2, sum3);
                 }
 
                 src += srcStride;
                 dst += dstStride;
             }
 
-            sums[0] += svaddv_f32(body, _sums[0]);
-            sums[1] += svaddv_f32(body, _sums[1]);
-            sums[2] += svaddv_f32(body, _sums[2]);
-            sums[3] += svaddv_f32(body, _sums[3]);
+            sums[0] += svaddv_f32(body, sum0);
+            sums[1] += svaddv_f32(body, sum1);
+            sums[2] += svaddv_f32(body, sum2);
+            sums[3] += svaddv_f32(body, sum3);
         }
     }
 #endif

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -120,6 +120,54 @@ namespace Simd
                 dst += dstStride;
             }
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void AddConvolution2x2Sum(const svbool_t& mask, const float* src, size_t stride, const svfloat32_t& dst, svfloat32_t sums[4])
+        {
+            sums[0] = svmla_f32_m(mask, sums[0], svld1_f32(mask, src), dst);
+            sums[1] = svmla_f32_m(mask, sums[1], svld1_f32(mask, src + 1), dst);
+            sums[2] = svmla_f32_m(mask, sums[2], svld1_f32(mask, src + stride), dst);
+            sums[3] = svmla_f32_m(mask, sums[3], svld1_f32(mask, src + stride + 1), dst);
+        }
+
+        void NeuralAddConvolution2x2Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _sums[4];
+            _sums[0] = svdup_n_f32(0.0f);
+            _sums[1] = svdup_n_f32(0.0f);
+            _sums[2] = svdup_n_f32(0.0f);
+            _sums[3] = svdup_n_f32(0.0f);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    AddConvolution2x2Sum(body, src + col + 0 * F, srcStride, svld1_f32(body, dst + col + 0 * F), _sums);
+                    AddConvolution2x2Sum(body, src + col + 1 * F, srcStride, svld1_f32(body, dst + col + 1 * F), _sums);
+                    AddConvolution2x2Sum(body, src + col + 2 * F, srcStride, svld1_f32(body, dst + col + 2 * F), _sums);
+                    AddConvolution2x2Sum(body, src + col + 3 * F, srcStride, svld1_f32(body, dst + col + 3 * F), _sums);
+                }
+                for (; col + F <= width; col += F)
+                    AddConvolution2x2Sum(body, src + col, srcStride, svld1_f32(body, dst + col), _sums);
+                if (col < width)
+                {
+                    svbool_t tail = svwhilelt_b32(col, width);
+                    AddConvolution2x2Sum(tail, src + col, srcStride, svld1_f32(tail, dst + col), _sums);
+                }
+
+                src += srcStride;
+                dst += dstStride;
+            }
+
+            sums[0] += svaddv_f32(body, _sums[0]);
+            sums[1] += svaddv_f32(body, _sums[1]);
+            sums[2] += svaddv_f32(body, _sums[2]);
+            sums[3] += svaddv_f32(body, _sums[3]);
+        }
     }
 #endif
 }

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -439,6 +439,11 @@ namespace Test
             result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Avx512bw::NeuralAddConvolution2x2Sum), FUNC_CS(SimdNeuralAddConvolution2x2Sum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Sve2::NeuralAddConvolution2x2Sum), FUNC_CS(SimdNeuralAddConvolution2x2Sum));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Neon::NeuralAddConvolution2x2Sum), FUNC_CS(SimdNeuralAddConvolution2x2Sum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdNeuralAddConvolution2x2Sum`.
- Extend the neural convolution autotest to cover the SVE2 2x2 sum path.
- Document the optimization in the 7.2.163 release notes.

### Testing
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -I./src -fsyntax-only src/Simd/SimdSve2NeuralConvolution.cpp`
- `git diff --check`
- `cmake --build build --parallel$(nproc)`
- `LD_LIBRARY_PATH=/workspace/build:$LD_LIBRARY_PATH ./Test "-r=.." -fi=NeuralAddConvolution2x2Sum -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-058b5630-f409-4014-a4d7-00c1a7098b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-058b5630-f409-4014-a4d7-00c1a7098b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

