### PR TITLE
Add SVE2 WinogradKernel1x3Block1x4SetFilter implementation

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -45,6 +45,7 @@
  <li>SVE2 optimizations of function ShiftBilinear.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
+ <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>
@@ -108,6 +109,7 @@
 <ul>
  <li>Tests for verifying functionality of function Yuv444pToHsv.</li>
  <li>Tests for verifying functionality of function Yuv444pToHue.</li>
+ <li>Tests for verifying functionality of function WinogradKernel1x3Block1x4SetFilter.</li>
  <li>Tests for verifying functionality of function Yuv420pToUyvy422.</li>
  <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
  <li>Tests for verifying functionality of function Yuva444pToBgraV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Winograd1.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgraV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgrV2.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -350,6 +350,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Winograd1.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8079,7 +8079,7 @@ SIMD_API void SimdWinogradKernel1x3Block1x4SetFilter(const float* src, size_t si
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetFilterPtr simdWinogradKernel1x3Block1x4SetFilter = SIMD_FUNC4(WinogradKernel1x3Block1x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetFilterPtr simdWinogradKernel1x3Block1x4SetFilter = SIMD_FUNC5(WinogradKernel1x3Block1x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel1x3Block1x4SetFilter(src, size, dst, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -219,6 +219,8 @@ namespace Simd
         void Uyvy422ToYuv420p(const uint8_t* uyvy, size_t uyvyStride, size_t width, size_t height,
             uint8_t* y, size_t yStride, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride);
 
+        void WinogradKernel1x3Block1x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -1,0 +1,92 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdWinograd.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetFilter(const svfloat32_t src[3], float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r4 = svdup_n_f32(1.0f / 4.0f);
+            const svfloat32_t mr6 = svdup_n_f32(-1.0f / 6.0f);
+            const svfloat32_t r12 = svdup_n_f32(1.0f / 12.0f);
+            const svfloat32_t r24 = svdup_n_f32(1.0f / 24.0f);
+
+            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r4, src[0]));
+            svfloat32_t s02 = svadd_f32_x(pg, src[0], src[2]);
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr6, svadd_f32_x(pg, s02, src[1])));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, mr6, svsub_f32_x(pg, s02, src[1])));
+            svfloat32_t a = svadd_f32_x(pg, svmul_f32_x(pg, r24, src[0]), svmul_f32_x(pg, r12, src[1]));
+            svfloat32_t b = svmul_f32_x(pg, svdup_n_f32(1.0f / 6.0f), src[2]);
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, a, b));
+            svst1_f32(pg, dst + 4 * stride, svsub_f32_x(pg, a, b));
+            svst1_f32(pg, dst + 5 * stride, src[2]);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s[3];
+            s[0] = svld1_f32(pg, src + 0 * srcStride);
+            s[1] = svld1_f32(pg, src + 1 * srcStride);
+            s[2] = svld1_f32(pg, src + 2 * srcStride);
+            WinogradKernel1x3Block1x4SetFilter(s, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svuint32_t offsets = svindex_u32(0, 3);
+            svfloat32_t s[3];
+            s[0] = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            s[1] = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            s[2] = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            WinogradKernel1x3Block1x4SetFilter(s, dst, dstStride, pg);
+        }
+
+        void WinogradKernel1x3Block1x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans)
+        {
+            const size_t F = svcntw();
+            const size_t sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            if (trans)
+            {
+                for (; i < sizeF; i += F)
+                    WinogradKernel1x3Block1x4SetFilterVt(src + i, size, dst + i, size, body);
+                if (i < size)
+                    WinogradKernel1x3Block1x4SetFilterVt(src + i, size, dst + i, size, svwhilelt_b32(i, size));
+            }
+            else
+            {
+                for (; i < sizeF; i += F, src += 3 * F, dst += F)
+                    WinogradKernel1x3Block1x4SetFilterVn(src, dst, size, body);
+                if (i < size)
+                    WinogradKernel1x3Block1x4SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -29,41 +29,39 @@ namespace Simd
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Sve2
     {
-        SIMD_INLINE void WinogradKernel1x3Block1x4SetFilter(const svfloat32_t src[3], float* dst, size_t stride, const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetFilter(svfloat32_t s0, svfloat32_t s1, svfloat32_t s2, float* dst, size_t stride, const svbool_t& pg)
         {
             const svfloat32_t r4 = svdup_n_f32(1.0f / 4.0f);
             const svfloat32_t mr6 = svdup_n_f32(-1.0f / 6.0f);
             const svfloat32_t r12 = svdup_n_f32(1.0f / 12.0f);
             const svfloat32_t r24 = svdup_n_f32(1.0f / 24.0f);
 
-            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r4, src[0]));
-            svfloat32_t s02 = svadd_f32_x(pg, src[0], src[2]);
-            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr6, svadd_f32_x(pg, s02, src[1])));
-            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, mr6, svsub_f32_x(pg, s02, src[1])));
-            svfloat32_t a = svadd_f32_x(pg, svmul_f32_x(pg, r24, src[0]), svmul_f32_x(pg, r12, src[1]));
-            svfloat32_t b = svmul_f32_x(pg, svdup_n_f32(1.0f / 6.0f), src[2]);
+            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r4, s0));
+            svfloat32_t s02 = svadd_f32_x(pg, s0, s2);
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr6, svadd_f32_x(pg, s02, s1)));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, mr6, svsub_f32_x(pg, s02, s1)));
+            svfloat32_t a = svadd_f32_x(pg, svmul_f32_x(pg, r24, s0), svmul_f32_x(pg, r12, s1));
+            svfloat32_t b = svmul_f32_x(pg, svdup_n_f32(1.0f / 6.0f), s2);
             svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, a, b));
             svst1_f32(pg, dst + 4 * stride, svsub_f32_x(pg, a, b));
-            svst1_f32(pg, dst + 5 * stride, src[2]);
+            svst1_f32(pg, dst + 5 * stride, s2);
         }
 
         SIMD_INLINE void WinogradKernel1x3Block1x4SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
         {
-            svfloat32_t s[3];
-            s[0] = svld1_f32(pg, src + 0 * srcStride);
-            s[1] = svld1_f32(pg, src + 1 * srcStride);
-            s[2] = svld1_f32(pg, src + 2 * srcStride);
-            WinogradKernel1x3Block1x4SetFilter(s, dst, dstStride, pg);
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcStride);
+            WinogradKernel1x3Block1x4SetFilter(s0, s1, s2, dst, dstStride, pg);
         }
 
         SIMD_INLINE void WinogradKernel1x3Block1x4SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
         {
             svuint32_t offsets = svindex_u32(0, 3);
-            svfloat32_t s[3];
-            s[0] = svld1_gather_u32index_f32(pg, src + 0, offsets);
-            s[1] = svld1_gather_u32index_f32(pg, src + 1, offsets);
-            s[2] = svld1_gather_u32index_f32(pg, src + 2, offsets);
-            WinogradKernel1x3Block1x4SetFilter(s, dst, dstStride, pg);
+            svfloat32_t s0 = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            svfloat32_t s1 = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            svfloat32_t s2 = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            WinogradKernel1x3Block1x4SetFilter(s0, s1, s2, dst, dstStride, pg);
         }
 
         void WinogradKernel1x3Block1x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans)

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -40,10 +40,11 @@ namespace Simd
             svfloat32_t s02 = svadd_f32_x(pg, s0, s2);
             svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr6, svadd_f32_x(pg, s02, s1)));
             svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, mr6, svsub_f32_x(pg, s02, s1)));
-            svfloat32_t a = svadd_f32_x(pg, svmul_f32_x(pg, r24, s0), svmul_f32_x(pg, r12, s1));
             svfloat32_t b = svmul_f32_x(pg, svdup_n_f32(1.0f / 6.0f), s2);
-            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, a, b));
-            svst1_f32(pg, dst + 4 * stride, svsub_f32_x(pg, a, b));
+            svfloat32_t d3 = svadd_f32_x(pg, svadd_f32_x(pg, svmul_f32_x(pg, r24, s0), svmul_f32_x(pg, r12, s1)), b);
+            svfloat32_t d4 = svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, r24, s0), svmul_f32_x(pg, r12, s1)), b);
+            svst1_f32(pg, dst + 3 * stride, d3);
+            svst1_f32(pg, dst + 4 * stride, d4);
             svst1_f32(pg, dst + 5 * stride, s2);
         }
 

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -122,6 +122,11 @@ namespace Test
             result = result && WinogradSetFilterAutoTest(_1x4, _1x3, FUNC_WF(Simd::Neon::WinogradKernel1x3Block1x4SetFilter), FUNC_WF(SimdWinogradKernel1x3Block1x4SetFilter));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradSetFilterAutoTest(_1x4, _1x3, FUNC_WF(Simd::Sve2::WinogradKernel1x3Block1x4SetFilter), FUNC_WF(SimdWinogradKernel1x3Block1x4SetFilter));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `WinogradKernel1x3Block1x4SetFilter` in new `src/Simd/SimdSve2Winograd1.cpp`.
- wire SVE2 dispatch for `SimdWinogradKernel1x3Block1x4SetFilter` in `SimdLib.cpp` and add declaration in `SimdSve2.h`.
- extend Winograd auto-test to explicitly validate `Simd::Sve2::WinogradKernel1x3Block1x4SetFilter`.
- update VS2022 SVE2 project files and release notes (`docs/2026.html`, release 7.2.164).
- fix SVE compilation by removing invalid arrays of sizeless SVE vector types.
- fix Winograd transform bug in SVE2 row-4 formula (`dst[4*stride]`) to match Base/Neon transform.

## Testing
- `cmake --build build --parallel4`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=WinogradKernel1x3Block1x4SetFilter -tt=1 -ts=1`

Notes:
- the comparison mismatch you reported is addressed by correcting the SVE2 `dst[4]` transform expression to `r24*s0 - r12*s1 + r6*s2`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cbe7063-0fa7-4c62-80d0-ad7b80dbc952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cbe7063-0fa7-4c62-80d0-ad7b80dbc952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

