### PR TITLE
Add SVE2 StretchGray2x2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -40,6 +40,9 @@
 <h3 id="R164">August X, 2026 (version 7.2.164)</h3> 
 <h4>Algorithms</h4>
 <h5>New features</h5>
+<ul>
+ <li>SVE2 optimizations of function StretchGray2x2.</li>
+</ul>
 
 <a href="#HOME">Home</a>
 <hr/>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -81,6 +81,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp">
+      <Filter>Sve2\Resize</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Float16.cpp">
       <Filter>Sve2\Descriptors</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6055,6 +6055,11 @@ SIMD_API void SimdStretchGray2x2(const uint8_t *src, size_t srcWidth, size_t src
         Sse41::StretchGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && srcWidth >= svcntb())
+        Sve2::StretchGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && srcWidth >= Neon::A)
         Neon::StretchGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -302,6 +302,9 @@ namespace Simd
         void ReduceGray5x5(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, int compensation);
 
+        void StretchGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
+
         void BgrToBayer(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bayer, size_t bayerStride, SimdPixelFormatType bayerFormat);
 
         void BgrToBgra(const uint8_t* bgr, size_t width, size_t height, size_t bgrStride, uint8_t* bgra, size_t bgraStride, uint8_t alpha);

--- a/src/Simd/SimdSve2StretchGray2x2.cpp
+++ b/src/Simd/SimdSve2StretchGray2x2.cpp
@@ -1,0 +1,65 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void StretchGray2x2(const uint8_t* src, size_t srcCol, size_t srcWidth, uint8_t* dst0, uint8_t* dst1, size_t dstWidth)
+        {
+            const size_t A = svcntb();
+            svbool_t srcMask = svwhilelt_b8(srcCol, srcWidth);
+            svuint8_t value = svld1_u8(srcMask, src + srcCol);
+            svuint8_t lo = svzip1_u8(value, value);
+            svuint8_t hi = svzip2_u8(value, value);
+            size_t dstCol = 2 * srcCol;
+            svbool_t loMask = svwhilelt_b8(dstCol, dstWidth);
+            svbool_t hiMask = svwhilelt_b8(dstCol + A, dstWidth);
+            svst1_u8(loMask, dst0 + dstCol, lo);
+            svst1_u8(hiMask, dst0 + dstCol + A, hi);
+            svst1_u8(loMask, dst1 + dstCol, lo);
+            svst1_u8(hiMask, dst1 + dstCol + A, hi);
+        }
+
+        void StretchGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
+            uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
+        {
+            assert(srcWidth * 2 == dstWidth && srcHeight * 2 == dstHeight);
+
+            const size_t A = svcntb();
+            for (size_t row = 0; row < srcHeight; ++row)
+            {
+                uint8_t* dst0 = dst;
+                uint8_t* dst1 = dst + dstStride;
+                for (size_t srcCol = 0; srcCol < srcWidth; srcCol += A)
+                    StretchGray2x2(src, srcCol, srcWidth, dst0, dst1, dstWidth);
+                src += srcStride;
+                dst += 2 * dstStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestStretchGray.cpp
+++ b/src/Test/TestStretchGray.cpp
@@ -107,6 +107,11 @@ namespace Test
             result = result && StretchGrayAutoTest(FUNC(Simd::Avx512bw::StretchGray2x2), FUNC(SimdStretchGray2x2), 2);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && StretchGrayAutoTest(FUNC(Simd::Sve2::StretchGray2x2), FUNC(SimdStretchGray2x2), 2);
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && StretchGrayAutoTest(FUNC(Simd::Neon::StretchGray2x2), FUNC(SimdStretchGray2x2), 2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `StretchGray2x2` using scalable byte duplication and predicated tail stores.
- Route `SimdStretchGray2x2` to the SVE2 implementation when available.
- Extend StretchGray2x2 auto-tests, VS2022 SVE2 project files, and 7.2.164 release notes.

### Testing
- `cmake --build build --target Test --parallel2`
- `./build/Test "-r=." -fi=StretchGray2x2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2StretchGray2x2.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Test/TestStretchGray.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a1a5928-590e-448d-9987-7b4a6c5fc780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a1a5928-590e-448d-9987-7b4a6c5fc780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

