### PR TITLE
Add SVE2 optimization for SquaredDifferenceSum

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -142,6 +142,7 @@
  <li>SVE2 optimizations of function ValueSquareSum.</li>
  <li>SVE2 optimizations of function ValueSquareSums.</li>
  <li>SVE2 optimizations of function CorrelationSum.</li>
+ <li>SVE2 optimizations of function SquaredDifferenceSum.</li>
  <li>SVE2 optimizations of function ConditionalCount8u.</li>
  <li>SVE2 optimizations of function ConditionalCount16i.</li>
  <li>SVE2 optimizations of function ConditionalSum.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -77,6 +77,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -302,6 +302,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5542,6 +5542,11 @@ SIMD_API void SimdSquaredDifferenceSum(const uint8_t *a, size_t aStride, const u
         Sse41::SquaredDifferenceSum(a, aStride, b, bStride, width, height, sum);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SquaredDifferenceSum(a, aStride, b, bStride, width, height, sum);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::SquaredDifferenceSum(a, aStride, b, bStride, width, height, sum);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -345,6 +345,9 @@ namespace Simd
 
         void CorrelationSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum);
 
+        void SquaredDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint64_t* sum);
+
         void DetectionHaarDetect32fp(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2SquaredDifferenceSum.cpp
+++ b/src/Simd/SimdSve2SquaredDifferenceSum.cpp
@@ -31,7 +31,8 @@ namespace Simd
         SIMD_INLINE void SquaredDifferenceSum(const uint8_t* a, const uint8_t* b, const svbool_t& mask, const svuint8_t& zero, svuint32_t& sum)
         {
             svuint8_t diff = svabd_u8_x(mask, svld1_u8(mask, a), svld1_u8(mask, b));
-            sum = svdot_u32(sum, svsel_u8(mask, diff, zero), svsel_u8(mask, diff, zero));
+            svuint8_t masked = svsel_u8(mask, diff, zero);
+            sum = svdot_u32(sum, masked, masked);
         }
 
         void SquaredDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,

--- a/src/Simd/SimdSve2SquaredDifferenceSum.cpp
+++ b/src/Simd/SimdSve2SquaredDifferenceSum.cpp
@@ -1,0 +1,63 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void SquaredDifferenceSum(const uint8_t* a, const uint8_t* b, const svbool_t& mask, const svuint8_t& zero, svuint32_t& sum)
+        {
+            svuint8_t diff = svabd_u8_x(mask, svld1_u8(mask, a), svld1_u8(mask, b));
+            sum = svdot_u32(sum, svsel_u8(mask, diff, zero), svsel_u8(mask, diff, zero));
+        }
+
+        void SquaredDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint64_t* sum)
+        {
+            assert(width < 0x10000);
+
+            const size_t A = svlen(svuint8_t());
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t zero = svdup_n_u8(0);
+            *sum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                svuint32_t rowSum = svdup_n_u32(0);
+                for (; col < widthA; col += A)
+                    SquaredDifferenceSum(a + col, b + col, body, zero, rowSum);
+                if (widthA < width)
+                    SquaredDifferenceSum(a + col, b + col, tail, zero, rowSum);
+                *sum += svaddv_u32(svptrue_b32(), rowSum);
+                a += aStride;
+                b += bStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -211,6 +211,11 @@ namespace Test
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Avx512bw::SquaredDifferenceSum), FUNC_S(SimdSquaredDifferenceSum), 1);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Sve2::SquaredDifferenceSum), FUNC_S(SimdSquaredDifferenceSum), 1);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Neon::SquaredDifferenceSum), FUNC_S(SimdSquaredDifferenceSum), 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `Sve2::SquaredDifferenceSum` implementation in `src/Simd/SimdSve2SquaredDifferenceSum.cpp`.
- wire SVE2 declaration and runtime dispatch for `SimdSquaredDifferenceSum`.
- extend `SquaredDifferenceSumAutoTest` with SVE2 coverage.
- register the new file in `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters`.
- update release notes for `7.2.163` in `docs/2026.html`.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." "-fi=SquaredDifferenceSum" -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efea1e98-b3e4-4dcb-9b12-299ee522708e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efea1e98-b3e4-4dcb-9b12-299ee522708e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

