### PR TITLE
Add SVE2 SobelDyAbs dispatch and test coverage

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -160,6 +160,7 @@
  <li>SVE2 optimizations of function SobelDxAbs.</li>
  <li>SVE2 optimizations of function SobelDxAbsSum.</li>
  <li>SVE2 optimizations of function SobelDy.</li>
+ <li>SVE2 optimizations of function SobelDyAbs.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>
@@ -254,6 +255,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDxAbs.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDy.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDxAbsSum.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SobelDyAbs.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvert.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralUpdateWeights.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5385,6 +5385,11 @@ SIMD_API void SimdSobelDyAbs(const uint8_t * src, size_t srcStride, size_t width
         Sse41::SobelDyAbs(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SobelDyAbs(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::SobelDyAbs(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -143,6 +143,11 @@ namespace Simd
             return (int16_t)Simd::Abs(SobelDy<false>(s0, s2, x0, x1, x2));
         }
 
+        SIMD_INLINE int16_t SobelDyAbs(const uint8_t* s0, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
+        {
+            return (int16_t)Simd::Abs((s2[x0] + 2 * s2[x1] + s2[x2]) - (s0[x0] + 2 * s0[x1] + s0[x2]));
+        }
+
         template <bool abs> SIMD_INLINE svint16_t SobelDy(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask);
 
         template <> SIMD_INLINE svint16_t SobelDy<false>(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
@@ -155,6 +160,18 @@ namespace Simd
         template <> SIMD_INLINE svint16_t SobelDy<true>(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
         {
             return svabs_s16_x(mask, SobelDy<false>(s0, s2, mask));
+        }
+
+        SIMD_INLINE svint16_t SobelDyAbs(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
+        {
+            svint16_t top = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s0 + 1), 1)), svld1ub_s16(mask, s0 + 2));
+            svint16_t bottom = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s2 + 1), 1)), svld1ub_s16(mask, s2 + 2));
+            return svabs_s16_x(mask, svsub_s16_x(mask, bottom, top));
+        }
+
+        SIMD_INLINE void SobelDyAbs(const uint8_t* s0, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
+        {
+            svst1_s16(mask, dst, SobelDyAbs(s0, s2, mask));
         }
 
         template <bool abs> SIMD_INLINE void SobelDy(const uint8_t* s0, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
@@ -198,7 +215,29 @@ namespace Simd
         {
             assert(dstStride % sizeof(int16_t) == 0);
 
-            SobelDy<true>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t* src0, * src1, * src2;
+            int16_t* dst16 = (int16_t*)dst;
+            size_t dst16Stride = dstStride / sizeof(int16_t);
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + srcStride * (row - 1);
+                src1 = src0 + srcStride;
+                src2 = src1 + srcStride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                dst16[0] = SobelDyAbs(src0, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    SobelDyAbs(src0 + col - 1, src2 + col - 1, dst16 + col, svwhilelt_b16(col, width - 1));
+                dst16[width - 1] = SobelDyAbs(src0, src2, width - 2, width - 1, width - 1);
+
+                dst16 += dst16Stride;
+            }
         }
 
         SIMD_INLINE int16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
@@ -213,13 +252,6 @@ namespace Simd
             svint16_t left = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s1), 1)), svld1ub_s16(mask, s2));
             svint16_t right = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0 + 2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s1 + 2), 1)), svld1ub_s16(mask, s2 + 2));
             return svabs_s16_x(mask, svsub_s16_x(mask, right, left));
-        }
-
-        SIMD_INLINE svint16_t SobelDyAbs(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
-        {
-            svint16_t top = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s0 + 1), 1)), svld1ub_s16(mask, s0 + 2));
-            svint16_t bottom = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s2 + 1), 1)), svld1ub_s16(mask, s2 + 2));
-            return svabs_s16_x(mask, svsub_s16_x(mask, bottom, top));
         }
 
         SIMD_INLINE svint16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -926,6 +926,17 @@ namespace
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Avx512bw::SobelDyAbs), FUNC_G(SimdSobelDyAbs));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcnth();
+            result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::SobelDyAbs), FUNC_G(SimdSobelDyAbs));
+            result = result && GrayFilterAutoTest(2, 3, View::Int16, FUNC_G(Simd::Sve2::SobelDyAbs), FUNC_G(SimdSobelDyAbs));
+            result = result && GrayFilterAutoTest(A + 1, 5, View::Int16, FUNC_G(Simd::Sve2::SobelDyAbs), FUNC_G(SimdSobelDyAbs));
+            result = result && GrayFilterAutoTest(A + 3, 7, View::Int16, FUNC_G(Simd::Sve2::SobelDyAbs), FUNC_G(SimdSobelDyAbs));
+        }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W - 1 >= Simd::Neon::A)
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Neon::SobelDyAbs), FUNC_G(SimdSobelDyAbs));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement dedicated SVE2 `SobelDyAbs` processing path in `src/Simd/SimdSve2Sobel.cpp`.
- wire SVE2 runtime dispatch for `SimdSobelDyAbs` in `src/Simd/SimdLib.cpp`.
- add SVE2 coverage to `Test::SobelDyAbsAutoTest` in `src/Test/TestFilter.cpp`, including tail-sensitive widths.
- update release notes in `docs/2026.html` (release 7.2.163) for algorithm and test additions.

## Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SobelDyAbs -tt=1 -ts=1`

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already include `src/Simd/SimdSve2Sobel.cpp` on current `dev`, so no additional edits were required there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d1b229d-edd7-4df6-b34d-307757e91cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d1b229d-edd7-4df6-b34d-307757e91cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

