### PR TITLE
Add SVE2 optimization for SimdYToGray

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -54,6 +54,7 @@
  <li>SVE2 optimizations of function VectorProduct.</li>
  <li>SVE2 optimizations of function VectorNormNa16f.</li>
  <li>SVE2 optimizations of function VectorNormNp16f.</li>
+ <li>SVE2 optimizations of function YToGray.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -350,5 +350,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdGrayToY.h
+++ b/src/Simd/SimdGrayToY.h
@@ -183,6 +183,21 @@ namespace Simd
             svuint8_t y = svqxtnt_u16(svqxtnb_u16(y0), y1);
             return svmin_u8_x(svptrue_b8(), svqadd_u8(y, G2Y_LO), G2Y_HI);
         }
+
+        SIMD_INLINE svuint8_t YToGray(const svuint8_t& y)
+        {
+            const svbool_t mask16 = svptrue_b16();
+            const svuint16_t Y2G_SCALE = svdup_n_u16(Base::Y2G_SCALE);
+            const svuint16_t Y2G_ROUND = svdup_n_u16(Base::Y2G_ROUND);
+            const svuint8_t G2Y_LO = svdup_n_u8(Base::G2Y_LO);
+            const svuint8_t G2Y_HI = svdup_n_u8(Base::G2Y_HI);
+            svuint8_t _y = svqsub_u8(svmin_u8_x(svptrue_b8(), y, G2Y_HI), G2Y_LO);
+            svuint16_t y0 = svmovlb_u16(_y);
+            svuint16_t y1 = svmovlt_u16(_y);
+            svuint16_t g0 = svlsr_n_u16_x(mask16, svadd_u16_x(mask16, svmul_u16_x(mask16, y0, Y2G_SCALE), Y2G_ROUND), Base::Y2G_SHIFT);
+            svuint16_t g1 = svlsr_n_u16_x(mask16, svadd_u16_x(mask16, svmul_u16_x(mask16, y1, Y2G_SCALE), Y2G_ROUND), Base::Y2G_SHIFT);
+            return svqxtnt_u16(svqxtnb_u16(g0), g1);
+        }
     }
 #endif
 

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8352,6 +8352,11 @@ SIMD_API void SimdYToGray(const uint8_t* y, size_t yStride, size_t width, size_t
         Sse41::YToGray(y, yStride, width, height, gray, grayStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::YToGray(y, yStride, width, height, gray, grayStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::YToGray(y, yStride, width, height, gray, grayStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -316,6 +316,8 @@ namespace Simd
 
         void GrayToY(const uint8_t* gray, size_t grayStride, size_t width, size_t height, uint8_t* y, size_t yStride);
 
+        void YToGray(const uint8_t* y, size_t yStride, size_t width, size_t height, uint8_t* gray, size_t grayStride);
+
         void ReduceColor2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride, size_t channelCount);
 

--- a/src/Simd/SimdSve2YToGray.cpp
+++ b/src/Simd/SimdSve2YToGray.cpp
@@ -1,0 +1,50 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdGrayToY.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void YToGray(const uint8_t* y, size_t yStride, size_t width, size_t height, uint8_t* gray, size_t grayStride)
+        {
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    svst1_u8(body, gray + col, YToGray(svld1_u8(body, y + col)));
+                if (col < width)
+                    svst1_u8(tail, gray + col, YToGray(svld1_u8(tail, y + col)));
+                y += yStride;
+                gray += grayStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAnyToAny.cpp
+++ b/src/Test/TestAnyToAny.cpp
@@ -626,6 +626,11 @@ namespace Test
             result = result && AnyToAnyAutoTest(View::Gray8, View::Gray8, FUNC_N(Simd::Avx512bw::YToGray), FUNC_N(SimdYToGray));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && AnyToAnyAutoTest(View::Gray8, View::Gray8, FUNC_N(Simd::Sve2::YToGray), FUNC_N(SimdYToGray));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && AnyToAnyAutoTest(View::Gray8, View::Gray8, FUNC_N(Simd::Neon::YToGray), FUNC_N(SimdYToGray));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Added SVE2 implementation of `SimdYToGray` in `src/Simd/SimdSve2YToGray.cpp`.
- Added SVE2 vector `YToGray` helper and SVE2 API declaration/dispatch wiring.
- Extended `Test::YToGrayAutoTest` to validate the SVE2 path.
- Updated `prj/vs2022/Sve2.vcxproj` and `.filters` to include the new source file.
- Updated release notes in `docs/2026.html` for release `7.2.164`.

## Validation plan
- Configure and build via CMake.
- Run targeted auto-test for `YToGray` from `build/Test`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a589a785-2b18-457a-b0d3-225515cf7122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a589a785-2b18-457a-b0d3-225515cf7122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

