### PR TITLE
Add SVE2 optimization for SegmentationShrinkRegion

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -123,6 +123,7 @@
  <li>SVE2 optimizations of function SegmentationChangeIndex.</li>
  <li>SVE2 optimizations of function SegmentationFillSingleHoles.</li>
  <li>SVE2 optimizations of function SegmentationPropagate2x2.</li>
+ <li>SVE2 optimizations of function SegmentationShrinkRegion.</li>
  <li>SVE2 optimizations of function BayerToBgr.</li>
  <li>SVE2 optimizations of function BayerToBgra.</li>
  <li>SVE2 optimizations of function BgraToBayer.</li>
@@ -254,6 +255,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function ReduceColor2x2.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationFillSingleHoles.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationPropagate2x2.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationShrinkRegion.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5167,6 +5167,11 @@ SIMD_API void SimdSegmentationShrinkRegion(const uint8_t * mask, size_t stride, 
         Sse41::SegmentationShrinkRegion(mask, stride, width, height, index, left, top, right, bottom);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntb() && *right - *left >= (ptrdiff_t)svcntb())
+        Sve2::SegmentationShrinkRegion(mask, stride, width, height, index, left, top, right, bottom);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A && *right - *left >= (ptrdiff_t)Neon::A)
         Neon::SegmentationShrinkRegion(mask, stride, width, height, index, left, top, right, bottom);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -374,6 +374,8 @@ namespace Simd
         void SegmentationPropagate2x2(const uint8_t* parent, size_t parentStride, size_t width, size_t height,
             uint8_t* child, size_t childStride, const uint8_t* difference, size_t differenceStride,
             uint8_t currentIndex, uint8_t invalidIndex, uint8_t emptyIndex, uint8_t differenceThreshold);
+        void SegmentationShrinkRegion(const uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index,
+            ptrdiff_t* left, ptrdiff_t* top, ptrdiff_t* right, ptrdiff_t* bottom);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 

--- a/src/Simd/SimdSve2Segmentation.cpp
+++ b/src/Simd/SimdSve2Segmentation.cpp
@@ -77,6 +77,127 @@ namespace Simd
             }
         }
 
+        SIMD_INLINE bool RowHasIndex(const uint8_t* mask, size_t width, const svuint8_t& index)
+        {
+            const size_t A = svcntb();
+            const svbool_t full = svptrue_b8();
+            size_t col = 0;
+            for (; col + A <= width; col += A)
+            {
+                if (svptest_any(full, svcmpeq_u8(full, svld1_u8(full, mask + col), index)))
+                    return true;
+            }
+            if (col < width)
+            {
+                const svbool_t tail = svwhilelt_b8(col, width);
+                if (svptest_any(tail, svcmpeq_u8(tail, svld1_u8(tail, mask + col), index)))
+                    return true;
+            }
+            return false;
+        }
+
+        SIMD_INLINE bool ColsHasIndex(const uint8_t* mask, size_t stride, size_t height, const svuint8_t& index, size_t width)
+        {
+            const svbool_t tail = svwhilelt_b8((size_t)0, width);
+            svbool_t cols = svpfalse_b();
+            for (size_t row = 0; row < height; ++row)
+            {
+                cols = svorr_b_z(tail, cols, svcmpeq_u8(tail, svld1_u8(tail, mask), index));
+                mask += stride;
+            }
+            return svptest_any(tail, cols);
+        }
+
+        void SegmentationShrinkRegion(const uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index,
+            ptrdiff_t* left, ptrdiff_t* top, ptrdiff_t* right, ptrdiff_t* bottom)
+        {
+            const size_t A = svcntb();
+            assert(*right - *left >= (ptrdiff_t)A && *bottom > *top);
+            assert(*left >= 0 && *right <= (ptrdiff_t)width && *top >= 0 && *bottom <= (ptrdiff_t)height);
+
+            const svuint8_t _index = svdup_n_u8(index);
+            bool search = true;
+            for (ptrdiff_t row = *top; search && row < *bottom; ++row)
+            {
+                if (RowHasIndex(mask + row * stride + *left, *right - *left, _index))
+                {
+                    search = false;
+                    *top = row;
+                }
+            }
+
+            if (search)
+            {
+                *left = 0;
+                *top = 0;
+                *right = 0;
+                *bottom = 0;
+                return;
+            }
+
+            search = true;
+            for (ptrdiff_t row = *bottom - 1; search && row >= *top; --row)
+            {
+                if (RowHasIndex(mask + row * stride + *left, *right - *left, _index))
+                {
+                    search = false;
+                    *bottom = row + 1;
+                }
+            }
+
+            search = true;
+            for (ptrdiff_t col = *left; search && col < *right; col += A)
+            {
+                const size_t block = (size_t)(*right - col >= (ptrdiff_t)A ? A : *right - col);
+                if (ColsHasIndex(mask + (*top) * stride + col, stride, *bottom - *top, _index, block))
+                {
+                    for (size_t i = 0; i < block; ++i)
+                    {
+                        const uint8_t* current = mask + (*top) * stride + col + i;
+                        for (ptrdiff_t row = *top; row < *bottom; ++row)
+                        {
+                            if (*current == index)
+                            {
+                                *left = col + i;
+                                search = false;
+                                break;
+                            }
+                            current += stride;
+                        }
+                        if (!search)
+                            break;
+                    }
+                }
+            }
+
+            search = true;
+            for (ptrdiff_t col = *right; search && col > *left;)
+            {
+                const ptrdiff_t start = col - (ptrdiff_t)A > *left ? col - (ptrdiff_t)A : *left;
+                const size_t block = (size_t)(col - start);
+                if (ColsHasIndex(mask + (*top) * stride + start, stride, *bottom - *top, _index, block))
+                {
+                    for (ptrdiff_t i = (ptrdiff_t)block - 1; i >= 0; --i)
+                    {
+                        const uint8_t* current = mask + (*top) * stride + start + i;
+                        for (ptrdiff_t row = *top; row < *bottom; ++row)
+                        {
+                            if (*current == index)
+                            {
+                                *right = start + i + 1;
+                                search = false;
+                                break;
+                            }
+                            current += stride;
+                        }
+                        if (!search)
+                            break;
+                    }
+                }
+                col = start;
+            }
+        }
+
         SIMD_INLINE void SegmentationPropagate2x2(const svbool_t& parentOne, const svbool_t& parentAll,
             const uint8_t* difference0, const uint8_t* difference1, uint8_t* child0, uint8_t* child1, size_t childCol,
             uint8_t invalidIndex, const svuint8_t& current, const svuint8_t& empty, uint8_t differenceThreshold, size_t childLimit)

--- a/src/Test/TestSegmentation.cpp
+++ b/src/Test/TestSegmentation.cpp
@@ -108,6 +108,11 @@ namespace Test
             result = result && SegmentationShrinkRegionAutoTest(FUNC_SR(Simd::Neon::SegmentationShrinkRegion), FUNC_SR(SimdSegmentationShrinkRegion));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SegmentationShrinkRegionAutoTest(FUNC_SR(Simd::Sve2::SegmentationShrinkRegion), FUNC_SR(SimdSegmentationShrinkRegion));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `SegmentationShrinkRegion` in `SimdSve2Segmentation.cpp`.
- add SVE2 declaration and runtime dispatch wiring for `SimdSegmentationShrinkRegion`.
- extend `SegmentationShrinkRegionAutoTest` with SVE2 coverage.
- update 7.2.163 release notes for algorithm and test additions.

## Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SegmentationShrinkRegion -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11f4850b-414b-4e5a-8227-ba565e5dee20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11f4850b-414b-4e5a-8227-ba565e5dee20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

