### PR TITLE
Add SVE2 TextureBoostedSaturatedGradient optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
+ <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -83,6 +83,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -335,5 +335,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp">
+      <Filter>Sve2\Motion</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7835,6 +7835,11 @@ SIMD_API void SimdTextureBoostedSaturatedGradient(const uint8_t * src, size_t sr
         Sse41::TextureBoostedSaturatedGradient(src, srcStride, width, height, saturation, boost, dx, dxStride, dy, dyStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::TextureBoostedSaturatedGradient(src, srcStride, width, height, saturation, boost, dx, dxStride, dy, dyStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::TextureBoostedSaturatedGradient(src, srcStride, width, height, saturation, boost, dx, dxStride, dy, dyStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -196,6 +196,9 @@ namespace Simd
 
         void LbpEstimate(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
+        void TextureBoostedSaturatedGradient(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t saturation, uint8_t boost, uint8_t* dx, size_t dxStride, uint8_t* dy, size_t dyStride);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Texture.cpp
+++ b/src/Simd/SimdSve2Texture.cpp
@@ -1,0 +1,85 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint8_t TextureBoostedSaturatedGradient(const svuint8_t& a, const svuint8_t& b,
+            const svuint8_t& saturation, const svuint8_t& boost, const svbool_t& mask)
+        {
+            svuint8_t positive = svmin_u8_x(mask, svqsub_u8_x(mask, b, a), saturation);
+            svuint8_t negative = svmin_u8_x(mask, svqsub_u8_x(mask, a, b), saturation);
+            return svmul_u8_x(mask, svsub_u8_x(mask, svadd_u8_x(mask, saturation, positive), negative), boost);
+        }
+
+        SIMD_INLINE void TextureBoostedSaturatedGradient(const uint8_t* src, size_t stride, uint8_t* dx, uint8_t* dy,
+            const svuint8_t& saturation, const svuint8_t& boost, const svbool_t& mask)
+        {
+            svuint8_t s10 = svld1_u8(mask, src - 1);
+            svuint8_t s12 = svld1_u8(mask, src + 1);
+            svuint8_t s01 = svld1_u8(mask, src - stride);
+            svuint8_t s21 = svld1_u8(mask, src + stride);
+            svst1_u8(mask, dx, TextureBoostedSaturatedGradient(s10, s12, saturation, boost, mask));
+            svst1_u8(mask, dy, TextureBoostedSaturatedGradient(s01, s21, saturation, boost, mask));
+        }
+
+        void TextureBoostedSaturatedGradient(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t saturation, uint8_t boost, uint8_t* dx, size_t dxStride, uint8_t* dy, size_t dyStride)
+        {
+            assert(int(2) * saturation * boost <= 0xFF);
+
+            size_t A = svcntb();
+            svuint8_t _saturation = svdup_n_u8(saturation);
+            svuint8_t _boost = svdup_n_u8(boost);
+
+            memset(dx, 0, width);
+            memset(dy, 0, width);
+            src += srcStride;
+            dx += dxStride;
+            dy += dyStride;
+            for (size_t row = 2; row < height; ++row)
+            {
+                dx[0] = 0;
+                dy[0] = 0;
+                for (size_t col = 1; col < width - 1; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, width - 1);
+                    TextureBoostedSaturatedGradient(src + col, srcStride, dx + col, dy + col, _saturation, _boost, mask);
+                }
+                dx[width - 1] = 0;
+                dy[width - 1] = 0;
+
+                src += srcStride;
+                dx += dxStride;
+                dy += dyStride;
+            }
+            memset(dx, 0, width);
+            memset(dy, 0, width);
+        }
+    }
+#endif
+}

--- a/src/Test/TestTexture.cpp
+++ b/src/Test/TestTexture.cpp
@@ -121,6 +121,11 @@ namespace Test
             result = result && TextureBoostedSaturatedGradientAutoTest(FUNC1(Simd::Avx512bw::TextureBoostedSaturatedGradient), FUNC1(SimdTextureBoostedSaturatedGradient));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && TextureBoostedSaturatedGradientAutoTest(FUNC1(Simd::Sve2::TextureBoostedSaturatedGradient), FUNC1(SimdTextureBoostedSaturatedGradient));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && TextureBoostedSaturatedGradientAutoTest(FUNC1(Simd::Neon::TextureBoostedSaturatedGradient), FUNC1(SimdTextureBoostedSaturatedGradient));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `TextureBoostedSaturatedGradient` and route public dispatch to it when SVE2 is available.
- Add SVE2 coverage to the texture gradient autotest.
- Add the SVE2 source to the VS2022 project and note the release change in `docs/2026.html`.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=TextureBoostedSaturatedGradient -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -fPIC -march=armv8.6-a+sve2 -I src -c src/Simd/SimdSve2Texture.cpp -o /tmp/SimdSve2Texture.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -fPIC -march=armv8.6-a+sve2 -I src -c src/Simd/SimdLib.cpp -o /tmp/SimdLib-sve2.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a554f9eb-2f23-4181-85f1-47144e44f44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a554f9eb-2f23-4181-85f1-47144e44f44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

