### PR TITLE
conan: exclude optional opencv dependency from package_id

### DIFF
--- a/prj/conan/conanfile.py
+++ b/prj/conan/conanfile.py
@@ -91,6 +91,13 @@ class SimdConan(ConanFile):
 
     def package_id(self):
         del self.info.options.opencv
+        # OpenCV is an optional build-time, headers-only dependency (libs=False) gated
+        # behind the SIMD_OPENCV_ENABLE macro that the consumer defines. Simd itself is
+        # never compiled against OpenCV (generate() forces SIMD_OPENCV=False), so the
+        # binary artifact is identical regardless of it and it must not contribute to
+        # the package id.
+        if "opencv" in self.info.requires:
+            self.info.requires.remove("opencv")
 
     def layout(self):
         cmake_layout(self, src_folder=".")


### PR DESCRIPTION
OpenCV is an optional, headers-only build dependency (`libs=False`) whose integration in the public headers is gated behind the user-defined `SIMD_OPENCV_ENABLE` macro that the *consumer* sets — not this recipe. Simd itself is never compiled against OpenCV (`generate()` forces `SIMD_OPENCV=False`), so the produced binary artifact is identical regardless of the `opencv` option.

Despite that, the `opencv` requirement still leaked into the `package_id`, producing a separate binary id depending on whether `opencv` was enabled. Deleting only the option (`del self.info.options.opencv`, as before) was insufficient because the requirement itself was hashed into the id.

This removes the `opencv` requirement in `package_id()` so the binary id no longer depends on it — both `opencv=True` and `opencv=False` now resolve to the same Simd binary.