### PR TITLE
Add SVE2 SobelDy optimization and tests

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -159,6 +159,7 @@
  <li>SVE2 optimizations of function SobelDx.</li>
  <li>SVE2 optimizations of function SobelDxAbs.</li>
  <li>SVE2 optimizations of function SobelDxAbsSum.</li>
+ <li>SVE2 optimizations of function SobelDy.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>
@@ -251,6 +252,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare3x3.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function MidpointFilterSquare5x5.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDxAbs.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SobelDy.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDxAbsSum.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvert.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5354,6 +5354,11 @@ SIMD_API void SimdSobelDy(const uint8_t * src, size_t srcStride, size_t width, s
         Sse41::SobelDy(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SobelDy(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::SobelDy(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -200,6 +200,10 @@ namespace Simd
 
         void SobelDxAbsSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum);
 
+        void SobelDy(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
+        void SobelDyAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
         void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -131,10 +131,80 @@ namespace Simd
             *sum = fullSum;
         }
 
+        template <bool abs> SIMD_INLINE int16_t SobelDy(const uint8_t* s0, const uint8_t* s2, size_t x0, size_t x1, size_t x2);
+
+        template <> SIMD_INLINE int16_t SobelDy<false>(const uint8_t* s0, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+        {
+            return (int16_t)((s2[x0] + 2 * s2[x1] + s2[x2]) - (s0[x0] + 2 * s0[x1] + s0[x2]));
+        }
+
+        template <> SIMD_INLINE int16_t SobelDy<true>(const uint8_t* s0, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+        {
+            return (int16_t)Simd::Abs(SobelDy<false>(s0, s2, x0, x1, x2));
+        }
+
+        template <bool abs> SIMD_INLINE svint16_t SobelDy(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask);
+
+        template <> SIMD_INLINE svint16_t SobelDy<false>(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
+        {
+            svint16_t top = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s0 + 1), 1)), svld1ub_s16(mask, s0 + 2));
+            svint16_t bottom = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s2 + 1), 1)), svld1ub_s16(mask, s2 + 2));
+            return svsub_s16_x(mask, bottom, top);
+        }
+
+        template <> SIMD_INLINE svint16_t SobelDy<true>(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
+        {
+            return svabs_s16_x(mask, SobelDy<false>(s0, s2, mask));
+        }
+
+        template <bool abs> SIMD_INLINE void SobelDy(const uint8_t* s0, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        {
+            svst1_s16(mask, dst, SobelDy<abs>(s0, s2, mask));
+        }
+
+        template <bool abs> void SobelDy(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t* src0, * src1, * src2;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + srcStride * (row - 1);
+                src1 = src0 + srcStride;
+                src2 = src1 + srcStride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                dst[0] = SobelDy<abs>(src0, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    SobelDy<abs>(src0 + col - 1, src2 + col - 1, dst + col, svwhilelt_b16(col, width - 1));
+                dst[width - 1] = SobelDy<abs>(src0, src2, width - 2, width - 1, width - 1);
+
+                dst += dstStride;
+            }
+        }
+
+        void SobelDy(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            SobelDy<false>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
+        void SobelDyAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+
+            SobelDy<true>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+        }
+
         SIMD_INLINE int16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
         {
             int dx = Simd::Abs((s0[x2] + 2 * s1[x2] + s2[x2]) - (s0[x0] + 2 * s1[x0] + s2[x0]));
-            int dy = Simd::Abs((s2[x0] + 2 * s2[x1] + s2[x2]) - (s0[x0] + 2 * s0[x1] + s0[x2]));
+            int dy = SobelDy<true>(s0, s2, x0, x1, x2);
             return (int16_t)((dx + dy) * 2 + (dx >= dy ? 0 : 1));
         }
 

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -885,6 +885,17 @@ namespace
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::SobelDy), FUNC_G(SimdSobelDy));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcnth();
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));
+            result = result && GrayFilterAutoTest(2, 3, View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));
+            result = result && GrayFilterAutoTest(A + 1, 5, View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));
+            result = result && GrayFilterAutoTest(A + 3, 7, View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));
+        }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Neon::SobelDy), FUNC_G(SimdSobelDy));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation for `SobelDy`/`SobelDyAbs` in `src/Simd/SimdSve2Sobel.cpp`.
- add SVE2 declarations in `src/Simd/SimdSve2.h`.
- route `SimdSobelDy` through SVE2 in `src/Simd/SimdLib.cpp` when available.
- add SVE2 coverage in `Test::SobelDyAutoTest` for regular and small-width edge cases.
- update release notes for 7.2.163 in `docs/2026.html`.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel $(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SobelDy -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39400f19-2551-44fc-a2ef-54bfaa691ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39400f19-2551-44fc-a2ef-54bfaa691ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

