### PR TITLE
Add SVE2 optimization for Yuv420pToUyvy422

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -59,6 +59,7 @@
  <li>SVE2 optimizations of function Yuv420pToBgraV2.</li>
  <li>SVE2 optimizations of function Yuva420pToBgraV2.</li>
  <li>SVE2 optimizations of function Yuv420pToHue.</li>
+ <li>SVE2 optimizations of function Yuv420pToUyvy422.</li>
  <li>SVE2 optimizations of function Yuv422pToBgrV2.</li>
  <li>SVE2 optimizations of function Yuv422pToRgbV2.</li>
  <li>SVE2 optimizations of function Yuv422pToBgraV2.</li>
@@ -87,6 +88,7 @@
 <ul>
  <li>Tests for verifying functionality of function Yuv444pToHsv.</li>
  <li>Tests for verifying functionality of function Yuv444pToHue.</li>
+ <li>Tests for verifying functionality of function Yuv420pToUyvy422.</li>
  <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
  <li>Tests for verifying functionality of function Yuva444pToBgraV2.</li>
 </ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -94,6 +94,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToHsl.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToHsv.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToHue.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2YuvToUyvy.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdAlphaBlending.h" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -368,5 +368,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToHue.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2YuvToUyvy.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8928,6 +8928,11 @@ SIMD_API void SimdYuv420pToUyvy422(const uint8_t* y, size_t yStride, const uint8
         Sse41::Yuv420pToUyvy422(y, yStride, u, uStride, v, vStride, width, height, uyvy, uyvyStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::Yuv420pToUyvy422(y, yStride, u, uStride, v, vStride, width, height, uyvy, uyvyStride);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::DA)
         Neon::Yuv420pToUyvy422(y, yStride, u, uStride, v, vStride, width, height, uyvy, uyvyStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -270,6 +270,9 @@ namespace Simd
         void Yuv444pToRgbV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* rgb, size_t rgbStride, SimdYuvType yuvType);
 
+        void Yuv420pToUyvy422(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* uyvy, size_t uyvyStride);
+
         void SobelDx(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
 
         void SobelDxAbs(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);

--- a/src/Simd/SimdSve2YuvToUyvy.cpp
+++ b/src/Simd/SimdSve2YuvToUyvy.cpp
@@ -1,0 +1,93 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void Yuv420pToUyvy422(const uint8_t* y0, size_t yStride, const uint8_t* u, const uint8_t* v, uint8_t* uyvy0, size_t uyvyStride, const svbool_t& body)
+        {
+            const size_t A = svcntb();
+            svuint8_t _u = svld1_u8(body, u);
+            svuint8_t _v = svld1_u8(body, v);
+            svuint8_t uv0 = svzip1_u8(_u, _v);
+            svuint8_t uv1 = svzip2_u8(_u, _v);
+
+            svuint8_t y00 = svld1_u8(body, y0 + 0 * A);
+            svuint8_t y01 = svld1_u8(body, y0 + 1 * A);
+            svst1_u8(body, uyvy0 + 0 * A, svzip1_u8(uv0, y00));
+            svst1_u8(body, uyvy0 + 1 * A, svzip2_u8(uv0, y00));
+            svst1_u8(body, uyvy0 + 2 * A, svzip1_u8(uv1, y01));
+            svst1_u8(body, uyvy0 + 3 * A, svzip2_u8(uv1, y01));
+
+            const uint8_t* y1 = y0 + yStride;
+            uint8_t* uyvy1 = uyvy0 + uyvyStride;
+            svuint8_t y10 = svld1_u8(body, y1 + 0 * A);
+            svuint8_t y11 = svld1_u8(body, y1 + 1 * A);
+            svst1_u8(body, uyvy1 + 0 * A, svzip1_u8(uv0, y10));
+            svst1_u8(body, uyvy1 + 1 * A, svzip2_u8(uv0, y10));
+            svst1_u8(body, uyvy1 + 2 * A, svzip1_u8(uv1, y11));
+            svst1_u8(body, uyvy1 + 3 * A, svzip2_u8(uv1, y11));
+        }
+
+        SIMD_INLINE void Yuv420pToUyvy422(const uint8_t* y0, size_t yStride, const uint8_t* u, const uint8_t* v, uint8_t* uyvy0, size_t uyvyStride)
+        {
+            const uint8_t* y1 = y0 + yStride;
+            uint8_t* uyvy1 = uyvy0 + uyvyStride;
+            uyvy0[1] = y0[0];
+            uyvy0[3] = y0[1];
+            uyvy1[1] = y1[0];
+            uyvy1[3] = y1[1];
+            uyvy0[0] = u[0];
+            uyvy1[0] = u[0];
+            uyvy0[2] = v[0];
+            uyvy1[2] = v[0];
+        }
+
+        void Yuv420pToUyvy422(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* uyvy, size_t uyvyStride)
+        {
+            assert((width % 2 == 0) && (height % 2 == 0) && width >= 2 && height >= 2);
+
+            const size_t A = svcntb(), DA = 2 * A, QA = 4 * A;
+            const size_t widthDA = AlignLo(width, DA);
+            const svbool_t body = svptrue_b8();
+            for (size_t row = 0; row < height; row += 2)
+            {
+                size_t colY = 0, colUV = 0, colUyvy = 0;
+                for (; colY < widthDA; colY += DA, colUV += A, colUyvy += QA)
+                    Yuv420pToUyvy422(y + colY, yStride, u + colUV, v + colUV, uyvy + colUyvy, uyvyStride, body);
+                for (; colY < width; colY += 2, colUV += 1, colUyvy += 4)
+                    Yuv420pToUyvy422(y + colY, yStride, u + colUV, v + colUV, uyvy + colUyvy, uyvyStride);
+                y += 2 * yStride;
+                u += uStride;
+                v += vStride;
+                uyvy += 2 * uyvyStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestYuvToAny.cpp
+++ b/src/Test/TestYuvToAny.cpp
@@ -261,6 +261,11 @@ namespace Test
             result = result && YuvToAnyAutoTest(2, 2, View::Uyvy16, FUNC(Simd::Avx512bw::Yuv420pToUyvy422), FUNC(SimdYuv420pToUyvy422));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && YuvToAnyAutoTest(2, 2, View::Uyvy16, FUNC(Simd::Sve2::Yuv420pToUyvy422), FUNC(SimdYuv420pToUyvy422));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && YuvToAnyAutoTest(2, 2, View::Uyvy16, FUNC(Simd::Neon::Yuv420pToUyvy422), FUNC(SimdYuv420pToUyvy422));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `Yuv420pToUyvy422` in new `src/Simd/SimdSve2YuvToUyvy.cpp`.
- wire SVE2 declaration/dispatch in `SimdSve2.h` and `SimdLib.cpp`.
- extend `Test::Yuv420pToUyvy422AutoTest` to validate the SVE2 path.
- add the new source file into `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters`.
- update release notes in `docs/2026.html` under release `7.2.164` for algorithm and test additions.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." "-fi=Yuv420pToUyvy422" -tt=1 -ts=1
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6417517d-7cdc-4c8e-a7e6-79bc68c1ff05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6417517d-7cdc-4c8e-a7e6-79bc68c1ff05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

