### PR TITLE
Add SVE2 texture compensation

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -46,6 +46,7 @@
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
+ <li>SVE2 optimizations of function TexturePerformCompensation.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7931,6 +7931,11 @@ SIMD_API void SimdTexturePerformCompensation(const uint8_t * src, size_t srcStri
         Sse41::TexturePerformCompensation(src, srcStride, width, height, shift, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::TexturePerformCompensation(src, srcStride, width, height, shift, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::TexturePerformCompensation(src, srcStride, width, height, shift, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -205,6 +205,9 @@ namespace Simd
         void TextureGetDifferenceSum(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride, int64_t* sum);
 
+        void TexturePerformCompensation(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            int shift, uint8_t* dst, size_t dstStride);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Texture.cpp
+++ b/src/Simd/SimdSve2Texture.cpp
@@ -161,6 +161,46 @@ namespace Simd
                 hi += hiStride;
             }
         }
+
+        SIMD_INLINE void TexturePerformCompensation(const uint8_t* src, uint8_t* dst, const svuint8_t& shift, bool add, const svbool_t& mask)
+        {
+            svuint8_t value = svld1_u8(mask, src);
+            svst1_u8(mask, dst, add ? svqadd_u8(value, shift) : svqsub_u8(value, shift));
+        }
+
+        void TexturePerformCompensation(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            int shift, uint8_t* dst, size_t dstStride)
+        {
+            assert(shift > -0xFF && shift < 0xFF);
+
+            if (shift == 0)
+            {
+                if (src != dst)
+                {
+                    for (size_t row = 0; row < height; ++row)
+                    {
+                        memcpy(dst, src, width);
+                        src += srcStride;
+                        dst += dstStride;
+                    }
+                }
+                return;
+            }
+
+            const size_t A = svcntb();
+            const bool add = shift > 0;
+            const svuint8_t _shift = svdup_n_u8(add ? shift : -shift);
+            for (size_t row = 0; row < height; ++row)
+            {
+                for (size_t col = 0; col < width; col += A)
+                {
+                    svbool_t mask = svwhilelt_b8(col, width);
+                    TexturePerformCompensation(src + col, dst + col, _shift, add, mask);
+                }
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestTexture.cpp
+++ b/src/Test/TestTexture.cpp
@@ -415,6 +415,11 @@ namespace Test
             result = result && TexturePerformCompensationAutoTest(FUNC4(Simd::Neon::TexturePerformCompensation), FUNC4(SimdTexturePerformCompensation));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && TexturePerformCompensationAutoTest(FUNC4(Simd::Sve2::TexturePerformCompensation), FUNC4(SimdTexturePerformCompensation));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and runtime dispatch for `TexturePerformCompensation`.
- Extend texture compensation auto-tests for SVE2.
- Document the optimization in the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=TexturePerformCompensation -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2Texture.cpp`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eccaa268-a065-44c2-810c-2d0cc5576d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eccaa268-a065-44c2-810c-2d0cc5576d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

