### PR TITLE
Add SVE2 optimization for SimdSquaredDifferenceSum32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -144,6 +144,7 @@
  <li>SVE2 optimizations of function CorrelationSum.</li>
  <li>SVE2 optimizations of function SquaredDifferenceSum.</li>
  <li>SVE2 optimizations of function SquaredDifferenceSumMasked.</li>
+ <li>SVE2 optimizations of function SquaredDifferenceSum32f.</li>
  <li>SVE2 optimizations of function ConditionalCount8u.</li>
  <li>SVE2 optimizations of function ConditionalCount16i.</li>
  <li>SVE2 optimizations of function ConditionalSum.</li>
@@ -272,6 +273,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationPropagate2x2.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationShrinkRegion.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SquaredDifferenceSumMasked.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SquaredDifferenceSum32f.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5591,7 +5591,7 @@ SIMD_API void SimdSquaredDifferenceSum32f(const float * a, const float * b, size
 {
     SIMD_EMPTY();
     typedef void (* SimdSquaredDifferenceSum32fPtr) (const float * a, const float * b, size_t size, float * sum);
-    const static SimdSquaredDifferenceSum32fPtr simdSquaredDifferenceSum32f = SIMD_FUNC4(SquaredDifferenceSum32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSquaredDifferenceSum32fPtr simdSquaredDifferenceSum32f = SIMD_FUNC5(SquaredDifferenceSum32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSquaredDifferenceSum32f(a, b, size, sum);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -351,6 +351,8 @@ namespace Simd
         void SquaredDifferenceSumMasked(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
             const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sum);
 
+        void SquaredDifferenceSum32f(const float* a, const float* b, size_t size, float* sum);
+
         void DetectionHaarDetect32fp(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2SquaredDifferenceSum.cpp
+++ b/src/Simd/SimdSve2SquaredDifferenceSum.cpp
@@ -22,6 +22,7 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
+#include "Simd/SimdMath.h"
 
 namespace Simd
 {
@@ -94,6 +95,32 @@ namespace Simd
                 b += bStride;
                 mask += maskStride;
             }
+        }
+
+        SIMD_INLINE void SquaredDifferenceSum32f(const float* a, const float* b, const svbool_t& mask, svfloat32_t& sum)
+        {
+            svfloat32_t _a = svld1_f32(mask, a);
+            svfloat32_t _b = svld1_f32(mask, b);
+            svfloat32_t _d = svsub_f32_m(mask, _a, _b);
+            sum = svmla_f32_m(mask, sum, _d, _d);
+        }
+
+        void SquaredDifferenceSum32f(const float* a, const float* b, size_t size, float* sum)
+        {
+            size_t F = svcntw(), DF = 2 * F, sizeDF = AlignLo(size, DF), sizeF = AlignLo(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sums0 = svdup_n_f32(0.0f), sums1 = svdup_n_f32(0.0f);
+            for (; i < sizeDF; i += DF)
+            {
+                SquaredDifferenceSum32f(a + i, b + i, body, sums0);
+                SquaredDifferenceSum32f(a + i + F, b + i + F, body, sums1);
+            }
+            sums0 = svadd_f32_x(body, sums0, sums1);
+            for (; i < sizeF; i += F)
+                SquaredDifferenceSum32f(a + i, b + i, body, sums0);
+            if (i < size)
+                SquaredDifferenceSum32f(a + i, b + i, svwhilelt_b32(i, size), sums0);
+            *sum = svaddv_f32(body, sums0);
         }
     }
 #endif

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -427,6 +427,11 @@ namespace Test
             result = result && DifferenceSum32fAutoTest(eps, FUNC_F(Simd::Avx512bw::SquaredDifferenceSum32f), FUNC_F(SimdSquaredDifferenceSum32f));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSum32fAutoTest(eps, FUNC_F(Simd::Sve2::SquaredDifferenceSum32f), FUNC_F(SimdSquaredDifferenceSum32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSum32fAutoTest(eps, FUNC_F(Simd::Neon::SquaredDifferenceSum32f), FUNC_F(SimdSquaredDifferenceSum32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Added `Simd::Sve2::SquaredDifferenceSum32f` implementation in `SimdSve2SquaredDifferenceSum.cpp` using SVE/SVE2 float32 vector accumulation.
- Added `Simd::Sve2::SquaredDifferenceSum32f` declaration to `SimdSve2.h`.
- Updated `SimdSquaredDifferenceSum32f` API dispatch in `SimdLib.cpp` to include the SVE2 path.
- Extended `Test::SquaredDifferenceSum32fAutoTest` to validate SVE2 implementation when available.
- Updated release notes in `docs/2026.html` (release 7.2.163) for the new SVE2 optimization and associated test coverage.

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already include `SimdSve2SquaredDifferenceSum.cpp` on current `dev`, so no additional project-file edits were required.

## Validation
- Configured and built with CMake (g++ toolchain) successfully.
- Ran targeted test: `./Test "-r=.." -fi=SquaredDifferenceSum32f -tt=1 -ts=1` (pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa2181c0-5dca-4f55-83fd-1b07baefcac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa2181c0-5dca-4f55-83fd-1b07baefcac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

