### PR TITLE
Add SVE2 ReduceGray2x2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -105,6 +105,7 @@
  <li>SVE2 optimizations of function GrayToBgr.</li>
  <li>SVE2 optimizations of function GrayToBgra.</li>
  <li>SVE2 optimizations of function GrayToY.</li>
+ <li>SVE2 optimizations of function ReduceGray2x2.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv444pV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Neural.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -281,6 +281,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp">
       <Filter>Sve2\Legacy</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp">
+      <Filter>Sve2\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4727,6 +4727,11 @@ SIMD_API void SimdReduceGray2x2(const uint8_t *src, size_t srcWidth, size_t srcH
         Sse41::ReduceGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && srcWidth >= svcntb())
+        Sve2::ReduceGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && srcWidth >= Neon::DA)
         Neon::ReduceGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -265,6 +265,9 @@ namespace Simd
 
         void GrayToY(const uint8_t* gray, size_t grayStride, size_t width, size_t height, uint8_t* y, size_t yStride);
 
+        void ReduceGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
+
         void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
 
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);

--- a/src/Simd/SimdSve2ReduceGray2x2.cpp
+++ b/src/Simd/SimdSve2ReduceGray2x2.cpp
@@ -1,0 +1,66 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdMath.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint16_t Average16(const uint8_t* src0, const uint8_t* src1, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svuint8_t s0 = svld1_u8(mask8, src0);
+            svuint8_t s1 = svld1_u8(mask8, src1);
+            svuint16_t sum0 = svaddlb_u16(s0, svext_u8(s0, s0, 1));
+            svuint16_t sum1 = svaddlb_u16(s1, svext_u8(s1, s1, 1));
+            return svlsr_n_u16_x(mask16, svadd_n_u16_x(mask16, svadd_u16_x(mask16, sum0, sum1), 2), 2);
+        }
+
+        void ReduceGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
+        {
+            assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight);
+
+            const size_t A = svcntb(), HA = svcnth();
+            const size_t evenWidth = AlignLo(srcWidth, 2), dstEvenWidth = evenWidth / 2;
+            for (size_t srcRow = 0; srcRow < srcHeight; srcRow += 2)
+            {
+                const uint8_t* src0 = src;
+                const uint8_t* src1 = (srcRow == srcHeight - 1 ? src : src + srcStride);
+                for (size_t dstCol = 0, srcCol = 0; dstCol < dstEvenWidth; dstCol += HA, srcCol += A)
+                {
+                    svbool_t mask16 = svwhilelt_b16(dstCol, dstEvenWidth);
+                    svst1_u8(svwhilelt_b8(dstCol, dstEvenWidth), dst + dstCol,
+                        svqxtnb_u16(Average16(src0 + srcCol, src1 + srcCol, svwhilelt_b8(srcCol, evenWidth), mask16)));
+                }
+                if (evenWidth != srcWidth)
+                    dst[dstWidth - 1] = Base::Average(src0[evenWidth], src1[evenWidth]);
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2ReduceGray2x2.cpp
+++ b/src/Simd/SimdSve2ReduceGray2x2.cpp
@@ -38,6 +38,12 @@ namespace Simd
             return svlsr_n_u16_x(mask16, svadd_n_u16_x(mask16, svadd_u16_x(mask16, sum0, sum1), 2), 2);
         }
 
+        SIMD_INLINE svuint8_t Average8(const uint8_t* src0, const uint8_t* src1, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svuint8_t even = svqxtnb_u16(Average16(src0, src1, mask8, mask16));
+            return svuzp1_u8(even, even);
+        }
+
         void ReduceGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
         {
@@ -53,7 +59,7 @@ namespace Simd
                 {
                     svbool_t mask16 = svwhilelt_b16(dstCol, dstEvenWidth);
                     svst1_u8(svwhilelt_b8(dstCol, dstEvenWidth), dst + dstCol,
-                        svqxtnb_u16(Average16(src0 + srcCol, src1 + srcCol, svwhilelt_b8(srcCol, evenWidth), mask16)));
+                        Average8(src0 + srcCol, src1 + srcCol, svwhilelt_b8(srcCol, evenWidth), mask16));
                 }
                 if (evenWidth != srcWidth)
                     dst[dstWidth - 1] = Base::Average(src0[evenWidth], src1[evenWidth]);

--- a/src/Test/TestReduce.cpp
+++ b/src/Test/TestReduce.cpp
@@ -227,6 +227,11 @@ namespace Test
             result = result && ReduceGrayAutoTest(FUNC_RG1(Simd::Avx512bw::ReduceGray2x2), FUNC_RG1(SimdReduceGray2x2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ReduceGrayAutoTest(FUNC_RG1(Simd::Sve2::ReduceGray2x2), FUNC_RG1(SimdReduceGray2x2));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ReduceGrayAutoTest(FUNC_RG1(Simd::Neon::ReduceGray2x2), FUNC_RG1(SimdReduceGray2x2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `ReduceGray2x2` with predicated tail handling.
- Dispatch `SimdReduceGray2x2` to SVE2 on SVE2-capable ARM builds.
- Add SVE2 coverage to `ReduceGray2x2AutoTest`, update VS2022 project metadata, and document the release note entry.
- Fix SVE2 byte packing so narrowed averages are stored contiguously instead of alternating byte lanes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=ReduceGray2x2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -I./src -fsyntax-only ./src/Simd/SimdSve2ReduceGray2x2.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -I./src -fsyntax-only ./src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I./src build/sve2_reduce_test.cpp src/Simd/SimdBaseReduceGray2x2.cpp src/Simd/SimdSve2ReduceGray2x2.cpp -o build/sve2_reduce_test && qemu-aarch64 -L /usr/aarch64-linux-gnu -cpu max,sve=on ./build/sve2_reduce_test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dc85862-38dd-425c-82d1-48a7a0f71646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dc85862-38dd-425c-82d1-48a7a0f71646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

