### PR TITLE
Add SVE2 optimization for NeuralAddConvolution3x3Sum

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -63,6 +63,7 @@
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Sum.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution3x3Sum.</li>
  <li>SVE2 optimizations of function NeuralPooling1x1Max3x3.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max2x2.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max3x3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4390,6 +4390,11 @@ SIMD_API void SimdNeuralAddConvolution3x3Sum(const float * src, size_t srcStride
         Sse41::NeuralAddConvolution3x3Sum(src, srcStride, dst, dstStride, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::NeuralAddConvolution3x3Sum(src, srcStride, dst, dstStride, width, height, sums);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::NeuralAddConvolution3x3Sum(src, srcStride, dst, dstStride, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -153,6 +153,8 @@ namespace Simd
 
         void NeuralAddConvolution2x2Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);
 
+        void NeuralAddConvolution3x3Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);
+
         void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
 
         void NeuralPooling2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -268,6 +268,73 @@ namespace Simd
             sums[2] += svaddv_f32(body, sum2);
             sums[3] += svaddv_f32(body, sum3);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void AddConvolution3x3Sum(const svbool_t& mask, const float* src, size_t stride, const svfloat32_t& dst,
+            svfloat32_t& sum0, svfloat32_t& sum1, svfloat32_t& sum2, svfloat32_t& sum3, svfloat32_t& sum4,
+            svfloat32_t& sum5, svfloat32_t& sum6, svfloat32_t& sum7, svfloat32_t& sum8)
+        {
+            const float* src0 = src;
+            const float* src1 = src + stride;
+            const float* src2 = src + 2 * stride;
+            sum0 = svmla_f32_m(mask, sum0, svld1_f32(mask, src0 + 0), dst);
+            sum1 = svmla_f32_m(mask, sum1, svld1_f32(mask, src0 + 1), dst);
+            sum2 = svmla_f32_m(mask, sum2, svld1_f32(mask, src0 + 2), dst);
+            sum3 = svmla_f32_m(mask, sum3, svld1_f32(mask, src1 + 0), dst);
+            sum4 = svmla_f32_m(mask, sum4, svld1_f32(mask, src1 + 1), dst);
+            sum5 = svmla_f32_m(mask, sum5, svld1_f32(mask, src1 + 2), dst);
+            sum6 = svmla_f32_m(mask, sum6, svld1_f32(mask, src2 + 0), dst);
+            sum7 = svmla_f32_m(mask, sum7, svld1_f32(mask, src2 + 1), dst);
+            sum8 = svmla_f32_m(mask, sum8, svld1_f32(mask, src2 + 2), dst);
+        }
+
+        void NeuralAddConvolution3x3Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            svfloat32_t sum2 = svdup_n_f32(0.0f);
+            svfloat32_t sum3 = svdup_n_f32(0.0f);
+            svfloat32_t sum4 = svdup_n_f32(0.0f);
+            svfloat32_t sum5 = svdup_n_f32(0.0f);
+            svfloat32_t sum6 = svdup_n_f32(0.0f);
+            svfloat32_t sum7 = svdup_n_f32(0.0f);
+            svfloat32_t sum8 = svdup_n_f32(0.0f);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    AddConvolution3x3Sum(body, src + col + 0 * F, srcStride, svld1_f32(body, dst + col + 0 * F), sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+                    AddConvolution3x3Sum(body, src + col + 1 * F, srcStride, svld1_f32(body, dst + col + 1 * F), sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+                    AddConvolution3x3Sum(body, src + col + 2 * F, srcStride, svld1_f32(body, dst + col + 2 * F), sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+                    AddConvolution3x3Sum(body, src + col + 3 * F, srcStride, svld1_f32(body, dst + col + 3 * F), sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+                }
+                for (; col + F <= width; col += F)
+                    AddConvolution3x3Sum(body, src + col, srcStride, svld1_f32(body, dst + col), sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+                if (col < width)
+                {
+                    svbool_t tail = svwhilelt_b32(col, width);
+                    AddConvolution3x3Sum(tail, src + col, srcStride, svld1_f32(tail, dst + col), sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+                }
+
+                src += srcStride;
+                dst += dstStride;
+            }
+
+            sums[0] += svaddv_f32(body, sum0);
+            sums[1] += svaddv_f32(body, sum1);
+            sums[2] += svaddv_f32(body, sum2);
+            sums[3] += svaddv_f32(body, sum3);
+            sums[4] += svaddv_f32(body, sum4);
+            sums[5] += svaddv_f32(body, sum5);
+            sums[6] += svaddv_f32(body, sum6);
+            sums[7] += svaddv_f32(body, sum7);
+            sums[8] += svaddv_f32(body, sum8);
+        }
     }
 #endif
 }

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -485,6 +485,11 @@ namespace Test
             result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Avx512bw::NeuralAddConvolution3x3Sum), FUNC_CS(SimdNeuralAddConvolution3x3Sum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Sve2::NeuralAddConvolution3x3Sum), FUNC_CS(SimdNeuralAddConvolution3x3Sum));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Neon::NeuralAddConvolution3x3Sum), FUNC_CS(SimdNeuralAddConvolution3x3Sum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `NeuralAddConvolution3x3Sum`.
- Wire the SVE2 path into public dispatch and auto-tests.
- Document the optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralAddConvolution3x3Sum -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.6-a+sve2 -I./src ./src/Simd/SimdSve2NeuralConvolution.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.6-a+sve2 -I./src ./src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.6-a+sve2 -I./src ./src/Test/TestNeuralConvolution.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b004660-a4ba-4993-94c6-987ca7a9b2db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b004660-a4ba-4993-94c6-987ca7a9b2db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

