### PR TITLE
Add SVE2 optimization for Yuva422pToBgraV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -62,6 +62,7 @@
  <li>SVE2 optimizations of function Yuv422pToBgrV2.</li>
  <li>SVE2 optimizations of function Yuv422pToRgbV2.</li>
  <li>SVE2 optimizations of function Yuv422pToBgraV2.</li>
+ <li>SVE2 optimizations of function Yuva422pToBgraV2.</li>
  <li>SVE2 optimizations of function Yuv444pToBgrV2.</li>
  <li>SVE2 optimizations of function Yuv444pToRgbV2.</li>
  <li>SVE2 optimizations of function Yuv444pToBgraV2.</li>
@@ -79,6 +80,10 @@
 </ul>
 
 <h4>Test framework</h4>
+<h5>New features</h5>
+<ul>
+ <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
+</ul>
 <h5>Bug fixing</h5>
 <ul>
  <li>Logical error in DifferenceSum16fAutoTest.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8416,6 +8416,11 @@ SIMD_API void SimdYuva422pToBgraV2(const uint8_t* y, size_t yStride, const uint8
         Sse41::Yuva422pToBgraV2(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Yuva422pToBgraV2(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::Yuva422pToBgraV2(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -234,6 +234,9 @@ namespace Simd
         void Yuva420pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride, SimdYuvType yuvType);
 
+        void Yuva422pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride, SimdYuvType yuvType);
+
         void Yuv420pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgra, size_t bgraStride, uint8_t alpha, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2YuvToBgraV2.cpp
+++ b/src/Simd/SimdSve2YuvToBgraV2.cpp
@@ -188,6 +188,48 @@ namespace Simd
             }
         }
 
+        template <class T> void Yuva422pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride)
+        {
+            assert((width % 2 == 0) && (width >= 2));
+
+            const size_t A = svcntb(), A4 = 4 * A, DA = 2 * A, A8 = 8 * A;
+            const size_t widthDA = AlignLo(width, DA);
+            const svbool_t body = svptrue_b8();
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t colUV = 0, colY = 0, colBgra = 0;
+                for (; colY < widthDA; colY += DA, colUV += A, colBgra += A8)
+                {
+                    svuint8_t _u = svld1_u8(body, u + colUV);
+                    svuint8_t _v = svld1_u8(body, v + colUV);
+                    Yuva422pToBgraV2<T>(y + colY + 0 * A, svzip1_u8(_u, _u), svzip1_u8(_v, _v), a + colY + 0 * A, bgra + colBgra + 0 * A4);
+                    Yuva422pToBgraV2<T>(y + colY + 1 * A, svzip2_u8(_u, _u), svzip2_u8(_v, _v), a + colY + 1 * A, bgra + colBgra + 1 * A4);
+                }
+                for (; colY < width; colY += 2, colUV += 1, colBgra += 8)
+                    Yuva422pToBgra<T>(y + colY, u[colUV], v[colUV], a + colY, bgra + colBgra);
+                y += yStride;
+                u += uStride;
+                v += vStride;
+                a += aStride;
+                bgra += bgraStride;
+            }
+        }
+
+        void Yuva422pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: Yuva422pToBgraV2<Base::Bt601>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            case SimdYuvBt709: Yuva422pToBgraV2<Base::Bt709>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            case SimdYuvBt2020: Yuva422pToBgraV2<Base::Bt2020>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            case SimdYuvTrect871: Yuva422pToBgraV2<Base::Trect871>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            default:
+                assert(0);
+            }
+        }
+
         template <class T> void Yuv422pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgra, size_t bgraStride, uint8_t alpha)
         {

--- a/src/Test/TestYuvToBgra.cpp
+++ b/src/Test/TestYuvToBgra.cpp
@@ -153,6 +153,11 @@ namespace Test
             result = result && YuvaToBgra2AutoTest(FUNC_YUVA2(Simd::Neon::Yuva422pToBgraV2), FUNC_YUVA2(SimdYuva422pToBgraV2), 2, 1);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && YuvaToBgra2AutoTest(FUNC_YUVA2(Simd::Sve2::Yuva422pToBgraV2), FUNC_YUVA2(SimdYuva422pToBgraV2), 2, 1);
+#endif 
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- added SVE2 implementation of `Yuva422pToBgraV2` in `src/Simd/SimdSve2YuvToBgraV2.cpp`.
- exposed the new SVE2 entry point in `src/Simd/SimdSve2.h` and wired API dispatch in `src/Simd/SimdLib.cpp`.
- extended `Test::Yuva422pToBgraV2AutoTest` to include SVE2 validation and updated release notes for 7.2.164 in `docs/2026.html`.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Yuva422pToBgraV2 -tt=1 -ts=1`

## Notes
- `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` already contained `SimdSve2YuvToBgraV2.cpp` on `dev`, so no additional project-file edits were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59ed1da3-631b-41c6-a13c-08b5f885b67e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59ed1da3-631b-41c6-a13c-08b5f885b67e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

