### PR TITLE
Add SVE2 optimization of SimdReduceColor2x2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -109,6 +109,7 @@
  <li>SVE2 optimizations of function GrayToBgr.</li>
  <li>SVE2 optimizations of function GrayToBgra.</li>
  <li>SVE2 optimizations of function GrayToY.</li>
+ <li>SVE2 optimizations of function ReduceColor2x2.</li>
  <li>SVE2 optimizations of function ReduceGray2x2.</li>
  <li>SVE2 optimizations of function ReduceGray3x3.</li>
  <li>SVE2 optimizations of function ReduceGray4x4.</li>
@@ -247,6 +248,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddConvolution5x5Forward.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddConvolution5x5Sum.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvolutionForward.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function ReduceColor2x2.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Neural.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Reduce.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray3x3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -281,6 +281,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp">
       <Filter>Sve2\Legacy</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Reduce.cpp">
+      <Filter>Sve2\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp">
       <Filter>Sve2\Image</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4710,6 +4710,11 @@ SIMD_API void SimdReduceColor2x2(const uint8_t *src, size_t srcWidth, size_t src
         Sse41::ReduceColor2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride, channelCount);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && srcWidth >= 2 * svcntb())
+        Sve2::ReduceColor2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride, channelCount);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && srcWidth >= Neon::DA)
         Neon::ReduceColor2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride, channelCount);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -273,6 +273,9 @@ namespace Simd
 
         void GrayToY(const uint8_t* gray, size_t grayStride, size_t width, size_t height, uint8_t* y, size_t yStride);
 
+        void ReduceColor2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, size_t channelCount);
+
         void ReduceGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
 

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -38,7 +38,7 @@ namespace Simd
 
         SIMD_INLINE svuint8_t PackI16ToU8(const svuint16_t& lo, const svuint16_t& hi)
         {
-            return svtrn1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+            return svqxtnt_u16(svqxtnb_u16(lo), hi);
         }
 
         SIMD_INLINE svuint8_t Average8(const svuint8_t& s00, const svuint8_t& s01, const svuint8_t& s10, const svuint8_t& s11,

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -30,17 +30,22 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint16_t Average16(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE svuint16_t Average16(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask16)
         {
             svuint16_t sum0 = svaddlb_u16(s0, svext_u8(s0, s0, 1));
             svuint16_t sum1 = svaddlb_u16(s1, svext_u8(s1, s1, 1));
             return svlsr_n_u16_x(mask16, svadd_n_u16_x(mask16, svadd_u16_x(mask16, sum0, sum1), 2), 2);
         }
 
-        SIMD_INLINE svuint8_t AverageRows(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE svuint8_t AverageRows(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask16)
         {
-            svuint8_t even = svqxtnb_u16(Average16(s0, s1, mask8, mask16));
+            svuint8_t even = svqxtnb_u16(Average16(s0, s1, mask16));
             return svuzp1_u8(even, even);
+        }
+
+        SIMD_INLINE svuint8_t AverageBgrPlane(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask16)
+        {
+            return svqxtnb_u16(Average16(s0, s1, mask16));
         }
 
         SIMD_INLINE bool InitReduceColor2x2Index(uint8_t index[2][SIMD_SVE2_VECTOR_SIZE_MAX])
@@ -71,70 +76,18 @@ namespace Simd
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t REDUCE_COLOR2X2_INDEX[2][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool REDUCE_COLOR2X2_INDEX_INITED = InitReduceColor2x2Index(REDUCE_COLOR2X2_INDEX);
 
-        SIMD_INLINE bool InitBgrDeinterlaceIndex(uint8_t index[3][SIMD_SVE2_VECTOR_SIZE_MAX])
+        SIMD_INLINE void ReduceBgr2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst, size_t pixelCount)
         {
-            size_t A = svlen(svuint8_t());
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
-            for (size_t i = 0; i < A; ++i)
-            {
-                index[0][i] = (uint8_t)(3 * i);
-                index[1][i] = (uint8_t)(3 * i + 1);
-                index[2][i] = (uint8_t)(3 * i + 2);
-            }
-            return true;
-        }
-
-        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_DEINTERLACE_INDEX[3][SIMD_SVE2_VECTOR_SIZE_MAX];
-        const bool BGR_DEINTERLACE_INDEX_INITED = InitBgrDeinterlaceIndex(BGR_DEINTERLACE_INDEX);
-
-        SIMD_INLINE bool InitReduceBgrPackIndex(uint8_t packIndex[SIMD_SVE2_VECTOR_SIZE_MAX], uint8_t channelIndex[SIMD_SVE2_VECTOR_SIZE_MAX])
-        {
-            size_t A = svlen(svuint8_t());
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
-            for (size_t i = 0; i < A; ++i)
-            {
-                packIndex[i] = (uint8_t)(2 * (i / 3));
-                channelIndex[i] = (uint8_t)(i % 3);
-            }
-            return true;
-        }
-
-        SIMD_ALIGNED(SIMD_ALIGN) uint8_t REDUCE_BGR_PACK_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
-        SIMD_ALIGNED(SIMD_ALIGN) uint8_t REDUCE_BGR_CHANNEL_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
-        const bool REDUCE_BGR_PACK_INDEX_INITED = InitReduceBgrPackIndex(REDUCE_BGR_PACK_INDEX, REDUCE_BGR_CHANNEL_INDEX);
-
-        SIMD_INLINE svuint8_t PackBgr(const svuint8_t& packIdx, const svuint8_t& channelIdx,
-            const svuint8_t& b, const svuint8_t& g, const svuint8_t& r, const svbool_t& mask)
-        {
-            svuint8_t bp = svtbl_u8(b, packIdx);
-            svuint8_t gp = svtbl_u8(g, packIdx);
-            svuint8_t rp = svtbl_u8(r, packIdx);
-            return svsel_u8(svcmpeq_n_u8(mask, channelIdx, 0), bp, svsel_u8(svcmpeq_n_u8(mask, channelIdx, 1), gp, rp));
-        }
-
-        SIMD_INLINE void ReduceBgr2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst, size_t pixelCount,
-            const svuint8_t& bIdx, const svuint8_t& gIdx, const svuint8_t& rIdx,
-            const svuint8_t& packIdx, const svuint8_t& channelIdx)
-        {
-            const uint64_t loadSize = pixelCount * 3;
             const uint64_t outPixels = pixelCount / 2;
-            const uint64_t outBytes = outPixels * 3;
-            const svbool_t maskLoad = svwhilelt_b8(0ull, loadSize);
-            const svbool_t maskPlane = svwhilelt_b8(0ull, pixelCount);
+            const svbool_t maskPix = svwhilelt_b8(0ull, pixelCount);
             const svbool_t mask16 = svwhilelt_b16(0ull, outPixels);
-            const svbool_t maskOut = svwhilelt_b8(0ull, outBytes);
-            svuint8_t inter0 = svld1_u8(maskLoad, src0);
-            svuint8_t inter1 = svld1_u8(maskLoad, src1);
-            svuint8_t b0 = svtbl_u8(inter0, bIdx);
-            svuint8_t g0 = svtbl_u8(inter0, gIdx);
-            svuint8_t r0 = svtbl_u8(inter0, rIdx);
-            svuint8_t b1 = svtbl_u8(inter1, bIdx);
-            svuint8_t g1 = svtbl_u8(inter1, gIdx);
-            svuint8_t r1 = svtbl_u8(inter1, rIdx);
-            svuint8_t db = AverageRows(b0, b1, maskPlane, mask16);
-            svuint8_t dg = AverageRows(g0, g1, maskPlane, mask16);
-            svuint8_t dr = AverageRows(r0, r1, maskPlane, mask16);
-            svst1_u8(maskOut, dst, PackBgr(packIdx, channelIdx, db, dg, dr, maskOut));
+            const svbool_t maskOut = svwhilelt_b8(0ull, outPixels);
+            svuint8x3_t s0 = svld3_u8(maskPix, src0);
+            svuint8x3_t s1 = svld3_u8(maskPix, src1);
+            svst3_u8(maskOut, dst, svcreate3_u8(
+                AverageBgrPlane(svget3(s0, 0), svget3(s1, 0), mask16),
+                AverageBgrPlane(svget3(s0, 1), svget3(s1, 1), mask16),
+                AverageBgrPlane(svget3(s0, 2), svget3(s1, 2), mask16)));
         }
 
         template <size_t channelCount> SIMD_INLINE void ReduceColor2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
@@ -148,8 +101,8 @@ namespace Simd
             svuint8_t s01 = svtbl_u8(svld1_u8(all, src0 + A), shuffleIdx);
             svuint8_t s10 = svtbl_u8(svld1_u8(all, src1), shuffleIdx);
             svuint8_t s11 = svtbl_u8(svld1_u8(all, src1 + A), shuffleIdx);
-            svst1_u8(maskLo, dst, AverageRows(s00, s10, all, mask16));
-            svst1_u8(maskHi, dst + HA, AverageRows(s01, s11, all, mask16));
+            svst1_u8(maskLo, dst, AverageRows(s00, s10, mask16));
+            svst1_u8(maskHi, dst + HA, AverageRows(s01, s11, mask16));
         }
 
         template <> SIMD_INLINE void ReduceColor2x2Kernel<4>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
@@ -160,8 +113,8 @@ namespace Simd
             svuint8_t s01 = svtbl_u8(svld1_u8(all, src0 + A), shuffleIdx);
             svuint8_t s10 = svtbl_u8(svld1_u8(all, src1), shuffleIdx);
             svuint8_t s11 = svtbl_u8(svld1_u8(all, src1 + A), shuffleIdx);
-            svst1_u8(maskLo, dst, AverageRows(s00, s10, all, mask16));
-            svst1_u8(maskHi, dst + HA, AverageRows(s01, s11, all, mask16));
+            svst1_u8(maskLo, dst, AverageRows(s00, s10, mask16));
+            svst1_u8(maskHi, dst + HA, AverageRows(s01, s11, mask16));
         }
 
         template <size_t channelCount> void ReduceColor2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
@@ -201,13 +154,6 @@ namespace Simd
         void ReduceBgr2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
         {
             const size_t A = svcntb(), DA = 2 * A, HA = svcnth();
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
-            const svbool_t all = svptrue_b8();
-            const svuint8_t bIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[0]);
-            const svuint8_t gIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[1]);
-            const svuint8_t rIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[2]);
-            const svuint8_t packIdx = svld1_u8(all, REDUCE_BGR_PACK_INDEX);
-            const svuint8_t channelIdx = svld1_u8(all, REDUCE_BGR_CHANNEL_INDEX);
             const size_t evenWidth = AlignLo(srcWidth, 2);
             const size_t alignedWidth = AlignLo(srcWidth, A);
             const size_t evenSize = evenWidth * 3;
@@ -221,15 +167,15 @@ namespace Simd
                 size_t srcOffset = 0, dstOffset = 0;
                 for (; srcOffset < alignedSize; srcOffset += srcStep, dstOffset += dstStep)
                 {
-                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
-                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A);
+                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A);
                 }
                 if (alignedSize != evenSize)
                 {
                     srcOffset = evenSize - srcStep;
                     dstOffset = srcOffset / 2;
-                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
-                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A);
+                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A);
                 }
                 if (evenWidth != srcWidth)
                 {

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -1,0 +1,247 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdMath.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint16_t Average16(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svuint16_t sum0 = svaddlb_u16(s0, svext_u8(s0, s0, 1));
+            svuint16_t sum1 = svaddlb_u16(s1, svext_u8(s1, s1, 1));
+            return svlsr_n_u16_x(mask16, svadd_n_u16_x(mask16, svadd_u16_x(mask16, sum0, sum1), 2), 2);
+        }
+
+        SIMD_INLINE svuint8_t PackI16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        {
+            return svtrn1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+        }
+
+        SIMD_INLINE svuint8_t Average8(const svuint8_t& s00, const svuint8_t& s01, const svuint8_t& s10, const svuint8_t& s11,
+            const svbool_t& mask8, const svbool_t& mask16)
+        {
+            return PackI16ToU8(Average16(s00, s10, mask8, mask16), Average16(s01, s11, mask8, mask16));
+        }
+
+        SIMD_INLINE bool InitReduceColor2x2Index(uint8_t index[2][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t i = 0; i < A; i += 4)
+            {
+                index[0][i] = (uint8_t)i;
+                index[0][i + 1] = (uint8_t)(i + 2);
+                index[0][i + 2] = (uint8_t)(i + 1);
+                index[0][i + 3] = (uint8_t)(i + 3);
+            }
+            for (size_t i = 0; i < A; i += 8)
+            {
+                index[1][i] = (uint8_t)i;
+                index[1][i + 1] = (uint8_t)(i + 4);
+                index[1][i + 2] = (uint8_t)(i + 1);
+                index[1][i + 3] = (uint8_t)(i + 5);
+                index[1][i + 4] = (uint8_t)(i + 2);
+                index[1][i + 5] = (uint8_t)(i + 6);
+                index[1][i + 6] = (uint8_t)(i + 3);
+                index[1][i + 7] = (uint8_t)(i + 7);
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t REDUCE_COLOR2X2_INDEX[2][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool REDUCE_COLOR2X2_INDEX_INITED = InitReduceColor2x2Index(REDUCE_COLOR2X2_INDEX);
+
+        SIMD_INLINE bool InitBgrDeinterlaceIndex(uint8_t index[3][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t i = 0; i < A; ++i)
+            {
+                index[0][i] = (uint8_t)(3 * i);
+                index[1][i] = (uint8_t)(3 * i + 1);
+                index[2][i] = (uint8_t)(3 * i + 2);
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_DEINTERLACE_INDEX[3][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool BGR_DEINTERLACE_INDEX_INITED = InitBgrDeinterlaceIndex(BGR_DEINTERLACE_INDEX);
+
+        SIMD_INLINE svuint8_t AveragePlane(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            svuint8_t avg = svqxtnb_u16(Average16(s0, s1, mask8, mask16));
+            return svuzp1_u8(avg, avg);
+        }
+
+        template <size_t channelCount> SIMD_INLINE void ReduceColor2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
+            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16);
+
+        template <> SIMD_INLINE void ReduceColor2x2Kernel<1>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
+            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            const svbool_t all = svptrue_b8();
+            svuint8_t s00 = svld1_u8(all, src0);
+            svuint8_t s01 = svld1_u8(all, src0 + A);
+            svuint8_t s10 = svld1_u8(all, src1);
+            svuint8_t s11 = svld1_u8(all, src1 + A);
+            svst1_u8(mask8, dst, Average8(s00, s01, s10, s11, all, mask16));
+        }
+
+        template <> SIMD_INLINE void ReduceColor2x2Kernel<2>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
+            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            const svbool_t all = svptrue_b8();
+            svuint8_t s00 = svtbl_u8(svld1_u8(all, src0), shuffleIdx);
+            svuint8_t s01 = svtbl_u8(svld1_u8(all, src0 + A), shuffleIdx);
+            svuint8_t s10 = svtbl_u8(svld1_u8(all, src1), shuffleIdx);
+            svuint8_t s11 = svtbl_u8(svld1_u8(all, src1 + A), shuffleIdx);
+            svst1_u8(mask8, dst, Average8(s00, s01, s10, s11, all, mask16));
+        }
+
+        template <> SIMD_INLINE void ReduceColor2x2Kernel<4>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
+            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            const svbool_t all = svptrue_b8();
+            svuint8_t s00 = svtbl_u8(svld1_u8(all, src0), shuffleIdx);
+            svuint8_t s01 = svtbl_u8(svld1_u8(all, src0 + A), shuffleIdx);
+            svuint8_t s10 = svtbl_u8(svld1_u8(all, src1), shuffleIdx);
+            svuint8_t s11 = svtbl_u8(svld1_u8(all, src1 + A), shuffleIdx);
+            svst1_u8(mask8, dst, Average8(s00, s01, s10, s11, all, mask16));
+        }
+
+        template <size_t channelCount> void ReduceColor2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            const size_t A = svcntb(), DA = 2 * A;
+            const svbool_t all = svptrue_b8();
+            const svbool_t mask8 = all;
+            const svbool_t mask16 = svptrue_b16();
+            const svuint8_t shuffleIdx = svld1_u8(all, REDUCE_COLOR2X2_INDEX[channelCount == 4 ? 1 : 0]);
+            const size_t evenWidth = AlignLo(srcWidth, 2);
+            const size_t evenSize = evenWidth * channelCount;
+            const size_t alignedSize = AlignLo(evenSize, DA);
+            for (size_t srcRow = 0; srcRow < srcHeight; srcRow += 2)
+            {
+                const uint8_t* src0 = src;
+                const uint8_t* src1 = (srcRow == srcHeight - 1 ? src : src + srcStride);
+                size_t srcOffset = 0, dstOffset = 0;
+                for (; srcOffset < alignedSize; srcOffset += DA, dstOffset += A)
+                    ReduceColor2x2Kernel<channelCount>(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, shuffleIdx, mask8, mask16);
+                if (alignedSize != evenSize)
+                {
+                    srcOffset = evenSize - DA;
+                    dstOffset = srcOffset / 2;
+                    ReduceColor2x2Kernel<channelCount>(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, shuffleIdx, mask8, mask16);
+                }
+                if (evenWidth != srcWidth)
+                {
+                    for (size_t c = 0; c < channelCount; ++c)
+                        dst[evenSize / 2 + c] = Base::Average(src0[evenSize + c], src1[evenSize + c]);
+                }
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+        }
+
+        SIMD_INLINE void ReduceBgr2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst, size_t pixelCount,
+            const svuint8_t& bIdx, const svuint8_t& gIdx, const svuint8_t& rIdx)
+        {
+            const uint64_t loadSize = pixelCount * 3;
+            const uint64_t outSize = (pixelCount / 2) * 3;
+            const svbool_t maskLoad = svwhilelt_b8(0ull, loadSize);
+            const svbool_t maskPlane = svwhilelt_b8(0ull, pixelCount);
+            const svbool_t mask16 = svwhilelt_b16(0ull, pixelCount / 2);
+            const svbool_t maskOut = svwhilelt_b8(0ull, outSize);
+            svuint8_t inter0 = svld1_u8(maskLoad, src0);
+            svuint8_t inter1 = svld1_u8(maskLoad, src1);
+            svuint8_t b0 = svtbl_u8(inter0, bIdx);
+            svuint8_t g0 = svtbl_u8(inter0, gIdx);
+            svuint8_t r0 = svtbl_u8(inter0, rIdx);
+            svuint8_t b1 = svtbl_u8(inter1, bIdx);
+            svuint8_t g1 = svtbl_u8(inter1, gIdx);
+            svuint8_t r1 = svtbl_u8(inter1, rIdx);
+            svst3_u8(maskOut, dst, svcreate3_u8(AveragePlane(b0, b1, maskPlane, mask16), AveragePlane(g0, g1, maskPlane, mask16), AveragePlane(r0, r1, maskPlane, mask16)));
+        }
+
+        void ReduceBgr2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            const size_t A = svcntb(), DA = 2 * A, HA = svcnth();
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            const svbool_t all = svptrue_b8();
+            const svuint8_t bIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[0]);
+            const svuint8_t gIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[1]);
+            const svuint8_t rIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[2]);
+            const size_t evenWidth = AlignLo(srcWidth, 2);
+            const size_t alignedWidth = AlignLo(srcWidth, A);
+            const size_t evenSize = evenWidth * 3;
+            const size_t alignedSize = alignedWidth * 3;
+            const size_t srcStep = DA * 3;
+            const size_t dstStep = A * 3;
+            for (size_t srcRow = 0; srcRow < srcHeight; srcRow += 2)
+            {
+                const uint8_t* src0 = src;
+                const uint8_t* src1 = (srcRow == srcHeight - 1 ? src : src + srcStride);
+                size_t srcOffset = 0, dstOffset = 0;
+                for (; srcOffset < alignedSize; srcOffset += srcStep, dstOffset += dstStep)
+                {
+                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx);
+                }
+                if (alignedSize != evenSize)
+                {
+                    srcOffset = evenSize - srcStep;
+                    dstOffset = srcOffset / 2;
+                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx);
+                }
+                if (evenWidth != srcWidth)
+                {
+                    for (size_t c = 0; c < 3; ++c)
+                        dst[evenSize / 2 + c] = Base::Average(src0[evenSize + c], src1[evenSize + c]);
+                }
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+        }
+
+        void ReduceColor2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, size_t channelCount)
+        {
+            assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight);
+            assert(srcWidth >= 2 * svcntb());
+
+            switch (channelCount)
+            {
+            case 1: ReduceColor2x2<1>(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
+            case 2: ReduceColor2x2<2>(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
+            case 3: ReduceBgr2x2(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
+            case 4: ReduceColor2x2<4>(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
+            default: assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -45,7 +45,8 @@ namespace Simd
 
         SIMD_INLINE svuint8_t AverageBgrPlane(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask16)
         {
-            return svqxtnb_u16(Average16(s0, s1, mask16));
+            svuint8_t even = svqxtnb_u16(Average16(s0, s1, mask16));
+            return svuzp1_u8(even, even);
         }
 
         SIMD_INLINE bool InitReduceColor2x2Index(uint8_t index[2][SIMD_SVE2_VECTOR_SIZE_MAX])

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -23,6 +23,7 @@
 */
 #include "Simd/SimdMemory.h"
 #include "Simd/SimdMath.h"
+#include "Simd/SimdSve2.h"
 
 namespace Simd
 {
@@ -36,15 +37,10 @@ namespace Simd
             return svlsr_n_u16_x(mask16, svadd_n_u16_x(mask16, svadd_u16_x(mask16, sum0, sum1), 2), 2);
         }
 
-        SIMD_INLINE svuint8_t PackI16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        SIMD_INLINE svuint8_t AverageRows(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
         {
-            return svqxtnt_u16(svqxtnb_u16(lo), hi);
-        }
-
-        SIMD_INLINE svuint8_t Average8(const svuint8_t& s00, const svuint8_t& s01, const svuint8_t& s10, const svuint8_t& s11,
-            const svbool_t& mask8, const svbool_t& mask16)
-        {
-            return PackI16ToU8(Average16(s00, s10, mask8, mask16), Average16(s01, s11, mask8, mask16));
+            svuint8_t even = svqxtnb_u16(Average16(s0, s1, mask8, mask16));
+            return svuzp1_u8(even, even);
         }
 
         SIMD_INLINE bool InitReduceColor2x2Index(uint8_t index[2][SIMD_SVE2_VECTOR_SIZE_MAX])
@@ -91,53 +87,39 @@ namespace Simd
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_DEINTERLACE_INDEX[3][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool BGR_DEINTERLACE_INDEX_INITED = InitBgrDeinterlaceIndex(BGR_DEINTERLACE_INDEX);
 
-        SIMD_INLINE svuint8_t AveragePlane(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
-        {
-            svuint8_t avg = svqxtnb_u16(Average16(s0, s1, mask8, mask16));
-            return svuzp1_u8(avg, avg);
-        }
-
         template <size_t channelCount> SIMD_INLINE void ReduceColor2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
-            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16);
-
-        template <> SIMD_INLINE void ReduceColor2x2Kernel<1>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
-            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16)
-        {
-            const svbool_t all = svptrue_b8();
-            svuint8_t s00 = svld1_u8(all, src0);
-            svuint8_t s01 = svld1_u8(all, src0 + A);
-            svuint8_t s10 = svld1_u8(all, src1);
-            svuint8_t s11 = svld1_u8(all, src1 + A);
-            svst1_u8(mask8, dst, Average8(s00, s01, s10, s11, all, mask16));
-        }
+            size_t A, size_t HA, const svuint8_t& shuffleIdx, const svbool_t& maskLo, const svbool_t& maskHi, const svbool_t& mask16);
 
         template <> SIMD_INLINE void ReduceColor2x2Kernel<2>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
-            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16)
+            size_t A, size_t HA, const svuint8_t& shuffleIdx, const svbool_t& maskLo, const svbool_t& maskHi, const svbool_t& mask16)
         {
             const svbool_t all = svptrue_b8();
             svuint8_t s00 = svtbl_u8(svld1_u8(all, src0), shuffleIdx);
             svuint8_t s01 = svtbl_u8(svld1_u8(all, src0 + A), shuffleIdx);
             svuint8_t s10 = svtbl_u8(svld1_u8(all, src1), shuffleIdx);
             svuint8_t s11 = svtbl_u8(svld1_u8(all, src1 + A), shuffleIdx);
-            svst1_u8(mask8, dst, Average8(s00, s01, s10, s11, all, mask16));
+            svst1_u8(maskLo, dst, AverageRows(s00, s10, all, mask16));
+            svst1_u8(maskHi, dst + HA, AverageRows(s01, s11, all, mask16));
         }
 
         template <> SIMD_INLINE void ReduceColor2x2Kernel<4>(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
-            size_t A, const svuint8_t& shuffleIdx, const svbool_t& mask8, const svbool_t& mask16)
+            size_t A, size_t HA, const svuint8_t& shuffleIdx, const svbool_t& maskLo, const svbool_t& maskHi, const svbool_t& mask16)
         {
             const svbool_t all = svptrue_b8();
             svuint8_t s00 = svtbl_u8(svld1_u8(all, src0), shuffleIdx);
             svuint8_t s01 = svtbl_u8(svld1_u8(all, src0 + A), shuffleIdx);
             svuint8_t s10 = svtbl_u8(svld1_u8(all, src1), shuffleIdx);
             svuint8_t s11 = svtbl_u8(svld1_u8(all, src1 + A), shuffleIdx);
-            svst1_u8(mask8, dst, Average8(s00, s01, s10, s11, all, mask16));
+            svst1_u8(maskLo, dst, AverageRows(s00, s10, all, mask16));
+            svst1_u8(maskHi, dst + HA, AverageRows(s01, s11, all, mask16));
         }
 
         template <size_t channelCount> void ReduceColor2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
         {
-            const size_t A = svcntb(), DA = 2 * A;
+            const size_t A = svcntb(), DA = 2 * A, HA = svcnth();
             const svbool_t all = svptrue_b8();
-            const svbool_t mask8 = all;
+            const svbool_t maskLo = all;
+            const svbool_t maskHi = all;
             const svbool_t mask16 = svptrue_b16();
             const svuint8_t shuffleIdx = svld1_u8(all, REDUCE_COLOR2X2_INDEX[channelCount == 4 ? 1 : 0]);
             const size_t evenWidth = AlignLo(srcWidth, 2);
@@ -149,12 +131,12 @@ namespace Simd
                 const uint8_t* src1 = (srcRow == srcHeight - 1 ? src : src + srcStride);
                 size_t srcOffset = 0, dstOffset = 0;
                 for (; srcOffset < alignedSize; srcOffset += DA, dstOffset += A)
-                    ReduceColor2x2Kernel<channelCount>(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, shuffleIdx, mask8, mask16);
+                    ReduceColor2x2Kernel<channelCount>(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, HA, shuffleIdx, maskLo, maskHi, mask16);
                 if (alignedSize != evenSize)
                 {
                     srcOffset = evenSize - DA;
                     dstOffset = srcOffset / 2;
-                    ReduceColor2x2Kernel<channelCount>(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, shuffleIdx, mask8, mask16);
+                    ReduceColor2x2Kernel<channelCount>(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, HA, shuffleIdx, maskLo, maskHi, mask16);
                 }
                 if (evenWidth != srcWidth)
                 {
@@ -183,7 +165,7 @@ namespace Simd
             svuint8_t b1 = svtbl_u8(inter1, bIdx);
             svuint8_t g1 = svtbl_u8(inter1, gIdx);
             svuint8_t r1 = svtbl_u8(inter1, rIdx);
-            svst3_u8(maskOut, dst, svcreate3_u8(AveragePlane(b0, b1, maskPlane, mask16), AveragePlane(g0, g1, maskPlane, mask16), AveragePlane(r0, r1, maskPlane, mask16)));
+            svst3_u8(maskOut, dst, svcreate3_u8(AverageRows(b0, b1, maskPlane, mask16), AverageRows(g0, g1, maskPlane, mask16), AverageRows(r0, r1, maskPlane, mask16)));
         }
 
         void ReduceBgr2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
@@ -235,7 +217,7 @@ namespace Simd
 
             switch (channelCount)
             {
-            case 1: ReduceColor2x2<1>(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
+            case 1: ReduceGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride); break;
             case 2: ReduceColor2x2<2>(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
             case 3: ReduceBgr2x2(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;
             case 4: ReduceColor2x2<4>(src, srcWidth, srcHeight, srcStride, dst, dstStride); break;

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -87,18 +87,13 @@ namespace Simd
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_DEINTERLACE_INDEX[3][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool BGR_DEINTERLACE_INDEX_INITED = InitBgrDeinterlaceIndex(BGR_DEINTERLACE_INDEX);
 
-        SIMD_INLINE svuint8_t AveragePlane(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
-        {
-            return svqxtnb_u16(Average16(s0, s1, mask8, mask16));
-        }
-
         SIMD_INLINE bool InitReduceBgrPackIndex(uint8_t packIndex[SIMD_SVE2_VECTOR_SIZE_MAX], uint8_t channelIndex[SIMD_SVE2_VECTOR_SIZE_MAX])
         {
             size_t A = svlen(svuint8_t());
             assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
             for (size_t i = 0; i < A; ++i)
             {
-                packIndex[i] = (uint8_t)(i / 3);
+                packIndex[i] = (uint8_t)(2 * (i / 3));
                 channelIndex[i] = (uint8_t)(i % 3);
             }
             return true;
@@ -136,9 +131,9 @@ namespace Simd
             svuint8_t b1 = svtbl_u8(inter1, bIdx);
             svuint8_t g1 = svtbl_u8(inter1, gIdx);
             svuint8_t r1 = svtbl_u8(inter1, rIdx);
-            svuint8_t db = AveragePlane(b0, b1, maskPlane, mask16);
-            svuint8_t dg = AveragePlane(g0, g1, maskPlane, mask16);
-            svuint8_t dr = AveragePlane(r0, r1, maskPlane, mask16);
+            svuint8_t db = AverageRows(b0, b1, maskPlane, mask16);
+            svuint8_t dg = AverageRows(g0, g1, maskPlane, mask16);
+            svuint8_t dr = AverageRows(r0, r1, maskPlane, mask16);
             svst1_u8(maskOut, dst, PackBgr(packIdx, channelIdx, db, dg, dr, maskOut));
         }
 

--- a/src/Simd/SimdSve2Reduce.cpp
+++ b/src/Simd/SimdSve2Reduce.cpp
@@ -87,6 +87,61 @@ namespace Simd
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t BGR_DEINTERLACE_INDEX[3][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool BGR_DEINTERLACE_INDEX_INITED = InitBgrDeinterlaceIndex(BGR_DEINTERLACE_INDEX);
 
+        SIMD_INLINE svuint8_t AveragePlane(const svuint8_t& s0, const svuint8_t& s1, const svbool_t& mask8, const svbool_t& mask16)
+        {
+            return svqxtnb_u16(Average16(s0, s1, mask8, mask16));
+        }
+
+        SIMD_INLINE bool InitReduceBgrPackIndex(uint8_t packIndex[SIMD_SVE2_VECTOR_SIZE_MAX], uint8_t channelIndex[SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t i = 0; i < A; ++i)
+            {
+                packIndex[i] = (uint8_t)(i / 3);
+                channelIndex[i] = (uint8_t)(i % 3);
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t REDUCE_BGR_PACK_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t REDUCE_BGR_CHANNEL_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool REDUCE_BGR_PACK_INDEX_INITED = InitReduceBgrPackIndex(REDUCE_BGR_PACK_INDEX, REDUCE_BGR_CHANNEL_INDEX);
+
+        SIMD_INLINE svuint8_t PackBgr(const svuint8_t& packIdx, const svuint8_t& channelIdx,
+            const svuint8_t& b, const svuint8_t& g, const svuint8_t& r, const svbool_t& mask)
+        {
+            svuint8_t bp = svtbl_u8(b, packIdx);
+            svuint8_t gp = svtbl_u8(g, packIdx);
+            svuint8_t rp = svtbl_u8(r, packIdx);
+            return svsel_u8(svcmpeq_n_u8(mask, channelIdx, 0), bp, svsel_u8(svcmpeq_n_u8(mask, channelIdx, 1), gp, rp));
+        }
+
+        SIMD_INLINE void ReduceBgr2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst, size_t pixelCount,
+            const svuint8_t& bIdx, const svuint8_t& gIdx, const svuint8_t& rIdx,
+            const svuint8_t& packIdx, const svuint8_t& channelIdx)
+        {
+            const uint64_t loadSize = pixelCount * 3;
+            const uint64_t outPixels = pixelCount / 2;
+            const uint64_t outBytes = outPixels * 3;
+            const svbool_t maskLoad = svwhilelt_b8(0ull, loadSize);
+            const svbool_t maskPlane = svwhilelt_b8(0ull, pixelCount);
+            const svbool_t mask16 = svwhilelt_b16(0ull, outPixels);
+            const svbool_t maskOut = svwhilelt_b8(0ull, outBytes);
+            svuint8_t inter0 = svld1_u8(maskLoad, src0);
+            svuint8_t inter1 = svld1_u8(maskLoad, src1);
+            svuint8_t b0 = svtbl_u8(inter0, bIdx);
+            svuint8_t g0 = svtbl_u8(inter0, gIdx);
+            svuint8_t r0 = svtbl_u8(inter0, rIdx);
+            svuint8_t b1 = svtbl_u8(inter1, bIdx);
+            svuint8_t g1 = svtbl_u8(inter1, gIdx);
+            svuint8_t r1 = svtbl_u8(inter1, rIdx);
+            svuint8_t db = AveragePlane(b0, b1, maskPlane, mask16);
+            svuint8_t dg = AveragePlane(g0, g1, maskPlane, mask16);
+            svuint8_t dr = AveragePlane(r0, r1, maskPlane, mask16);
+            svst1_u8(maskOut, dst, PackBgr(packIdx, channelIdx, db, dg, dr, maskOut));
+        }
+
         template <size_t channelCount> SIMD_INLINE void ReduceColor2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst,
             size_t A, size_t HA, const svuint8_t& shuffleIdx, const svbool_t& maskLo, const svbool_t& maskHi, const svbool_t& mask16);
 
@@ -148,26 +203,6 @@ namespace Simd
             }
         }
 
-        SIMD_INLINE void ReduceBgr2x2Kernel(const uint8_t* src0, const uint8_t* src1, uint8_t* dst, size_t pixelCount,
-            const svuint8_t& bIdx, const svuint8_t& gIdx, const svuint8_t& rIdx)
-        {
-            const uint64_t loadSize = pixelCount * 3;
-            const uint64_t outSize = (pixelCount / 2) * 3;
-            const svbool_t maskLoad = svwhilelt_b8(0ull, loadSize);
-            const svbool_t maskPlane = svwhilelt_b8(0ull, pixelCount);
-            const svbool_t mask16 = svwhilelt_b16(0ull, pixelCount / 2);
-            const svbool_t maskOut = svwhilelt_b8(0ull, outSize);
-            svuint8_t inter0 = svld1_u8(maskLoad, src0);
-            svuint8_t inter1 = svld1_u8(maskLoad, src1);
-            svuint8_t b0 = svtbl_u8(inter0, bIdx);
-            svuint8_t g0 = svtbl_u8(inter0, gIdx);
-            svuint8_t r0 = svtbl_u8(inter0, rIdx);
-            svuint8_t b1 = svtbl_u8(inter1, bIdx);
-            svuint8_t g1 = svtbl_u8(inter1, gIdx);
-            svuint8_t r1 = svtbl_u8(inter1, rIdx);
-            svst3_u8(maskOut, dst, svcreate3_u8(AverageRows(b0, b1, maskPlane, mask16), AverageRows(g0, g1, maskPlane, mask16), AverageRows(r0, r1, maskPlane, mask16)));
-        }
-
         void ReduceBgr2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride, uint8_t* dst, size_t dstStride)
         {
             const size_t A = svcntb(), DA = 2 * A, HA = svcnth();
@@ -176,6 +211,8 @@ namespace Simd
             const svuint8_t bIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[0]);
             const svuint8_t gIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[1]);
             const svuint8_t rIdx = svld1_u8(all, BGR_DEINTERLACE_INDEX[2]);
+            const svuint8_t packIdx = svld1_u8(all, REDUCE_BGR_PACK_INDEX);
+            const svuint8_t channelIdx = svld1_u8(all, REDUCE_BGR_CHANNEL_INDEX);
             const size_t evenWidth = AlignLo(srcWidth, 2);
             const size_t alignedWidth = AlignLo(srcWidth, A);
             const size_t evenSize = evenWidth * 3;
@@ -189,15 +226,15 @@ namespace Simd
                 size_t srcOffset = 0, dstOffset = 0;
                 for (; srcOffset < alignedSize; srcOffset += srcStep, dstOffset += dstStep)
                 {
-                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx);
-                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
                 }
                 if (alignedSize != evenSize)
                 {
                     srcOffset = evenSize - srcStep;
                     dstOffset = srcOffset / 2;
-                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx);
-                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
+                    ReduceBgr2x2Kernel(src0 + srcOffset + 3 * A, src1 + srcOffset + 3 * A, dst + dstOffset + 3 * HA, A, bIdx, gIdx, rIdx, packIdx, channelIdx);
                 }
                 if (evenWidth != srcWidth)
                 {

--- a/src/Test/TestReduce.cpp
+++ b/src/Test/TestReduce.cpp
@@ -118,6 +118,11 @@ namespace Test
             result = result && ReduceColorAutoTest(FUNC_RC(Simd::Avx512bw::ReduceColor2x2), FUNC_RC(SimdReduceColor2x2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ReduceColorAutoTest(FUNC_RC(Simd::Sve2::ReduceColor2x2), FUNC_RC(SimdReduceColor2x2));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ReduceColorAutoTest(FUNC_RC(Simd::Neon::ReduceColor2x2), FUNC_RC(SimdReduceColor2x2));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **ReduceColor2x2 channel 3 (BGR)** test failures caused by sparse `svqxtnb_u16` output.

### Root cause

`svqxtnb_u16` places narrowed bytes in **even lanes only** (odd lanes are zero). `svst3_u8` then wrote:
- Pixel 0 (col 0): correct
- Pixel 1 (col 1): `(0,0,0)`
- Pixel 2 (col 2): previous pixel's value (shifted)

This matches the reported errors at `[1,0]`, `[2,0]`, `[3,0]`, … — note Compare prints **`[col, row]`**, so these are horizontal errors on row 0, not column 0 vertically.

### Fix

Add `svuzp1_u8(even, even)` after `svqxtnb_u16` in `AverageBgrPlane`, same as the working `AverageRows` / `ReduceGray2x2::Average8` pattern.

## Testing

- x86 build: PASS
- aarch64 cross-compile: PASS
- Please re-run on ARM: `./Test "-r=.." -fi=ReduceColor2x2 -tt=1 -ts=1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e9a1eaa-c76e-4395-b1a2-17820a0054e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e9a1eaa-c76e-4395-b1a2-17820a0054e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

