### PR TITLE
Add SVE2 optimization for neural 3x3 convolution forward

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -59,6 +59,7 @@
  <li>SVE2 optimizations of function NeuralUpdateWeights.</li>
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Forward.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution3x3Forward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Sum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4240,6 +4240,11 @@ SIMD_API void SimdNeuralAddConvolution3x3Forward(const float * src, size_t srcSt
         Sse41::NeuralAddConvolution3x3Forward(src, srcStride, width, height, weights, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::NeuralAddConvolution3x3Forward(src, srcStride, width, height, weights, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::NeuralAddConvolution3x3Forward(src, srcStride, width, height, weights, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -145,6 +145,8 @@ namespace Simd
 
         void NeuralAddConvolution2x2Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
+        void NeuralAddConvolution3x3Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
+
         void NeuralAddConvolution2x2Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
         void NeuralAddConvolution3x3Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -76,6 +76,71 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE svfloat32_t Convolution3x3Forward(const svbool_t& mask, const float* src, size_t stride,
+            const svfloat32_t& weight0, const svfloat32_t& weight1, const svfloat32_t& weight2,
+            const svfloat32_t& weight3, const svfloat32_t& weight4, const svfloat32_t& weight5,
+            const svfloat32_t& weight6, const svfloat32_t& weight7, const svfloat32_t& weight8)
+        {
+            const float* src0 = src;
+            const float* src1 = src + stride;
+            const float* src2 = src + 2 * stride;
+            svfloat32_t sum = svmul_f32_x(mask, svld1_f32(mask, src0 + 0), weight0);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src0 + 1), weight1);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src0 + 2), weight2);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 0), weight3);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 1), weight4);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 2), weight5);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 0), weight6);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 1), weight7);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 2), weight8);
+            return sum;
+        }
+
+        SIMD_INLINE void AddConvolution3x3Forward(const svbool_t& mask, const float* src, size_t stride,
+            const svfloat32_t& weight0, const svfloat32_t& weight1, const svfloat32_t& weight2,
+            const svfloat32_t& weight3, const svfloat32_t& weight4, const svfloat32_t& weight5,
+            const svfloat32_t& weight6, const svfloat32_t& weight7, const svfloat32_t& weight8, float* dst)
+        {
+            svfloat32_t sum = Convolution3x3Forward(mask, src, stride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8);
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), sum));
+        }
+
+        void NeuralAddConvolution3x3Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t weight0 = svdup_n_f32(weights[0]);
+            const svfloat32_t weight1 = svdup_n_f32(weights[1]);
+            const svfloat32_t weight2 = svdup_n_f32(weights[2]);
+            const svfloat32_t weight3 = svdup_n_f32(weights[3]);
+            const svfloat32_t weight4 = svdup_n_f32(weights[4]);
+            const svfloat32_t weight5 = svdup_n_f32(weights[5]);
+            const svfloat32_t weight6 = svdup_n_f32(weights[6]);
+            const svfloat32_t weight7 = svdup_n_f32(weights[7]);
+            const svfloat32_t weight8 = svdup_n_f32(weights[8]);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    AddConvolution3x3Forward(body, src + col + 0 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8, dst + col + 0 * F);
+                    AddConvolution3x3Forward(body, src + col + 1 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8, dst + col + 1 * F);
+                    AddConvolution3x3Forward(body, src + col + 2 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8, dst + col + 2 * F);
+                    AddConvolution3x3Forward(body, src + col + 3 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8, dst + col + 3 * F);
+                }
+                for (; col + F <= width; col += F)
+                    AddConvolution3x3Forward(body, src + col, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8, dst + col);
+                if (col < width)
+                    AddConvolution3x3Forward(svwhilelt_b32(col, width), src + col, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7, weight8, dst + col);
+
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AddMultiplied(const svbool_t& mask, const float* src, const svfloat32_t& value, float* dst)
         {
             svst1_f32(mask, dst, svmla_f32_m(mask, svld1_f32(mask, dst), svld1_f32(mask, src), value));

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -158,6 +158,11 @@ namespace Test
             result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Avx512bw::NeuralAddConvolution3x3Forward), FUNC_C2(SimdNeuralAddConvolution3x3Forward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Sve2::NeuralAddConvolution3x3Forward), FUNC_C2(SimdNeuralAddConvolution3x3Forward));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Neon::NeuralAddConvolution3x3Forward), FUNC_C2(SimdNeuralAddConvolution3x3Forward));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdNeuralAddConvolution3x3Forward`.
- Extend `NeuralAddConvolution3x3ForwardAutoTest` to cover the SVE2 path.
- Document the SVE2 optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralAddConvolution3x3Forward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -fsyntax-only -I src src/Simd/SimdSve2NeuralConvolution.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -fsyntax-only -I src src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61f4aa33-9b11-4ff2-8767-7d7c5dd1ea04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61f4aa33-9b11-4ff2-8767-7d7c5dd1ea04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

