### PR TITLE
Add SVE2 optimization for Yuv422pToBgrV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -55,6 +55,7 @@
  <li>SVE2 optimizations of function VectorNormNa16f.</li>
  <li>SVE2 optimizations of function VectorNormNp16f.</li>
  <li>SVE2 optimizations of function Yuv420pToBgrV2.</li>
+ <li>SVE2 optimizations of function Yuv422pToBgrV2.</li>
  <li>SVE2 optimizations of function YToGray.</li>
 </ul>
 

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8497,6 +8497,11 @@ SIMD_API void SimdYuv422pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t
         Sse41::Yuv422pToBgrV2(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Yuv422pToBgrV2(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::Yuv422pToBgrV2(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -222,6 +222,9 @@ namespace Simd
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 
+        void Yuv422pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2YuvToBgrV2.cpp
+++ b/src/Simd/SimdSve2YuvToBgrV2.cpp
@@ -105,9 +105,10 @@ namespace Simd
         {
             const svbool_t body = svptrue_b8();
             const size_t A = svcntb(), A3 = A * 3;
-            svuint8_t blue = YuvToBlue<T>(svld1_u8(body, y), u);
-            svuint8_t green = YuvToGreen<T>(svld1_u8(body, y), u, v);
-            svuint8_t red = YuvToRed<T>(svld1_u8(body, y), v);
+            svuint8_t _y = svld1_u8(body, y);
+            svuint8_t blue = YuvToBlue<T>(_y, u);
+            svuint8_t green = YuvToGreen<T>(_y, u, v);
+            svuint8_t red = YuvToRed<T>(_y, v);
             svst3_u8(body, bgr + 0 * A3, svcreate3_u8(blue, green, red));
         }
 
@@ -163,6 +164,47 @@ namespace Simd
             case SimdYuvBt709: Yuv420pToBgrV2<Base::Bt709>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
             case SimdYuvBt2020: Yuv420pToBgrV2<Base::Bt2020>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
             case SimdYuvTrect871: Yuv420pToBgrV2<Base::Trect871>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            default:
+                assert(0);
+            }
+        }
+
+        template <class T> void Yuv422pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride)
+        {
+            assert((width % 2 == 0) && (width >= 2));
+
+            const size_t A = svcntb(), A3 = 3 * A, DA = 2 * A, A6 = 6 * A;
+            const size_t widthDA = AlignLo(width, DA);
+            const svbool_t body = svptrue_b8();
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t colUV = 0, colY = 0, colBgr = 0;
+                for (; colY < widthDA; colY += DA, colUV += A, colBgr += A6)
+                {
+                    svuint8_t _u = svld1_u8(body, u + colUV);
+                    svuint8_t _v = svld1_u8(body, v + colUV);
+                    Yuv422pToBgrV2<T>(y + colY + 0 * A, svzip1_u8(_u, _u), svzip1_u8(_v, _v), bgr + colBgr + 0 * A3);
+                    Yuv422pToBgrV2<T>(y + colY + 1 * A, svzip2_u8(_u, _u), svzip2_u8(_v, _v), bgr + colBgr + 1 * A3);
+                }
+                for (; colY < width; colY += 2, colUV += 1, colBgr += 6)
+                    Yuv422pToBgr<T>(y + colY, u[colUV], v[colUV], bgr + colBgr);
+                y += yStride;
+                u += uStride;
+                v += vStride;
+                bgr += bgrStride;
+            }
+        }
+
+        void Yuv422pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: Yuv422pToBgrV2<Base::Bt601>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            case SimdYuvBt709: Yuv422pToBgrV2<Base::Bt709>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            case SimdYuvBt2020: Yuv422pToBgrV2<Base::Bt2020>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
+            case SimdYuvTrect871: Yuv422pToBgrV2<Base::Trect871>(y, yStride, u, uStride, v, vStride, width, height, bgr, bgrStride); break;
             default:
                 assert(0);
             }

--- a/src/Test/TestYuvToAny.cpp
+++ b/src/Test/TestYuvToAny.cpp
@@ -374,6 +374,11 @@ namespace Test
             result = result && YuvToBgr2AutoTest(FUNC_YUV2(Simd::Neon::Yuv422pToBgrV2), FUNC_YUV2(SimdYuv422pToBgrV2), 2, 1);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && YuvToBgr2AutoTest(FUNC_YUV2(Simd::Sve2::Yuv422pToBgrV2), FUNC_YUV2(SimdYuv422pToBgrV2), 2, 1);
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `Yuv422pToBgrV2` in `SimdSve2YuvToBgrV2.cpp` with vectorized body and scalar tail handling.
- route `SimdYuv422pToBgrV2` dispatcher through SVE2 and expose declaration in `SimdSve2.h`.
- extend `Yuv422pToBgrV2AutoTest` to validate SVE2 path.
- update release notes for 7.2.164 with `Yuv422pToBgrV2` SVE2 optimization.

## Validation plan
- configure and build with CMake.
- run targeted C++ test for `Yuv422pToBgrV2AutoTest` via `Test` filter.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c503f509-5efc-43cf-ac81-7cf1d1a2d7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c503f509-5efc-43cf-ac81-7cf1d1a2d7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

