### PR TITLE
Add SVE2 SobelDyAbsSum implementation and tests

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -161,6 +161,7 @@
  <li>SVE2 optimizations of function SobelDxAbsSum.</li>
  <li>SVE2 optimizations of function SobelDy.</li>
  <li>SVE2 optimizations of function SobelDyAbs.</li>
+ <li>SVE2 optimizations of function SobelDyAbsSum.</li>
  <li>SVE2 optimizations of function HogDirectionHistograms.</li>
  <li>SVE2 optimizations of function HogExtractFeatures.</li>
  <li>SVE2 optimizations of function HogDeinterleave.</li>
@@ -256,6 +257,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDy.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDxAbsSum.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SobelDyAbs.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SobelDyAbsSum.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralConvert.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralAddValue.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function NeuralUpdateWeights.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5416,6 +5416,11 @@ SIMD_API void SimdSobelDyAbsSum(const uint8_t * src, size_t stride, size_t width
         Sse41::SobelDyAbsSum(src, stride, width, height, sum);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SobelDyAbsSum(src, stride, width, height, sum);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width > Neon::A)
         Neon::SobelDyAbsSum(src, stride, width, height, sum);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -204,6 +204,8 @@ namespace Simd
 
         void SobelDyAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
+        void SobelDyAbsSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum);
+
         void Laplace(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void LaplaceAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -240,6 +240,39 @@ namespace Simd
             }
         }
 
+        SIMD_INLINE uint64_t SobelDyAbsSum(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
+        {
+            svuint16_t sobel = svreinterpret_u16_s16(SobelDy<true>(s0, s2, mask));
+            return svaddv_u32(svptrue_b32(), svunpklo_u32(sobel)) + svaddv_u32(svptrue_b32(), svunpkhi_u32(sobel));
+        }
+
+        void SobelDyAbsSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum)
+        {
+            assert(width > 1);
+
+            const size_t A = svcnth();
+            const uint8_t* src0, * src1, * src2;
+            uint64_t fullSum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                src0 = src + stride * (row - 1);
+                src1 = src0 + stride;
+                src2 = src1 + stride;
+                if (row == 0)
+                    src0 = src1;
+                if (row == height - 1)
+                    src2 = src1;
+
+                uint64_t rowSum = SobelDy<true>(src0, src2, 0, 0, 1);
+                for (size_t col = 1; col < width - 1; col += A)
+                    rowSum += SobelDyAbsSum(src0 + col - 1, src2 + col - 1, svwhilelt_b16(col, width - 1));
+                rowSum += SobelDy<true>(src0, src2, width - 2, width - 1, width - 1);
+
+                fullSum += rowSum;
+            }
+            *sum = fullSum;
+        }
+
         SIMD_INLINE int16_t ContourMetrics(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x1, size_t x2)
         {
             int dx = Simd::Abs((s0[x2] + 2 * s1[x2] + s2[x2]) - (s0[x0] + 2 * s1[x0] + s2[x0]));

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -806,6 +806,11 @@ namespace Test
             result = result && SumAutoTest(FUNC4(Simd::Neon::SobelDyAbsSum), FUNC4(SimdSobelDyAbsSum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SumAutoTest(FUNC4(Simd::Sve2::SobelDyAbsSum), FUNC4(SimdSobelDyAbsSum));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `SobelDyAbsSum` in `SimdSve2Sobel.cpp`.
- expose and dispatch `Sve2::SobelDyAbsSum` through `SimdSve2.h`, `SimdLib.cpp`, and `Test::SobelDyAbsSumAutoTest`.
- update release notes for 7.2.163 with the new algorithm and test coverage entries.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SobelDyAbsSum -tt=1 -ts=1`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SobelDxAbsSum -tt=1 -ts=1`

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already include `SimdSve2Sobel.cpp`, so no additional project-file entry was required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f82608b-692d-4f89-9c75-31a671b0143e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f82608b-692d-4f89-9c75-31a671b0143e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

