### PR TITLE
Add SVE2 ShiftBilinear optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
+ <li>SVE2 optimizations of function ShiftBilinear.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -77,6 +77,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ShiftBilinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -284,6 +284,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ShiftBilinear.cpp">
+      <Filter>Sve2\Motion</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Sobel.cpp">
       <Filter>Sve2\Filter</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5213,6 +5213,12 @@ SIMD_API void SimdShiftBilinear(const uint8_t * src, size_t srcStride, size_t wi
         shiftX, shiftY, cropLeft, cropTop, cropRight, cropBottom, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::ShiftBilinear(src, srcStride, width, height, channelCount, bkg, bkgStride,
+        shiftX, shiftY, cropLeft, cropTop, cropRight, cropBottom, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable)
         Neon::ShiftBilinear(src, srcStride, width, height, channelCount, bkg, bkgStride,

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -406,6 +406,10 @@ namespace Simd
         void SegmentationShrinkRegion(const uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index,
             ptrdiff_t* left, ptrdiff_t* top, ptrdiff_t* right, ptrdiff_t* bottom);
 
+        void ShiftBilinear(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            const uint8_t* bkg, size_t bkgStride, const double* shiftX, const double* shiftY,
+            size_t cropLeft, size_t cropTop, size_t cropRight, size_t cropBottom, uint8_t* dst, size_t dstStride);
+
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 
         void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2ShiftBilinear.cpp
+++ b/src/Simd/SimdSve2ShiftBilinear.cpp
@@ -29,40 +29,27 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint8_t Interpolate(svuint8_t s[2][2], svuint8_t k[2][2])
+        SIMD_INLINE svuint8_t Interpolate(const svuint8_t& s00, const svuint8_t& s01, const svuint8_t& s10, const svuint8_t& s11,
+            const svuint8_t& k00, const svuint8_t& k01, const svuint8_t& k10, const svuint8_t& k11)
         {
-            svuint16_t lo = svmlalb_u16(svdup_n_u16(Base::BILINEAR_ROUND_TERM), s[0][0], k[0][0]);
-            svuint16_t hi = svmlalt_u16(svdup_n_u16(Base::BILINEAR_ROUND_TERM), s[0][0], k[0][0]);
-            lo = svmlalb_u16(lo, s[0][1], k[0][1]);
-            hi = svmlalt_u16(hi, s[0][1], k[0][1]);
-            lo = svmlalb_u16(lo, s[1][0], k[1][0]);
-            hi = svmlalt_u16(hi, s[1][0], k[1][0]);
-            lo = svmlalb_u16(lo, s[1][1], k[1][1]);
-            hi = svmlalt_u16(hi, s[1][1], k[1][1]);
+            svuint16_t lo = svmlalb_u16(svdup_n_u16(Base::BILINEAR_ROUND_TERM), s00, k00);
+            svuint16_t hi = svmlalt_u16(svdup_n_u16(Base::BILINEAR_ROUND_TERM), s00, k00);
+            lo = svmlalb_u16(lo, s01, k01);
+            hi = svmlalt_u16(hi, s01, k01);
+            lo = svmlalb_u16(lo, s10, k10);
+            hi = svmlalt_u16(hi, s10, k10);
+            lo = svmlalb_u16(lo, s11, k11);
+            hi = svmlalt_u16(hi, s11, k11);
             return svshrnt_n_u16(svshrnb_n_u16(lo, Base::BILINEAR_SHIFT), hi, Base::BILINEAR_SHIFT);
         }
 
-        SIMD_INLINE svuint8_t Interpolate(svuint8_t s[2], svuint8_t k[2])
+        SIMD_INLINE svuint8_t Interpolate(const svuint8_t& s0, const svuint8_t& s1, const svuint8_t& k0, const svuint8_t& k1)
         {
-            svuint16_t lo = svmlalb_u16(svdup_n_u16(Base::LINEAR_ROUND_TERM), s[0], k[0]);
-            svuint16_t hi = svmlalt_u16(svdup_n_u16(Base::LINEAR_ROUND_TERM), s[0], k[0]);
-            lo = svmlalb_u16(lo, s[1], k[1]);
-            hi = svmlalt_u16(hi, s[1], k[1]);
+            svuint16_t lo = svmlalb_u16(svdup_n_u16(Base::LINEAR_ROUND_TERM), s0, k0);
+            svuint16_t hi = svmlalt_u16(svdup_n_u16(Base::LINEAR_ROUND_TERM), s0, k0);
+            lo = svmlalb_u16(lo, s1, k1);
+            hi = svmlalt_u16(hi, s1, k1);
             return svshrnt_n_u16(svshrnb_n_u16(lo, Base::LINEAR_SHIFT), hi, Base::LINEAR_SHIFT);
-        }
-
-        SIMD_INLINE void LoadBlock(const uint8_t* src, size_t dx, size_t dy, svuint8_t s[2][2], const svbool_t& mask)
-        {
-            s[0][0] = svld1_u8(mask, src);
-            s[0][1] = svld1_u8(mask, src + dx);
-            s[1][0] = svld1_u8(mask, src + dy);
-            s[1][1] = svld1_u8(mask, src + dy + dx);
-        }
-
-        SIMD_INLINE void LoadBlock(const uint8_t* src, size_t dr, svuint8_t s[2], const svbool_t& mask)
-        {
-            s[0] = svld1_u8(mask, src);
-            s[1] = svld1_u8(mask, src + dr);
         }
 
         void ShiftBilinear(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
@@ -74,19 +61,21 @@ namespace Simd
             {
                 if (fDx)
                 {
-                    svuint8_t k[2][2], s[2][2];
-                    k[0][0] = svdup_n_u8((Base::FRACTION_RANGE - fDx) * (Base::FRACTION_RANGE - fDy));
-                    k[0][1] = svdup_n_u8(fDx * (Base::FRACTION_RANGE - fDy));
-                    k[1][0] = svdup_n_u8((Base::FRACTION_RANGE - fDx) * fDy);
-                    k[1][1] = svdup_n_u8(fDx * fDy);
+                    svuint8_t k00 = svdup_n_u8((Base::FRACTION_RANGE - fDx) * (Base::FRACTION_RANGE - fDy));
+                    svuint8_t k01 = svdup_n_u8(fDx * (Base::FRACTION_RANGE - fDy));
+                    svuint8_t k10 = svdup_n_u8((Base::FRACTION_RANGE - fDx) * fDy);
+                    svuint8_t k11 = svdup_n_u8(fDx * fDy);
                     for (size_t row = 0; row < height; ++row)
                     {
                         size_t col = 0;
                         for (; col < size; col += A)
                         {
                             svbool_t mask = svwhilelt_b8(col, size);
-                            LoadBlock(src + col, channelCount, srcStride, s, mask);
-                            svst1_u8(mask, dst + col, Interpolate(s, k));
+                            svuint8_t s00 = svld1_u8(mask, src + col);
+                            svuint8_t s01 = svld1_u8(mask, src + col + channelCount);
+                            svuint8_t s10 = svld1_u8(mask, src + col + srcStride);
+                            svuint8_t s11 = svld1_u8(mask, src + col + srcStride + channelCount);
+                            svst1_u8(mask, dst + col, Interpolate(s00, s01, s10, s11, k00, k01, k10, k11));
                         }
                         src += srcStride;
                         dst += dstStride;
@@ -94,17 +83,17 @@ namespace Simd
                 }
                 else
                 {
-                    svuint8_t k[2], s[2];
-                    k[0] = svdup_n_u8(Base::FRACTION_RANGE - fDy);
-                    k[1] = svdup_n_u8(fDy);
+                    svuint8_t k0 = svdup_n_u8(Base::FRACTION_RANGE - fDy);
+                    svuint8_t k1 = svdup_n_u8(fDy);
                     for (size_t row = 0; row < height; ++row)
                     {
                         size_t col = 0;
                         for (; col < size; col += A)
                         {
                             svbool_t mask = svwhilelt_b8(col, size);
-                            LoadBlock(src + col, srcStride, s, mask);
-                            svst1_u8(mask, dst + col, Interpolate(s, k));
+                            svuint8_t s0 = svld1_u8(mask, src + col);
+                            svuint8_t s1 = svld1_u8(mask, src + col + srcStride);
+                            svst1_u8(mask, dst + col, Interpolate(s0, s1, k0, k1));
                         }
                         src += srcStride;
                         dst += dstStride;
@@ -115,17 +104,17 @@ namespace Simd
             {
                 if (fDx)
                 {
-                    svuint8_t k[2], s[2];
-                    k[0] = svdup_n_u8(Base::FRACTION_RANGE - fDx);
-                    k[1] = svdup_n_u8(fDx);
+                    svuint8_t k0 = svdup_n_u8(Base::FRACTION_RANGE - fDx);
+                    svuint8_t k1 = svdup_n_u8(fDx);
                     for (size_t row = 0; row < height; ++row)
                     {
                         size_t col = 0;
                         for (; col < size; col += A)
                         {
                             svbool_t mask = svwhilelt_b8(col, size);
-                            LoadBlock(src + col, channelCount, s, mask);
-                            svst1_u8(mask, dst + col, Interpolate(s, k));
+                            svuint8_t s0 = svld1_u8(mask, src + col);
+                            svuint8_t s1 = svld1_u8(mask, src + col + channelCount);
+                            svst1_u8(mask, dst + col, Interpolate(s0, s1, k0, k1));
                         }
                         src += srcStride;
                         dst += dstStride;

--- a/src/Simd/SimdSve2ShiftBilinear.cpp
+++ b/src/Simd/SimdSve2ShiftBilinear.cpp
@@ -1,0 +1,163 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdBase.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint8_t Interpolate(svuint8_t s[2][2], svuint8_t k[2][2])
+        {
+            svuint16_t lo = svmlalb_u16(svdup_n_u16(Base::BILINEAR_ROUND_TERM), s[0][0], k[0][0]);
+            svuint16_t hi = svmlalt_u16(svdup_n_u16(Base::BILINEAR_ROUND_TERM), s[0][0], k[0][0]);
+            lo = svmlalb_u16(lo, s[0][1], k[0][1]);
+            hi = svmlalt_u16(hi, s[0][1], k[0][1]);
+            lo = svmlalb_u16(lo, s[1][0], k[1][0]);
+            hi = svmlalt_u16(hi, s[1][0], k[1][0]);
+            lo = svmlalb_u16(lo, s[1][1], k[1][1]);
+            hi = svmlalt_u16(hi, s[1][1], k[1][1]);
+            return svshrnt_n_u16(svshrnb_n_u16(lo, Base::BILINEAR_SHIFT), hi, Base::BILINEAR_SHIFT);
+        }
+
+        SIMD_INLINE svuint8_t Interpolate(svuint8_t s[2], svuint8_t k[2])
+        {
+            svuint16_t lo = svmlalb_u16(svdup_n_u16(Base::LINEAR_ROUND_TERM), s[0], k[0]);
+            svuint16_t hi = svmlalt_u16(svdup_n_u16(Base::LINEAR_ROUND_TERM), s[0], k[0]);
+            lo = svmlalb_u16(lo, s[1], k[1]);
+            hi = svmlalt_u16(hi, s[1], k[1]);
+            return svshrnt_n_u16(svshrnb_n_u16(lo, Base::LINEAR_SHIFT), hi, Base::LINEAR_SHIFT);
+        }
+
+        SIMD_INLINE void LoadBlock(const uint8_t* src, size_t dx, size_t dy, svuint8_t s[2][2], const svbool_t& mask)
+        {
+            s[0][0] = svld1_u8(mask, src);
+            s[0][1] = svld1_u8(mask, src + dx);
+            s[1][0] = svld1_u8(mask, src + dy);
+            s[1][1] = svld1_u8(mask, src + dy + dx);
+        }
+
+        SIMD_INLINE void LoadBlock(const uint8_t* src, size_t dr, svuint8_t s[2], const svbool_t& mask)
+        {
+            s[0] = svld1_u8(mask, src);
+            s[1] = svld1_u8(mask, src + dr);
+        }
+
+        void ShiftBilinear(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            int fDx, int fDy, uint8_t* dst, size_t dstStride)
+        {
+            const size_t size = width * channelCount;
+            const size_t A = svcntb();
+            if (fDy)
+            {
+                if (fDx)
+                {
+                    svuint8_t k[2][2], s[2][2];
+                    k[0][0] = svdup_n_u8((Base::FRACTION_RANGE - fDx) * (Base::FRACTION_RANGE - fDy));
+                    k[0][1] = svdup_n_u8(fDx * (Base::FRACTION_RANGE - fDy));
+                    k[1][0] = svdup_n_u8((Base::FRACTION_RANGE - fDx) * fDy);
+                    k[1][1] = svdup_n_u8(fDx * fDy);
+                    for (size_t row = 0; row < height; ++row)
+                    {
+                        size_t col = 0;
+                        for (; col < size; col += A)
+                        {
+                            svbool_t mask = svwhilelt_b8(col, size);
+                            LoadBlock(src + col, channelCount, srcStride, s, mask);
+                            svst1_u8(mask, dst + col, Interpolate(s, k));
+                        }
+                        src += srcStride;
+                        dst += dstStride;
+                    }
+                }
+                else
+                {
+                    svuint8_t k[2], s[2];
+                    k[0] = svdup_n_u8(Base::FRACTION_RANGE - fDy);
+                    k[1] = svdup_n_u8(fDy);
+                    for (size_t row = 0; row < height; ++row)
+                    {
+                        size_t col = 0;
+                        for (; col < size; col += A)
+                        {
+                            svbool_t mask = svwhilelt_b8(col, size);
+                            LoadBlock(src + col, srcStride, s, mask);
+                            svst1_u8(mask, dst + col, Interpolate(s, k));
+                        }
+                        src += srcStride;
+                        dst += dstStride;
+                    }
+                }
+            }
+            else
+            {
+                if (fDx)
+                {
+                    svuint8_t k[2], s[2];
+                    k[0] = svdup_n_u8(Base::FRACTION_RANGE - fDx);
+                    k[1] = svdup_n_u8(fDx);
+                    for (size_t row = 0; row < height; ++row)
+                    {
+                        size_t col = 0;
+                        for (; col < size; col += A)
+                        {
+                            svbool_t mask = svwhilelt_b8(col, size);
+                            LoadBlock(src + col, channelCount, s, mask);
+                            svst1_u8(mask, dst + col, Interpolate(s, k));
+                        }
+                        src += srcStride;
+                        dst += dstStride;
+                    }
+                }
+                else
+                {
+                    for (size_t row = 0; row < height; ++row)
+                    {
+                        memcpy(dst, src, size);
+                        src += srcStride;
+                        dst += dstStride;
+                    }
+                }
+            }
+        }
+
+        void ShiftBilinear(
+            const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t channelCount,
+            const uint8_t* bkg, size_t bkgStride, const double* shiftX, const double* shiftY,
+            size_t cropLeft, size_t cropTop, size_t cropRight, size_t cropBottom, uint8_t* dst, size_t dstStride)
+        {
+            int fDx, fDy;
+            Base::CommonShiftAction(src, srcStride, width, height, channelCount, bkg, bkgStride, shiftX, shiftY,
+                cropLeft, cropTop, cropRight, cropBottom, dst, dstStride, fDx, fDy);
+
+            if (*shiftX + svcntb() < cropRight - cropLeft)
+                Sve2::ShiftBilinear(src, srcStride, width, height, channelCount, fDx, fDy, dst, dstStride);
+            else
+                Base::ShiftBilinear(src, srcStride, width, height, channelCount, fDx, fDy, dst, dstStride);
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestShift.cpp
+++ b/src/Test/TestShift.cpp
@@ -130,6 +130,11 @@ namespace Test
             result = result && ShiftBilinearAutoTest(FUNC(Simd::Avx512bw::ShiftBilinear), FUNC(SimdShiftBilinear));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ShiftBilinearAutoTest(FUNC(Simd::Sve2::ShiftBilinear), FUNC(SimdShiftBilinear));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ShiftBilinearAutoTest(FUNC(Simd::Neon::ShiftBilinear), FUNC(SimdShiftBilinear));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdShiftBilinear`.
- Add SVE2 auto-test coverage for `ShiftBilinear`.
- Register the new source in VS2022 SVE2 project files and document the 7.2.164 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=ShiftBilinear -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -march=armv8.6-a+sve2 -I./src -fsyntax-only src/Simd/SimdSve2ShiftBilinear.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1ab32a1-b808-4f22-8483-f554c842066f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ab32a1-b808-4f22-8483-f554c842066f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

