### PR TITLE
Add SVE2 SegmentationFillSingleHoles implementation

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -121,6 +121,7 @@
  <li>SVE2 optimizations of function Reorder32bit.</li>
  <li>SVE2 optimizations of function Reorder64bit.</li>
  <li>SVE2 optimizations of function SegmentationChangeIndex.</li>
+ <li>SVE2 optimizations of function SegmentationFillSingleHoles.</li>
  <li>SVE2 optimizations of function BayerToBgr.</li>
  <li>SVE2 optimizations of function BayerToBgra.</li>
  <li>SVE2 optimizations of function BgraToBayer.</li>
@@ -250,6 +251,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddConvolution5x5Sum.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvolutionForward.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function ReduceColor2x2.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationFillSingleHoles.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5096,6 +5096,11 @@ SIMD_API void SimdSegmentationFillSingleHoles(uint8_t * mask, size_t stride, siz
         Sse41::SegmentationFillSingleHoles(mask, stride, width, height, index);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width > svcntb() + 2)
+        Sve2::SegmentationFillSingleHoles(mask, stride, width, height, index);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
         if (Neon::Enable && width > Neon::A + 2)
             Neon::SegmentationFillSingleHoles(mask, stride, width, height, index);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -370,6 +370,7 @@ namespace Simd
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);
 
         void SegmentationChangeIndex(uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t oldIndex, uint8_t newIndex);
+        void SegmentationFillSingleHoles(uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 

--- a/src/Simd/SimdSve2Segmentation.cpp
+++ b/src/Simd/SimdSve2Segmentation.cpp
@@ -28,6 +28,36 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE void FillSingleHoles(uint8_t* mask, ptrdiff_t stride, size_t offset, size_t width, const svuint8_t& index)
+        {
+            const svbool_t tail = svwhilelt_b8(offset, width);
+            const svuint8_t up = svld1_u8(tail, mask - stride + offset);
+            const svuint8_t left = svld1_u8(tail, mask + offset - 1);
+            const svuint8_t right = svld1_u8(tail, mask + offset + 1);
+            const svuint8_t down = svld1_u8(tail, mask + stride + offset);
+            const svuint8_t current = svld1_u8(tail, mask + offset);
+            svbool_t fill = svcmpeq_u8(tail, up, index);
+            fill = svand_b_z(tail, fill, svcmpeq_u8(tail, left, index));
+            fill = svand_b_z(tail, fill, svcmpeq_u8(tail, right, index));
+            fill = svand_b_z(tail, fill, svcmpeq_u8(tail, down, index));
+            svst1_u8(tail, mask + offset, svsel_u8(fill, index, current));
+        }
+
+        void SegmentationFillSingleHoles(uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index)
+        {
+            const size_t A = svcntb();
+            assert(width > A + 2 && height > 2);
+
+            const svuint8_t _index = svdup_n_u8(index);
+            const size_t bodyEnd = width - 1;
+            for (size_t row = 1; row < height - 1; ++row)
+            {
+                uint8_t* current = mask + row * stride;
+                for (size_t col = 1; col < bodyEnd; col += A)
+                    FillSingleHoles(current, (ptrdiff_t)stride, col, bodyEnd, _index);
+            }
+        }
+
         SIMD_INLINE void ChangeIndex(uint8_t* mask, const svuint8_t& oldIndex, const svuint8_t& newIndex, const svbool_t& tail)
         {
             svuint8_t _mask = svld1_u8(tail, mask);

--- a/src/Test/TestSegmentation.cpp
+++ b/src/Test/TestSegmentation.cpp
@@ -191,6 +191,11 @@ namespace Test
             result = result && SegmentationFillSingleHolesAutoTest(FUNC_FSH(Simd::Neon::SegmentationFillSingleHoles), FUNC_FSH(SimdSegmentationFillSingleHoles));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SegmentationFillSingleHolesAutoTest(FUNC_FSH(Simd::Sve2::SegmentationFillSingleHoles), FUNC_FSH(SimdSegmentationFillSingleHoles));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `SegmentationFillSingleHoles` in `SimdSve2Segmentation.cpp`.
- wire SVE2 dispatch in `SimdSegmentationFillSingleHoles` and expose declaration in `SimdSve2.h`.
- extend `SegmentationFillSingleHolesAutoTest` to validate SVE2 specialization.
- update release notes for 7.2.163 in `docs/2026.html`.

## Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SegmentationFillSingleHoles -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b9d9f45-0622-4898-94d6-b5d0f23843b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b9d9f45-0622-4898-94d6-b5d0f23843b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

