### PR TITLE
Add SVE2 optimization for Yuv420pToBgrV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -54,6 +54,7 @@
  <li>SVE2 optimizations of function VectorProduct.</li>
  <li>SVE2 optimizations of function VectorNormNa16f.</li>
  <li>SVE2 optimizations of function VectorNormNp16f.</li>
+ <li>SVE2 optimizations of function Yuv420pToBgrV2.</li>
  <li>SVE2 optimizations of function YToGray.</li>
 </ul>
 

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgrV2.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -353,5 +353,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgrV2.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8465,6 +8465,11 @@ SIMD_API void SimdYuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t
         Sse41::Yuv420pToBgrV2(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Yuv420pToBgrV2(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::Yuv420pToBgrV2(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -219,6 +219,9 @@ namespace Simd
         void Uyvy422ToYuv420p(const uint8_t* uyvy, size_t uyvyStride, size_t width, size_t height,
             uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride);
 
+        void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2YuvToBgrV2.cpp
+++ b/src/Simd/SimdSve2YuvToBgrV2.cpp
@@ -1,0 +1,172 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdYuvToBgr.h"
+#include "Simd/SimdPack.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template<class T> SIMD_INLINE svint16_t AdjustYLo(const svuint8_t& y)
+        {
+            return svsub_n_s16_x(svptrue_b16(), svreinterpret_s16_u16(svmovlb_u16(y)), T::Y_LO);
+        }
+
+        template<class T> SIMD_INLINE svint16_t AdjustYHi(const svuint8_t& y)
+        {
+            return svsub_n_s16_x(svptrue_b16(), svreinterpret_s16_u16(svmovlt_u16(y)), T::Y_LO);
+        }
+
+        template<class T> SIMD_INLINE svint16_t AdjustUVLo(const svuint8_t& uv)
+        {
+            return svsub_n_s16_x(svptrue_b16(), svreinterpret_s16_u16(svmovlb_u16(uv)), T::UV_Z);
+        }
+
+        template<class T> SIMD_INLINE svint16_t AdjustUVHi(const svuint8_t& uv)
+        {
+            return svsub_n_s16_x(svptrue_b16(), svreinterpret_s16_u16(svmovlt_u16(uv)), T::UV_Z);
+        }
+
+        template<class T> SIMD_INLINE svint16_t YuvToBlue16(const svint16_t& y, const svint16_t& u)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t lo = svmlalb_n_s32(svdup_n_s32(T::F_ROUND), y, T::Y_2_A);
+            svint32_t hi = svmlalt_n_s32(svdup_n_s32(T::F_ROUND), y, T::Y_2_A);
+            lo = svmlalb_n_s32(lo, u, T::U_2_B);
+            hi = svmlalt_n_s32(hi, u, T::U_2_B);
+            return svqxtnt_s32(svqxtnb_s32(svasr_n_s32_x(mask, lo, T::F_SHIFT)), svasr_n_s32_x(mask, hi, T::F_SHIFT));
+        }
+
+        template<class T> SIMD_INLINE svint16_t YuvToGreen16(const svint16_t& y, const svint16_t& u, const svint16_t& v)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t lo = svmlalb_n_s32(svdup_n_s32(T::F_ROUND), y, T::Y_2_A);
+            svint32_t hi = svmlalt_n_s32(svdup_n_s32(T::F_ROUND), y, T::Y_2_A);
+            lo = svmlalb_n_s32(svmlalb_n_s32(lo, u, T::U_2_G), v, T::V_2_G);
+            hi = svmlalt_n_s32(svmlalt_n_s32(hi, u, T::U_2_G), v, T::V_2_G);
+            return svqxtnt_s32(svqxtnb_s32(svasr_n_s32_x(mask, lo, T::F_SHIFT)), svasr_n_s32_x(mask, hi, T::F_SHIFT));
+        }
+
+        template<class T> SIMD_INLINE svint16_t YuvToRed16(const svint16_t& y, const svint16_t& v)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint32_t lo = svmlalb_n_s32(svdup_n_s32(T::F_ROUND), y, T::Y_2_A);
+            svint32_t hi = svmlalt_n_s32(svdup_n_s32(T::F_ROUND), y, T::Y_2_A);
+            lo = svmlalb_n_s32(lo, v, T::V_2_R);
+            hi = svmlalt_n_s32(hi, v, T::V_2_R);
+            return svqxtnt_s32(svqxtnb_s32(svasr_n_s32_x(mask, lo, T::F_SHIFT)), svasr_n_s32_x(mask, hi, T::F_SHIFT));
+        }
+
+        template<class T> SIMD_INLINE svuint8_t YuvToBlue(const svuint8_t& y, const svuint8_t& u)
+        {
+            return PackSatIntI16ToU8(
+                YuvToBlue16<T>(AdjustYLo<T>(y), AdjustUVLo<T>(u)),
+                YuvToBlue16<T>(AdjustYHi<T>(y), AdjustUVHi<T>(u)));
+        }
+
+        template<class T> SIMD_INLINE svuint8_t YuvToGreen(const svuint8_t& y, const svuint8_t& u, const svuint8_t& v)
+        {
+            return PackSatIntI16ToU8(
+                YuvToGreen16<T>(AdjustYLo<T>(y), AdjustUVLo<T>(u), AdjustUVLo<T>(v)),
+                YuvToGreen16<T>(AdjustYHi<T>(y), AdjustUVHi<T>(u), AdjustUVHi<T>(v)));
+        }
+
+        template<class T> SIMD_INLINE svuint8_t YuvToRed(const svuint8_t& y, const svuint8_t& v)
+        {
+            return PackSatIntI16ToU8(
+                YuvToRed16<T>(AdjustYLo<T>(y), AdjustUVLo<T>(v)),
+                YuvToRed16<T>(AdjustYHi<T>(y), AdjustUVHi<T>(v)));
+        }
+
+        template <class T> SIMD_INLINE void Yuv422pToBgrV2(const uint8_t* y, const svuint8_t& u, const svuint8_t& v, uint8_t* bgr)
+        {
+            const svbool_t body = svptrue_b8();
+            const size_t A = svcntb(), A3 = A * 3;
+            svuint8_t blue = YuvToBlue<T>(svld1_u8(body, y), u);
+            svuint8_t green = YuvToGreen<T>(svld1_u8(body, y), u, v);
+            svuint8_t red = YuvToRed<T>(svld1_u8(body, y), v);
+            svst3_u8(body, bgr + 0 * A3, svcreate3_u8(blue, green, red));
+        }
+
+        template <class T> SIMD_INLINE void Yuv422pToBgr(const uint8_t* y, int u, int v, uint8_t* bgr)
+        {
+            Base::YuvToBgr<T>(y[0], u, v, bgr + 0);
+            Base::YuvToBgr<T>(y[1], u, v, bgr + 3);
+        }
+
+        template <class T> void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0) && (width >= 2) && (height >= 2));
+
+            const size_t A = svcntb(), DA = 2 * A, A6 = 6 * A;
+            const size_t widthDA = AlignLo(width, DA);
+            const svbool_t body = svptrue_b8();
+            for (size_t row = 0; row < height; row += 2)
+            {
+                size_t colUV = 0, colY = 0, colBgr = 0;
+                for (; colY < widthDA; colY += DA, colUV += A, colBgr += A6)
+                {
+                    svuint8_t _u = svld1_u8(body, u + colUV);
+                    svuint8_t _v = svld1_u8(body, v + colUV);
+                    svuint8_t u0 = svzip1_u8(_u, _u);
+                    svuint8_t u1 = svzip2_u8(_u, _u);
+                    svuint8_t v0 = svzip1_u8(_v, _v);
+                    svuint8_t v1 = svzip2_u8(_v, _v);
+                    Yuv422pToBgrV2<T>(y + colY + 0 * A, u0, v0, bgr + colBgr + 0 * A3);
+                    Yuv422pToBgrV2<T>(y + colY + 1 * A, u1, v1, bgr + colBgr + 1 * A3);
+                    Yuv422pToBgrV2<T>(y + yStride + colY + 0 * A, u0, v0, bgr + bgrStride + colBgr + 0 * A3);
+                    Yuv422pToBgrV2<T>(y + yStride + colY + 1 * A, u1, v1, bgr + bgrStride + colBgr + 1 * A3);
+                }
+                for (; colY < width; colY += 2, colUV += 1, colBgr += 6)
+                {
+                    int _u = u[colUV], _v = v[colUV];
+                    Yuv422pToBgr<T>(y + colY, _u, _v, bgr + colBgr);
+                    Yuv422pToBgr<T>(y + yStride + colY, _u, _v, bgr + bgrStride + colBgr);
+                }
+                y += 2 * yStride;
+                u += uStride;
+                v += vStride;
+                bgr += 2 * bgrStride;
+            }
+        }
+
+        void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: Yuv420pToBgrV2<Base::Bt601>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            case SimdYuvBt709: Yuv420pToBgrV2<Base::Bt709>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            case SimdYuvBt2020: Yuv420pToBgrV2<Base::Bt2020>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            case SimdYuvTrect871: Yuv420pToBgrV2<Base::Trect871>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2YuvToBgrV2.cpp
+++ b/src/Simd/SimdSve2YuvToBgrV2.cpp
@@ -122,7 +122,7 @@ namespace Simd
         {
             assert((width % 2 == 0) && (height % 2 == 0) && (width >= 2) && (height >= 2));
 
-            const size_t A = svcntb(), DA = 2 * A, A6 = 6 * A;
+            const size_t A = svcntb(), A3 = 3 * A, DA = 2 * A, A6 = 6 * A;
             const size_t widthDA = AlignLo(width, DA);
             const svbool_t body = svptrue_b8();
             for (size_t row = 0; row < height; row += 2)

--- a/src/Test/TestYuvToAny.cpp
+++ b/src/Test/TestYuvToAny.cpp
@@ -339,6 +339,11 @@ namespace Test
             result = result && YuvToBgr2AutoTest(FUNC_YUV2(Simd::Neon::Yuv420pToBgrV2), FUNC_YUV2(SimdYuv420pToBgrV2), 2, 2);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && YuvToBgr2AutoTest(FUNC_YUV2(Simd::Sve2::Yuv420pToBgrV2), FUNC_YUV2(SimdYuv420pToBgrV2), 2, 2);
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `Yuv420pToBgrV2` in new `src/Simd/SimdSve2YuvToBgrV2.cpp`.
- wire SVE2 dispatch for `SimdYuv420pToBgrV2` in `src/Simd/SimdLib.cpp`.
- add SVE2 coverage in `Test::Yuv420pToBgrV2AutoTest`.
- update SVE2 VS2022 project files and release notes (`docs/2026.html`, section 7.2.164).
- fix CI compile issue by defining missing local `A3` constant in SVE2 implementation.

## Validation
- `cmake --build build --parallel$(nproc)` passes.
- `./Test "-r=.." -fi=Yuv420pToBgrV2 -tt=1 -ts=1` passes.

## Environment note
- Validation ran on x86_64 environment; SVE2 runtime execution is not available there, so SVE2 runtime path cannot be executed natively in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e619944b-f3d9-4e6d-ae03-d9a98ec933d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e619944b-f3d9-4e6d-ae03-d9a98ec933d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

