### PR TITLE
Add SVE2 Winograd 2x2 filter optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetOutput.</li>
+ <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetFilter.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Winograd1.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Winograd2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgraV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgrV2.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -353,6 +353,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Winograd1.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Winograd2.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8153,7 +8153,7 @@ SIMD_API void SimdWinogradKernel2x2Block2x2SetFilter(const float* src, size_t si
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetFilterPtr simdWinogradKernel2x2Block2x2SetFilter = SIMD_FUNC4(WinogradKernel2x2Block2x2SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetFilterPtr simdWinogradKernel2x2Block2x2SetFilter = SIMD_FUNC5(WinogradKernel2x2Block2x2SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel2x2Block2x2SetFilter(src, size, dst, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -233,6 +233,8 @@ namespace Simd
 
         void WinogradKernel1x5Block1x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
 
+        void WinogradKernel2x2Block2x2SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd2.cpp
+++ b/src/Simd/SimdSve2Winograd2.cpp
@@ -1,0 +1,91 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdWinograd.h"
+#include "Simd/SimdBase.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetFilter(const svfloat32_t& s0, const svfloat32_t& s1,
+            const svfloat32_t& s2, const svfloat32_t& s3, float* dst, size_t stride, const svbool_t& pg)
+        {
+            svst1_f32(pg, dst + 0 * stride, s0);
+            svst1_f32(pg, dst + 1 * stride, svadd_f32_x(pg, s0, s1));
+            svst1_f32(pg, dst + 2 * stride, s1);
+
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, s0, s2));
+            svst1_f32(pg, dst + 4 * stride, svadd_f32_x(pg, svadd_f32_x(pg, s0, s1), svadd_f32_x(pg, s2, s3)));
+            svst1_f32(pg, dst + 5 * stride, svadd_f32_x(pg, s1, s3));
+
+            svst1_f32(pg, dst + 6 * stride, s2);
+            svst1_f32(pg, dst + 7 * stride, svadd_f32_x(pg, s2, s3));
+            svst1_f32(pg, dst + 8 * stride, s3);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcStride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * srcStride);
+            WinogradKernel2x2Block2x2SetFilter(s0, s1, s2, s3, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svuint32_t offsets = svindex_u32(0, 4);
+            svfloat32_t s0 = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            svfloat32_t s1 = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            svfloat32_t s2 = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            svfloat32_t s3 = svld1_gather_u32index_f32(pg, src + 3, offsets);
+            WinogradKernel2x2Block2x2SetFilter(s0, s1, s2, s3, dst, dstStride, pg);
+        }
+
+        void WinogradKernel2x2Block2x2SetFilter(const float* src, size_t size, float* dst, SimdBool trans)
+        {
+            const size_t F = svcntw();
+            const size_t sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            if (trans)
+            {
+                for (; i < sizeF; i += F)
+                    WinogradKernel2x2Block2x2SetFilterVt(src + i, size, dst + i, size, body);
+                if (i < size)
+                    WinogradKernel2x2Block2x2SetFilterVt(src + i, size, dst + i, size, svwhilelt_b32(i, size));
+            }
+            else
+            {
+                for (; i < sizeF; i += F, src += 4 * F, dst += F)
+                    WinogradKernel2x2Block2x2SetFilterVn(src, dst, size, body);
+                if (i < size)
+                    WinogradKernel2x2Block2x2SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -194,6 +194,11 @@ namespace Test
             result = result && WinogradSetFilterAutoTest(_2x2, _2x2, FUNC_WF(Simd::Neon::WinogradKernel2x2Block2x2SetFilter), FUNC_WF(SimdWinogradKernel2x2Block2x2SetFilter));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradSetFilterAutoTest(_2x2, _2x2, FUNC_WF(Simd::Sve2::WinogradKernel2x2Block2x2SetFilter), FUNC_WF(SimdWinogradKernel2x2Block2x2SetFilter));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `WinogradKernel2x2Block2x2SetFilter`.
- Wire SVE2 dispatch and auto-test coverage for `SimdWinogradKernel2x2Block2x2SetFilter`.
- Register the new source in VS2022 SVE2 project files and update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=WinogradKernel2x2Block2x2SetFilter -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2Winograd2.cpp -o /tmp/SimdSve2Winograd2.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdLib.cpp -o /tmp/SimdLib.sve2.o && aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Test/TestWinograd.cpp -o /tmp/TestWinograd.sve2.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eca2f08d-e893-4460-aa53-904986923b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eca2f08d-e893-4460-aa53-904986923b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

