### PR TITLE
Add SVE2 SobelDx optimization and enable SobelDx SVE2 autotest

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -156,6 +156,7 @@
  <li>SVE2 optimizations of function MedianFilterSquare3x3.</li>
  <li>SVE2 optimizations of function MedianFilterSquare5x5.</li>
  <li>SVE2 optimizations of function MinFilterSquare5x5.</li>
+ <li>SVE2 optimizations of function SobelDx.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5261,6 +5261,11 @@ SIMD_API void SimdSobelDx(const uint8_t * src, size_t srcStride, size_t width, s
         Sse41::SobelDx(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SobelDx(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::SobelDx(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -194,6 +194,8 @@ namespace Simd
 
         void LbpEstimate(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
+        void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
         void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -28,6 +28,69 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        template <bool abs> SIMD_INLINE int16_t SobelDx(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x2);
+
+        template <> SIMD_INLINE int16_t SobelDx<false>(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x2)
+        {
+            return (int16_t)((s0[x2] + 2 * s1[x2] + s2[x2]) - (s0[x0] + 2 * s1[x0] + s2[x0]));
+        }
+
+        template <> SIMD_INLINE int16_t SobelDx<true>(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x2)
+        {
+            return (int16_t)Simd::Abs(SobelDx<false>(s0, s1, s2, x0, x2));
+        }
+
+        template <bool abs> SIMD_INLINE svint16_t SobelDx(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask);
+
+        template <> SIMD_INLINE svint16_t SobelDx<false>(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+        {
+            svint16_t left = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s1), 1)), svld1ub_s16(mask, s2));
+            svint16_t right = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0 + 2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s1 + 2), 1)), svld1ub_s16(mask, s2 + 2));
+            return svsub_s16_x(mask, right, left);
+        }
+
+        template <> SIMD_INLINE svint16_t SobelDx<true>(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+        {
+            return svabs_s16_x(mask, SobelDx<false>(s0, s1, s2, mask));
+        }
+
+        template <bool abs> SIMD_INLINE void SobelDx(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        {
+            svst1_s16(mask, dst, SobelDx<abs>(s0, s1, s2, mask));
+        }
+
+        template <bool abs> void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t * src0, * src1, * src2;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + srcStride * (row - 1);
+                src1 = src0 + srcStride;
+                src2 = src1 + srcStride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                dst[0] = SobelDx<abs>(src0, src1, src2, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    SobelDx<abs>(src0 + col - 1, src1 + col - 1, src2 + col - 1, dst + col, svwhilelt_b16(col, width - 1));
+                dst[width - 1] = SobelDx<abs>(src0, src1, src2, width - 2, width - 1);
+
+                dst += dstStride;
+            }
+        }
+
+        void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            SobelDx<false>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
         SIMD_INLINE int16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
         {
             int dx = Simd::Abs((s0[x2] + 2 * s1[x2] + s2[x2]) - (s0[x0] + 2 * s1[x0] + s2[x0]));

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -803,6 +803,17 @@ namespace
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::SobelDx), FUNC_G(SimdSobelDx));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcnth();
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::SobelDx), FUNC_G(SimdSobelDx));
+            result = result && GrayFilterAutoTest(2, 3, View::Int16, FUNC_G(Simd::Sve2::SobelDx), FUNC_G(SimdSobelDx));
+            result = result && GrayFilterAutoTest(A + 1, 5, View::Int16, FUNC_G(Simd::Sve2::SobelDx), FUNC_G(SimdSobelDx));
+            result = result && GrayFilterAutoTest(A + 3, 7, View::Int16, FUNC_G(Simd::Sve2::SobelDx), FUNC_G(SimdSobelDx));
+        }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Neon::SobelDx), FUNC_G(SimdSobelDx));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 vectorized implementation for `Simd::Sve2::SobelDx` in `src/Simd/SimdSve2Sobel.cpp` with scalar border handling and masked tail processing
- update `SimdSobelDx` dispatcher to call SVE2 implementation when SVE2 is enabled
- extend `Test::SobelDxAutoTest` with SVE2 path and extra small/tail-sensitive width cases
- declare `Sve2::SobelDx` in `src/Simd/SimdSve2.h` so `SimdLib.cpp` can resolve the symbol during SVE2 builds
- update release notes for 7.2.163 with SVE2 SobelDx optimization entry

## Validation
- configured and built the project with CMake using `g++`
- rebuilt after the header declaration fix (pass)
- executed focused Sobel test run: `./Test "-r=.." -fi=SobelDx -tt=1 -ts=1` (pass)

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already include `SimdSve2Sobel.cpp` in `dev`; no additional changes were required there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-541f79be-3e77-4201-a145-897b6890866a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-541f79be-3e77-4201-a145-897b6890866a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

