### PR TITLE
Add SVE2 SquaredDifferenceKahanSum32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -145,6 +145,7 @@
  <li>SVE2 optimizations of function SquaredDifferenceSum.</li>
  <li>SVE2 optimizations of function SquaredDifferenceSumMasked.</li>
  <li>SVE2 optimizations of function SquaredDifferenceSum32f.</li>
+ <li>SVE2 optimizations of function SquaredDifferenceKahanSum32f.</li>
  <li>SVE2 optimizations of function ConditionalCount8u.</li>
  <li>SVE2 optimizations of function ConditionalCount16i.</li>
  <li>SVE2 optimizations of function ConditionalSum.</li>
@@ -274,6 +275,7 @@
  <li>Tests for verifying functionality of SVE2 optimizations of function SegmentationShrinkRegion.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SquaredDifferenceSumMasked.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of function SquaredDifferenceSum32f.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of function SquaredDifferenceKahanSum32f.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5600,7 +5600,7 @@ SIMD_API void SimdSquaredDifferenceKahanSum32f(const float * a, const float * b,
 {
     SIMD_EMPTY();
     typedef void (* SimdSquaredDifferenceKahanSum32fPtr) (const float * a, const float * b, size_t size, float * sum);
-    const static SimdSquaredDifferenceKahanSum32fPtr simdSquaredDifferenceKahanSum32f = SIMD_FUNC4(SquaredDifferenceKahanSum32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSquaredDifferenceKahanSum32fPtr simdSquaredDifferenceKahanSum32f = SIMD_FUNC5(SquaredDifferenceKahanSum32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSquaredDifferenceKahanSum32f(a, b, size, sum);
 }

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -353,6 +353,8 @@ namespace Simd
 
         void SquaredDifferenceSum32f(const float* a, const float* b, size_t size, float* sum);
 
+        void SquaredDifferenceKahanSum32f(const float* a, const float* b, size_t size, float* sum);
+
         void DetectionHaarDetect32fp(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 

--- a/src/Simd/SimdSve2SquaredDifferenceSum.cpp
+++ b/src/Simd/SimdSve2SquaredDifferenceSum.cpp
@@ -122,6 +122,37 @@ namespace Simd
                 SquaredDifferenceSum32f(a + i, b + i, svwhilelt_b32(i, size), sums0);
             *sum = svaddv_f32(body, sums0);
         }
+
+        SIMD_INLINE void SquaredDifferenceKahanSum32f(const float* a, const float* b, const svbool_t& mask, svfloat32_t& sum, svfloat32_t& correction)
+        {
+            svfloat32_t _a = svld1_f32(mask, a);
+            svfloat32_t _b = svld1_f32(mask, b);
+            svfloat32_t _d = svsub_f32_m(mask, _a, _b);
+            svfloat32_t term = svsub_f32_m(mask, svmul_f32_m(mask, _d, _d), correction);
+            svfloat32_t temp = svadd_f32_m(mask, sum, term);
+            correction = svsub_f32_m(mask, svsub_f32_m(mask, temp, sum), term);
+            sum = temp;
+        }
+
+        void SquaredDifferenceKahanSum32f(const float* a, const float* b, size_t size, float* sum)
+        {
+            size_t F = svcntw(), DF = 2 * F, sizeDF = AlignLo(size, DF), sizeF = AlignLo(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sums0 = svdup_n_f32(0.0f), sums1 = svdup_n_f32(0.0f);
+            svfloat32_t corrections0 = svdup_n_f32(0.0f), corrections1 = svdup_n_f32(0.0f);
+            for (; i < sizeDF; i += DF)
+            {
+                SquaredDifferenceKahanSum32f(a + i, b + i, body, sums0, corrections0);
+                SquaredDifferenceKahanSum32f(a + i + F, b + i + F, body, sums1, corrections1);
+            }
+            sums0 = svadd_f32_x(body, sums0, sums1);
+            corrections0 = svadd_f32_x(body, corrections0, corrections1);
+            for (; i < sizeF; i += F)
+                SquaredDifferenceKahanSum32f(a + i, b + i, body, sums0, corrections0);
+            if (i < size)
+                SquaredDifferenceKahanSum32f(a + i, b + i, svwhilelt_b32(i, size), sums0, corrections0);
+            *sum = svaddv_f32(body, sums0);
+        }
     }
 #endif
 }

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -462,6 +462,11 @@ namespace Test
             result = result && DifferenceSum32fAutoTest(EPS*EPS, FUNC_F(Simd::Avx512bw::SquaredDifferenceKahanSum32f), FUNC_F(SimdSquaredDifferenceKahanSum32f));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSum32fAutoTest(EPS*EPS, FUNC_F(Simd::Sve2::SquaredDifferenceKahanSum32f), FUNC_F(SimdSquaredDifferenceKahanSum32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSum32fAutoTest(EPS*EPS, FUNC_F(Simd::Neon::SquaredDifferenceKahanSum32f), FUNC_F(SimdSquaredDifferenceKahanSum32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `Simd::Sve2::SquaredDifferenceKahanSum32f` in `src/Simd/SimdSve2SquaredDifferenceSum.cpp` using vectorized Kahan accumulation with SVE2 predicates and tail handling.
- add SVE2 declaration in `src/Simd/SimdSve2.h`.
- include SVE2 in runtime dispatch for `SimdSquaredDifferenceKahanSum32f` in `src/Simd/SimdLib.cpp`.
- extend `Test::SquaredDifferenceKahanSum32fAutoTest` with the SVE2 branch in `src/Test/TestDifferenceSum.cpp`.
- update release notes for `7.2.163` in `docs/2026.html` for both algorithm optimization and test coverage.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SquaredDifferenceKahanSum32f -tt=1 -ts=1`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SquaredDifferenceSum32f -tt=1 -ts=1`

## Notes
- this CI host is x86_64, so SVE2 code path execution is not available here; correctness validation is via existing test framework integration and successful full build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f610ac5-27b1-4e97-8591-7ac29ebf6cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f610ac5-27b1-4e97-8591-7ac29ebf6cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

