### PR TITLE
Add SVE2 Yuva444pToBgraV2 optimization and tests

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -63,6 +63,7 @@
  <li>SVE2 optimizations of function Yuv422pToRgbV2.</li>
  <li>SVE2 optimizations of function Yuv422pToBgraV2.</li>
  <li>SVE2 optimizations of function Yuva422pToBgraV2.</li>
+ <li>SVE2 optimizations of function Yuva444pToBgraV2.</li>
  <li>SVE2 optimizations of function Yuv444pToBgrV2.</li>
  <li>SVE2 optimizations of function Yuv444pToRgbV2.</li>
  <li>SVE2 optimizations of function Yuv444pToBgraV2.</li>
@@ -83,6 +84,7 @@
 <h5>New features</h5>
 <ul>
  <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
+ <li>Tests for verifying functionality of function Yuva444pToBgraV2.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8448,6 +8448,11 @@ SIMD_API void SimdYuva444pToBgraV2(const uint8_t* y, size_t yStride, const uint8
         Sse41::Yuva444pToBgraV2(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride, yuvType);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Yuva444pToBgraV2(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride, yuvType);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::Yuva444pToBgraV2(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride, yuvType);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -237,6 +237,9 @@ namespace Simd
         void Yuva422pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride, SimdYuvType yuvType);
 
+        void Yuva444pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride, SimdYuvType yuvType);
+
         void Yuv420pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgra, size_t bgraStride, uint8_t alpha, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2YuvToBgraV2.cpp
+++ b/src/Simd/SimdSve2YuvToBgraV2.cpp
@@ -371,6 +371,54 @@ namespace Simd
             }
         }
 
+        template <class T> SIMD_INLINE void Yuva444pToBgraV2(const uint8_t* y, const uint8_t* u, const uint8_t* v, const uint8_t* a, uint8_t* bgra)
+        {
+            const svbool_t body = svptrue_b8();
+            const size_t A = svcntb(), A4 = A * 4;
+            svuint8_t _y = svld1_u8(body, y);
+            svuint8_t _u = svld1_u8(body, u);
+            svuint8_t _v = svld1_u8(body, v);
+            svuint8_t _a = svld1_u8(body, a);
+            svuint8_t blue = YuvToBlue<T>(_y, _u);
+            svuint8_t green = YuvToGreen<T>(_y, _u, _v);
+            svuint8_t red = YuvToRed<T>(_y, _v);
+            svst4_u8(body, bgra + 0 * A4, svcreate4_u8(blue, green, red, _a));
+        }
+
+        template <class T> void Yuva444pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride)
+        {
+            const size_t A = svcntb();
+            const size_t widthA = AlignLo(width, A);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, colBgra = 0;
+                for (; col < widthA; col += A, colBgra += 4 * A)
+                    Yuva444pToBgraV2<T>(y + col, u + col, v + col, a + col, bgra + colBgra);
+                for (; col < width; ++col, colBgra += 4)
+                    Base::YuvToBgra<T>(y[col], u[col], v[col], a[col], bgra + colBgra);
+                y += yStride;
+                u += uStride;
+                v += vStride;
+                a += aStride;
+                bgra += bgraStride;
+            }
+        }
+
+        void Yuva444pToBgraV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            const uint8_t* a, size_t aStride, size_t width, size_t height, uint8_t* bgra, size_t bgraStride, SimdYuvType yuvType)
+        {
+            switch (yuvType)
+            {
+            case SimdYuvBt601: Yuva444pToBgraV2<Base::Bt601>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            case SimdYuvBt709: Yuva444pToBgraV2<Base::Bt709>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            case SimdYuvBt2020: Yuva444pToBgraV2<Base::Bt2020>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            case SimdYuvTrect871: Yuva444pToBgraV2<Base::Trect871>(y, yStride, u, uStride, v, vStride, a, aStride, width, height, bgra, bgraStride); break;
+            default:
+                assert(0);
+            }
+        }
+
         //-------------------------------------------------------------------------------------------------
 
         template <class T> SIMD_INLINE void Yuv444pToRgbaV2(const uint8_t* y, const uint8_t* u, const uint8_t* v, const svuint8_t& a, uint8_t* rgba)

--- a/src/Test/TestYuvToBgra.cpp
+++ b/src/Test/TestYuvToBgra.cpp
@@ -188,6 +188,11 @@ namespace Test
             result = result && YuvaToBgra2AutoTest(FUNC_YUVA2(Simd::Neon::Yuva444pToBgraV2), FUNC_YUVA2(SimdYuva444pToBgraV2), 1, 1);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && YuvaToBgra2AutoTest(FUNC_YUVA2(Simd::Sve2::Yuva444pToBgraV2), FUNC_YUVA2(SimdYuva444pToBgraV2), 1, 1);
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `Simd::Sve2::Yuva444pToBgraV2` in `src/Simd/SimdSve2YuvToBgraV2.cpp` using SVE2 vector YUV->BGRA conversion with per-pixel alpha.
- add `Sve2::Yuva444pToBgraV2` declaration in `src/Simd/SimdSve2.h`.
- wire API dispatch in `src/Simd/SimdLib.cpp` so `SimdYuva444pToBgraV2` can select SVE2.
- extend `Test::Yuva444pToBgraV2AutoTest` with an SVE2 path check.
- update release notes in `docs/2026.html` for release 7.2.164 (algorithm + test framework sections).

## Validation
- configured and built with CMake using GCC toolchain.
- ran targeted C++ test filter for `Yuva444pToBgraV2` successfully.
- note: this runner is x86_64, so runtime execution of SVE2 code path is not possible here; integration is verified by build + dispatch/test wiring consistency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bc6ee6d-179c-48f8-b9f5-71c27198e61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bc6ee6d-179c-48f8-b9f5-71c27198e61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

