### PR TITLE
Add SVE2 Winograd 1x3 output optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetInput.</li>
+ <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetOutput.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>
@@ -111,6 +112,7 @@
  <li>Tests for verifying functionality of function Yuv444pToHsv.</li>
  <li>Tests for verifying functionality of function Yuv444pToHue.</li>
  <li>Tests for verifying functionality of function WinogradKernel1x3Block1x4SetFilter.</li>
+ <li>Tests for verifying functionality of function WinogradKernel1x3Block1x4SetOutput.</li>
  <li>Tests for verifying functionality of function Yuv420pToUyvy422.</li>
  <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
  <li>Tests for verifying functionality of function Yuva444pToBgraV2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8104,7 +8104,7 @@ SIMD_API void SimdWinogradKernel1x3Block1x4SetOutput(const float* src, size_t sr
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetOutputPtr simdWinogradKernel1x3Block1x4SetOutput = SIMD_FUNC4(WinogradKernel1x3Block1x4SetOutput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetOutputPtr simdWinogradKernel1x3Block1x4SetOutput = SIMD_FUNC5(WinogradKernel1x3Block1x4SetOutput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel1x3Block1x4SetOutput(src, srcStride, dst, dstChannels, dstHeight, dstWidth, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -224,6 +224,8 @@ namespace Simd
         void WinogradKernel1x3Block1x4SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
             size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans);
 
+        void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -188,6 +188,105 @@ namespace Simd
                 src += srcWidth * srcChannels;
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetOutputStore(const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2,
+            const svfloat32_t& s3, const svfloat32_t& s4, const svfloat32_t& s5, float* dst, size_t dstC, const svbool_t& pg)
+        {
+            const svfloat32_t _2 = svdup_n_f32(2.0f);
+            const svfloat32_t _4 = svdup_n_f32(4.0f);
+            const svfloat32_t _8 = svdup_n_f32(8.0f);
+            svst1_f32(pg, dst + 0 * dstC, svadd_f32_x(pg, svadd_f32_x(pg, svadd_f32_x(pg, s0, s1), svadd_f32_x(pg, s2, s3)), s4));
+            svst1_f32(pg, dst + 1 * dstC, svadd_f32_x(pg, svsub_f32_x(pg, s1, s2), svmul_f32_x(pg, _2, svsub_f32_x(pg, s3, s4))));
+            svst1_f32(pg, dst + 2 * dstC, svadd_f32_x(pg, svadd_f32_x(pg, s1, s2), svmul_f32_x(pg, _4, svadd_f32_x(pg, s3, s4))));
+            svst1_f32(pg, dst + 3 * dstC, svadd_f32_x(pg, svadd_f32_x(pg, svsub_f32_x(pg, s1, s2), svmul_f32_x(pg, _8, svsub_f32_x(pg, s3, s4))), s5));
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstC, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcStride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * srcStride);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * srcStride);
+            svfloat32_t s5 = svld1_f32(pg, src + 5 * srcStride);
+            WinogradKernel1x3Block1x4SetOutputStore(s0, s1, s2, s3, s4, s5, dst, dstC, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstC)
+        {
+            const size_t F = svcntw();
+            const size_t dstCF = AlignLo(dstC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < dstCF; c += F)
+                WinogradKernel1x3Block1x4SetOutput(src + c, srcStride, dst + c, dstC, body);
+            if (c < dstC)
+                WinogradKernel1x3Block1x4SetOutput(src + c, srcStride, dst + c, dstC, svwhilelt_b32(c, dstC));
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetOutputStore(const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2,
+            const svfloat32_t& s3, const svfloat32_t& s4, const svfloat32_t& s5, float* dst, size_t dstC, size_t colE, const svbool_t& pg)
+        {
+            const svfloat32_t _2 = svdup_n_f32(2.0f);
+            const svfloat32_t _4 = svdup_n_f32(4.0f);
+            const svfloat32_t _8 = svdup_n_f32(8.0f);
+            svfloat32_t d0 = svadd_f32_x(pg, svadd_f32_x(pg, svadd_f32_x(pg, s0, s1), svadd_f32_x(pg, s2, s3)), s4);
+            svfloat32_t d1 = svadd_f32_x(pg, svsub_f32_x(pg, s1, s2), svmul_f32_x(pg, _2, svsub_f32_x(pg, s3, s4)));
+            svfloat32_t d2 = svadd_f32_x(pg, svadd_f32_x(pg, s1, s2), svmul_f32_x(pg, _4, svadd_f32_x(pg, s3, s4)));
+            svfloat32_t d3 = svadd_f32_x(pg, svadd_f32_x(pg, svsub_f32_x(pg, s1, s2), svmul_f32_x(pg, _8, svsub_f32_x(pg, s3, s4))), s5);
+            if (0 < colE)
+                svst1_f32(pg, dst + 0 * dstC, d0);
+            if (1 < colE)
+                svst1_f32(pg, dst + 1 * dstC, d1);
+            if (2 < colE)
+                svst1_f32(pg, dst + 2 * dstC, d2);
+            if (3 < colE)
+                svst1_f32(pg, dst + 3 * dstC, d3);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstC, size_t colE, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcStride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * srcStride);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * srcStride);
+            svfloat32_t s5 = svld1_f32(pg, src + 5 * srcStride);
+            WinogradKernel1x3Block1x4SetOutputStore(s0, s1, s2, s3, s4, s5, dst, dstC, colE, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstC, size_t colE)
+        {
+            const size_t F = svcntw();
+            const size_t dstCF = AlignLo(dstC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < dstCF; c += F)
+                WinogradKernel1x3Block1x4SetOutput(src + c, srcStride, dst + c, dstC, colE, body);
+            if (c < dstC)
+                WinogradKernel1x3Block1x4SetOutput(src + c, srcStride, dst + c, dstC, colE, svwhilelt_b32(c, dstC));
+        }
+
+        void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans)
+        {
+            if (!trans)
+            {
+                Base::WinogradKernel1x3Block1x4SetOutput(src, srcStride, dst, dstChannels, dstHeight, dstWidth, trans);
+                return;
+            }
+            size_t dstW4 = AlignLo(dstWidth, 4);
+            for (size_t row = 0; row < dstHeight; row += 1)
+            {
+                size_t col = 0;
+                for (; col < dstW4; col += 4)
+                    WinogradKernel1x3Block1x4SetOutput(src, srcStride, dst + col * dstChannels, dstChannels), src += dstChannels;
+                if (col < dstWidth)
+                    WinogradKernel1x3Block1x4SetOutput(src, srcStride, dst + col * dstChannels, dstChannels, dstWidth - col), src += dstChannels;
+                dst += dstWidth * dstChannels;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -794,6 +794,11 @@ namespace Test
             result = result && WinogradKernel1x3SetOutputAutoTest(4, FUNC_WO(Simd::Neon::WinogradKernel1x3Block1x4SetOutput), FUNC_WO(SimdWinogradKernel1x3Block1x4SetOutput));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradKernel1x3SetOutputAutoTest(4, FUNC_WO(Simd::Sve2::WinogradKernel1x3Block1x4SetOutput), FUNC_WO(SimdWinogradKernel1x3Block1x4SetOutput));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Added SVE2 implementation and dispatch for `WinogradKernel1x3Block1x4SetOutput`.
* Added SVE2 autotest coverage for the Winograd output path.
* Updated release 7.2.164 notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=WinogradKernel1x3Block1x4SetOutput -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2Winograd1.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-991b4af0-94ac-4c39-9cc6-9a9d6f7226ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-991b4af0-94ac-4c39-9cc6-9a9d6f7226ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

