### PR TITLE
Add SVE2 optimization for SimdRgbToBgra

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -90,6 +90,7 @@
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNp.</li>
  <li>SVE2 optimizations of function BgrToBgra.</li>
+ <li>SVE2 optimizations of function RgbToBgra.</li>
  <li>SVE2 optimizations of function BgraToBgr.</li>
  <li>SVE2 optimizations of function BgraToRgb.</li>
  <li>SVE2 optimizations of function BgraToRgba.</li>
@@ -253,6 +254,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddConvolution5x5Sum.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvolutionForward.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function ReduceColor2x2.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function RgbToBgra.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationFillSingleHoles.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationPropagate2x2.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationShrinkRegion.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4977,6 +4977,11 @@ SIMD_API void SimdRgbToBgra(const uint8_t* rgb, size_t width, size_t height, siz
         Sse41::RgbToBgra(rgb, width, height, rgbStride, bgra, bgraStride, alpha);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::RgbToBgra(rgb, width, height, rgbStride, bgra, bgraStride, alpha);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::RgbToBgra(rgb, width, height, rgbStride, bgra, bgraStride, alpha);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -369,6 +369,8 @@ namespace Simd
 
         void RgbToGray(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* gray, size_t grayStride);
 
+        void RgbToBgra(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);
+
         void SegmentationChangeIndex(uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t oldIndex, uint8_t newIndex);
         void SegmentationFillSingleHoles(uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index);
         void SegmentationPropagate2x2(const uint8_t* parent, size_t parentStride, size_t width, size_t height,

--- a/src/Simd/SimdSve2BgrToBgra.cpp
+++ b/src/Simd/SimdSve2BgrToBgra.cpp
@@ -53,6 +53,31 @@ namespace Simd
             }
         }
 
+        SIMD_INLINE void RgbToBgra(const uint8_t* rgb, uint8_t* bgra, const svuint8_t& alpha, const svbool_t& mask)
+        {
+            svuint8x3_t _rgb = svld3_u8(mask, rgb);
+            svst4_u8(mask, bgra, svcreate4_u8(svget3(_rgb, 2), svget3(_rgb, 1), svget3(_rgb, 0), alpha));
+        }
+
+        void RgbToBgra(const uint8_t* rgb, size_t width, size_t height, size_t rgbStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha)
+        {
+            size_t A = svlen(svuint8_t()), A3 = A * 3, A4 = A * 4;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _alpha = svdup_n_u8(alpha);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, rgbOffset = 0, bgraOffset = 0;
+                for (; col < widthA; col += A, rgbOffset += A3, bgraOffset += A4)
+                    RgbToBgra(rgb + rgbOffset, bgra + bgraOffset, _alpha, body);
+                if (widthA < width)
+                    RgbToBgra(rgb + rgbOffset, bgra + bgraOffset, _alpha, tail);
+                rgb += rgbStride;
+                bgra += bgraStride;
+            }
+        }
+
         //-------------------------------------------------------------------------------------------------
 
         SIMD_INLINE void Bgr48pToBgra32(const uint8_t* blue, const uint8_t* green, const uint8_t* red, const svbool_t& mask, 

--- a/src/Test/TestAnyToBgra.cpp
+++ b/src/Test/TestAnyToBgra.cpp
@@ -173,6 +173,11 @@ namespace Test
             result = result && AnyToBgraAutoTest(View::Rgb24, FUNC(Simd::Avx512bw::RgbToBgra), FUNC(SimdRgbToBgra));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToBgraAutoTest(View::Rgb24, FUNC(Simd::Sve2::RgbToBgra), FUNC(SimdRgbToBgra));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToBgraAutoTest(View::Rgb24, FUNC(Simd::Neon::RgbToBgra), FUNC(SimdRgbToBgra));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `Simd::Sve2::RgbToBgra` in `src/Simd/SimdSve2BgrToBgra.cpp`.
- wire SVE2 dispatch for `SimdRgbToBgra` in `src/Simd/SimdLib.cpp` and add declaration in `src/Simd/SimdSve2.h`.
- extend `Test::RgbToBgraAutoTest` with SVE2 coverage.
- update release notes in `docs/2026.html` for release `7.2.163`.

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already contain `SimdSve2BgrToBgra.cpp`; no additional project entry was required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8c274ee-62b4-4397-9ad4-3e587213176c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8c274ee-62b4-4397-9ad4-3e587213176c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

