### PR TITLE
Add SVE2 TextureGetDifferenceSum optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -45,6 +45,7 @@
  <li>SVE2 optimizations of function ShiftBilinear.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
+ <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7899,6 +7899,11 @@ SIMD_API void SimdTextureGetDifferenceSum(const uint8_t * src, size_t srcStride,
         Sse41::TextureGetDifferenceSum(src, srcStride, width, height, lo, loStride, hi, hiStride, sum);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::TextureGetDifferenceSum(src, srcStride, width, height, lo, loStride, hi, hiStride, sum);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::TextureGetDifferenceSum(src, srcStride, width, height, lo, loStride, hi, hiStride, sum);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -202,6 +202,9 @@ namespace Simd
         void TextureBoostedUv(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             uint8_t boost, uint8_t* dst, size_t dstStride);
 
+        void TextureGetDifferenceSum(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride, int64_t* sum);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Texture.cpp
+++ b/src/Simd/SimdSve2Texture.cpp
@@ -22,6 +22,7 @@
 * SOFTWARE.
 */
 #include "Simd/SimdMemory.h"
+#include "Simd/SimdMath.h"
 
 namespace Simd
 {
@@ -111,6 +112,53 @@ namespace Simd
                 }
                 src += srcStride;
                 dst += dstStride;
+            }
+        }
+
+        SIMD_INLINE void TextureGetDifferenceSum(const uint8_t* src, const uint8_t* lo, const uint8_t* hi,
+            const svbool_t& mask, const svuint8_t& zero, svint32_t& sum)
+        {
+            svuint8_t _src = svsel_u8(mask, svld1_u8(mask, src), zero);
+            svuint8_t avg = svsel_u8(mask, svrhadd_u8_x(mask, svld1_u8(mask, lo), svld1_u8(mask, hi)), zero);
+
+            svint16_t diffLo = svsub_s16_x(svptrue_b16(), svreinterpret_s16_u16(svmovlb_u16(_src)), svreinterpret_s16_u16(svmovlb_u16(avg)));
+            svint16_t diffHi = svsub_s16_x(svptrue_b16(), svreinterpret_s16_u16(svmovlt_u16(_src)), svreinterpret_s16_u16(svmovlt_u16(avg)));
+            sum = svadd_s32_x(svptrue_b32(), sum, svmovlb_s32(diffLo));
+            sum = svadd_s32_x(svptrue_b32(), sum, svmovlt_s32(diffLo));
+            sum = svadd_s32_x(svptrue_b32(), sum, svmovlb_s32(diffHi));
+            sum = svadd_s32_x(svptrue_b32(), sum, svmovlt_s32(diffHi));
+        }
+
+        void TextureGetDifferenceSum(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride, int64_t* sum)
+        {
+            const size_t A = svcntb();
+            const size_t widthA = AlignLo(width, A);
+            const size_t blockSize = A << 12;
+            const size_t blockCount = (widthA + blockSize - 1) / blockSize;
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t zero = svdup_n_u8(0);
+
+            *sum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t block = 0; block < blockCount; ++block)
+                {
+                    svint32_t blockSum = svdup_n_s32(0);
+                    for (size_t col = block * blockSize, end = Min(col + blockSize, widthA); col < end; col += A)
+                        TextureGetDifferenceSum(src + col, lo + col, hi + col, body, zero, blockSum);
+                    *sum += svaddv_s32(svptrue_b32(), blockSum);
+                }
+                if (widthA < width)
+                {
+                    svint32_t tailSum = svdup_n_s32(0);
+                    TextureGetDifferenceSum(src + widthA, lo + widthA, hi + widthA, tail, zero, tailSum);
+                    *sum += svaddv_s32(svptrue_b32(), tailSum);
+                }
+                src += srcStride;
+                lo += loStride;
+                hi += hiStride;
             }
         }
     }

--- a/src/Test/TestTexture.cpp
+++ b/src/Test/TestTexture.cpp
@@ -309,6 +309,11 @@ namespace Test
             result = result && TextureGetDifferenceSumAutoTest(FUNC3(Simd::Avx512bw::TextureGetDifferenceSum), FUNC3(SimdTextureGetDifferenceSum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && TextureGetDifferenceSumAutoTest(FUNC3(Simd::Sve2::TextureGetDifferenceSum), FUNC3(SimdTextureGetDifferenceSum));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && TextureGetDifferenceSumAutoTest(FUNC3(Simd::Neon::TextureGetDifferenceSum), FUNC3(SimdTextureGetDifferenceSum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `TextureGetDifferenceSum`.
- Extend the texture auto-test matrix with the SVE2 implementation.
- Document the optimization in release 7.2.164.

### Validation
- `aarch64-linux-gnu-g++ -fsyntax-only -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdSve2Texture.cpp`
- `aarch64-linux-gnu-g++ -c -std=c++17 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdSve2Texture.cpp -o /tmp/SimdSve2Texture.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=TextureGetDifferenceSum -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63feab83-85ed-490b-8871-128b4c7691d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63feab83-85ed-490b-8871-128b4c7691d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

