### PR TITLE
Add SVE2 TextureBoostedUv optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -44,6 +44,7 @@
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
+ <li>SVE2 optimizations of function TextureBoostedUv.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7867,6 +7867,11 @@ SIMD_API void SimdTextureBoostedUv(const uint8_t * src, size_t srcStride, size_t
         Sse41::TextureBoostedUv(src, srcStride, width, height, boost, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::TextureBoostedUv(src, srcStride, width, height, boost, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::TextureBoostedUv(src, srcStride, width, height, boost, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -199,6 +199,9 @@ namespace Simd
         void TextureBoostedSaturatedGradient(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             uint8_t saturation, uint8_t boost, uint8_t* dx, size_t dxStride, uint8_t* dy, size_t dyStride);
 
+        void TextureBoostedUv(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t boost, uint8_t* dst, size_t dstStride);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Texture.cpp
+++ b/src/Simd/SimdSve2Texture.cpp
@@ -80,6 +80,39 @@ namespace Simd
             memset(dx, 0, width);
             memset(dy, 0, width);
         }
+
+        SIMD_INLINE void TextureBoostedUv(const uint8_t* src, uint8_t* dst, const svuint8_t& min,
+            const svuint8_t& max, const svuint8_t& boost, const svbool_t& mask)
+        {
+            svuint8_t value = svld1_u8(mask, src);
+            value = svmin_u8_x(mask, svmax_u8_x(mask, value, min), max);
+            svst1_u8(mask, dst, svmul_u8_x(mask, svsub_u8_x(mask, value, min), boost));
+        }
+
+        void TextureBoostedUv(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            uint8_t boost, uint8_t* dst, size_t dstStride)
+        {
+            assert(boost < 0x80);
+
+            size_t A = svcntb();
+            int min = 128 - (128 / boost);
+            int max = 255 - min;
+
+            svuint8_t _min = svdup_n_u8(min);
+            svuint8_t _max = svdup_n_u8(max);
+            svuint8_t _boost = svdup_n_u8(boost);
+
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t col = 0; col < width; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, width);
+                    TextureBoostedUv(src + col, dst + col, _min, _max, _boost, mask);
+                }
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestTexture.cpp
+++ b/src/Test/TestTexture.cpp
@@ -219,6 +219,11 @@ namespace Test
             result = result && TextureBoostedUvAutoTest(FUNC2(Simd::Avx512bw::TextureBoostedUv), FUNC2(SimdTextureBoostedUv));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && TextureBoostedUvAutoTest(FUNC2(Simd::Sve2::TextureBoostedUv), FUNC2(SimdTextureBoostedUv));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && TextureBoostedUvAutoTest(FUNC2(Simd::Neon::TextureBoostedUv), FUNC2(SimdTextureBoostedUv));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdTextureBoostedUv`.
- Extend texture auto-tests to cover `Simd::Sve2::TextureBoostedUv`.
- Document the optimization in release 7.2.164 notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=TextureBoostedUv -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.6-a+sve2 -I src src/Simd/SimdSve2Texture.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f731905b-850a-4156-ae1d-173728ba1ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f731905b-850a-4156-ae1d-173728ba1ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

