### PR TITLE
reject non-dividing sampling factors in JpegProcessFrameHeader

### DIFF
--- a/src/Simd/SimdAvx2ImageLoadJpeg.cpp
+++ b/src/Simd/SimdAvx2ImageLoadJpeg.cpp
@@ -1405,6 +1405,9 @@ namespace Simd
             // compute interleaved mcu info
             z->img_h_max = h_max;
             z->img_v_max = v_max;
+            for (i = 0; i < s->img_n; ++i)
+                if (h_max % z->img_comp[i].h || v_max % z->img_comp[i].v)
+                    return JpegLoadError("bad sampling factor", "Corrupt JPEG");
             z->img_mcu_w = h_max * 8;
             z->img_mcu_h = v_max * 8;
             // these sizes can't be more than 17 bits

--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -914,6 +914,9 @@ namespace Simd
             }
             z->img_h_max = h_max;
             z->img_v_max = v_max;
+            for (int i = 0; i < z->img_n; ++i)
+                if (h_max % z->img_comp[i].h || v_max % z->img_comp[i].v)
+                    return JpegLoadError("bad sampling factor", "Corrupt JPEG");
             z->img_mcu_w = h_max * 8;
             z->img_mcu_h = v_max * 8;
             z->img_mcu_x = (z->img_x + z->img_mcu_w - 1) / z->img_mcu_w;


### PR DESCRIPTION
**Out-of-bounds read on non-dividing JPEG sampling factors**

The SOF parser checks each component's horizontal and vertical sampling factor lies in 1..4 but never that it divides the frame maximum. `JpegToRgba`'s colour upsampler assumes integer ratios: it takes `hs = img_h_max / comp.h`, and when that floors to 1 it leaves the component row at its decoded width `comp.x = ceil(img_x * comp.h / img_h_max)`, which is narrower than `img_x`. The `YCbCr` to RGB row loop then reads `img_x` luma samples from that short row and runs off the end of the component buffer on the last image row. A 3-component baseline JPEG with horizontal factors 2,3,1 (so `img_h_max == 3` and component 0's factor 2 does not divide it) triggers it; ASan reports a heap-buffer-overflow read in `JpegYuvToRgbRow`. Rejecting frames whose factors do not divide the maximum keeps every resample ratio exact and looks the cleanest place to draw the line, since valid 4:4:4/4:2:2/4:2:0 files always satisfy it. The Avx2 decoder carries its own copy of the frame-header parser and gets the same check; Sse41 reuses the base path so it needs no separate change.