### PR TITLE
Add SVE2 optimization of ReduceGray5x5 function

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -112,6 +112,7 @@
  <li>SVE2 optimizations of function ReduceGray2x2.</li>
  <li>SVE2 optimizations of function ReduceGray3x3.</li>
  <li>SVE2 optimizations of function ReduceGray4x4.</li>
+ <li>SVE2 optimizations of function ReduceGray5x5.</li>
  <li>SVE2 optimizations of function BgrToYuv420pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv422pV2.</li>
  <li>SVE2 optimizations of function BgrToYuv444pV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -73,6 +73,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -290,6 +290,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp">
       <Filter>Sve2\Image</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp">
+      <Filter>Sve2\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4833,6 +4833,11 @@ SIMD_API void SimdReduceGray5x5(const uint8_t *src, size_t srcWidth, size_t srcH
         Sse41::ReduceGray5x5(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride, compensation);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && srcWidth > svcntb())
+        Sve2::ReduceGray5x5(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride, compensation);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && srcWidth >= Neon::DA)
         Neon::ReduceGray5x5(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride, compensation);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -282,6 +282,9 @@ namespace Simd
         void ReduceGray4x4(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
 
+        void ReduceGray5x5(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, int compensation);
+
         void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
 
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);

--- a/src/Simd/SimdSve2ReduceGray5x5.cpp
+++ b/src/Simd/SimdSve2ReduceGray5x5.cpp
@@ -30,16 +30,19 @@ namespace Simd
     {
         namespace
         {
+            const size_t BA = 16;
+            const size_t BHA = BA / 2;
+
             struct Buffer
             {
-                Buffer(size_t width, size_t tail)
+                Buffer(size_t width)
                 {
-                    _p = Allocate(sizeof(uint16_t) * (5 * width + tail));
+                    _p = Allocate(sizeof(uint16_t) * (5 * width + BA));
                     in0 = (uint16_t*)_p;
                     in1 = in0 + width;
                     out0 = in1 + width;
                     out1 = out0 + width;
-                    dst = out1 + width + tail / 2;
+                    dst = out1 + width + BHA;
                 }
 
                 ~Buffer()
@@ -69,45 +72,41 @@ namespace Simd
             return svlsr_n_u16_x(mask, value, 8);
         }
 
-        SIMD_INLINE void FirstRow5x5(const uint8_t* src, Buffer& buffer, size_t col,
-            const svbool_t& mask8, const svbool_t& mask16Lo, const svbool_t& mask16Hi)
+        SIMD_INLINE void FirstRow5x5Part(svuint16_t src, Buffer& buffer, size_t offset, const svbool_t& mask16)
         {
-            const size_t HA = svcnth();
-            svuint8_t s = svld1_u8(mask8, src + col);
-            svuint16_t lo = svunpklo_u16(s);
-            svuint16_t hi = svunpkhi_u16(s);
-            svst1_u16(mask16Lo, buffer.in0 + col, lo);
-            svst1_u16(mask16Hi, buffer.in0 + col + HA, hi);
-            svst1_u16(mask16Lo, buffer.in1 + col, svmul_n_u16_x(mask16Lo, lo, 5));
-            svst1_u16(mask16Hi, buffer.in1 + col + HA, svmul_n_u16_x(mask16Hi, hi, 5));
+            svst1_u16(mask16, buffer.in0 + offset, src);
+            svst1_u16(mask16, buffer.in1 + offset, svmul_n_u16_x(mask16, src, 5));
         }
 
-        SIMD_INLINE void MainRowY5x5(const uint8_t* odd, const uint8_t* even, Buffer& buffer, size_t col,
-            const svbool_t& mask8, const svbool_t& mask16Lo, const svbool_t& mask16Hi)
+        SIMD_INLINE void FirstRow5x5Part(const uint8_t* src, Buffer& buffer, size_t offset,
+            const svbool_t& mask8, const svbool_t& mask16)
         {
-            const size_t HA = svcnth();
-            svuint8_t sOdd = svld1_u8(mask8, odd + col);
-            svuint8_t sEven = svld1_u8(mask8, even + col);
-            svuint16_t oddLo = svunpklo_u16(sOdd);
-            svuint16_t oddHi = svunpkhi_u16(sOdd);
-            svuint16_t evenLo = svunpklo_u16(sEven);
-            svuint16_t evenHi = svunpkhi_u16(sEven);
+            FirstRow5x5Part(svld1ub_u16(mask16, src + offset), buffer, offset, mask16);
+        }
 
-            svuint16_t cpLo = svmul_n_u16_x(mask16Lo, oddLo, 4);
-            svuint16_t c0Lo = svld1_u16(mask16Lo, buffer.in0 + col);
-            svuint16_t c1Lo = svld1_u16(mask16Lo, buffer.in1 + col);
-            svst1_u16(mask16Lo, buffer.dst + col, svadd_u16_x(mask16Lo, evenLo,
-                svadd_u16_x(mask16Lo, c1Lo, svadd_u16_x(mask16Lo, cpLo, svmul_n_u16_x(mask16Lo, c0Lo, 6)))));
-            svst1_u16(mask16Lo, buffer.out1 + col, svadd_u16_x(mask16Lo, c0Lo, cpLo));
-            svst1_u16(mask16Lo, buffer.out0 + col, evenLo);
+        SIMD_INLINE void FirstRow5x5(const uint8_t* src, Buffer& buffer, size_t offset,
+            const svbool_t& mask8, const svbool_t& mask16)
+        {
+            FirstRow5x5Part(src, buffer, offset, mask8, mask16);
+            FirstRow5x5Part(src, buffer, offset + BHA, mask8, mask16);
+        }
 
-            svuint16_t cpHi = svmul_n_u16_x(mask16Hi, oddHi, 4);
-            svuint16_t c0Hi = svld1_u16(mask16Hi, buffer.in0 + col + HA);
-            svuint16_t c1Hi = svld1_u16(mask16Hi, buffer.in1 + col + HA);
-            svst1_u16(mask16Hi, buffer.dst + col + HA, svadd_u16_x(mask16Hi, evenHi,
-                svadd_u16_x(mask16Hi, c1Hi, svadd_u16_x(mask16Hi, cpHi, svmul_n_u16_x(mask16Hi, c0Hi, 6)))));
-            svst1_u16(mask16Hi, buffer.out1 + col + HA, svadd_u16_x(mask16Hi, c0Hi, cpHi));
-            svst1_u16(mask16Hi, buffer.out0 + col + HA, evenHi);
+        SIMD_INLINE void MainRowY5x5Part(svuint16_t odd, svuint16_t even, Buffer& buffer, size_t offset, const svbool_t& mask16)
+        {
+            svuint16_t cp = svmul_n_u16_x(mask16, odd, 4);
+            svuint16_t c0 = svld1_u16(mask16, buffer.in0 + offset);
+            svuint16_t c1 = svld1_u16(mask16, buffer.in1 + offset);
+            svst1_u16(mask16, buffer.dst + offset, svadd_u16_x(mask16, even,
+                svadd_u16_x(mask16, c1, svadd_u16_x(mask16, cp, svmul_n_u16_x(mask16, c0, 6)))));
+            svst1_u16(mask16, buffer.out1 + offset, svadd_u16_x(mask16, c0, cp));
+            svst1_u16(mask16, buffer.out0 + offset, even);
+        }
+
+        SIMD_INLINE void MainRowY5x5(const uint8_t* odd, const uint8_t* even, Buffer& buffer, size_t offset,
+            const svbool_t& mask8, const svbool_t& mask16)
+        {
+            MainRowY5x5Part(svld1ub_u16(mask16, odd + offset), svld1ub_u16(mask16, even + offset), buffer, offset, mask16);
+            MainRowY5x5Part(svld1ub_u16(mask16, odd + offset + BHA), svld1ub_u16(mask16, even + offset + BHA), buffer, offset + BHA, mask16);
         }
 
         template <bool compensation> SIMD_INLINE svuint16_t MainRowX5x5(uint16_t* row, const svbool_t& mask16)
@@ -122,13 +121,28 @@ namespace Simd
             return DivideBy256<compensation>(t2, mask16);
         }
 
-        template <bool compensation> SIMD_INLINE void MainRowX5x5(Buffer& buffer, size_t col, uint8_t* dst,
-            const svbool_t& mask16, const svbool_t& mask8)
+        template <bool compensation> SIMD_INLINE svuint8_t PackReduceGray5x5(const svuint16_t& lo, const svuint16_t& hi)
         {
-            const size_t HA = svcnth();
-            svuint16_t lo = MainRowX5x5<compensation>(buffer.dst + col, mask16);
-            svuint16_t hi = MainRowX5x5<compensation>(buffer.dst + col + HA, mask16);
-            svst1_u8(mask8, dst, svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi)));
+            const svbool_t mask16 = svptrue_pat_b16(SV_VL8);
+            const svbool_t mask8 = svptrue_pat_b8(SV_VL8);
+            uint16_t buf16[BA];
+            uint8_t out[BHA];
+            svst1_u16(mask16, buf16, lo);
+            svst1_u16(mask16, buf16 + BHA, hi);
+            for (size_t i = 0; i < BHA / 2; ++i)
+            {
+                out[i] = (uint8_t)buf16[i * 2];
+                out[BHA / 2 + i] = (uint8_t)buf16[BHA + i * 2];
+            }
+            return svld1_u8(mask8, out);
+        }
+
+        template <bool compensation> SIMD_INLINE void MainRowX5x5(Buffer& buffer, size_t offset, uint8_t* dst,
+            const svbool_t& mask16Lo, const svbool_t& mask16Hi, const svbool_t& mask8)
+        {
+            svuint16_t lo = MainRowX5x5<compensation>(buffer.dst + offset, mask16Lo);
+            svuint16_t hi = MainRowX5x5<compensation>(buffer.dst + offset + BHA, mask16Hi);
+            svst1_u8(mask8, dst, PackReduceGray5x5<compensation>(lo, hi));
         }
 
         template <bool compensation> void ReduceGray5x5(
@@ -137,20 +151,20 @@ namespace Simd
         {
             assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight && srcWidth > svcntb());
 
-            const size_t A = svcntb(), HA = svcnth();
-            const svbool_t body8 = svptrue_b8(), body16 = svptrue_b16();
-            size_t alignedWidth = AlignLo(srcWidth, A);
-            size_t bufferDstTail = AlignHi(srcWidth - A, 2);
+            const svbool_t body8 = svptrue_pat_b8(SV_VL16);
+            const svbool_t body16 = svptrue_pat_b16(SV_VL8);
+            size_t alignedWidth = AlignLo(srcWidth, BA);
+            size_t bufferDstTail = AlignHi(srcWidth - BA, 2);
 
-            Buffer buffer(AlignHi(srcWidth, A), A);
+            Buffer buffer(AlignHi(srcWidth, BA));
 
-            for (size_t col = 0; col < alignedWidth; col += A)
-                FirstRow5x5(src, buffer, col, body8, body16, body16);
+            for (size_t col = 0; col < alignedWidth; col += BA)
+                FirstRow5x5(src, buffer, col, body8, body16);
             if (alignedWidth != srcWidth)
             {
-                size_t col = srcWidth - A;
-                FirstRow5x5(src, buffer, col, svwhilelt_b8(col, srcWidth),
-                    svwhilelt_b16(col, srcWidth), svwhilelt_b16(col + HA, srcWidth));
+                size_t col = srcWidth - BA;
+                FirstRow5x5Part(src, buffer, col, svwhilelt_b8(col, srcWidth), svwhilelt_b16(col, srcWidth));
+                FirstRow5x5Part(src, buffer, col + BHA, svwhilelt_b8(col + BHA, srcWidth), svwhilelt_b16(col + BHA, srcWidth));
             }
             src += srcStride;
 
@@ -159,13 +173,15 @@ namespace Simd
                 const uint8_t* odd = src - (row < srcHeight ? 0 : srcStride);
                 const uint8_t* even = odd + (row < srcHeight - 1 ? srcStride : 0);
 
-                for (size_t col = 0; col < alignedWidth; col += A)
-                    MainRowY5x5(odd, even, buffer, col, body8, body16, body16);
+                for (size_t col = 0; col < alignedWidth; col += BA)
+                    MainRowY5x5(odd, even, buffer, col, body8, body16);
                 if (alignedWidth != srcWidth)
                 {
-                    size_t col = srcWidth - A;
-                    MainRowY5x5(odd, even, buffer, col, svwhilelt_b8(col, srcWidth),
-                        svwhilelt_b16(col, srcWidth), svwhilelt_b16(col + HA, srcWidth));
+                    size_t col = srcWidth - BA;
+                    MainRowY5x5Part(svld1ub_u16(svwhilelt_b16(col, srcWidth), odd + col),
+                        svld1ub_u16(svwhilelt_b16(col, srcWidth), even + col), buffer, col, svwhilelt_b16(col, srcWidth));
+                    MainRowY5x5Part(svld1ub_u16(svwhilelt_b16(col + BHA, srcWidth), odd + col + BHA),
+                        svld1ub_u16(svwhilelt_b16(col + BHA, srcWidth), even + col + BHA), buffer, col + BHA, svwhilelt_b16(col + BHA, srcWidth));
                 }
 
                 Swap(buffer.in0, buffer.out0);
@@ -176,13 +192,13 @@ namespace Simd
                 buffer.dst[srcWidth] = buffer.dst[srcWidth - 1];
                 buffer.dst[srcWidth + 1] = buffer.dst[srcWidth - 1];
 
-                for (size_t srcCol = 0, dstCol = 0; srcCol < alignedWidth; srcCol += A, dstCol += HA)
-                    MainRowX5x5<compensation>(buffer, srcCol, dst + dstCol, body16, svwhilelt_b8(dstCol, dstWidth));
+                for (size_t srcCol = 0, dstCol = 0; srcCol < alignedWidth; srcCol += BA, dstCol += BHA)
+                    MainRowX5x5<compensation>(buffer, srcCol, dst + dstCol, body16, body16, svptrue_pat_b8(SV_VL8));
                 if (alignedWidth != srcWidth)
-                {
-                    MainRowX5x5<compensation>(buffer, bufferDstTail, dst + dstWidth - HA,
-                        svwhilelt_b16(bufferDstTail, srcWidth), svwhilelt_b8(dstWidth - HA, dstWidth));
-                }
+                    MainRowX5x5<compensation>(buffer, bufferDstTail, dst + dstWidth - BHA,
+                        svwhilelt_b16(bufferDstTail, srcWidth),
+                        svwhilelt_b16(bufferDstTail + BHA, srcWidth),
+                        svwhilelt_b8(size_t(0), dstWidth - (dstWidth - BHA)));
             }
         }
 

--- a/src/Simd/SimdSve2ReduceGray5x5.cpp
+++ b/src/Simd/SimdSve2ReduceGray5x5.cpp
@@ -1,0 +1,199 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        namespace
+        {
+            struct Buffer
+            {
+                Buffer(size_t width, size_t tail)
+                {
+                    _p = Allocate(sizeof(uint16_t) * (5 * width + tail));
+                    in0 = (uint16_t*)_p;
+                    in1 = in0 + width;
+                    out0 = in1 + width;
+                    out1 = out0 + width;
+                    dst = out1 + width + tail / 2;
+                }
+
+                ~Buffer()
+                {
+                    Free(_p);
+                }
+
+                uint16_t* in0;
+                uint16_t* in1;
+                uint16_t* out0;
+                uint16_t* out1;
+                uint16_t* dst;
+            private:
+                void* _p;
+            };
+        }
+
+        template <bool compensation> SIMD_INLINE svuint16_t DivideBy256(const svuint16_t& value, const svbool_t& mask);
+
+        template <> SIMD_INLINE svuint16_t DivideBy256<true>(const svuint16_t& value, const svbool_t& mask)
+        {
+            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 128), 8);
+        }
+
+        template <> SIMD_INLINE svuint16_t DivideBy256<false>(const svuint16_t& value, const svbool_t& mask)
+        {
+            return svlsr_n_u16_x(mask, value, 8);
+        }
+
+        SIMD_INLINE void FirstRow5x5(const uint8_t* src, Buffer& buffer, size_t col,
+            const svbool_t& mask8, const svbool_t& mask16Lo, const svbool_t& mask16Hi)
+        {
+            const size_t HA = svcnth();
+            svuint8_t s = svld1_u8(mask8, src + col);
+            svuint16_t lo = svunpklo_u16(s);
+            svuint16_t hi = svunpkhi_u16(s);
+            svst1_u16(mask16Lo, buffer.in0 + col, lo);
+            svst1_u16(mask16Hi, buffer.in0 + col + HA, hi);
+            svst1_u16(mask16Lo, buffer.in1 + col, svmul_n_u16_x(mask16Lo, lo, 5));
+            svst1_u16(mask16Hi, buffer.in1 + col + HA, svmul_n_u16_x(mask16Hi, hi, 5));
+        }
+
+        SIMD_INLINE void MainRowY5x5(const uint8_t* odd, const uint8_t* even, Buffer& buffer, size_t col,
+            const svbool_t& mask8, const svbool_t& mask16Lo, const svbool_t& mask16Hi)
+        {
+            const size_t HA = svcnth();
+            svuint8_t sOdd = svld1_u8(mask8, odd + col);
+            svuint8_t sEven = svld1_u8(mask8, even + col);
+            svuint16_t oddLo = svunpklo_u16(sOdd);
+            svuint16_t oddHi = svunpkhi_u16(sOdd);
+            svuint16_t evenLo = svunpklo_u16(sEven);
+            svuint16_t evenHi = svunpkhi_u16(sEven);
+
+            svuint16_t cpLo = svmul_n_u16_x(mask16Lo, oddLo, 4);
+            svuint16_t c0Lo = svld1_u16(mask16Lo, buffer.in0 + col);
+            svuint16_t c1Lo = svld1_u16(mask16Lo, buffer.in1 + col);
+            svst1_u16(mask16Lo, buffer.dst + col, svadd_u16_x(mask16Lo, evenLo,
+                svadd_u16_x(mask16Lo, c1Lo, svadd_u16_x(mask16Lo, cpLo, svmul_n_u16_x(mask16Lo, c0Lo, 6)))));
+            svst1_u16(mask16Lo, buffer.out1 + col, svadd_u16_x(mask16Lo, c0Lo, cpLo));
+            svst1_u16(mask16Lo, buffer.out0 + col, evenLo);
+
+            svuint16_t cpHi = svmul_n_u16_x(mask16Hi, oddHi, 4);
+            svuint16_t c0Hi = svld1_u16(mask16Hi, buffer.in0 + col + HA);
+            svuint16_t c1Hi = svld1_u16(mask16Hi, buffer.in1 + col + HA);
+            svst1_u16(mask16Hi, buffer.dst + col + HA, svadd_u16_x(mask16Hi, evenHi,
+                svadd_u16_x(mask16Hi, c1Hi, svadd_u16_x(mask16Hi, cpHi, svmul_n_u16_x(mask16Hi, c0Hi, 6)))));
+            svst1_u16(mask16Hi, buffer.out1 + col + HA, svadd_u16_x(mask16Hi, c0Hi, cpHi));
+            svst1_u16(mask16Hi, buffer.out0 + col + HA, evenHi);
+        }
+
+        template <bool compensation> SIMD_INLINE svuint16_t MainRowX5x5(uint16_t* row, const svbool_t& mask16)
+        {
+            svuint16_t t0 = svld1_u16(mask16, row - 2);
+            svuint16_t t1 = svld1_u16(mask16, row - 1);
+            svuint16_t t2 = svld1_u16(mask16, row);
+            svuint16_t t3 = svld1_u16(mask16, row + 1);
+            svuint16_t t4 = svld1_u16(mask16, row + 2);
+            t2 = svadd_u16_x(mask16, svadd_u16_x(mask16, svmul_n_u16_x(mask16, t2, 6),
+                svmul_n_u16_x(mask16, svadd_u16_x(mask16, t1, t3), 4)), svadd_u16_x(mask16, t0, t4));
+            return DivideBy256<compensation>(t2, mask16);
+        }
+
+        template <bool compensation> SIMD_INLINE void MainRowX5x5(Buffer& buffer, size_t col, uint8_t* dst,
+            const svbool_t& mask16, const svbool_t& mask8)
+        {
+            const size_t HA = svcnth();
+            svuint16_t lo = MainRowX5x5<compensation>(buffer.dst + col, mask16);
+            svuint16_t hi = MainRowX5x5<compensation>(buffer.dst + col + HA, mask16);
+            svst1_u8(mask8, dst, svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi)));
+        }
+
+        template <bool compensation> void ReduceGray5x5(
+            const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
+        {
+            assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight && srcWidth > svcntb());
+
+            const size_t A = svcntb(), HA = svcnth();
+            const svbool_t body8 = svptrue_b8(), body16 = svptrue_b16();
+            size_t alignedWidth = AlignLo(srcWidth, A);
+            size_t bufferDstTail = AlignHi(srcWidth - A, 2);
+
+            Buffer buffer(AlignHi(srcWidth, A), A);
+
+            for (size_t col = 0; col < alignedWidth; col += A)
+                FirstRow5x5(src, buffer, col, body8, body16, body16);
+            if (alignedWidth != srcWidth)
+            {
+                size_t col = srcWidth - A;
+                FirstRow5x5(src, buffer, col, svwhilelt_b8(col, srcWidth),
+                    svwhilelt_b16(col, srcWidth), svwhilelt_b16(col + HA, srcWidth));
+            }
+            src += srcStride;
+
+            for (size_t row = 1; row <= srcHeight; row += 2, dst += dstStride, src += 2 * srcStride)
+            {
+                const uint8_t* odd = src - (row < srcHeight ? 0 : srcStride);
+                const uint8_t* even = odd + (row < srcHeight - 1 ? srcStride : 0);
+
+                for (size_t col = 0; col < alignedWidth; col += A)
+                    MainRowY5x5(odd, even, buffer, col, body8, body16, body16);
+                if (alignedWidth != srcWidth)
+                {
+                    size_t col = srcWidth - A;
+                    MainRowY5x5(odd, even, buffer, col, svwhilelt_b8(col, srcWidth),
+                        svwhilelt_b16(col, srcWidth), svwhilelt_b16(col + HA, srcWidth));
+                }
+
+                Swap(buffer.in0, buffer.out0);
+                Swap(buffer.in1, buffer.out1);
+
+                buffer.dst[-2] = buffer.dst[0];
+                buffer.dst[-1] = buffer.dst[0];
+                buffer.dst[srcWidth] = buffer.dst[srcWidth - 1];
+                buffer.dst[srcWidth + 1] = buffer.dst[srcWidth - 1];
+
+                for (size_t srcCol = 0, dstCol = 0; srcCol < alignedWidth; srcCol += A, dstCol += HA)
+                    MainRowX5x5<compensation>(buffer, srcCol, dst + dstCol, body16, svwhilelt_b8(dstCol, dstWidth));
+                if (alignedWidth != srcWidth)
+                {
+                    MainRowX5x5<compensation>(buffer, bufferDstTail, dst + dstWidth - HA,
+                        svwhilelt_b16(bufferDstTail, srcWidth), svwhilelt_b8(dstWidth - HA, dstWidth));
+                }
+            }
+        }
+
+        void ReduceGray5x5(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, int compensation)
+        {
+            if (compensation)
+                ReduceGray5x5<true>(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+            else
+                ReduceGray5x5<false>(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+        }
+    }
+#endif
+}

--- a/src/Test/TestReduce.cpp
+++ b/src/Test/TestReduce.cpp
@@ -362,6 +362,14 @@ namespace Test
         }
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options) && W > svcntb())
+        {
+            result = result && ReduceGrayAutoTest(FUNC_RG2(Simd::Sve2::ReduceGray5x5, true), FUNC_RG2(SimdReduceGray5x5, true));
+            result = result && ReduceGrayAutoTest(FUNC_RG2(Simd::Sve2::ReduceGray5x5, false), FUNC_RG2(SimdReduceGray5x5, false));
+        }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds SVE2/SVE SIMD optimization for `SimdReduceGray5x5` on ARM/ARM64, following the same buffer-based algorithm used by the existing Neon and Avx2 implementations.

## Changes

- **New file:** `src/Simd/SimdSve2ReduceGray5x5.cpp` — SVE2 implementation with compensation support
- **`src/Simd/SimdSve2.h`** — declaration of `Sve2::ReduceGray5x5`
- **`src/Simd/SimdLib.cpp`** — dispatch to SVE2 when enabled and `srcWidth > svcntb()`
- **`src/Test/TestReduce.cpp`** — `ReduceGray5x5AutoTest` coverage for SVE2
- **`prj/vs2022/Sve2.vcxproj`** and **`Sve2.vcxproj.filters`** — include the new source file
- **`docs/2026.html`** — release 7.2.163 note

## Fix (correctness)

The initial implementation had three issues on ARM SVE:

1. **Tile size:** processing `svcntb()` bytes per step did not match the Neon/Avx2 16-byte tile algorithm. Fixed by using fixed `BA=16` / `BHA=8` tiles.
2. **Output packing:** `svuzp1(svqxtnb(lo), svqxtnb(hi))` produced wrong bytes on wide SVE vectors because `svqxtnb` stores narrowed values in interleaved byte lanes. Fixed by packing through a uint16 buffer and selecting even columns, matching Neon `Deinterleave(PackU16(lo, hi))`.
3. **Predicates:** body tiles use `svptrue_pat_b8(SV_VL16)` / `svptrue_pat_b16(SV_VL8)`; horizontal tail uses separate masks for lo/hi halves.

## Testing

- x86_64 Release build + `./Test -r=.. -fi=ReduceGray5x5 -tt=1 -ts=1` — passed
- aarch64 SVE2 (qemu, scalable vectors): Base vs Sve2 comparison for 640×480, odd widths, compensation on/off — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-493075c5-faec-4559-abb8-92ef1a1091c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-493075c5-faec-4559-abb8-92ef1a1091c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

