### PR TITLE
Add SVE2 SobelDxAbs implementation and coverage

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -157,6 +157,7 @@
  <li>SVE2 optimizations of function MedianFilterSquare5x5.</li>
  <li>SVE2 optimizations of function MinFilterSquare5x5.</li>
  <li>SVE2 optimizations of function SobelDx.</li>
+ <li>SVE2 optimizations of function SobelDxAbs.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>
@@ -248,6 +249,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MeanFilter3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SobelDxAbs.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvert.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralUpdateWeights.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5292,6 +5292,11 @@ SIMD_API void SimdSobelDxAbs(const uint8_t * src, size_t srcStride, size_t width
         Sse41::SobelDxAbs(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SobelDxAbs(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::SobelDxAbs(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -196,6 +196,8 @@ namespace Simd
 
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
+        void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
         void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -91,6 +91,13 @@ namespace Simd
             SobelDx<false>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
         }
 
+        void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            SobelDx<true>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
         SIMD_INLINE int16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
         {
             int dx = Simd::Abs((s0[x2] + 2 * s1[x2] + s2[x2]) - (s0[x0] + 2 * s1[x0] + s2[x0]));

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -844,6 +844,17 @@ namespace
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::SobelDxAbs), FUNC_G(SimdSobelDxAbs));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcnth();
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::SobelDxAbs), FUNC_G(SimdSobelDxAbs));
+            result = result && GrayFilterAutoTest(2, 3, View::Int16, FUNC_G(Simd::Sve2::SobelDxAbs), FUNC_G(SimdSobelDxAbs));
+            result = result && GrayFilterAutoTest(A + 1, 5, View::Int16, FUNC_G(Simd::Sve2::SobelDxAbs), FUNC_G(SimdSobelDxAbs));
+            result = result && GrayFilterAutoTest(A + 3, 7, View::Int16, FUNC_G(Simd::Sve2::SobelDxAbs), FUNC_G(SimdSobelDxAbs));
+        }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Neon::SobelDxAbs), FUNC_G(SimdSobelDxAbs));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 `SobelDxAbs` implementation in `SimdSve2Sobel.cpp` by reusing the existing vector SobelDx template with absolute mode.
- expose `Sve2::SobelDxAbs` in `SimdSve2.h` and wire runtime dispatch in `SimdLib.cpp` so `SimdSobelDxAbs` can select SVE2.
- extend `Test::SobelDxAbsAutoTest` with SVE2 checks, including small-width and tail-width cases (`2x3`, `A+1`, `A+3`).
- update release notes for `7.2.163` in `docs/2026.html` for both algorithm and test-framework changes.

## Validation
- configured and built with CMake using `g++` and shared library mode.
- ran targeted filter tests with `./build/Test "-r=." -fi=SobelDxAbs -tt=1 -ts=1` and confirmed success.

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already include `src/Simd/SimdSve2Sobel.cpp` in `dev`, so no additional project-file edits were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-285e1ab6-b9e5-4643-a387-15809b08e4b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-285e1ab6-b9e5-4643-a387-15809b08e4b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

