### PR TITLE
Add SVE2 optimization for SimdSquaredDifferenceSumMasked

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -143,6 +143,7 @@
  <li>SVE2 optimizations of function ValueSquareSums.</li>
  <li>SVE2 optimizations of function CorrelationSum.</li>
  <li>SVE2 optimizations of function SquaredDifferenceSum.</li>
+ <li>SVE2 optimizations of function SquaredDifferenceSumMasked.</li>
  <li>SVE2 optimizations of function ConditionalCount8u.</li>
  <li>SVE2 optimizations of function ConditionalCount16i.</li>
  <li>SVE2 optimizations of function ConditionalSum.</li>
@@ -270,6 +271,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationFillSingleHoles.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationPropagate2x2.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationShrinkRegion.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SquaredDifferenceSumMasked.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5574,6 +5574,11 @@ SIMD_API void SimdSquaredDifferenceSumMasked(const uint8_t *a, size_t aStride, c
         Sse41::SquaredDifferenceSumMasked(a, aStride, b, bStride, mask, maskStride, index, width, height, sum);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::SquaredDifferenceSumMasked(a, aStride, b, bStride, mask, maskStride, index, width, height, sum);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::SquaredDifferenceSumMasked(a, aStride, b, bStride, mask, maskStride, index, width, height, sum);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -348,6 +348,9 @@ namespace Simd
         void SquaredDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
             size_t width, size_t height, uint64_t* sum);
 
+        void SquaredDifferenceSumMasked(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sum);
+
         void DetectionHaarDetect32fp(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2SquaredDifferenceSum.cpp
+++ b/src/Simd/SimdSve2SquaredDifferenceSum.cpp
@@ -35,6 +35,15 @@ namespace Simd
             sum = svdot_u32(sum, masked, masked);
         }
 
+        SIMD_INLINE void SquaredDifferenceSumMasked(const uint8_t* a, const uint8_t* b, const uint8_t* m, const svbool_t& pg, const svuint8_t& index, const svuint8_t& zero, svuint32_t& sum)
+        {
+            svuint8_t diff = svabd_u8_x(pg, svld1_u8(pg, a), svld1_u8(pg, b));
+            svuint8_t mask = svld1_u8(pg, m);
+            svbool_t eq = svcmpeq_u8(pg, mask, index);
+            svuint8_t selected = svsel_u8(eq, diff, zero);
+            sum = svdot_u32(sum, selected, selected);
+        }
+
         void SquaredDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
             size_t width, size_t height, uint64_t* sum)
         {
@@ -57,6 +66,33 @@ namespace Simd
                 *sum += svaddv_u32(svptrue_b32(), rowSum);
                 a += aStride;
                 b += bStride;
+            }
+        }
+
+        void SquaredDifferenceSumMasked(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sum)
+        {
+            assert(width < 0x10000);
+
+            const size_t A = svlen(svuint8_t());
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _index = svdup_n_u8(index);
+            const svuint8_t zero = svdup_n_u8(0);
+            *sum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                svuint32_t rowSum = svdup_n_u32(0);
+                for (; col < widthA; col += A)
+                    SquaredDifferenceSumMasked(a + col, b + col, mask + col, body, _index, zero, rowSum);
+                if (widthA < width)
+                    SquaredDifferenceSumMasked(a + col, b + col, mask + col, tail, _index, zero, rowSum);
+                *sum += svaddv_u32(svptrue_b32(), rowSum);
+                a += aStride;
+                b += bStride;
+                mask += maskStride;
             }
         }
     }

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -245,6 +245,11 @@ namespace Test
             result = result && DifferenceSumsMaskedAutoTest(FUNC_M(Simd::Avx512bw::SquaredDifferenceSumMasked), FUNC_M(SimdSquaredDifferenceSumMasked), 1);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSumsMaskedAutoTest(FUNC_M(Simd::Sve2::SquaredDifferenceSumMasked), FUNC_M(SimdSquaredDifferenceSumMasked), 1);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSumsMaskedAutoTest(FUNC_M(Simd::Neon::SquaredDifferenceSumMasked), FUNC_M(SimdSquaredDifferenceSumMasked), 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `Sve2::SquaredDifferenceSumMasked` in `src/Simd/SimdSve2SquaredDifferenceSum.cpp` using SVE2 masked compare + dot-product accumulation.
- add SVE2 declaration and public API dispatch path so `SimdSquaredDifferenceSumMasked` can select the SVE2 implementation.
- extend `SquaredDifferenceSumMaskedAutoTest` with SVE2 coverage.
- update release notes for 7.2.163 with the new SVE2 optimization and corresponding test entry.

## Validation
- configured and built with CMake using the repo's cloud instructions.
- ran focused test: `./Test "-r=.." -fi=SquaredDifferenceSumMasked -tt=1 -ts=1` (pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae7e50c2-0f04-48f9-b96d-59569ccdf7c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae7e50c2-0f04-48f9-b96d-59569ccdf7c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

