### PR TITLE
Add SVE2 NeuralAddConvolution4x4Sum optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -66,6 +66,7 @@
  <li>SVE2 optimizations of function NeuralAddConvolution4x4Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Sum.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Sum.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution4x4Sum.</li>
  <li>SVE2 optimizations of function NeuralPooling1x1Max3x3.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max2x2.</li>
  <li>SVE2 optimizations of function NeuralPooling2x2Max3x3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4426,6 +4426,11 @@ SIMD_API void SimdNeuralAddConvolution4x4Sum(const float * src, size_t srcStride
         Sse41::NeuralAddConvolution4x4Sum(src, srcStride, dst, dstStride, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::NeuralAddConvolution4x4Sum(src, srcStride, dst, dstStride, width, height, sums);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::F)
         Neon::NeuralAddConvolution4x4Sum(src, srcStride, dst, dstStride, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -159,6 +159,8 @@ namespace Simd
 
         void NeuralAddConvolution3x3Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);
 
+        void NeuralAddConvolution4x4Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);
+
         void NeuralPooling1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);
 
         void NeuralPooling2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -474,6 +474,103 @@ namespace Simd
             sums[7] += svaddv_f32(body, sum7);
             sums[8] += svaddv_f32(body, sum8);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void AddConvolution4x4Sum(const svbool_t& mask, const float* src, size_t stride, const svfloat32_t& dst,
+            svfloat32_t& sum0, svfloat32_t& sum1, svfloat32_t& sum2, svfloat32_t& sum3,
+            svfloat32_t& sum4, svfloat32_t& sum5, svfloat32_t& sum6, svfloat32_t& sum7,
+            svfloat32_t& sum8, svfloat32_t& sum9, svfloat32_t& sum10, svfloat32_t& sum11,
+            svfloat32_t& sum12, svfloat32_t& sum13, svfloat32_t& sum14, svfloat32_t& sum15)
+        {
+            const float* src0 = src;
+            const float* src1 = src + stride;
+            const float* src2 = src + 2 * stride;
+            const float* src3 = src + 3 * stride;
+            sum0 = svmla_f32_m(mask, sum0, svld1_f32(mask, src0 + 0), dst);
+            sum1 = svmla_f32_m(mask, sum1, svld1_f32(mask, src0 + 1), dst);
+            sum2 = svmla_f32_m(mask, sum2, svld1_f32(mask, src0 + 2), dst);
+            sum3 = svmla_f32_m(mask, sum3, svld1_f32(mask, src0 + 3), dst);
+            sum4 = svmla_f32_m(mask, sum4, svld1_f32(mask, src1 + 0), dst);
+            sum5 = svmla_f32_m(mask, sum5, svld1_f32(mask, src1 + 1), dst);
+            sum6 = svmla_f32_m(mask, sum6, svld1_f32(mask, src1 + 2), dst);
+            sum7 = svmla_f32_m(mask, sum7, svld1_f32(mask, src1 + 3), dst);
+            sum8 = svmla_f32_m(mask, sum8, svld1_f32(mask, src2 + 0), dst);
+            sum9 = svmla_f32_m(mask, sum9, svld1_f32(mask, src2 + 1), dst);
+            sum10 = svmla_f32_m(mask, sum10, svld1_f32(mask, src2 + 2), dst);
+            sum11 = svmla_f32_m(mask, sum11, svld1_f32(mask, src2 + 3), dst);
+            sum12 = svmla_f32_m(mask, sum12, svld1_f32(mask, src3 + 0), dst);
+            sum13 = svmla_f32_m(mask, sum13, svld1_f32(mask, src3 + 1), dst);
+            sum14 = svmla_f32_m(mask, sum14, svld1_f32(mask, src3 + 2), dst);
+            sum15 = svmla_f32_m(mask, sum15, svld1_f32(mask, src3 + 3), dst);
+        }
+
+        void NeuralAddConvolution4x4Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            svfloat32_t sum2 = svdup_n_f32(0.0f);
+            svfloat32_t sum3 = svdup_n_f32(0.0f);
+            svfloat32_t sum4 = svdup_n_f32(0.0f);
+            svfloat32_t sum5 = svdup_n_f32(0.0f);
+            svfloat32_t sum6 = svdup_n_f32(0.0f);
+            svfloat32_t sum7 = svdup_n_f32(0.0f);
+            svfloat32_t sum8 = svdup_n_f32(0.0f);
+            svfloat32_t sum9 = svdup_n_f32(0.0f);
+            svfloat32_t sum10 = svdup_n_f32(0.0f);
+            svfloat32_t sum11 = svdup_n_f32(0.0f);
+            svfloat32_t sum12 = svdup_n_f32(0.0f);
+            svfloat32_t sum13 = svdup_n_f32(0.0f);
+            svfloat32_t sum14 = svdup_n_f32(0.0f);
+            svfloat32_t sum15 = svdup_n_f32(0.0f);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col + QF <= width; col += QF)
+                {
+                    AddConvolution4x4Sum(body, src + col + 0 * F, srcStride, svld1_f32(body, dst + col + 0 * F),
+                        sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8, sum9, sum10, sum11, sum12, sum13, sum14, sum15);
+                    AddConvolution4x4Sum(body, src + col + 1 * F, srcStride, svld1_f32(body, dst + col + 1 * F),
+                        sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8, sum9, sum10, sum11, sum12, sum13, sum14, sum15);
+                    AddConvolution4x4Sum(body, src + col + 2 * F, srcStride, svld1_f32(body, dst + col + 2 * F),
+                        sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8, sum9, sum10, sum11, sum12, sum13, sum14, sum15);
+                    AddConvolution4x4Sum(body, src + col + 3 * F, srcStride, svld1_f32(body, dst + col + 3 * F),
+                        sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8, sum9, sum10, sum11, sum12, sum13, sum14, sum15);
+                }
+                for (; col + F <= width; col += F)
+                    AddConvolution4x4Sum(body, src + col, srcStride, svld1_f32(body, dst + col),
+                        sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8, sum9, sum10, sum11, sum12, sum13, sum14, sum15);
+                if (col < width)
+                {
+                    svbool_t tail = svwhilelt_b32(col, width);
+                    AddConvolution4x4Sum(tail, src + col, srcStride, svld1_f32(tail, dst + col),
+                        sum0, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8, sum9, sum10, sum11, sum12, sum13, sum14, sum15);
+                }
+
+                src += srcStride;
+                dst += dstStride;
+            }
+
+            sums[0] += svaddv_f32(body, sum0);
+            sums[1] += svaddv_f32(body, sum1);
+            sums[2] += svaddv_f32(body, sum2);
+            sums[3] += svaddv_f32(body, sum3);
+            sums[4] += svaddv_f32(body, sum4);
+            sums[5] += svaddv_f32(body, sum5);
+            sums[6] += svaddv_f32(body, sum6);
+            sums[7] += svaddv_f32(body, sum7);
+            sums[8] += svaddv_f32(body, sum8);
+            sums[9] += svaddv_f32(body, sum9);
+            sums[10] += svaddv_f32(body, sum10);
+            sums[11] += svaddv_f32(body, sum11);
+            sums[12] += svaddv_f32(body, sum12);
+            sums[13] += svaddv_f32(body, sum13);
+            sums[14] += svaddv_f32(body, sum14);
+            sums[15] += svaddv_f32(body, sum15);
+        }
     }
 #endif
 }

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -531,6 +531,11 @@ namespace Test
             result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Avx512bw::NeuralAddConvolution4x4Sum), FUNC_CS(SimdNeuralAddConvolution4x4Sum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Sve2::NeuralAddConvolution4x4Sum), FUNC_CS(SimdNeuralAddConvolution4x4Sum));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionSumAutoTest(EPS, core, FUNC_CS(Simd::Neon::NeuralAddConvolution4x4Sum), FUNC_CS(SimdNeuralAddConvolution4x4Sum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `NeuralAddConvolution4x4Sum`.
- Extend the 4x4 neural convolution sum auto-test to cover SVE2.
- Update 7.2.163 release notes for the new optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=NeuralAddConvolution4x4Sum -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -I./src -fPIC -c src/Simd/SimdSve2NeuralConvolution.cpp -o /tmp/SimdSve2NeuralConvolution.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-221a7f24-c287-4c34-8ace-da011a42c802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-221a7f24-c287-4c34-8ace-da011a42c802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

