### PR TITLE
Add SVE2 NeuralAddConvolution4x4Forward optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -60,6 +60,7 @@
  <li>SVE2 optimizations of function NeuralAdaptiveGradientUpdate.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Forward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Forward.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution4x4Forward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution4x4Backward.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4271,6 +4271,11 @@ SIMD_API void SimdNeuralAddConvolution4x4Forward(const float * src, size_t srcSt
         Sse41::NeuralAddConvolution4x4Forward(src, srcStride, width, height, weights, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::NeuralAddConvolution4x4Forward(src, srcStride, width, height, weights, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::NeuralAddConvolution4x4Forward(src, srcStride, width, height, weights, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -147,6 +147,8 @@ namespace Simd
 
         void NeuralAddConvolution3x3Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
+        void NeuralAddConvolution4x4Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
+
         void NeuralAddConvolution2x2Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
         void NeuralAddConvolution3x3Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -141,6 +141,95 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE svfloat32_t Convolution4x4Forward(const svbool_t& mask, const float* src, size_t stride,
+            const svfloat32_t& weight0, const svfloat32_t& weight1, const svfloat32_t& weight2, const svfloat32_t& weight3,
+            const svfloat32_t& weight4, const svfloat32_t& weight5, const svfloat32_t& weight6, const svfloat32_t& weight7,
+            const svfloat32_t& weight8, const svfloat32_t& weight9, const svfloat32_t& weight10, const svfloat32_t& weight11,
+            const svfloat32_t& weight12, const svfloat32_t& weight13, const svfloat32_t& weight14, const svfloat32_t& weight15)
+        {
+            const float* src0 = src;
+            const float* src1 = src + stride;
+            const float* src2 = src + 2 * stride;
+            const float* src3 = src + 3 * stride;
+            svfloat32_t sum = svmul_f32_x(mask, svld1_f32(mask, src0 + 0), weight0);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src0 + 1), weight1);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src0 + 2), weight2);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src0 + 3), weight3);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 0), weight4);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 1), weight5);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 2), weight6);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src1 + 3), weight7);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 0), weight8);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 1), weight9);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 2), weight10);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src2 + 3), weight11);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src3 + 0), weight12);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src3 + 1), weight13);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src3 + 2), weight14);
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src3 + 3), weight15);
+            return sum;
+        }
+
+        SIMD_INLINE void AddConvolution4x4Forward(const svbool_t& mask, const float* src, size_t stride,
+            const svfloat32_t& weight0, const svfloat32_t& weight1, const svfloat32_t& weight2, const svfloat32_t& weight3,
+            const svfloat32_t& weight4, const svfloat32_t& weight5, const svfloat32_t& weight6, const svfloat32_t& weight7,
+            const svfloat32_t& weight8, const svfloat32_t& weight9, const svfloat32_t& weight10, const svfloat32_t& weight11,
+            const svfloat32_t& weight12, const svfloat32_t& weight13, const svfloat32_t& weight14, const svfloat32_t& weight15, float* dst)
+        {
+            svfloat32_t sum = Convolution4x4Forward(mask, src, stride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15);
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), sum));
+        }
+
+        void NeuralAddConvolution4x4Forward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t weight0 = svdup_n_f32(weights[0]);
+            const svfloat32_t weight1 = svdup_n_f32(weights[1]);
+            const svfloat32_t weight2 = svdup_n_f32(weights[2]);
+            const svfloat32_t weight3 = svdup_n_f32(weights[3]);
+            const svfloat32_t weight4 = svdup_n_f32(weights[4]);
+            const svfloat32_t weight5 = svdup_n_f32(weights[5]);
+            const svfloat32_t weight6 = svdup_n_f32(weights[6]);
+            const svfloat32_t weight7 = svdup_n_f32(weights[7]);
+            const svfloat32_t weight8 = svdup_n_f32(weights[8]);
+            const svfloat32_t weight9 = svdup_n_f32(weights[9]);
+            const svfloat32_t weight10 = svdup_n_f32(weights[10]);
+            const svfloat32_t weight11 = svdup_n_f32(weights[11]);
+            const svfloat32_t weight12 = svdup_n_f32(weights[12]);
+            const svfloat32_t weight13 = svdup_n_f32(weights[13]);
+            const svfloat32_t weight14 = svdup_n_f32(weights[14]);
+            const svfloat32_t weight15 = svdup_n_f32(weights[15]);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    AddConvolution4x4Forward(body, src + col + 0 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                        weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15, dst + col + 0 * F);
+                    AddConvolution4x4Forward(body, src + col + 1 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                        weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15, dst + col + 1 * F);
+                    AddConvolution4x4Forward(body, src + col + 2 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                        weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15, dst + col + 2 * F);
+                    AddConvolution4x4Forward(body, src + col + 3 * F, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                        weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15, dst + col + 3 * F);
+                }
+                for (; col + F <= width; col += F)
+                    AddConvolution4x4Forward(body, src + col, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                        weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15, dst + col);
+                if (col < width)
+                    AddConvolution4x4Forward(svwhilelt_b32(col, width), src + col, srcStride, weight0, weight1, weight2, weight3, weight4, weight5, weight6, weight7,
+                        weight8, weight9, weight10, weight11, weight12, weight13, weight14, weight15, dst + col);
+
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AddMultiplied(const svbool_t& mask, const float* src, const svfloat32_t& value, float* dst)
         {
             svst1_f32(mask, dst, svmla_f32_m(mask, svld1_f32(mask, dst), svld1_f32(mask, src), value));

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -194,6 +194,11 @@ namespace Test
             result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Avx512bw::NeuralAddConvolution4x4Forward), FUNC_C2(SimdNeuralAddConvolution4x4Forward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Sve2::NeuralAddConvolution4x4Forward), FUNC_C2(SimdNeuralAddConvolution4x4Forward));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionAutoTest(EPS, core, true, FUNC_C2(Simd::Neon::NeuralAddConvolution4x4Forward), FUNC_C2(SimdNeuralAddConvolution4x4Forward));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdNeuralAddConvolution4x4Forward`.
- Extend the 4x4 forward auto test to exercise `Simd::Sve2::NeuralAddConvolution4x4Forward`.
- Document the SVE2 optimization in release 7.2.163 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralAddConvolution4x4Forward -tt=1 -ts=1`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD~1..HEAD`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -I src -std=c++17 -fsyntax-only src/Simd/SimdSve2NeuralConvolution.cpp`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -I src -std=c++17 -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -I src -std=c++17 -fsyntax-only src/Test/TestNeuralConvolution.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55f9fda9-b32c-46c3-9114-56ac3c3eca1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55f9fda9-b32c-46c3-9114-56ac3c3eca1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

