### PR TITLE
Add SVE2 optimization for Yuv444pToHue

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -67,6 +67,7 @@
  <li>SVE2 optimizations of function Yuv444pToBgrV2.</li>
  <li>SVE2 optimizations of function Yuv444pToRgbV2.</li>
  <li>SVE2 optimizations of function Yuv444pToBgraV2.</li>
+ <li>SVE2 optimizations of function Yuv444pToHue.</li>
  <li>SVE2 optimizations of function Yuv444pToHsl.</li>
  <li>SVE2 optimizations of function Yuv444pToRgbaV2.</li>
  <li>SVE2 optimizations of function YToGray.</li>
@@ -83,6 +84,7 @@
 <h4>Test framework</h4>
 <h5>New features</h5>
 <ul>
+ <li>Tests for verifying functionality of function Yuv444pToHue.</li>
  <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
  <li>Tests for verifying functionality of function Yuva444pToBgraV2.</li>
 </ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8763,6 +8763,11 @@ SIMD_API void SimdYuv444pToHue(const uint8_t * y, size_t yStride, const uint8_t 
         Sse41::Yuv444pToHue(y, yStride, u, uStride, v, vStride, width, height, hue, hueStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Yuv444pToHue(y, yStride, u, uStride, v, vStride, width, height, hue, hueStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::Yuv444pToHue(y, yStride, u, uStride, v, vStride, width, height, hue, hueStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -225,6 +225,9 @@ namespace Simd
         void Yuv420pToHue(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* hue, size_t hueStride);
 
+        void Yuv444pToHue(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* hue, size_t hueStride);
+
         void Yuv444pToHsl(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* hsl, size_t hslStride);
 

--- a/src/Simd/SimdSve2YuvToHue.cpp
+++ b/src/Simd/SimdSve2YuvToHue.cpp
@@ -204,6 +204,32 @@ namespace Simd
                 hue += 2 * hueStride;
             }
         }
+
+        void Yuv444pToHue(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* hue, size_t hueStride)
+        {
+            const size_t A = svcntb();
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svfloat32_t scale = svdup_n_f32(Base::KF_255_DIV_6);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                {
+                    svuint8_t _y = svld1_u8(body, y + col);
+                    svuint8_t _u = svld1_u8(body, u + col);
+                    svuint8_t _v = svld1_u8(body, v + col);
+                    svst1_u8(body, hue + col, YuvToHue(_y, _u, _v, scale));
+                }
+                for (; col < width; ++col)
+                    hue[col] = YuvToHue(y[col], u[col], v[col]);
+                y += yStride;
+                u += uStride;
+                v += vStride;
+                hue += hueStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestYuvToAny.cpp
+++ b/src/Test/TestYuvToAny.cpp
@@ -186,6 +186,11 @@ namespace Test
             result = result && YuvToAnyAutoTest(1, 1, View::Gray8, FUNC(Simd::Avx512bw::Yuv444pToHue), FUNC(SimdYuv444pToHue));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && YuvToAnyAutoTest(1, 1, View::Gray8, FUNC(Simd::Sve2::Yuv444pToHue), FUNC(SimdYuv444pToHue));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && YuvToAnyAutoTest(1, 1, View::Gray8, FUNC(Simd::Neon::Yuv444pToHue), FUNC(SimdYuv444pToHue), MAX_DIFFERECE);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `Yuv444pToHue` in `src/Simd/SimdSve2YuvToHue.cpp`.
- expose `Sve2::Yuv444pToHue` declaration and route `SimdYuv444pToHue` through SVE2 dispatch path.
- extend `Test::Yuv444pToHueAutoTest` with SVE2 coverage.
- update release notes for 7.2.164 with the new SVE2 optimization and related test coverage.

## Notes
- `src/Simd/SimdSve2YuvToHue.cpp` was already listed in `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters` on `dev`, so no project-file edits were necessary.

## Validation plan
- configure/build via CMake as documented in AGENTS.md.
- run focused `Test` checks for `Yuv444pToHue` and `Yuv420pToHue` from `build/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1ec2aa1-9742-41b0-8b82-8e124493261d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ec2aa1-9742-41b0-8b82-8e124493261d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

