### PR TITLE
Add SVE2 optimization for SimdVectorProduct

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of function Uyvy422ToBgr.</li>
  <li>SVE2 optimizations of function Uyvy422ToYuv420p.</li>
  <li>SVE2 optimizations of function Uint8ToFloat32.</li>
+ <li>SVE2 optimizations of function VectorProduct.</li>
  <li>SVE2 optimizations of function VectorNormNa16f.</li>
  <li>SVE2 optimizations of function VectorNormNp16f.</li>
 </ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2MinFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Neural.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Operation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reduce.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray3x3.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -278,6 +278,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2NeuralConvolution.cpp">
       <Filter>Sve2\Legacy</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Operation.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp">
       <Filter>Sve2\Transform</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4688,6 +4688,11 @@ SIMD_API void SimdVectorProduct(const uint8_t * vertical, const uint8_t * horizo
         Sse41::VectorProduct(vertical, horizontal, dst, stride, width, height);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntb())
+        Sve2::VectorProduct(vertical, horizontal, dst, stride, width, height);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::VectorProduct(vertical, horizontal, dst, stride, width, height);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -281,6 +281,8 @@ namespace Simd
         void VectorNormNp16f(size_t N, size_t K, const uint16_t* A, float* norms);
 
         void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
+
+        void VectorProduct(const uint8_t* vertical, const uint8_t* horizontal, uint8_t* dst, size_t stride, size_t width, size_t height);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);
 

--- a/src/Simd/SimdSve2Operation.cpp
+++ b/src/Simd/SimdSve2Operation.cpp
@@ -1,0 +1,71 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint8_t DivideI16By255(const svuint16_t & value)
+        {
+            const svbool_t full = svptrue_b16();
+            svuint16_t sum = svadd_n_u16_x(full, value, 1);
+            sum = svadd_u16_x(full, sum, svlsr_n_u16_x(full, sum, 8));
+            return svqxtnb_u16(svlsr_n_u16_x(full, sum, 8));
+        }
+
+        SIMD_INLINE svuint8_t VectorProduct(const svuint16_t & vertical, const svuint8_t & horizontal)
+        {
+            const svbool_t full = svptrue_b16();
+            svuint8_t lo = DivideI16By255(svmul_u16_x(full, vertical, svunpklo_u16(horizontal)));
+            svuint8_t hi = DivideI16By255(svmul_u16_x(full, vertical, svunpkhi_u16(horizontal)));
+            return svuzp1_u8(lo, hi);
+        }
+
+        void VectorProduct(const uint8_t * vertical, const uint8_t * horizontal, uint8_t * dst, size_t stride, size_t width, size_t height)
+        {
+            size_t A = svcntb();
+            size_t widthA = AlignLo(width, A);
+            for (size_t row = 0; row < height; ++row)
+            {
+                const svuint16_t _vertical = svdup_n_u16(vertical[row]);
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                {
+                    svuint8_t _horizontal = svld1_u8(svptrue_b8(), horizontal + col);
+                    svst1_u8(svptrue_b8(), dst + col, VectorProduct(_vertical, _horizontal));
+                }
+                if (widthA < width)
+                {
+                    svbool_t tail = svwhilelt_b8(col, width);
+                    svuint8_t _horizontal = svld1_u8(tail, horizontal + col);
+                    svst1_u8(tail, dst + col, VectorProduct(_vertical, _horizontal));
+                }
+                dst += stride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestOperation.cpp
+++ b/src/Test/TestOperation.cpp
@@ -349,6 +349,11 @@ namespace Test
             result = result && VectorProductAutoTest(ARGS_VP(Simd::Neon::VectorProduct), ARGS_VP(SimdVectorProduct));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && VectorProductAutoTest(ARGS_VP(Simd::Sve2::VectorProduct), ARGS_VP(SimdVectorProduct));
+#endif 
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- added `Sve2::VectorProduct` implementation in new `src/Simd/SimdSve2Operation.cpp` using SVE2 vector math and masked tail handling.
- wired `SimdVectorProduct` runtime dispatch to prefer SVE2 on ARM/ARM64 when available.
- exposed the new SVE2 declaration in `SimdSve2.h`.
- updated `Test::VectorProductAutoTest` to validate the SVE2 implementation.
- added `SimdSve2Operation.cpp` to `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters`.
- updated release notes in `docs/2026.html` (release 7.2.164).

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=VectorProduct -tt=1 -ts=1`

## Notes
- this cloud validation ran on x86_64, so the SVE2 path cannot be executed here; correctness is covered by implementation parity with existing SIMD backends and by updated SVE2 test wiring for ARM/ARM64 environments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e640425e-c067-48aa-9552-761e7964eed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e640425e-c067-48aa-9552-761e7964eed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

