### PR TITLE
Add SVE2 Winograd 1x3 input transform

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -46,6 +46,7 @@
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>
+ <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetInput.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8092,7 +8092,7 @@ SIMD_API void SimdWinogradKernel1x3Block1x4SetInput(const float* src, size_t src
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetInputPtr simdWinogradKernel1x3Block1x4SetInput = SIMD_FUNC4(WinogradKernel1x3Block1x4SetInput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetInputPtr simdWinogradKernel1x3Block1x4SetInput = SIMD_FUNC5(WinogradKernel1x3Block1x4SetInput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel1x3Block1x4SetInput(src, srcChannels, srcHeight, srcWidth, padY, padX, padH, padW, dst, dstStride, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -221,6 +221,9 @@ namespace Simd
 
         void WinogradKernel1x3Block1x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
 
+        void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
+            size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -23,6 +23,7 @@
 */
 #include "Simd/SimdMemory.h"
 #include "Simd/SimdWinograd.h"
+#include "Simd/SimdBase.h"
 
 namespace Simd
 {
@@ -84,6 +85,117 @@ namespace Simd
                     WinogradKernel1x3Block1x4SetFilterVn(src, dst, size, body);
                 if (i < size)
                     WinogradKernel1x3Block1x4SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputStore(const svfloat32_t src[6], float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t _2 = svdup_n_f32(2.0f);
+            const svfloat32_t _4 = svdup_n_f32(4.0f);
+            const svfloat32_t _5 = svdup_n_f32(5.0f);
+            svst1_f32(pg, dst + 0 * stride, svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, _4, src[0]), svmul_f32_x(pg, _5, src[2])), src[4]));
+            svst1_f32(pg, dst + 1 * stride, svsub_f32_x(pg, svadd_f32_x(pg, src[3], src[4]), svmul_f32_x(pg, _4, svadd_f32_x(pg, src[1], src[2]))));
+            svst1_f32(pg, dst + 2 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _4, svsub_f32_x(pg, src[1], src[2])), svsub_f32_x(pg, src[4], src[3])));
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _2, svsub_f32_x(pg, src[3], src[1])), svsub_f32_x(pg, src[4], src[2])));
+            svst1_f32(pg, dst + 4 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _2, svsub_f32_x(pg, src[1], src[3])), svsub_f32_x(pg, src[4], src[2])));
+            svst1_f32(pg, dst + 5 * stride, svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, _4, src[1]), svmul_f32_x(pg, _5, src[3])), src[5]));
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputLoad(const float* src, size_t srcC, svfloat32_t dst[6], const svbool_t& pg)
+        {
+            dst[0] = svld1_f32(pg, src + 0 * srcC);
+            dst[1] = svld1_f32(pg, src + 1 * srcC);
+            dst[2] = svld1_f32(pg, src + 2 * srcC);
+            dst[3] = svld1_f32(pg, src + 3 * srcC);
+            dst[4] = svld1_f32(pg, src + 4 * srcC);
+            dst[5] = svld1_f32(pg, src + 5 * srcC);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcC, float* dst, size_t dstStride)
+        {
+            const size_t F = svcntw();
+            const size_t srcCF = AlignLo(srcC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < srcCF; c += F)
+            {
+                svfloat32_t tmp[6];
+                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, tmp, body);
+                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, body);
+            }
+            if (c < srcC)
+            {
+                svfloat32_t tmp[6];
+                svbool_t tail = svwhilelt_b32(c, srcC);
+                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, tmp, tail);
+                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, tail);
+            }
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputLoad(const float* src, size_t srcC, size_t colB, size_t colE, svfloat32_t dst[6], const svbool_t& pg)
+        {
+            for (size_t col = 0; col < colB; ++col)
+                dst[col] = svdup_n_f32(0.0f);
+            for (size_t col = colB; col < colE; ++col)
+                dst[col] = svld1_f32(pg, src + col * srcC);
+            for (size_t col = colE; col < 6; ++col)
+                dst[col] = svdup_n_f32(0.0f);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcC, size_t colB, size_t colE, float* dst, size_t dstStride)
+        {
+            const size_t F = svcntw();
+            const size_t srcCF = AlignLo(srcC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < srcCF; c += F)
+            {
+                svfloat32_t tmp[6];
+                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, colB, colE, tmp, body);
+                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, body);
+            }
+            if (c < srcC)
+            {
+                svfloat32_t tmp[6];
+                svbool_t tail = svwhilelt_b32(c, srcC);
+                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, colB, colE, tmp, tail);
+                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, tail);
+            }
+        }
+
+        void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
+            size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans)
+        {
+            assert(padX == padW && padY == 0 && padH == 0 && (padX == 0 || padX == 1));
+            if (!trans)
+            {
+                Base::WinogradKernel1x3Block1x4SetInput(src, srcChannels, srcHeight, srcWidth, padY, padX, padH, padW, dst, dstStride, trans);
+                return;
+            }
+            size_t dstH = srcHeight;
+            size_t dstW = padX ? srcWidth : srcWidth - 2;
+            size_t dstW4 = AlignLo(dstW, 4);
+            size_t noseW = Simd::Min<size_t>(6, dstW + 1);
+            size_t startX = padX ? 4 : 0;
+            if (padX)
+            {
+                if (dstW == dstW4)
+                    dstW4 -= 4;
+                src -= srcChannels;
+            }
+            size_t tailW = dstW - dstW4 + (padX ? 1 : 2);
+            for (size_t row = 0; row < dstH; row += 1)
+            {
+                size_t col = 0;
+                if (padX)
+                    WinogradKernel1x3Block1x4SetInput(src, srcChannels, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = startX; col < dstW4; col += 4)
+                    WinogradKernel1x3Block1x4SetInput(src + col * srcChannels, srcChannels, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel1x3Block1x4SetInput(src + col * srcChannels, srcChannels, 0, tailW, dst, dstStride), dst += srcChannels;
+                src += srcWidth * srcChannels;
             }
         }
     }

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -90,27 +90,29 @@ namespace Simd
 
         //-----------------------------------------------------------------------
 
-        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputStore(const svfloat32_t src[6], float* dst, size_t stride, const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputStore(const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2,
+            const svfloat32_t& s3, const svfloat32_t& s4, const svfloat32_t& s5, float* dst, size_t stride, const svbool_t& pg)
         {
             const svfloat32_t _2 = svdup_n_f32(2.0f);
             const svfloat32_t _4 = svdup_n_f32(4.0f);
             const svfloat32_t _5 = svdup_n_f32(5.0f);
-            svst1_f32(pg, dst + 0 * stride, svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, _4, src[0]), svmul_f32_x(pg, _5, src[2])), src[4]));
-            svst1_f32(pg, dst + 1 * stride, svsub_f32_x(pg, svadd_f32_x(pg, src[3], src[4]), svmul_f32_x(pg, _4, svadd_f32_x(pg, src[1], src[2]))));
-            svst1_f32(pg, dst + 2 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _4, svsub_f32_x(pg, src[1], src[2])), svsub_f32_x(pg, src[4], src[3])));
-            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _2, svsub_f32_x(pg, src[3], src[1])), svsub_f32_x(pg, src[4], src[2])));
-            svst1_f32(pg, dst + 4 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _2, svsub_f32_x(pg, src[1], src[3])), svsub_f32_x(pg, src[4], src[2])));
-            svst1_f32(pg, dst + 5 * stride, svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, _4, src[1]), svmul_f32_x(pg, _5, src[3])), src[5]));
+            svst1_f32(pg, dst + 0 * stride, svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, _4, s0), svmul_f32_x(pg, _5, s2)), s4));
+            svst1_f32(pg, dst + 1 * stride, svsub_f32_x(pg, svadd_f32_x(pg, s3, s4), svmul_f32_x(pg, _4, svadd_f32_x(pg, s1, s2))));
+            svst1_f32(pg, dst + 2 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _4, svsub_f32_x(pg, s1, s2)), svsub_f32_x(pg, s4, s3)));
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _2, svsub_f32_x(pg, s3, s1)), svsub_f32_x(pg, s4, s2)));
+            svst1_f32(pg, dst + 4 * stride, svadd_f32_x(pg, svmul_f32_x(pg, _2, svsub_f32_x(pg, s1, s3)), svsub_f32_x(pg, s4, s2)));
+            svst1_f32(pg, dst + 5 * stride, svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, _4, s1), svmul_f32_x(pg, _5, s3)), s5));
         }
 
-        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputLoad(const float* src, size_t srcC, svfloat32_t dst[6], const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcC, float* dst, size_t dstStride, const svbool_t& pg)
         {
-            dst[0] = svld1_f32(pg, src + 0 * srcC);
-            dst[1] = svld1_f32(pg, src + 1 * srcC);
-            dst[2] = svld1_f32(pg, src + 2 * srcC);
-            dst[3] = svld1_f32(pg, src + 3 * srcC);
-            dst[4] = svld1_f32(pg, src + 4 * srcC);
-            dst[5] = svld1_f32(pg, src + 5 * srcC);
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcC);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcC);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcC);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * srcC);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * srcC);
+            svfloat32_t s5 = svld1_f32(pg, src + 5 * srcC);
+            WinogradKernel1x3Block1x4SetInputStore(s0, s1, s2, s3, s4, s5, dst, dstStride, pg);
         }
 
         SIMD_INLINE void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcC, float* dst, size_t dstStride)
@@ -120,28 +122,25 @@ namespace Simd
             const svbool_t body = svptrue_b32();
             size_t c = 0;
             for (; c < srcCF; c += F)
-            {
-                svfloat32_t tmp[6];
-                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, tmp, body);
-                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, body);
-            }
+                WinogradKernel1x3Block1x4SetInput(src + c, srcC, dst + c, dstStride, body);
             if (c < srcC)
-            {
-                svfloat32_t tmp[6];
-                svbool_t tail = svwhilelt_b32(c, srcC);
-                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, tmp, tail);
-                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, tail);
-            }
+                WinogradKernel1x3Block1x4SetInput(src + c, srcC, dst + c, dstStride, svwhilelt_b32(c, srcC));
         }
 
-        SIMD_INLINE void WinogradKernel1x3Block1x4SetInputLoad(const float* src, size_t srcC, size_t colB, size_t colE, svfloat32_t dst[6], const svbool_t& pg)
+        SIMD_INLINE svfloat32_t WinogradKernel1x3Block1x4SetInputLoad(const float* src, size_t srcC, size_t col, size_t colB, size_t colE, const svbool_t& pg)
         {
-            for (size_t col = 0; col < colB; ++col)
-                dst[col] = svdup_n_f32(0.0f);
-            for (size_t col = colB; col < colE; ++col)
-                dst[col] = svld1_f32(pg, src + col * srcC);
-            for (size_t col = colE; col < 6; ++col)
-                dst[col] = svdup_n_f32(0.0f);
+            return col >= colB && col < colE ? svld1_f32(pg, src + col * srcC) : svdup_n_f32(0.0f);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcC, size_t colB, size_t colE, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s0 = WinogradKernel1x3Block1x4SetInputLoad(src, srcC, 0, colB, colE, pg);
+            svfloat32_t s1 = WinogradKernel1x3Block1x4SetInputLoad(src, srcC, 1, colB, colE, pg);
+            svfloat32_t s2 = WinogradKernel1x3Block1x4SetInputLoad(src, srcC, 2, colB, colE, pg);
+            svfloat32_t s3 = WinogradKernel1x3Block1x4SetInputLoad(src, srcC, 3, colB, colE, pg);
+            svfloat32_t s4 = WinogradKernel1x3Block1x4SetInputLoad(src, srcC, 4, colB, colE, pg);
+            svfloat32_t s5 = WinogradKernel1x3Block1x4SetInputLoad(src, srcC, 5, colB, colE, pg);
+            WinogradKernel1x3Block1x4SetInputStore(s0, s1, s2, s3, s4, s5, dst, dstStride, pg);
         }
 
         SIMD_INLINE void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcC, size_t colB, size_t colE, float* dst, size_t dstStride)
@@ -151,18 +150,9 @@ namespace Simd
             const svbool_t body = svptrue_b32();
             size_t c = 0;
             for (; c < srcCF; c += F)
-            {
-                svfloat32_t tmp[6];
-                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, colB, colE, tmp, body);
-                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, body);
-            }
+                WinogradKernel1x3Block1x4SetInput(src + c, srcC, colB, colE, dst + c, dstStride, body);
             if (c < srcC)
-            {
-                svfloat32_t tmp[6];
-                svbool_t tail = svwhilelt_b32(c, srcC);
-                WinogradKernel1x3Block1x4SetInputLoad(src + c, srcC, colB, colE, tmp, tail);
-                WinogradKernel1x3Block1x4SetInputStore(tmp, dst + c, dstStride, tail);
-            }
+                WinogradKernel1x3Block1x4SetInput(src + c, srcC, colB, colE, dst + c, dstStride, svwhilelt_b32(c, srcC));
         }
 
         void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -427,6 +427,11 @@ namespace Test
             result = result && WinogradKernel1x3SetInputAutoTest(4, FUNC_WI(Simd::Neon::WinogradKernel1x3Block1x4SetInput), FUNC_WI(SimdWinogradKernel1x3Block1x4SetInput));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradKernel1x3SetInputAutoTest(4, FUNC_WI(Simd::Sve2::WinogradKernel1x3Block1x4SetInput), FUNC_WI(SimdWinogradKernel1x3Block1x4SetInput));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `WinogradKernel1x3Block1x4SetInput` for transposed input layout.
- Wire SVE2 into the public Winograd input dispatcher and auto-test coverage.
- Document the optimization in the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -march=armv8-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2Winograd1.cpp`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=WinogradKernel1x3Block1x4SetInput -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96157738-9ffe-430a-a225-c0f7714ec51a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96157738-9ffe-430a-a225-c0f7714ec51a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

