### PR TITLE
Add SVE2 TransformImage optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
+ <li>SVE2 optimizations of function TransformImage.</li>
  <li>SVE2 optimizations of function Uint8ToFloat32.</li>
 </ul>
 

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -84,6 +84,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -338,5 +338,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp">
+      <Filter>Sve2\Transform</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7967,6 +7967,11 @@ SIMD_API void SimdTransformImage(const uint8_t * src, size_t srcStride, size_t w
         Sse41::TransformImage(src, srcStride, width, height, pixelSize, transform, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::TransformImage(src, srcStride, width, height, pixelSize, transform, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::HA)
         Neon::TransformImage(src, srcStride, width, height, pixelSize, transform, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -210,6 +210,9 @@ namespace Simd
         void TexturePerformCompensation(const uint8_t* src, size_t srcStride, size_t width, size_t height,
             int shift, uint8_t* dst, size_t dstStride);
 
+        void TransformImage(const uint8_t* src, size_t srcStride, size_t width, size_t height,
+            size_t pixelSize, SimdTransformType transform, uint8_t* dst, size_t dstStride);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2Transform.cpp
+++ b/src/Simd/SimdSve2Transform.cpp
@@ -112,10 +112,19 @@ namespace Simd
             transforms[SimdTransformTransposeRotate90] = TransformImageTransposeRotate90<N>;
         }
 
-        struct ImageTransforms : public Base::ImageTransforms
+        struct ImageTransforms :
+#ifdef SIMD_NEON_ENABLE
+            public Neon::ImageTransforms
+#else
+            public Base::ImageTransforms
+#endif
         {
             ImageTransforms()
+#ifdef SIMD_NEON_ENABLE
+                : Neon::ImageTransforms::ImageTransforms()
+#else
                 : Base::ImageTransforms::ImageTransforms()
+#endif
             {
                 Init<1>(transforms[0]);
                 Init<2>(transforms[1]);

--- a/src/Simd/SimdSve2Transform.cpp
+++ b/src/Simd/SimdSve2Transform.cpp
@@ -1,0 +1,136 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdTransform.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template<size_t N> SIMD_INLINE void TransformImageReverse(const uint8_t* src, size_t width, uint8_t* dst)
+        {
+            for (size_t col = 0; col < width; ++col)
+                Base::CopyPixel<N>(src + col * N, dst + (width - col - 1) * N);
+        }
+
+        template<> SIMD_INLINE void TransformImageReverse<1>(const uint8_t* src, size_t width, uint8_t* dst)
+        {
+            const size_t A = svcntb();
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            size_t col = 0;
+            for (; col < widthA; col += A)
+                svst1_u8(body, dst + width - col - A, svrev_u8(svld1_u8(body, src + col)));
+            for (; col < width; ++col)
+                dst[width - col - 1] = src[col];
+        }
+
+        template<> SIMD_INLINE void TransformImageReverse<2>(const uint8_t* src, size_t width, uint8_t* dst)
+        {
+            const size_t A = svcntb();
+            const size_t P = A / 2;
+            const size_t widthP = AlignLo(width, P);
+            const svbool_t body = svptrue_b8();
+            size_t col = 0;
+            for (; col < widthP; col += P)
+            {
+                svuint8_t src0 = svld1_u8(body, src + col * 2);
+                svuint8_t dst0 = svreinterpret_u8_u16(svrev_u16(svreinterpret_u16_u8(src0)));
+                svst1_u8(body, dst + (width - col - P) * 2, dst0);
+            }
+            for (; col < width; ++col)
+                Base::CopyPixel<2>(src + col * 2, dst + (width - col - 1) * 2);
+        }
+
+        template<> SIMD_INLINE void TransformImageReverse<4>(const uint8_t* src, size_t width, uint8_t* dst)
+        {
+            const size_t A = svcntb();
+            const size_t P = A / 4;
+            const size_t widthP = AlignLo(width, P);
+            const svbool_t body = svptrue_b8();
+            size_t col = 0;
+            for (; col < widthP; col += P)
+            {
+                svuint8_t src0 = svld1_u8(body, src + col * 4);
+                svuint8_t dst0 = svreinterpret_u8_u32(svrev_u32(svreinterpret_u32_u8(src0)));
+                svst1_u8(body, dst + (width - col - P) * 4, dst0);
+            }
+            for (; col < width; ++col)
+                Base::CopyPixel<4>(src + col * 4, dst + (width - col - 1) * 4);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<size_t N> void TransformImageRotate180(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
+        {
+            dst += (height - 1) * dstStride;
+            for (size_t row = 0; row < height; ++row)
+            {
+                TransformImageReverse<N>(src, width, dst);
+                src += srcStride;
+                dst -= dstStride;
+            }
+        }
+
+        template<size_t N> void TransformImageTransposeRotate90(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
+        {
+            for (size_t row = 0; row < height; ++row)
+            {
+                TransformImageReverse<N>(src, width, dst);
+                src += srcStride;
+                dst += dstStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<size_t N> void Init(Base::ImageTransforms::TransformPtr transforms[8])
+        {
+            transforms[SimdTransformRotate180] = TransformImageRotate180<N>;
+            transforms[SimdTransformTransposeRotate90] = TransformImageTransposeRotate90<N>;
+        }
+
+        struct ImageTransforms : public Base::ImageTransforms
+        {
+            ImageTransforms()
+                : Base::ImageTransforms::ImageTransforms()
+            {
+                Init<1>(transforms[0]);
+                Init<2>(transforms[1]);
+                Init<4>(transforms[3]);
+            }
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void TransformImage(const uint8_t* src, size_t srcStride, size_t width, size_t height, size_t pixelSize, SimdTransformType transform, uint8_t* dst, size_t dstStride)
+        {
+            static ImageTransforms transforms = ImageTransforms();
+
+            transforms.TransformImage(src, srcStride, width, height, pixelSize, transform, dst, dstStride);
+        }
+    }
+#endif// SIMD_SVE2_ENABLE
+}

--- a/src/Test/TestTransform.cpp
+++ b/src/Test/TestTransform.cpp
@@ -165,6 +165,11 @@ namespace Test
             result = result && TransformImageAutoTest(FUNC_TI(Simd::Neon::TransformImage), FUNC_TI(SimdTransformImage));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && TransformImageAutoTest(FUNC_TI(Simd::Sve2::TransformImage), FUNC_TI(SimdTransformImage));
+#endif 
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `TransformImage` optimization for row-reversal transform cases (`Rotate180` and `TransposeRotate90`) for 1-, 2-, and 4-byte pixels.
- Wire SVE2 dispatch and auto-test coverage for `SimdTransformImage`.
- Add the SVE2 transform source to VS2022 project files and release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=TransformImage -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I./src -fsyntax-only src/Simd/SimdSve2Transform.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1aebfc0-20e5-403b-b1fe-abb620aa8e70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1aebfc0-20e5-403b-b1fe-abb620aa8e70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

