### PR TITLE
Add SVE2 Uyvy422ToYuv420p optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -49,6 +49,7 @@
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>
  <li>SVE2 optimizations of function Uyvy422ToBgr.</li>
+ <li>SVE2 optimizations of function Uyvy422ToYuv420p.</li>
  <li>SVE2 optimizations of function Uint8ToFloat32.</li>
 </ul>
 

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -344,5 +344,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8029,6 +8029,11 @@ SIMD_API void SimdUyvy422ToYuv420p(const uint8_t* uyvy, size_t uyvyStride, size_
         Sse41::Uyvy422ToYuv420p(uyvy, uyvyStride, width, height, y, yStride, u, uStride, v, vStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Uyvy422ToYuv420p(uyvy, uyvyStride, width, height, y, yStride, u, uStride, v, vStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::Uyvy422ToYuv420p(uyvy, uyvyStride, width, height, y, yStride, u, uStride, v, vStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -216,6 +216,9 @@ namespace Simd
         void Uyvy422ToBgr(const uint8_t* uyvy, size_t uyvyStride, size_t width, size_t height,
             uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 
+        void Uyvy422ToYuv420p(const uint8_t* uyvy, size_t uyvyStride, size_t width, size_t height,
+            uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2UyvyToYuv.cpp
+++ b/src/Simd/SimdSve2UyvyToYuv.cpp
@@ -1,0 +1,85 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void Uyvy422ToYuv420p(const uint8_t* uyvy0, size_t uyvyStride, uint8_t* y0, size_t yStride, uint8_t* u, uint8_t* v, const svbool_t& mask)
+        {
+            size_t A = svcntb();
+            const uint8_t* uyvy1 = uyvy0 + uyvyStride;
+            uint8_t* y1 = y0 + yStride;
+
+            svuint8x4_t uyvy00 = svld4_u8(mask, uyvy0);
+            svuint8x4_t uyvy10 = svld4_u8(mask, uyvy1);
+            svuint8_t y00 = svget4(uyvy00, 1);
+            svuint8_t y01 = svget4(uyvy00, 3);
+            svuint8_t y10 = svget4(uyvy10, 1);
+            svuint8_t y11 = svget4(uyvy10, 3);
+
+            svst1_u8(mask, y0 + 0 * A, svzip1_u8(y00, y01));
+            svst1_u8(mask, y0 + 1 * A, svzip2_u8(y00, y01));
+            svst1_u8(mask, y1 + 0 * A, svzip1_u8(y10, y11));
+            svst1_u8(mask, y1 + 1 * A, svzip2_u8(y10, y11));
+            svst1_u8(mask, u, svrhadd_u8_x(mask, svget4(uyvy00, 0), svget4(uyvy10, 0)));
+            svst1_u8(mask, v, svrhadd_u8_x(mask, svget4(uyvy00, 2), svget4(uyvy10, 2)));
+        }
+
+        SIMD_INLINE void Uyvy422ToYuv420p(const uint8_t* uyvy0, size_t uyvyStride, uint8_t* y0, size_t yStride, uint8_t* u, uint8_t* v)
+        {
+            const uint8_t* uyvy1 = uyvy0 + uyvyStride;
+            uint8_t* y1 = y0 + yStride;
+            y0[0] = uyvy0[1];
+            y0[1] = uyvy0[3];
+            y1[0] = uyvy1[1];
+            y1[1] = uyvy1[3];
+            u[0] = (uyvy0[0] + uyvy1[0] + 1) / 2;
+            v[0] = (uyvy0[2] + uyvy1[2] + 1) / 2;
+        }
+
+        void Uyvy422ToYuv420p(const uint8_t* uyvy, size_t uyvyStride, size_t width, size_t height, uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0));
+
+            size_t A = svcntb(), DA = 2 * A, A4 = 4 * A, widthDA = AlignLo(width, DA);
+            const svbool_t mask = svptrue_b8();
+            for (size_t row = 0; row < height; row += 2)
+            {
+                size_t col = 0, colUyvy = 0, colY = 0, colUV = 0;
+                for (; col < widthDA; col += DA, colUyvy += A4, colY += DA, colUV += A)
+                    Uyvy422ToYuv420p(uyvy + colUyvy, uyvyStride, y + colY, yStride, u + colUV, v + colUV, mask);
+                for (; col < width; col += 2, colUyvy += 4, colY += 2, colUV += 1)
+                    Uyvy422ToYuv420p(uyvy + colUyvy, uyvyStride, y + colY, yStride, u + colUV, v + colUV);
+                uyvy += 2 * uyvyStride;
+                y += 2 * yStride;
+                u += uStride;
+                v += vStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -141,6 +141,11 @@ namespace Test
             result = result && AnyToYuvAutoTest(View::Uyvy16, 2, 2, FUNC_YUVN(Simd::Neon::Uyvy422ToYuv420p), FUNC_YUVN(SimdUyvy422ToYuv420p));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToYuvAutoTest(View::Uyvy16, 2, 2, FUNC_YUVN(Simd::Sve2::Uyvy422ToYuv420p), FUNC_YUVN(SimdUyvy422ToYuv420p));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdUyvy422ToYuv420p`.
- Add SVE2 coverage to `Uyvy422ToYuv420pAutoTest`.
- Register the new SVE2 source in the VS2022 SVE2 project and update 7.2.164 release notes.

### Validation
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -I src -c src/Simd/SimdSve2UyvyToYuv.cpp -o /tmp/SimdSve2UyvyToYuv.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Uyvy422ToYuv420p -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b2a2baf-3a98-45c6-a219-9900d2f7806d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b2a2baf-3a98-45c6-a219-9900d2f7806d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

