### PR TITLE
Add SVE2 Winograd 1x5 filter optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetOutput.</li>
+ <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetFilter.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8116,7 +8116,7 @@ SIMD_API void SimdWinogradKernel1x5Block1x4SetFilter(const float* src, size_t si
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetFilterPtr simdWinogradKernel1x5Block1x4SetFilter = SIMD_FUNC4(WinogradKernel1x5Block1x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetFilterPtr simdWinogradKernel1x5Block1x4SetFilter = SIMD_FUNC5(WinogradKernel1x5Block1x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel1x5Block1x4SetFilter(src, size, dst, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -226,6 +226,8 @@ namespace Simd
 
         void WinogradKernel1x3Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
 
+        void WinogradKernel1x5Block1x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd1.cpp
+++ b/src/Simd/SimdSve2Winograd1.cpp
@@ -287,6 +287,79 @@ namespace Simd
                 dst += dstWidth * dstChannels;
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel1x5Block1x4SetFilter(const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2,
+            const svfloat32_t& s3, const svfloat32_t& s4, float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r36 = svdup_n_f32(1.0f / 36.0f);
+            const svfloat32_t r48 = svdup_n_f32(1.0f / 48.0f);
+            const svfloat32_t mr120 = svdup_n_f32(-1.0f / 120.0f);
+            const svfloat32_t r720 = svdup_n_f32(1.0f / 720.0f);
+            const svfloat32_t _2 = svdup_n_f32(2.0f);
+            const svfloat32_t _3 = svdup_n_f32(3.0f);
+            const svfloat32_t _4 = svdup_n_f32(4.0f);
+            const svfloat32_t _9 = svdup_n_f32(9.0f);
+
+            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r36, s0));
+            svfloat32_t a0 = svadd_f32_x(pg, svadd_f32_x(pg, s0, s2), s4);
+            svfloat32_t a1 = svadd_f32_x(pg, s1, s3);
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, r48, svadd_f32_x(pg, a0, a1)));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, r48, svsub_f32_x(pg, a0, a1)));
+            a0 = svadd_f32_x(pg, s0, svmul_f32_x(pg, _4, svadd_f32_x(pg, s2, svmul_f32_x(pg, _4, s4))));
+            a1 = svmul_f32_x(pg, _2, svadd_f32_x(pg, s1, svmul_f32_x(pg, _4, s3)));
+            svst1_f32(pg, dst + 3 * stride, svmul_f32_x(pg, mr120, svadd_f32_x(pg, a0, a1)));
+            svst1_f32(pg, dst + 4 * stride, svmul_f32_x(pg, mr120, svsub_f32_x(pg, a0, a1)));
+            a0 = svadd_f32_x(pg, s0, svmul_f32_x(pg, _9, svadd_f32_x(pg, s2, svmul_f32_x(pg, _9, s4))));
+            a1 = svmul_f32_x(pg, _3, svadd_f32_x(pg, s1, svmul_f32_x(pg, _9, s3)));
+            svst1_f32(pg, dst + 5 * stride, svmul_f32_x(pg, r720, svadd_f32_x(pg, a0, a1)));
+            svst1_f32(pg, dst + 6 * stride, svmul_f32_x(pg, r720, svsub_f32_x(pg, a0, a1)));
+            svst1_f32(pg, dst + 7 * stride, s4);
+        }
+
+        SIMD_INLINE void WinogradKernel1x5Block1x4SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcStride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * srcStride);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * srcStride);
+            WinogradKernel1x5Block1x4SetFilter(s0, s1, s2, s3, s4, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel1x5Block1x4SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svuint32_t offsets = svindex_u32(0, 5);
+            svfloat32_t s0 = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            svfloat32_t s1 = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            svfloat32_t s2 = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            svfloat32_t s3 = svld1_gather_u32index_f32(pg, src + 3, offsets);
+            svfloat32_t s4 = svld1_gather_u32index_f32(pg, src + 4, offsets);
+            WinogradKernel1x5Block1x4SetFilter(s0, s1, s2, s3, s4, dst, dstStride, pg);
+        }
+
+        void WinogradKernel1x5Block1x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans)
+        {
+            const size_t F = svcntw();
+            const size_t sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            if (trans)
+            {
+                for (; i < sizeF; i += F)
+                    WinogradKernel1x5Block1x4SetFilterVt(src + i, size, dst + i, size, body);
+                if (i < size)
+                    WinogradKernel1x5Block1x4SetFilterVt(src + i, size, dst + i, size, svwhilelt_b32(i, size));
+            }
+            else
+            {
+                for (; i < sizeF; i += F, src += 5 * F, dst += F)
+                    WinogradKernel1x5Block1x4SetFilterVn(src, dst, size, body);
+                if (i < size)
+                    WinogradKernel1x5Block1x4SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -158,6 +158,11 @@ namespace Test
             result = result && WinogradSetFilterAutoTest(_1x4, _1x5, FUNC_WF(Simd::Neon::WinogradKernel1x5Block1x4SetFilter), FUNC_WF(SimdWinogradKernel1x5Block1x4SetFilter));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradSetFilterAutoTest(_1x4, _1x5, FUNC_WF(Simd::Sve2::WinogradKernel1x5Block1x4SetFilter), FUNC_WF(SimdWinogradKernel1x5Block1x4SetFilter));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `WinogradKernel1x5Block1x4SetFilter`.
- Dispatch the public C API to SVE2 when available.
- Extend Winograd auto-tests and release notes for the new optimization.
- Verified `SimdSve2Winograd1.cpp` is already included in `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters`.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=WinogradKernel1x5Block1x4SetFilter -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Winograd1.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dcbdef0-890b-4e84-8217-af54b7869693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dcbdef0-890b-4e84-8217-af54b7869693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

