### PR TITLE
Add SVE2 optimization for 5x5 neural backward convolution

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -64,6 +64,7 @@
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution4x4Backward.</li>
+ <li>SVE2 optimizations of function NeuralAddConvolution5x5Backward.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution2x2Sum.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution3x3Sum.</li>
  <li>SVE2 optimizations of function NeuralAddConvolution4x4Sum.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4341,7 +4341,7 @@ SIMD_API void SimdNeuralAddConvolution5x5Backward(const float * src, size_t srcS
 {
     SIMD_EMPTY();
     typedef void(*SimdNeuralAddConvolution5x5BackwardPtr) (const float * src, size_t srcStride, size_t width, size_t height, const float * weights, float * dst, size_t dstStride);
-    const static SimdNeuralAddConvolution5x5BackwardPtr simdNeuralAddConvolution5x5Backward = SIMD_FUNC4(NeuralAddConvolution5x5Backward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdNeuralAddConvolution5x5BackwardPtr simdNeuralAddConvolution5x5Backward = SIMD_FUNC5(NeuralAddConvolution5x5Backward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdNeuralAddConvolution5x5Backward(src, srcStride, width, height, weights, dst, dstStride);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -155,6 +155,8 @@ namespace Simd
 
         void NeuralAddConvolution4x4Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
 
+        void NeuralAddConvolution5x5Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride);
+
         void NeuralAddConvolution2x2Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);
 
         void NeuralAddConvolution3x3Sum(const float* src, size_t srcStride, const float* dst, size_t dstStride, size_t width, size_t height, float* sums);

--- a/src/Simd/SimdSve2NeuralConvolution.cpp
+++ b/src/Simd/SimdSve2NeuralConvolution.cpp
@@ -362,6 +362,75 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        void NeuralAddConvolution5x5Backward(const float* src, size_t srcStride, size_t width, size_t height, const float* weights, float* dst, size_t dstStride)
+        {
+            const svfloat32_t weight0 = svdup_n_f32(weights[0]);
+            const svfloat32_t weight1 = svdup_n_f32(weights[1]);
+            const svfloat32_t weight2 = svdup_n_f32(weights[2]);
+            const svfloat32_t weight3 = svdup_n_f32(weights[3]);
+            const svfloat32_t weight4 = svdup_n_f32(weights[4]);
+            const svfloat32_t weight5 = svdup_n_f32(weights[5]);
+            const svfloat32_t weight6 = svdup_n_f32(weights[6]);
+            const svfloat32_t weight7 = svdup_n_f32(weights[7]);
+            const svfloat32_t weight8 = svdup_n_f32(weights[8]);
+            const svfloat32_t weight9 = svdup_n_f32(weights[9]);
+            const svfloat32_t weight10 = svdup_n_f32(weights[10]);
+            const svfloat32_t weight11 = svdup_n_f32(weights[11]);
+            const svfloat32_t weight12 = svdup_n_f32(weights[12]);
+            const svfloat32_t weight13 = svdup_n_f32(weights[13]);
+            const svfloat32_t weight14 = svdup_n_f32(weights[14]);
+            const svfloat32_t weight15 = svdup_n_f32(weights[15]);
+            const svfloat32_t weight16 = svdup_n_f32(weights[16]);
+            const svfloat32_t weight17 = svdup_n_f32(weights[17]);
+            const svfloat32_t weight18 = svdup_n_f32(weights[18]);
+            const svfloat32_t weight19 = svdup_n_f32(weights[19]);
+            const svfloat32_t weight20 = svdup_n_f32(weights[20]);
+            const svfloat32_t weight21 = svdup_n_f32(weights[21]);
+            const svfloat32_t weight22 = svdup_n_f32(weights[22]);
+            const svfloat32_t weight23 = svdup_n_f32(weights[23]);
+            const svfloat32_t weight24 = svdup_n_f32(weights[24]);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                float* dst0 = dst;
+                float* dst1 = dst + dstStride;
+                float* dst2 = dst + 2 * dstStride;
+                float* dst3 = dst + 3 * dstStride;
+                float* dst4 = dst + 4 * dstStride;
+
+                AddMultiplied(src, width, weight0, dst0 + 0);
+                AddMultiplied(src, width, weight1, dst0 + 1);
+                AddMultiplied(src, width, weight2, dst0 + 2);
+                AddMultiplied(src, width, weight3, dst0 + 3);
+                AddMultiplied(src, width, weight4, dst0 + 4);
+                AddMultiplied(src, width, weight5, dst1 + 0);
+                AddMultiplied(src, width, weight6, dst1 + 1);
+                AddMultiplied(src, width, weight7, dst1 + 2);
+                AddMultiplied(src, width, weight8, dst1 + 3);
+                AddMultiplied(src, width, weight9, dst1 + 4);
+                AddMultiplied(src, width, weight10, dst2 + 0);
+                AddMultiplied(src, width, weight11, dst2 + 1);
+                AddMultiplied(src, width, weight12, dst2 + 2);
+                AddMultiplied(src, width, weight13, dst2 + 3);
+                AddMultiplied(src, width, weight14, dst2 + 4);
+                AddMultiplied(src, width, weight15, dst3 + 0);
+                AddMultiplied(src, width, weight16, dst3 + 1);
+                AddMultiplied(src, width, weight17, dst3 + 2);
+                AddMultiplied(src, width, weight18, dst3 + 3);
+                AddMultiplied(src, width, weight19, dst3 + 4);
+                AddMultiplied(src, width, weight20, dst4 + 0);
+                AddMultiplied(src, width, weight21, dst4 + 1);
+                AddMultiplied(src, width, weight22, dst4 + 2);
+                AddMultiplied(src, width, weight23, dst4 + 3);
+                AddMultiplied(src, width, weight24, dst4 + 4);
+
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE void AddConvolution2x2Sum(const svbool_t& mask, const float* src, size_t stride, const svfloat32_t& dst,
             svfloat32_t& sum0, svfloat32_t& sum1, svfloat32_t& sum2, svfloat32_t& sum3)
         {

--- a/src/Test/TestNeuralConvolution.cpp
+++ b/src/Test/TestNeuralConvolution.cpp
@@ -369,6 +369,11 @@ namespace Test
             result = result && NeuralAddConvolutionAutoTest(EPS, core, false, FUNC_C2(Simd::Avx512bw::NeuralAddConvolution5x5Backward), FUNC_C2(SimdNeuralAddConvolution5x5Backward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && NeuralAddConvolutionAutoTest(EPS, core, false, FUNC_C2(Simd::Sve2::NeuralAddConvolution5x5Backward), FUNC_C2(SimdNeuralAddConvolution5x5Backward));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && NeuralAddConvolutionAutoTest(EPS, core, false, FUNC_C2(Simd::Neon::NeuralAddConvolution5x5Backward), FUNC_C2(SimdNeuralAddConvolution5x5Backward));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `NeuralAddConvolution5x5Backward`.
- Add SVE2 auto-test coverage for the 5x5 backward convolution path.
- Update 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralAddConvolution5x5Backward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -I./src -march=armv8.2-a+sve2 src/Simd/SimdSve2NeuralConvolution.cpp`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=NeuralAddConvolution -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b143765-dcf3-48c1-a2a8-5a79c4e7ed5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b143765-dcf3-48c1-a2a8-5a79c4e7ed5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

