### PR TITLE
Add SVE2 optimization of SimdReduceGray4x4

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -111,6 +111,7 @@
  <li>SVE2 optimizations of function GrayToY.</li>
  <li>SVE2 optimizations of function ReduceGray2x2.</li>
  <li>SVE2 optimizations of function ReduceGray3x3.</li>
+ <li>SVE2 optimizations of function ReduceGray4x4.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv444pV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -72,6 +72,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray3x3.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -287,6 +287,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray3x3.cpp">
       <Filter>Sve2\Image</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp">
+      <Filter>Sve2\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4801,6 +4801,11 @@ SIMD_API void SimdReduceGray4x4(const uint8_t *src, size_t srcWidth, size_t srcH
         Sse41::ReduceGray4x4(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && srcWidth > svcntb())
+        Sve2::ReduceGray4x4(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && srcWidth > Neon::DA)
         Neon::ReduceGray4x4(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -279,6 +279,9 @@ namespace Simd
         void ReduceGray3x3(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, int compensation);
 
+        void ReduceGray4x4(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
+
         void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
 
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -85,18 +85,24 @@ namespace Simd
             odd = svtbl_u8(value, idxOdd);
         }
 
+        SIMD_INLINE svuint16_t BinomialSum8(const svuint8_t& t01e, const svuint8_t& t01o, const svuint8_t& t23e, const svuint8_t& t23o, const svbool_t& mask16)
+        {
+            svuint16_t s0 = svadd_u16_x(mask16, svmovlb_u16(t01e), svmovlb_u16(t23o));
+            svuint16_t s1 = svadd_u16_x(mask16, svmovlb_u16(t01o), svmovlb_u16(t23e));
+            return svadd_u16_x(mask16, s0, svadd_u16_x(mask16, s1, svlsl_n_u16_x(mask16, s1, 1)));
+        }
+
         SIMD_INLINE svuint16_t BinomialSum8(const svuint8x2_t& t01, const svuint8x2_t& t23, const svbool_t& mask16)
         {
-            svuint16_t s0 = svadd_u16_x(mask16, svmovlb_u16(t01.val[0]), svmovlb_u16(t23.val[1]));
-            svuint16_t s1 = svadd_u16_x(mask16, svmovlb_u16(t01.val[1]), svmovlb_u16(t23.val[0]));
-            return svadd_u16_x(mask16, s0, svadd_u16_x(mask16, s1, svlsl_n_u16_x(mask16, s1, 1)));
+            return BinomialSum8(svget2(t01, 0), svget2(t01, 1), svget2(t23, 0), svget2(t23, 1), mask16);
         }
 
         SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            svuint8x2_t t01;
-            EvenOdd(PrependFirst(svld1_u8(mask8, src)), mask8, t01.val[0], t01.val[1]);
-            return BinomialSum8(t01, svld2_u8(mask8, src + 1), mask16);
+            svuint8_t t01e, t01o;
+            EvenOdd(PrependFirst(svld1_u8(mask8, src)), mask8, t01e, t01o);
+            svuint8x2_t t23 = svld2_u8(mask8, src + 1);
+            return BinomialSum8(t01e, t01o, svget2(t23, 0), svget2(t23, 1), mask16);
         }
 
         SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
@@ -108,17 +114,19 @@ namespace Simd
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<true>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            svuint8x2_t t23;
-            EvenOdd(AppendLast1(svld1_u8(mask8, src), mask8), mask8, t23.val[0], t23.val[1]);
-            return BinomialSum8(svld2_u8(mask8, src - 1), t23, mask16);
+            svuint8_t t23e, t23o;
+            EvenOdd(AppendLast1(svld1_u8(mask8, src), mask8), mask8, t23e, t23o);
+            svuint8x2_t t01 = svld2_u8(mask8, src - 1);
+            return BinomialSum8(svget2(t01, 0), svget2(t01, 1), t23e, t23o, mask16);
         }
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<false>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
             svuint8_t ab = svld1_u8(mask8, src - 1);
-            svuint8x2_t t23;
-            EvenOdd(AppendLast2(ab, mask8), mask8, t23.val[0], t23.val[1]);
-            return BinomialSum8(svld2_u8(mask8, src - 1), t23, mask16);
+            svuint8_t t23e, t23o;
+            EvenOdd(AppendLast2(ab, mask8), mask8, t23e, t23o);
+            svuint8x2_t t01 = svld2_u8(mask8, src - 1);
+            return BinomialSum8(svget2(t01, 0), svget2(t01, 1), t23e, t23o, mask16);
         }
 
         SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svuint16_t& d, const svbool_t& mask)

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -90,30 +90,6 @@ namespace Simd
             return BinomialSum8(t01, AppendLast2(t01, mask8), mask8, mask16);
         }
 
-        SIMD_INLINE void ReduceColNose(const uint8_t* s[4], svuint16_t a[4], const svbool_t& mask8, const svbool_t& mask16)
-        {
-            a[0] = ReduceColNose(s[0], mask8, mask16);
-            a[1] = ReduceColNose(s[1], mask8, mask16);
-            a[2] = ReduceColNose(s[2], mask8, mask16);
-            a[3] = ReduceColNose(s[3], mask8, mask16);
-        }
-
-        SIMD_INLINE void ReduceColBody(const uint8_t* s[4], size_t offset, svuint16_t a[4], const svbool_t& mask8, const svbool_t& mask16)
-        {
-            a[0] = ReduceColBody(s[0] + offset, mask8, mask16);
-            a[1] = ReduceColBody(s[1] + offset, mask8, mask16);
-            a[2] = ReduceColBody(s[2] + offset, mask8, mask16);
-            a[3] = ReduceColBody(s[3] + offset, mask8, mask16);
-        }
-
-        template <bool even> SIMD_INLINE void ReduceColTail(const uint8_t* s[4], size_t offset, svuint16_t a[4], const svbool_t& mask8, const svbool_t& mask16)
-        {
-            a[0] = ReduceColTail<even>(s[0] + offset, mask8, mask16);
-            a[1] = ReduceColTail<even>(s[1] + offset, mask8, mask16);
-            a[2] = ReduceColTail<even>(s[2] + offset, mask8, mask16);
-            a[3] = ReduceColTail<even>(s[3] + offset, mask8, mask16);
-        }
-
         SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svuint16_t& d, const svbool_t& mask)
         {
             svuint16_t bc = svadd_u16_x(mask, b, c);
@@ -130,12 +106,14 @@ namespace Simd
             return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
         }
 
-        SIMD_INLINE svuint8_t ReduceRow(const svuint16_t lo[4], const svuint16_t hi[4],
+        SIMD_INLINE svuint8_t ReduceRow(
+            const svuint16_t& lo0, const svuint16_t& lo1, const svuint16_t& lo2, const svuint16_t& lo3,
+            const svuint16_t& hi0, const svuint16_t& hi1, const svuint16_t& hi2, const svuint16_t& hi3,
             const svbool_t& maskLo16, const svbool_t& maskHi16)
         {
             return PackU16ToU8(
-                DivideBy64(BinomialSum16(lo[0], lo[1], lo[2], lo[3], maskLo16), maskLo16),
-                DivideBy64(BinomialSum16(hi[0], hi[1], hi[2], hi[3], maskHi16), maskHi16));
+                DivideBy64(BinomialSum16(lo0, lo1, lo2, lo3, maskLo16), maskLo16),
+                DivideBy64(BinomialSum16(hi0, hi1, hi2, hi3, maskHi16), maskHi16));
         }
 
         template <bool even> void ReduceGray4x4(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
@@ -150,22 +128,27 @@ namespace Simd
 
             for (size_t row = 0; row < srcHeight; row += 2, dst += dstStride)
             {
-                const uint8_t* s[4];
-                s[1] = src + srcStride * row;
-                s[0] = s[1] - (row ? srcStride : 0);
-                s[2] = s[1] + (row < srcHeight - 1 ? srcStride : 0);
-                s[3] = s[2] + (row < srcHeight - 2 ? srcStride : 0);
+                const uint8_t* s0 = src + srcStride * row - (row ? srcStride : 0);
+                const uint8_t* s1 = src + srcStride * row;
+                const uint8_t* s2 = s1 + (row < srcHeight - 1 ? srcStride : 0);
+                const uint8_t* s3 = s2 + (row < srcHeight - 2 ? srcStride : 0);
 
-                svuint16_t lo[4], hi[4];
+                svuint16_t lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3;
                 {
                     svbool_t mask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
                     svbool_t mask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
                     svbool_t mask8Hi = svwhilelt_b8(A, Simd::Min(srcWidth, A + A));
                     svbool_t mask16Hi = svwhilelt_b16(HA, Simd::Min(dstWidth, A));
                     svbool_t maskStore = svwhilelt_b8(size_t(0), Simd::Min(dstWidth, A));
-                    ReduceColNose(s, lo, mask8, mask16);
-                    ReduceColBody(s, A, hi, mask8Hi, mask16Hi);
-                    svst1_u8(maskStore, dst, ReduceRow(lo, hi, mask16, mask16Hi));
+                    lo0 = ReduceColNose(s0, mask8, mask16);
+                    lo1 = ReduceColNose(s1, mask8, mask16);
+                    lo2 = ReduceColNose(s2, mask8, mask16);
+                    lo3 = ReduceColNose(s3, mask8, mask16);
+                    hi0 = ReduceColBody(s0 + A, mask8Hi, mask16Hi);
+                    hi1 = ReduceColBody(s1 + A, mask8Hi, mask16Hi);
+                    hi2 = ReduceColBody(s2 + A, mask8Hi, mask16Hi);
+                    hi3 = ReduceColBody(s3 + A, mask8Hi, mask16Hi);
+                    svst1_u8(maskStore, dst, ReduceRow(lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3, mask16, mask16Hi));
                 }
 
                 for (size_t srcCol = A, dstCol = A; srcCol < bodyWidth; srcCol += A, dstCol += A)
@@ -175,9 +158,15 @@ namespace Simd
                     svbool_t mask16Lo = svwhilelt_b16(dstCol, dstWidth);
                     svbool_t mask16Hi = svwhilelt_b16(dstCol + HA, dstWidth);
                     svbool_t maskStore = svwhilelt_b8(dstCol, dstWidth);
-                    ReduceColBody(s, srcCol, lo, mask8Lo, mask16Lo);
-                    ReduceColBody(s, srcCol + A, hi, mask8Hi, mask16Hi);
-                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo, hi, mask16Lo, mask16Hi));
+                    lo0 = ReduceColBody(s0 + srcCol, mask8Lo, mask16Lo);
+                    lo1 = ReduceColBody(s1 + srcCol, mask8Lo, mask16Lo);
+                    lo2 = ReduceColBody(s2 + srcCol, mask8Lo, mask16Lo);
+                    lo3 = ReduceColBody(s3 + srcCol, mask8Lo, mask16Lo);
+                    hi0 = ReduceColBody(s0 + srcCol + A, mask8Hi, mask16Hi);
+                    hi1 = ReduceColBody(s1 + srcCol + A, mask8Hi, mask16Hi);
+                    hi2 = ReduceColBody(s2 + srcCol + A, mask8Hi, mask16Hi);
+                    hi3 = ReduceColBody(s3 + srcCol + A, mask8Hi, mask16Hi);
+                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3, mask16Lo, mask16Hi));
                 }
 
                 if (bodyWidth != srcWidth)
@@ -188,9 +177,15 @@ namespace Simd
                     svbool_t mask16Lo = svwhilelt_b16(dstCol, dstWidth);
                     svbool_t mask16Hi = svwhilelt_b16(dstCol + HA, dstWidth);
                     svbool_t maskStore = svwhilelt_b8(dstCol, dstWidth);
-                    ReduceColBody(s, srcTail, lo, mask8Lo, mask16Lo);
-                    ReduceColTail<even>(s, srcTail + A, hi, mask8Hi, mask16Hi);
-                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo, hi, mask16Lo, mask16Hi));
+                    lo0 = ReduceColBody(s0 + srcTail, mask8Lo, mask16Lo);
+                    lo1 = ReduceColBody(s1 + srcTail, mask8Lo, mask16Lo);
+                    lo2 = ReduceColBody(s2 + srcTail, mask8Lo, mask16Lo);
+                    lo3 = ReduceColBody(s3 + srcTail, mask8Lo, mask16Lo);
+                    hi0 = ReduceColTail<even>(s0 + srcTail + A, mask8Hi, mask16Hi);
+                    hi1 = ReduceColTail<even>(s1 + srcTail + A, mask8Hi, mask16Hi);
+                    hi2 = ReduceColTail<even>(s2 + srcTail + A, mask8Hi, mask16Hi);
+                    hi3 = ReduceColTail<even>(s3 + srcTail + A, mask8Hi, mask16Hi);
+                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3, mask16Lo, mask16Hi));
                 }
             }
         }

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -118,19 +118,26 @@ namespace Simd
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 32), 6);
         }
 
-        SIMD_INLINE svuint8_t NarrowU16ToU8(const svuint16_t& value)
+        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
         {
-            const size_t half = svcnth() >> 1;
-            return svqxtnt_u16(svqxtnb_u16(value), svext_u16(value, value, (uint32_t)half));
+            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
         }
 
-        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16)
+        SIMD_INLINE svuint16_t ReduceRow16(const Buffer& buffer, size_t offset, const svbool_t& mask16)
         {
-            return NarrowU16ToU8(DivideBy64(BinomialSum16(
+            return DivideBy64(BinomialSum16(
                 svld1_u16(mask16, buffer.src0 + offset),
                 svld1_u16(mask16, buffer.src1 + offset),
                 svld1_u16(mask16, buffer.src2 + offset),
-                svld1_u16(mask16, buffer.src3 + offset), mask16), mask16));
+                svld1_u16(mask16, buffer.src3 + offset), mask16), mask16);
+        }
+
+        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16Lo, const svbool_t& mask16Hi)
+        {
+            const size_t half = svcnth() >> 1;
+            return PackU16ToU8(
+                ReduceRow16(buffer, offset, mask16Lo),
+                ReduceRow16(buffer, offset + half, mask16Hi));
         }
 
         SIMD_INLINE void StoreColNose(uint16_t* dst, const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
@@ -206,19 +213,22 @@ namespace Simd
                     StoreColTail<even>(buffer.src3, src3, srcTail, mask8, mask16);
                 }
 
+                const size_t half = HA >> 1;
                 for (size_t col = 0; col < alignedDstWidth; col += HA)
                 {
-                    svbool_t mask16 = svwhilelt_b16(col, dstWidth);
+                    svbool_t mask16Lo = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - col));
+                    svbool_t mask16Hi = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - (col + half)));
                     svbool_t mask8 = svwhilelt_b8(col, dstWidth);
-                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16Lo, mask16Hi));
                 }
 
                 if (alignedDstWidth != dstWidth)
                 {
                     size_t col = dstWidth - HA;
-                    svbool_t mask16 = svwhilelt_b16(col, dstWidth);
+                    svbool_t mask16Lo = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - col));
+                    svbool_t mask16Hi = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - (col + half)));
                     svbool_t mask8 = svwhilelt_b8(col, dstWidth);
-                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16Lo, mask16Hi));
                 }
 
                 Swap(buffer.src0, buffer.src2);

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -90,8 +90,8 @@ namespace Simd
             svuint8_t t01e, t01o, t23e, t23o;
             EvenOdd(t01, mask8, t01e, t01o);
             EvenOdd(t23, mask8, t23e, t23o);
-            svuint16_t lo = svaddlbt_u16(t01e, t23o);
-            svuint16_t mid = svaddlbt_u16(t01o, t23e);
+            svuint16_t lo = svadd_u16_x(mask16, svmovlb_u16(t01e), svmovlb_u16(t23o));
+            svuint16_t mid = svadd_u16_x(mask16, svmovlb_u16(t01o), svmovlb_u16(t23e));
             return svadd_u16_x(mask16, lo, svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
         }
 

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -76,35 +76,49 @@ namespace Simd
             return svext_u8(svext_u8(value, last, 1), last, 1);
         }
 
-        SIMD_INLINE svuint16_t BinomialSum8(const svuint8_t& ab, const svuint8_t& cd, const svbool_t& mask16)
+        SIMD_INLINE void EvenOdd(const svuint8_t& value, const svbool_t& mask8, svuint8_t& even, svuint8_t& odd)
         {
-            svuint8_t cd1 = svext_u8(cd, cd, 1);
-            svuint16_t lo = svaddlb_u16(ab, cd1);
-            svuint16_t mid = svaddlt_u16(ab, cd);
-            return svadd_u16_x(mask16, lo, svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
+            svuint8_t iota = svindex_u8(0, 1);
+            svuint8_t idxEven = svlsl_n_u8_x(mask8, iota, 1);
+            svuint8_t idxOdd = svadd_n_u8_x(mask8, idxEven, 1);
+            even = svtbl_u8(value, idxEven);
+            odd = svtbl_u8(value, idxOdd);
+        }
+
+        SIMD_INLINE svuint16_t BinomialSum8(const svuint8x2_t& t01, const svuint8x2_t& t23, const svbool_t& mask16)
+        {
+            svuint16_t s0 = svadd_u16_x(mask16, svmovlb_u16(t01.val[0]), svmovlb_u16(t23.val[1]));
+            svuint16_t s1 = svadd_u16_x(mask16, svmovlb_u16(t01.val[1]), svmovlb_u16(t23.val[0]));
+            return svadd_u16_x(mask16, s0, svadd_u16_x(mask16, s1, svlsl_n_u16_x(mask16, s1, 1)));
         }
 
         SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(PrependFirst(svld1_u8(mask8, src)), svld1_u8(mask8, src + 1), mask16);
+            svuint8x2_t t01;
+            EvenOdd(PrependFirst(svld1_u8(mask8, src)), mask8, t01.val[0], t01.val[1]);
+            return BinomialSum8(t01, svld2_u8(mask8, src + 1), mask16);
         }
 
         SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(svld1_u8(mask8, src - 1), svld1_u8(mask8, src + 1), mask16);
+            return BinomialSum8(svld2_u8(mask8, src - 1), svld2_u8(mask8, src + 1), mask16);
         }
 
         template <bool even> SIMD_INLINE svuint16_t ReduceColTail(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16);
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<true>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(svld1_u8(mask8, src - 1), AppendLast1(svld1_u8(mask8, src), mask8), mask16);
+            svuint8x2_t t23;
+            EvenOdd(AppendLast1(svld1_u8(mask8, src), mask8), mask8, t23.val[0], t23.val[1]);
+            return BinomialSum8(svld2_u8(mask8, src - 1), t23, mask16);
         }
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<false>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
             svuint8_t ab = svld1_u8(mask8, src - 1);
-            return BinomialSum8(ab, AppendLast2(ab, mask8), mask16);
+            svuint8x2_t t23;
+            EvenOdd(AppendLast2(ab, mask8), mask8, t23.val[0], t23.val[1]);
+            return BinomialSum8(svld2_u8(mask8, src - 1), t23, mask16);
         }
 
         SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svuint16_t& d, const svbool_t& mask)
@@ -118,11 +132,6 @@ namespace Simd
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 32), 6);
         }
 
-        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
-        {
-            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
-        }
-
         SIMD_INLINE svuint16_t ReduceRow16(const Buffer& buffer, size_t offset, const svbool_t& mask16)
         {
             return DivideBy64(BinomialSum16(
@@ -132,12 +141,10 @@ namespace Simd
                 svld1_u16(mask16, buffer.src3 + offset), mask16), mask16);
         }
 
-        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16Lo, const svbool_t& mask16Hi)
+        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16)
         {
-            const size_t half = svcnth() >> 1;
-            return PackU16ToU8(
-                ReduceRow16(buffer, offset, mask16Lo),
-                ReduceRow16(buffer, offset + half, mask16Hi));
+            svuint8_t value = svqxtnb_u16(ReduceRow16(buffer, offset, mask16));
+            return svuzp1_u8(value, value);
         }
 
         SIMD_INLINE void StoreColNose(uint16_t* dst, const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
@@ -213,22 +220,19 @@ namespace Simd
                     StoreColTail<even>(buffer.src3, src3, srcTail, mask8, mask16);
                 }
 
-                const size_t half = HA >> 1;
                 for (size_t col = 0; col < alignedDstWidth; col += HA)
                 {
-                    svbool_t mask16Lo = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - col));
-                    svbool_t mask16Hi = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - (col + half)));
+                    svbool_t mask16 = svwhilelt_b16(col, dstWidth);
                     svbool_t mask8 = svwhilelt_b8(col, dstWidth);
-                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16Lo, mask16Hi));
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
                 }
 
                 if (alignedDstWidth != dstWidth)
                 {
                     size_t col = dstWidth - HA;
-                    svbool_t mask16Lo = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - col));
-                    svbool_t mask16Hi = svwhilelt_b16(size_t(0), Simd::Min(half, dstWidth - (col + half)));
+                    svbool_t mask16 = svwhilelt_b16(col, dstWidth);
                     svbool_t mask8 = svwhilelt_b8(col, dstWidth);
-                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16Lo, mask16Hi));
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
                 }
 
                 Swap(buffer.src0, buffer.src2);

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -1,0 +1,208 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint8_t PrependFirst(const svuint8_t& value)
+        {
+            const svbool_t mask = svptrue_b8();
+            svuint8_t iota = svindex_u8(0, 1);
+            svuint8_t idx = svqsub_u8_x(mask, iota, svdup_n_u8(1));
+            idx = svsel_u8(svcmpeq_n_u8(mask, idx, 255), svdup_n_u8(0), idx);
+            return svtbl_u8(value, idx);
+        }
+
+        SIMD_INLINE svuint8_t AppendLast1(const svuint8_t& value, const svbool_t& mask8)
+        {
+            svuint8_t last = svdup_u8(svlastb_u8(mask8, value));
+            return svext_u8(value, last, 1);
+        }
+
+        SIMD_INLINE svuint8_t AppendLast2(const svuint8_t& value, const svbool_t& mask8)
+        {
+            svuint8_t last = svdup_u8(svlastb_u8(mask8, value));
+            return svext_u8(svext_u8(value, last, 1), last, 1);
+        }
+
+        SIMD_INLINE void EvenOdd(const svuint8_t& value, const svbool_t& mask8, svuint8_t& even, svuint8_t& odd)
+        {
+            svuint8_t iota = svindex_u8(0, 1);
+            svuint8_t idxEven = svlsl_n_u8_x(mask8, iota, 1);
+            svuint8_t idxOdd = svadd_n_u8_x(mask8, idxEven, 1);
+            even = svtbl_u8(value, idxEven);
+            odd = svtbl_u8(value, idxOdd);
+        }
+
+        SIMD_INLINE svuint16_t BinomialSum8(const svuint8_t& t01, const svuint8_t& t23, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svuint8_t t01e, t01o, t23e, t23o;
+            EvenOdd(t01, mask8, t01e, t01o);
+            EvenOdd(t23, mask8, t23e, t23o);
+            svuint16_t mid = svaddlb_u16(t01o, t23e);
+            return svadd_u16_x(mask16, svaddlb_u16(t01e, t23o), svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
+        }
+
+        SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            return BinomialSum8(PrependFirst(svld1_u8(mask8, src)), svld1_u8(mask8, src + 1), mask8, mask16);
+        }
+
+        SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            return BinomialSum8(svld1_u8(mask8, src - 1), svld1_u8(mask8, src + 1), mask8, mask16);
+        }
+
+        template <bool even> SIMD_INLINE svuint16_t ReduceColTail(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16);
+
+        template <> SIMD_INLINE svuint16_t ReduceColTail<true>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            return BinomialSum8(svld1_u8(mask8, src - 1), AppendLast1(svld1_u8(mask8, src), mask8), mask8, mask16);
+        }
+
+        template <> SIMD_INLINE svuint16_t ReduceColTail<false>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svuint8_t t01 = svld1_u8(mask8, src - 1);
+            return BinomialSum8(t01, AppendLast2(t01, mask8), mask8, mask16);
+        }
+
+        SIMD_INLINE void ReduceColNose(const uint8_t* s[4], svuint16_t a[4], const svbool_t& mask8, const svbool_t& mask16)
+        {
+            a[0] = ReduceColNose(s[0], mask8, mask16);
+            a[1] = ReduceColNose(s[1], mask8, mask16);
+            a[2] = ReduceColNose(s[2], mask8, mask16);
+            a[3] = ReduceColNose(s[3], mask8, mask16);
+        }
+
+        SIMD_INLINE void ReduceColBody(const uint8_t* s[4], size_t offset, svuint16_t a[4], const svbool_t& mask8, const svbool_t& mask16)
+        {
+            a[0] = ReduceColBody(s[0] + offset, mask8, mask16);
+            a[1] = ReduceColBody(s[1] + offset, mask8, mask16);
+            a[2] = ReduceColBody(s[2] + offset, mask8, mask16);
+            a[3] = ReduceColBody(s[3] + offset, mask8, mask16);
+        }
+
+        template <bool even> SIMD_INLINE void ReduceColTail(const uint8_t* s[4], size_t offset, svuint16_t a[4], const svbool_t& mask8, const svbool_t& mask16)
+        {
+            a[0] = ReduceColTail<even>(s[0] + offset, mask8, mask16);
+            a[1] = ReduceColTail<even>(s[1] + offset, mask8, mask16);
+            a[2] = ReduceColTail<even>(s[2] + offset, mask8, mask16);
+            a[3] = ReduceColTail<even>(s[3] + offset, mask8, mask16);
+        }
+
+        SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svuint16_t& d, const svbool_t& mask)
+        {
+            svuint16_t bc = svadd_u16_x(mask, b, c);
+            return svadd_u16_x(mask, svadd_u16_x(mask, a, d), svadd_u16_x(mask, bc, svlsl_n_u16_x(mask, bc, 1)));
+        }
+
+        SIMD_INLINE svuint16_t DivideBy64(const svuint16_t& value, const svbool_t& mask)
+        {
+            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 32), 6);
+        }
+
+        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        {
+            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+        }
+
+        SIMD_INLINE svuint8_t ReduceRow(const svuint16_t lo[4], const svuint16_t hi[4],
+            const svbool_t& maskLo16, const svbool_t& maskHi16)
+        {
+            return PackU16ToU8(
+                DivideBy64(BinomialSum16(lo[0], lo[1], lo[2], lo[3], maskLo16), maskLo16),
+                DivideBy64(BinomialSum16(hi[0], hi[1], hi[2], hi[3], maskHi16), maskHi16));
+        }
+
+        template <bool even> void ReduceGray4x4(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
+        {
+            assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight && srcWidth > svcntb());
+
+            const size_t A = svcntb();
+            const size_t HA = svcnth();
+            size_t bodyWidth = AlignLo(srcWidth, A);
+            size_t srcTail = AlignHi(srcWidth - A, 2);
+
+            for (size_t row = 0; row < srcHeight; row += 2, dst += dstStride)
+            {
+                const uint8_t* s[4];
+                s[1] = src + srcStride * row;
+                s[0] = s[1] - (row ? srcStride : 0);
+                s[2] = s[1] + (row < srcHeight - 1 ? srcStride : 0);
+                s[3] = s[2] + (row < srcHeight - 2 ? srcStride : 0);
+
+                svuint16_t lo[4], hi[4];
+                {
+                    svbool_t mask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
+                    svbool_t mask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
+                    svbool_t mask8Hi = svwhilelt_b8(A, Simd::Min(srcWidth, A + A));
+                    svbool_t mask16Hi = svwhilelt_b16(HA, Simd::Min(dstWidth, A));
+                    svbool_t maskStore = svwhilelt_b8(size_t(0), Simd::Min(dstWidth, A));
+                    ReduceColNose(s, lo, mask8, mask16);
+                    ReduceColBody(s, A, hi, mask8Hi, mask16Hi);
+                    svst1_u8(maskStore, dst, ReduceRow(lo, hi, mask16, mask16Hi));
+                }
+
+                for (size_t srcCol = A, dstCol = A; srcCol < bodyWidth; srcCol += A, dstCol += A)
+                {
+                    svbool_t mask8Lo = svwhilelt_b8(srcCol, srcWidth);
+                    svbool_t mask8Hi = svwhilelt_b8(srcCol + A, srcWidth);
+                    svbool_t mask16Lo = svwhilelt_b16(dstCol, dstWidth);
+                    svbool_t mask16Hi = svwhilelt_b16(dstCol + HA, dstWidth);
+                    svbool_t maskStore = svwhilelt_b8(dstCol, dstWidth);
+                    ReduceColBody(s, srcCol, lo, mask8Lo, mask16Lo);
+                    ReduceColBody(s, srcCol + A, hi, mask8Hi, mask16Hi);
+                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo, hi, mask16Lo, mask16Hi));
+                }
+
+                if (bodyWidth != srcWidth)
+                {
+                    size_t dstCol = dstWidth - A;
+                    svbool_t mask8Lo = svwhilelt_b8(srcTail, srcWidth);
+                    svbool_t mask8Hi = svwhilelt_b8(srcTail + A, srcWidth);
+                    svbool_t mask16Lo = svwhilelt_b16(dstCol, dstWidth);
+                    svbool_t mask16Hi = svwhilelt_b16(dstCol + HA, dstWidth);
+                    svbool_t maskStore = svwhilelt_b8(dstCol, dstWidth);
+                    ReduceColBody(s, srcTail, lo, mask8Lo, mask16Lo);
+                    ReduceColTail<even>(s, srcTail + A, hi, mask8Hi, mask16Hi);
+                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo, hi, mask16Lo, mask16Hi));
+                }
+            }
+        }
+
+        void ReduceGray4x4(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
+        {
+            if (Aligned(srcWidth, 2))
+                ReduceGray4x4<true>(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+            else
+                ReduceGray4x4<false>(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -85,48 +85,37 @@ namespace Simd
             odd = svtbl_u8(value, idxOdd);
         }
 
-        SIMD_INLINE svuint16_t BinomialSum8(const svuint8_t& t01e, const svuint8_t& t01o, const svuint8_t& t23e, const svuint8_t& t23o, const svbool_t& mask16)
+        SIMD_INLINE svuint16_t BinomialSum16Pairs(const svuint8_t& ab, const svuint8_t& cd, const svbool_t& mask8, const svbool_t& mask16)
         {
-            svuint16_t s0 = svadd_u16_x(mask16, svmovlb_u16(t01e), svmovlb_u16(t23o));
-            svuint16_t s1 = svadd_u16_x(mask16, svmovlb_u16(t01o), svmovlb_u16(t23e));
-            return svadd_u16_x(mask16, s0, svadd_u16_x(mask16, s1, svlsl_n_u16_x(mask16, s1, 1)));
-        }
-
-        SIMD_INLINE svuint16_t BinomialSum8(const svuint8x2_t& t01, const svuint8x2_t& t23, const svbool_t& mask16)
-        {
-            return BinomialSum8(svget2(t01, 0), svget2(t01, 1), svget2(t23, 0), svget2(t23, 1), mask16);
+            svuint8_t abe, abo, cde, cdo;
+            EvenOdd(ab, mask8, abe, abo);
+            EvenOdd(cd, mask8, cde, cdo);
+            svuint16_t s0 = svadd_u16_x(mask16, svunpklo_u16(abe), svmul_n_u16_x(mask16, svunpklo_u16(abo), 3));
+            svuint16_t s1 = svadd_u16_x(mask16, svmul_n_u16_x(mask16, svunpklo_u16(cde), 3), svunpklo_u16(cdo));
+            return svadd_u16_x(mask16, s0, s1);
         }
 
         SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            svuint8_t t01e, t01o;
-            EvenOdd(PrependFirst(svld1_u8(mask8, src)), mask8, t01e, t01o);
-            svuint8x2_t t23 = svld2_u8(mask8, src + 1);
-            return BinomialSum8(t01e, t01o, svget2(t23, 0), svget2(t23, 1), mask16);
+            return BinomialSum16Pairs(PrependFirst(svld1_u8(mask8, src)), svld1_u8(mask8, src + 1), mask8, mask16);
         }
 
         SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(svld2_u8(mask8, src - 1), svld2_u8(mask8, src + 1), mask16);
+            return BinomialSum16Pairs(svld1_u8(mask8, src - 1), svld1_u8(mask8, src + 1), mask8, mask16);
         }
 
         template <bool even> SIMD_INLINE svuint16_t ReduceColTail(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16);
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<true>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            svuint8_t t23e, t23o;
-            EvenOdd(AppendLast1(svld1_u8(mask8, src), mask8), mask8, t23e, t23o);
-            svuint8x2_t t01 = svld2_u8(mask8, src - 1);
-            return BinomialSum8(svget2(t01, 0), svget2(t01, 1), t23e, t23o, mask16);
+            return BinomialSum16Pairs(svld1_u8(mask8, src - 1), AppendLast1(svld1_u8(mask8, src), mask8), mask8, mask16);
         }
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<false>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
             svuint8_t ab = svld1_u8(mask8, src - 1);
-            svuint8_t t23e, t23o;
-            EvenOdd(AppendLast2(ab, mask8), mask8, t23e, t23o);
-            svuint8x2_t t01 = svld2_u8(mask8, src - 1);
-            return BinomialSum8(svget2(t01, 0), svget2(t01, 1), t23e, t23o, mask16);
+            return BinomialSum16Pairs(ab, AppendLast2(ab, mask8), mask8, mask16);
         }
 
         SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svuint16_t& d, const svbool_t& mask)
@@ -191,13 +180,13 @@ namespace Simd
                 {
                     mask8 = svwhilelt_b8(srcCol, srcWidth);
                     mask16 = svwhilelt_b16(dstCol, dstWidth);
-                    StoreColBody(buffer.src0, src, srcCol, mask8, mask16);
-                    StoreColBody(buffer.src1, src, srcCol, mask8, mask16);
+                    StoreColBody(buffer.src0 + dstCol, src, srcCol, mask8, mask16);
+                    StoreColBody(buffer.src1 + dstCol, src, srcCol, mask8, mask16);
                 }
                 mask8 = svwhilelt_b8(srcTail, srcWidth);
                 mask16 = svwhilelt_b16(dstWidth - HA, dstWidth);
-                StoreColTail<even>(buffer.src0, src, srcTail, mask8, mask16);
-                StoreColTail<even>(buffer.src1, src, srcTail, mask8, mask16);
+                StoreColTail<even>(buffer.src0 + dstWidth - HA, src, srcTail, mask8, mask16);
+                StoreColTail<even>(buffer.src1 + dstWidth - HA, src, srcTail, mask8, mask16);
             }
 
             for (size_t row = 0; row < srcHeight; row += 2, dst += dstStride)
@@ -219,19 +208,19 @@ namespace Simd
                     {
                         mask8 = svwhilelt_b8(srcCol, srcWidth);
                         mask16 = svwhilelt_b16(dstCol, dstWidth);
-                        StoreColBody(buffer.src2, src2, srcCol, mask8, mask16);
-                        StoreColBody(buffer.src3, src3, srcCol, mask8, mask16);
+                        StoreColBody(buffer.src2 + dstCol, src2, srcCol, mask8, mask16);
+                        StoreColBody(buffer.src3 + dstCol, src3, srcCol, mask8, mask16);
                     }
                     mask8 = svwhilelt_b8(srcTail, srcWidth);
                     mask16 = svwhilelt_b16(dstWidth - HA, dstWidth);
-                    StoreColTail<even>(buffer.src2, src2, srcTail, mask8, mask16);
-                    StoreColTail<even>(buffer.src3, src3, srcTail, mask8, mask16);
+                    StoreColTail<even>(buffer.src2 + dstWidth - HA, src2, srcTail, mask8, mask16);
+                    StoreColTail<even>(buffer.src3 + dstWidth - HA, src3, srcTail, mask8, mask16);
                 }
 
                 for (size_t col = 0; col < alignedDstWidth; col += HA)
                 {
                     svbool_t mask16 = svwhilelt_b16(col, dstWidth);
-                    svbool_t mask8 = svwhilelt_b8(col, dstWidth);
+                    svbool_t mask8 = svwhilelt_b8(col, Simd::Min(col + HA, dstWidth));
                     svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
                 }
 
@@ -239,7 +228,7 @@ namespace Simd
                 {
                     size_t col = dstWidth - HA;
                     svbool_t mask16 = svwhilelt_b16(col, dstWidth);
-                    svbool_t mask8 = svwhilelt_b8(col, dstWidth);
+                    svbool_t mask8 = svwhilelt_b8(col, Simd::Min(col + HA, dstWidth));
                     svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
                 }
 

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -76,46 +76,35 @@ namespace Simd
             return svext_u8(svext_u8(value, last, 1), last, 1);
         }
 
-        SIMD_INLINE void EvenOdd(const svuint8_t& value, const svbool_t& mask8, svuint8_t& even, svuint8_t& odd)
+        SIMD_INLINE svuint16_t BinomialSum8(const svuint8_t& ab, const svuint8_t& cd, const svbool_t& mask16)
         {
-            svuint8_t iota = svindex_u8(0, 1);
-            svuint8_t idxEven = svlsl_n_u8_x(mask8, iota, 1);
-            svuint8_t idxOdd = svadd_n_u8_x(mask8, idxEven, 1);
-            even = svtbl_u8(value, idxEven);
-            odd = svtbl_u8(value, idxOdd);
-        }
-
-        SIMD_INLINE svuint16_t BinomialSum8(const svuint8_t& t01, const svuint8_t& t23, const svbool_t& mask8, const svbool_t& mask16)
-        {
-            svuint8_t t01e, t01o, t23e, t23o;
-            EvenOdd(t01, mask8, t01e, t01o);
-            EvenOdd(t23, mask8, t23e, t23o);
-            svuint16_t lo = svadd_u16_x(mask16, svmovlb_u16(t01e), svmovlb_u16(t23o));
-            svuint16_t mid = svadd_u16_x(mask16, svmovlb_u16(t01o), svmovlb_u16(t23e));
+            svuint8_t cd1 = svext_u8(cd, cd, 1);
+            svuint16_t lo = svaddlb_u16(ab, cd1);
+            svuint16_t mid = svaddlt_u16(ab, cd);
             return svadd_u16_x(mask16, lo, svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
         }
 
         SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(PrependFirst(svld1_u8(mask8, src)), svld1_u8(mask8, src + 1), mask8, mask16);
+            return BinomialSum8(PrependFirst(svld1_u8(mask8, src)), svld1_u8(mask8, src + 1), mask16);
         }
 
         SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(svld1_u8(mask8, src - 1), svld1_u8(mask8, src + 1), mask8, mask16);
+            return BinomialSum8(svld1_u8(mask8, src - 1), svld1_u8(mask8, src + 1), mask16);
         }
 
         template <bool even> SIMD_INLINE svuint16_t ReduceColTail(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16);
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<true>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return BinomialSum8(svld1_u8(mask8, src - 1), AppendLast1(svld1_u8(mask8, src), mask8), mask8, mask16);
+            return BinomialSum8(svld1_u8(mask8, src - 1), AppendLast1(svld1_u8(mask8, src), mask8), mask16);
         }
 
         template <> SIMD_INLINE svuint16_t ReduceColTail<false>(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            svuint8_t t01 = svld1_u8(mask8, src - 1);
-            return BinomialSum8(t01, AppendLast2(t01, mask8), mask8, mask16);
+            svuint8_t ab = svld1_u8(mask8, src - 1);
+            return BinomialSum8(ab, AppendLast2(ab, mask8), mask16);
         }
 
         SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svuint16_t& d, const svbool_t& mask)
@@ -129,22 +118,27 @@ namespace Simd
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 32), 6);
         }
 
-        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16, const svbool_t& mask8)
+        SIMD_INLINE svuint8_t NarrowU16ToU8(const svuint16_t& value)
         {
-            svuint8_t value = svqxtnb_u16(DivideBy64(BinomialSum16(
+            const size_t half = svcnth() >> 1;
+            return svqxtnt_u16(svqxtnb_u16(value), svext_u16(value, value, (uint32_t)half));
+        }
+
+        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16)
+        {
+            return NarrowU16ToU8(DivideBy64(BinomialSum16(
                 svld1_u16(mask16, buffer.src0 + offset),
                 svld1_u16(mask16, buffer.src1 + offset),
                 svld1_u16(mask16, buffer.src2 + offset),
                 svld1_u16(mask16, buffer.src3 + offset), mask16), mask16));
-            return svuzp1_u8(value, value);
         }
 
-        SIMD_INLINE void StoreCol(uint16_t* dst, const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE void StoreColNose(uint16_t* dst, const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
             svst1_u16(mask16, dst, ReduceColNose(src, mask8, mask16));
         }
 
-        SIMD_INLINE void StoreCol(uint16_t* dst, const uint8_t* src, size_t srcCol, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE void StoreColBody(uint16_t* dst, const uint8_t* src, size_t srcCol, const svbool_t& mask8, const svbool_t& mask16)
         {
             svst1_u16(mask16, dst, ReduceColBody(src + srcCol, mask8, mask16));
         }
@@ -169,14 +163,14 @@ namespace Simd
             {
                 svbool_t mask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
                 svbool_t mask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
-                StoreCol(buffer.src0, src, mask8, mask16);
-                StoreCol(buffer.src1, src, mask8, mask16);
+                StoreColNose(buffer.src0, src, mask8, mask16);
+                StoreColNose(buffer.src1, src, mask8, mask16);
                 for (size_t srcCol = A, dstCol = HA; srcCol < srcWidth - A; srcCol += A, dstCol += HA)
                 {
                     mask8 = svwhilelt_b8(srcCol, srcWidth);
                     mask16 = svwhilelt_b16(dstCol, dstWidth);
-                    StoreCol(buffer.src0, src, srcCol, mask8, mask16);
-                    StoreCol(buffer.src1, src, srcCol, mask8, mask16);
+                    StoreColBody(buffer.src0, src, srcCol, mask8, mask16);
+                    StoreColBody(buffer.src1, src, srcCol, mask8, mask16);
                 }
                 mask8 = svwhilelt_b8(srcTail, srcWidth);
                 mask16 = svwhilelt_b16(dstWidth - HA, dstWidth);
@@ -197,14 +191,14 @@ namespace Simd
                 {
                     svbool_t mask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
                     svbool_t mask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
-                    StoreCol(buffer.src2, src2, mask8, mask16);
-                    StoreCol(buffer.src3, src3, mask8, mask16);
+                    StoreColNose(buffer.src2, src2, mask8, mask16);
+                    StoreColNose(buffer.src3, src3, mask8, mask16);
                     for (size_t srcCol = A, dstCol = HA; srcCol < srcWidth - A; srcCol += A, dstCol += HA)
                     {
                         mask8 = svwhilelt_b8(srcCol, srcWidth);
                         mask16 = svwhilelt_b16(dstCol, dstWidth);
-                        StoreCol(buffer.src2, src2, srcCol, mask8, mask16);
-                        StoreCol(buffer.src3, src3, srcCol, mask8, mask16);
+                        StoreColBody(buffer.src2, src2, srcCol, mask8, mask16);
+                        StoreColBody(buffer.src3, src3, srcCol, mask8, mask16);
                     }
                     mask8 = svwhilelt_b8(srcTail, srcWidth);
                     mask16 = svwhilelt_b16(dstWidth - HA, dstWidth);
@@ -216,7 +210,7 @@ namespace Simd
                 {
                     svbool_t mask16 = svwhilelt_b16(col, dstWidth);
                     svbool_t mask8 = svwhilelt_b8(col, dstWidth);
-                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16, mask8));
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
                 }
 
                 if (alignedDstWidth != dstWidth)
@@ -224,7 +218,7 @@ namespace Simd
                     size_t col = dstWidth - HA;
                     svbool_t mask16 = svwhilelt_b16(col, dstWidth);
                     svbool_t mask8 = svwhilelt_b8(col, dstWidth);
-                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16, mask8));
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16));
                 }
 
                 Swap(buffer.src0, buffer.src2);

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -63,8 +63,9 @@ namespace Simd
             svuint8_t t01e, t01o, t23e, t23o;
             EvenOdd(t01, mask8, t01e, t01o);
             EvenOdd(t23, mask8, t23e, t23o);
-            svuint16_t mid = svaddlb_u16(t01o, t23e);
-            return svadd_u16_x(mask16, svaddlb_u16(t01e, t23o), svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
+            svuint16_t lo = svadd_u16_x(mask16, svmovlb_u16(t01e), svmovlb_u16(t23o));
+            svuint16_t mid = svadd_u16_x(mask16, svmovlb_u16(t01o), svmovlb_u16(t23e));
+            return svadd_u16_x(mask16, lo, svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
         }
 
         SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)

--- a/src/Simd/SimdSve2ReduceGray4x4.cpp
+++ b/src/Simd/SimdSve2ReduceGray4x4.cpp
@@ -28,6 +28,33 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        namespace
+        {
+            struct Buffer
+            {
+                Buffer(size_t width)
+                {
+                    _p = Allocate(sizeof(uint16_t) * 4 * width);
+                    src0 = (uint16_t*)_p;
+                    src1 = src0 + width;
+                    src2 = src1 + width;
+                    src3 = src2 + width;
+                }
+
+                ~Buffer()
+                {
+                    Free(_p);
+                }
+
+                uint16_t* src0;
+                uint16_t* src1;
+                uint16_t* src2;
+                uint16_t* src3;
+            private:
+                void* _p;
+            };
+        }
+
         SIMD_INLINE svuint8_t PrependFirst(const svuint8_t& value)
         {
             const svbool_t mask = svptrue_b8();
@@ -63,8 +90,8 @@ namespace Simd
             svuint8_t t01e, t01o, t23e, t23o;
             EvenOdd(t01, mask8, t01e, t01o);
             EvenOdd(t23, mask8, t23e, t23o);
-            svuint16_t lo = svadd_u16_x(mask16, svmovlb_u16(t01e), svmovlb_u16(t23o));
-            svuint16_t mid = svadd_u16_x(mask16, svmovlb_u16(t01o), svmovlb_u16(t23e));
+            svuint16_t lo = svaddlbt_u16(t01e, t23o);
+            svuint16_t mid = svaddlbt_u16(t01o, t23e);
             return svadd_u16_x(mask16, lo, svadd_u16_x(mask16, mid, svlsl_n_u16_x(mask16, mid, 1)));
         }
 
@@ -102,19 +129,29 @@ namespace Simd
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 32), 6);
         }
 
-        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        SIMD_INLINE svuint8_t ReduceRow(const Buffer& buffer, size_t offset, const svbool_t& mask16, const svbool_t& mask8)
         {
-            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+            svuint8_t value = svqxtnb_u16(DivideBy64(BinomialSum16(
+                svld1_u16(mask16, buffer.src0 + offset),
+                svld1_u16(mask16, buffer.src1 + offset),
+                svld1_u16(mask16, buffer.src2 + offset),
+                svld1_u16(mask16, buffer.src3 + offset), mask16), mask16));
+            return svuzp1_u8(value, value);
         }
 
-        SIMD_INLINE svuint8_t ReduceRow(
-            const svuint16_t& lo0, const svuint16_t& lo1, const svuint16_t& lo2, const svuint16_t& lo3,
-            const svuint16_t& hi0, const svuint16_t& hi1, const svuint16_t& hi2, const svuint16_t& hi3,
-            const svbool_t& maskLo16, const svbool_t& maskHi16)
+        SIMD_INLINE void StoreCol(uint16_t* dst, const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return PackU16ToU8(
-                DivideBy64(BinomialSum16(lo0, lo1, lo2, lo3, maskLo16), maskLo16),
-                DivideBy64(BinomialSum16(hi0, hi1, hi2, hi3, maskHi16), maskHi16));
+            svst1_u16(mask16, dst, ReduceColNose(src, mask8, mask16));
+        }
+
+        SIMD_INLINE void StoreCol(uint16_t* dst, const uint8_t* src, size_t srcCol, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svst1_u16(mask16, dst, ReduceColBody(src + srcCol, mask8, mask16));
+        }
+
+        template <bool even> SIMD_INLINE void StoreColTail(uint16_t* dst, const uint8_t* src, size_t srcCol, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svst1_u16(mask16, dst, ReduceColTail<even>(src + srcCol, mask8, mask16));
         }
 
         template <bool even> void ReduceGray4x4(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
@@ -124,70 +161,74 @@ namespace Simd
 
             const size_t A = svcntb();
             const size_t HA = svcnth();
-            size_t bodyWidth = AlignLo(srcWidth, A);
+            size_t alignedDstWidth = AlignLo(dstWidth, HA);
             size_t srcTail = AlignHi(srcWidth - A, 2);
+
+            Buffer buffer(AlignHi(dstWidth, A));
+
+            {
+                svbool_t mask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
+                svbool_t mask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
+                StoreCol(buffer.src0, src, mask8, mask16);
+                StoreCol(buffer.src1, src, mask8, mask16);
+                for (size_t srcCol = A, dstCol = HA; srcCol < srcWidth - A; srcCol += A, dstCol += HA)
+                {
+                    mask8 = svwhilelt_b8(srcCol, srcWidth);
+                    mask16 = svwhilelt_b16(dstCol, dstWidth);
+                    StoreCol(buffer.src0, src, srcCol, mask8, mask16);
+                    StoreCol(buffer.src1, src, srcCol, mask8, mask16);
+                }
+                mask8 = svwhilelt_b8(srcTail, srcWidth);
+                mask16 = svwhilelt_b16(dstWidth - HA, dstWidth);
+                StoreColTail<even>(buffer.src0, src, srcTail, mask8, mask16);
+                StoreColTail<even>(buffer.src1, src, srcTail, mask8, mask16);
+            }
 
             for (size_t row = 0; row < srcHeight; row += 2, dst += dstStride)
             {
-                const uint8_t* s0 = src + srcStride * row - (row ? srcStride : 0);
-                const uint8_t* s1 = src + srcStride * row;
-                const uint8_t* s2 = s1 + (row < srcHeight - 1 ? srcStride : 0);
-                const uint8_t* s3 = s2 + (row < srcHeight - 2 ? srcStride : 0);
+                const uint8_t* src2 = src + srcStride * (row + 1);
+                const uint8_t* src3 = src2 + srcStride;
+                if (row >= srcHeight - 2)
+                {
+                    src2 = src + srcStride * (srcHeight - 1);
+                    src3 = src2;
+                }
 
-                svuint16_t lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3;
                 {
                     svbool_t mask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
                     svbool_t mask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
-                    svbool_t mask8Hi = svwhilelt_b8(A, Simd::Min(srcWidth, A + A));
-                    svbool_t mask16Hi = svwhilelt_b16(HA, Simd::Min(dstWidth, A));
-                    svbool_t maskStore = svwhilelt_b8(size_t(0), Simd::Min(dstWidth, A));
-                    lo0 = ReduceColNose(s0, mask8, mask16);
-                    lo1 = ReduceColNose(s1, mask8, mask16);
-                    lo2 = ReduceColNose(s2, mask8, mask16);
-                    lo3 = ReduceColNose(s3, mask8, mask16);
-                    hi0 = ReduceColBody(s0 + A, mask8Hi, mask16Hi);
-                    hi1 = ReduceColBody(s1 + A, mask8Hi, mask16Hi);
-                    hi2 = ReduceColBody(s2 + A, mask8Hi, mask16Hi);
-                    hi3 = ReduceColBody(s3 + A, mask8Hi, mask16Hi);
-                    svst1_u8(maskStore, dst, ReduceRow(lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3, mask16, mask16Hi));
+                    StoreCol(buffer.src2, src2, mask8, mask16);
+                    StoreCol(buffer.src3, src3, mask8, mask16);
+                    for (size_t srcCol = A, dstCol = HA; srcCol < srcWidth - A; srcCol += A, dstCol += HA)
+                    {
+                        mask8 = svwhilelt_b8(srcCol, srcWidth);
+                        mask16 = svwhilelt_b16(dstCol, dstWidth);
+                        StoreCol(buffer.src2, src2, srcCol, mask8, mask16);
+                        StoreCol(buffer.src3, src3, srcCol, mask8, mask16);
+                    }
+                    mask8 = svwhilelt_b8(srcTail, srcWidth);
+                    mask16 = svwhilelt_b16(dstWidth - HA, dstWidth);
+                    StoreColTail<even>(buffer.src2, src2, srcTail, mask8, mask16);
+                    StoreColTail<even>(buffer.src3, src3, srcTail, mask8, mask16);
                 }
 
-                for (size_t srcCol = A, dstCol = A; srcCol < bodyWidth; srcCol += A, dstCol += A)
+                for (size_t col = 0; col < alignedDstWidth; col += HA)
                 {
-                    svbool_t mask8Lo = svwhilelt_b8(srcCol, srcWidth);
-                    svbool_t mask8Hi = svwhilelt_b8(srcCol + A, srcWidth);
-                    svbool_t mask16Lo = svwhilelt_b16(dstCol, dstWidth);
-                    svbool_t mask16Hi = svwhilelt_b16(dstCol + HA, dstWidth);
-                    svbool_t maskStore = svwhilelt_b8(dstCol, dstWidth);
-                    lo0 = ReduceColBody(s0 + srcCol, mask8Lo, mask16Lo);
-                    lo1 = ReduceColBody(s1 + srcCol, mask8Lo, mask16Lo);
-                    lo2 = ReduceColBody(s2 + srcCol, mask8Lo, mask16Lo);
-                    lo3 = ReduceColBody(s3 + srcCol, mask8Lo, mask16Lo);
-                    hi0 = ReduceColBody(s0 + srcCol + A, mask8Hi, mask16Hi);
-                    hi1 = ReduceColBody(s1 + srcCol + A, mask8Hi, mask16Hi);
-                    hi2 = ReduceColBody(s2 + srcCol + A, mask8Hi, mask16Hi);
-                    hi3 = ReduceColBody(s3 + srcCol + A, mask8Hi, mask16Hi);
-                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3, mask16Lo, mask16Hi));
+                    svbool_t mask16 = svwhilelt_b16(col, dstWidth);
+                    svbool_t mask8 = svwhilelt_b8(col, dstWidth);
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16, mask8));
                 }
 
-                if (bodyWidth != srcWidth)
+                if (alignedDstWidth != dstWidth)
                 {
-                    size_t dstCol = dstWidth - A;
-                    svbool_t mask8Lo = svwhilelt_b8(srcTail, srcWidth);
-                    svbool_t mask8Hi = svwhilelt_b8(srcTail + A, srcWidth);
-                    svbool_t mask16Lo = svwhilelt_b16(dstCol, dstWidth);
-                    svbool_t mask16Hi = svwhilelt_b16(dstCol + HA, dstWidth);
-                    svbool_t maskStore = svwhilelt_b8(dstCol, dstWidth);
-                    lo0 = ReduceColBody(s0 + srcTail, mask8Lo, mask16Lo);
-                    lo1 = ReduceColBody(s1 + srcTail, mask8Lo, mask16Lo);
-                    lo2 = ReduceColBody(s2 + srcTail, mask8Lo, mask16Lo);
-                    lo3 = ReduceColBody(s3 + srcTail, mask8Lo, mask16Lo);
-                    hi0 = ReduceColTail<even>(s0 + srcTail + A, mask8Hi, mask16Hi);
-                    hi1 = ReduceColTail<even>(s1 + srcTail + A, mask8Hi, mask16Hi);
-                    hi2 = ReduceColTail<even>(s2 + srcTail + A, mask8Hi, mask16Hi);
-                    hi3 = ReduceColTail<even>(s3 + srcTail + A, mask8Hi, mask16Hi);
-                    svst1_u8(maskStore, dst + dstCol, ReduceRow(lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3, mask16Lo, mask16Hi));
+                    size_t col = dstWidth - HA;
+                    svbool_t mask16 = svwhilelt_b16(col, dstWidth);
+                    svbool_t mask8 = svwhilelt_b8(col, dstWidth);
+                    svst1_u8(mask8, dst + col, ReduceRow(buffer, col, mask16, mask8));
                 }
+
+                Swap(buffer.src0, buffer.src2);
+                Swap(buffer.src1, buffer.src3);
             }
         }
 

--- a/src/Test/TestReduce.cpp
+++ b/src/Test/TestReduce.cpp
@@ -315,6 +315,11 @@ namespace Test
             result = result && ReduceGrayAutoTest(FUNC_RG1(Simd::Avx512bw::ReduceGray4x4), FUNC_RG1(SimdReduceGray4x4));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W > svcntb())
+            result = result && ReduceGrayAutoTest(FUNC_RG1(Simd::Sve2::ReduceGray4x4), FUNC_RG1(SimdReduceGray4x4));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W > Simd::Neon::DA)
             result = result && ReduceGrayAutoTest(FUNC_RG1(Simd::Neon::ReduceGray4x4), FUNC_RG1(SimdReduceGray4x4));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds SVE/SVE2 SIMD optimization for `SimdReduceGray4x4` on ARM/ARM64.

## Changes

- **New file:** `src/Simd/SimdSve2ReduceGray4x4.cpp` — SVE2 implementation using a four-row vertical processing approach (same algorithm structure as the Avx512bw version), with column filtering via `svtbl_u8`-based even/odd extraction instead of interleave/deinterleave loads.
- **`src/Simd/SimdSve2.h`** — declaration for `Sve2::ReduceGray4x4`.
- **`src/Simd/SimdLib.cpp`** — dispatch to SVE2 when `Sve2::Enable` and `srcWidth > svcntb()`.
- **`src/Test/TestReduce.cpp`** — `ReduceGray4x4AutoTest` coverage for SVE2.
- **`prj/vs2022/Sve2.vcxproj`** and **`Sve2.vcxproj.filters`** — added new source file.
- **`docs/2026.html`** — release 7.2.163 changelog entry.

## Testing

- Built successfully with CMake (Release, shared library).
- `./Test "-r=.." -fi=ReduceGray4x4 -tt=1 -ts=1` passes on x86 (Base/SSE41/AVX2/AVX512BW paths).
- SVE2 path is compiled only when `SIMD_SVE2_ENABLE` is defined; runtime validation requires an ARM64 host with SVE2.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52f34fc9-d99c-4267-a5a4-e0119226b4a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52f34fc9-d99c-4267-a5a4-e0119226b4a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

