### PR TITLE
Add SVE2 optimization for SimdSquaredDifferenceSum16f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function Float32ToUint8.</li>
  <li>SVE2 optimizations of function Float32ToFloat16.</li>
  <li>SVE2 optimizations of function Float16ToFloat32.</li>
+ <li>SVE2 optimizations of function SquaredDifferenceSum16f.</li>
  <li>SVE2 optimizations of function NeuralConvert.</li>
  <li>SVE2 optimizations of function NeuralProductSum.</li>
  <li>SVE2 optimizations of function NeuralAddVectorMultipliedByValue.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2752,6 +2752,11 @@ SIMD_API void SimdSquaredDifferenceSum16f(const uint16_t * a, const uint16_t * b
         Avx2::SquaredDifferenceSum16f(a, b, size, sum);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::SquaredDifferenceSum16f(a, b, size, sum);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && size >= Neon::F)
         Neon::SquaredDifferenceSum16f(a, b, size, sum);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -121,6 +121,8 @@ namespace Simd
 
         void Float16ToFloat32(const uint16_t* src, size_t size, float* dst);
 
+        void SquaredDifferenceSum16f(const uint16_t* a, const uint16_t* b, size_t size, float* sum);
+
         void NeuralConvert(const uint8_t* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride, int inversion);
 
         void NeuralProductSum(const float* a, const float* b, size_t size, float* sum);

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -80,6 +80,34 @@ namespace Simd
             }
         }
 
+        SIMD_INLINE void SquaredDifferenceSum16f(const uint16_t* a, const uint16_t* b, const svbool_t& load, const svbool_t& lo,
+            const svbool_t& hi, svfloat32_t& sum0, svfloat32_t& sum1)
+        {
+            svfloat16_t _a = svreinterpret_f16_u16(svld1_u16(load, a));
+            svfloat16_t _b = svreinterpret_f16_u16(svld1_u16(load, b));
+            svfloat32_t d0 = svsub_f32_x(lo, svcvt_f32_f16_x(lo, _a), svcvt_f32_f16_x(lo, _b));
+            svfloat32_t d1 = svsub_f32_x(hi, svcvtlt_f32_f16_x(hi, _a), svcvtlt_f32_f16_x(hi, _b));
+            sum0 = svmla_f32_x(lo, sum0, d0, d0);
+            sum1 = svmla_f32_x(hi, sum1, d1, d1);
+        }
+
+        void SquaredDifferenceSum16f(const uint16_t* a, const uint16_t* b, size_t size, float* sum)
+        {
+            size_t A = svlen(svuint16_t()), sizeA = AlignLo(size, A), i = 0;
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+            for (; i < sizeA; i += A)
+                SquaredDifferenceSum16f(a + i, b + i, body16, body32, body32, sum0, sum1);
+            if (i < size)
+            {
+                size_t tail = size - i;
+                SquaredDifferenceSum16f(a + i, b + i, svwhilelt_b16(size_t(0), tail),
+                    svwhilelt_b32(size_t(0), (tail + 1) / 2), svwhilelt_b32(size_t(0), tail / 2), sum0, sum1);
+            }
+            *sum = svaddv_f32(body32, svadd_f32_x(body32, sum0, sum1));
+        }
+
         SIMD_INLINE void CosineDistance16f(const uint16_t* a, const uint16_t* b, const svbool_t& load, const svbool_t& lo, const svbool_t& hi,
             svfloat32_t& aa0, svfloat32_t& aa1, svfloat32_t& ab0, svfloat32_t& ab1, svfloat32_t& bb0, svfloat32_t& bb1)
         {

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -288,6 +288,11 @@ namespace Test
             result = result && DifferenceSum16fAutoTest(EPS, FUNC_S(Simd::Avx512bw::SquaredDifferenceSum16f), FUNC_S(SimdSquaredDifferenceSum16f), check);
 #endif
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSum16fAutoTest(EPS, FUNC_S(Simd::Sve2::SquaredDifferenceSum16f), FUNC_S(SimdSquaredDifferenceSum16f), check);
+#endif
+
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && DifferenceSum16fAutoTest(EPS, FUNC_S(Simd::Neon::SquaredDifferenceSum16f), FUNC_S(SimdSquaredDifferenceSum16f), check);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `Simd::Sve2::SquaredDifferenceSum16f` in `src/Simd/SimdSve2Float16.cpp` using SVE2 FP16 load/convert and vectorized squared-difference accumulation with masked tail handling.
- expose the new SVE2 symbol in `src/Simd/SimdSve2.h` and add SVE2 dispatch for `SimdSquaredDifferenceSum16f` in `src/Simd/SimdLib.cpp`.
- extend `Test::SquaredDifferenceSum16fAutoTest` with SVE2 coverage and update release notes for 7.2.163 in `docs/2026.html`.

## Validation
- configured and built with CMake using the repository-recommended flags/toolchain.
- ran focused `SquaredDifferenceSum16f` test and broader `Float16` test filter successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8b7a662-0c6c-4de2-a19e-ab31996b390f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8b7a662-0c6c-4de2-a19e-ab31996b390f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

