### PR TITLE
Add SVE2 optimization for SimdVectorNormNp16f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -52,6 +52,7 @@
  <li>SVE2 optimizations of function Uyvy422ToYuv420p.</li>
  <li>SVE2 optimizations of function Uint8ToFloat32.</li>
  <li>SVE2 optimizations of function VectorNormNa16f.</li>
+ <li>SVE2 optimizations of function VectorNormNp16f.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2882,6 +2882,11 @@ SIMD_API void SimdVectorNormNp16f(size_t N, size_t K, const uint16_t* A, float* 
         Avx2::VectorNormNp16f(N, K, A, norms);
     else
 #endif
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+    if (Sve2::Enable)
+        Sve2::VectorNormNp16f(N, K, A, norms);
+    else
+#endif
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
     if (Neon::Enable && K >= Neon::F)
         Neon::VectorNormNp16f(N, K, A, norms);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -278,6 +278,8 @@ namespace Simd
 
         void VectorNormNa16f(size_t N, size_t K, const uint16_t* const* A, float* norms);
 
+        void VectorNormNp16f(size_t N, size_t K, const uint16_t* A, float* norms);
+
         void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);

--- a/src/Simd/SimdSve2Float16.cpp
+++ b/src/Simd/SimdSve2Float16.cpp
@@ -439,6 +439,28 @@ namespace Simd
                 svst1_f32(tail, norms + j, svsqrt_f32_x(tail, svld1_f32(tail, norms + j)));
             }
         }
+
+        void VectorNormNp16f(size_t N, size_t K, const uint16_t* A, float* norms)
+        {
+            size_t A_ = svlen(svuint16_t()), KA = AlignLoAny(K, A_);
+            const svbool_t body16 = svptrue_b16();
+            const svbool_t body32 = svptrue_b32();
+            for (size_t i = 0; i < N; ++i)
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+                size_t k = 0;
+                const uint16_t* row = A + i * K;
+                for (; k < KA; k += A_)
+                    Square16f(row + k, body16, body32, body32, sum0, sum1);
+                if (k < K)
+                {
+                    size_t tail = K - k;
+                    Square16f(row + k, svwhilelt_b16(size_t(0), tail),
+                        svwhilelt_b32(size_t(0), (tail + 1) / 2), svwhilelt_b32(size_t(0), tail / 2), sum0, sum1);
+                }
+                norms[i] = ::sqrt(Sum16f(body32, sum0, sum1));
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestFloat16.cpp
+++ b/src/Test/TestFloat16.cpp
@@ -640,6 +640,11 @@ namespace Test
             result = result && VectorNormNp16fAutoTest(EPS, FUNC_VNP(Simd::Avx512bw::VectorNormNp16f), FUNC_VNP(SimdVectorNormNp16f));
 #endif
 
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && VectorNormNp16fAutoTest(EPS, FUNC_VNP(Simd::Sve2::VectorNormNp16f), FUNC_VNP(SimdVectorNormNp16f));
+#endif
+
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_NEON_FP16_ENABLE)
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && VectorNormNp16fAutoTest(EPS, FUNC_VNP(Simd::Neon::VectorNormNp16f), FUNC_VNP(SimdVectorNormNp16f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `Sve2::VectorNormNp16f` implementation in `src/Simd/SimdSve2Float16.cpp` using SVE/SVE2 FP16 load-convert-accumulate flow.
- add SVE2 declaration to `src/Simd/SimdSve2.h` and wire SVE2 dispatch for `SimdVectorNormNp16f` in `src/Simd/SimdLib.cpp`.
- extend `Test::VectorNormNp16fAutoTest` to validate SVE2 implementation in `src/Test/TestFloat16.cpp`.
- update release notes for 7.2.164 in `docs/2026.html`.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=VectorNorm -tt=1 -ts=1` (from `build/`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cb23a0f-4dbb-4161-a8df-27fb700fcd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cb23a0f-4dbb-4161-a8df-27fb700fcd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

