### PR TITLE
Add SVE2 Winograd 2x2 SetInput optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -52,6 +52,7 @@
  <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetOutput.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetFilter.</li>
+ <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetInput.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8166,7 +8166,7 @@ SIMD_API void SimdWinogradKernel2x2Block2x2SetInput(const float* src, size_t src
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetInputPtr simdWinogradKernel2x2Block2x2SetInput = SIMD_FUNC4(WinogradKernel2x2Block2x2SetInput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetInputPtr simdWinogradKernel2x2Block2x2SetInput = SIMD_FUNC5(WinogradKernel2x2Block2x2SetInput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel2x2Block2x2SetInput(src, srcChannels, srcHeight, srcWidth, padY, padX, padH, padW, dst, dstStride, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -235,6 +235,9 @@ namespace Simd
 
         void WinogradKernel2x2Block2x2SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
 
+        void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
+            size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd2.cpp
+++ b/src/Simd/SimdSve2Winograd2.cpp
@@ -86,6 +86,143 @@ namespace Simd
                     WinogradKernel2x2Block2x2SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetInputStore(const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2,
+            const svfloat32_t& s3, const svfloat32_t& s4, const svfloat32_t& s5, const svfloat32_t& s6, const svfloat32_t& s7,
+            const svfloat32_t& s8, float* dst, size_t stride, const svbool_t& pg)
+        {
+            svst1_f32(pg, dst + 0 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s0, s1), svsub_f32_x(pg, s4, s3)));
+            svst1_f32(pg, dst + 1 * stride, svsub_f32_x(pg, s1, s4));
+            svst1_f32(pg, dst + 2 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s2, s1), svsub_f32_x(pg, s4, s5)));
+            svst1_f32(pg, dst + 3 * stride, svsub_f32_x(pg, s3, s4));
+            svst1_f32(pg, dst + 4 * stride, s4);
+            svst1_f32(pg, dst + 5 * stride, svsub_f32_x(pg, s5, s4));
+            svst1_f32(pg, dst + 6 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s4, s3), svsub_f32_x(pg, s6, s7)));
+            svst1_f32(pg, dst + 7 * stride, svsub_f32_x(pg, s7, s4));
+            svst1_f32(pg, dst + 8 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s4, s5), svsub_f32_x(pg, s8, s7)));
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcS, size_t srcC, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcS + 0 * srcC);
+            svfloat32_t s1 = svld1_f32(pg, src + 0 * srcS + 1 * srcC);
+            svfloat32_t s2 = svld1_f32(pg, src + 0 * srcS + 2 * srcC);
+            svfloat32_t s3 = svld1_f32(pg, src + 1 * srcS + 0 * srcC);
+            svfloat32_t s4 = svld1_f32(pg, src + 1 * srcS + 1 * srcC);
+            svfloat32_t s5 = svld1_f32(pg, src + 1 * srcS + 2 * srcC);
+            svfloat32_t s6 = svld1_f32(pg, src + 2 * srcS + 0 * srcC);
+            svfloat32_t s7 = svld1_f32(pg, src + 2 * srcS + 1 * srcC);
+            svfloat32_t s8 = svld1_f32(pg, src + 2 * srcS + 2 * srcC);
+            WinogradKernel2x2Block2x2SetInputStore(s0, s1, s2, s3, s4, s5, s6, s7, s8, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcW, size_t srcC, float* dst, size_t dstStride)
+        {
+            const size_t F = svcntw();
+            const size_t srcS = srcW * srcC;
+            const size_t srcCF = AlignLo(srcC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < srcCF; c += F)
+                WinogradKernel2x2Block2x2SetInput(src + c, srcS, srcC, dst + c, dstStride, body);
+            if (c < srcC)
+                WinogradKernel2x2Block2x2SetInput(src + c, srcS, srcC, dst + c, dstStride, svwhilelt_b32(c, srcC));
+        }
+
+        SIMD_INLINE svfloat32_t WinogradKernel2x2Block2x2SetInputLoad(const float* src, size_t srcS, size_t srcC, size_t row,
+            size_t rowB, size_t rowE, size_t col, size_t colB, size_t colE, const svbool_t& pg)
+        {
+            return row >= rowB && row < rowE && col >= colB && col < colE ? svld1_f32(pg, src + row * srcS + col * srcC) : svdup_n_f32(0.0f);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcS, size_t srcC, size_t rowB, size_t rowE,
+            size_t colB, size_t colE, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s0 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 0, colB, colE, pg);
+            svfloat32_t s1 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 1, colB, colE, pg);
+            svfloat32_t s2 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 2, colB, colE, pg);
+            svfloat32_t s3 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 0, colB, colE, pg);
+            svfloat32_t s4 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 1, colB, colE, pg);
+            svfloat32_t s5 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 2, colB, colE, pg);
+            svfloat32_t s6 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 0, colB, colE, pg);
+            svfloat32_t s7 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 1, colB, colE, pg);
+            svfloat32_t s8 = WinogradKernel2x2Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 2, colB, colE, pg);
+            WinogradKernel2x2Block2x2SetInputStore(s0, s1, s2, s3, s4, s5, s6, s7, s8, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcW, size_t srcC, size_t rowB, size_t rowE,
+            size_t colB, size_t colE, float* dst, size_t dstStride)
+        {
+            const size_t F = svcntw();
+            const size_t srcS = srcW * srcC;
+            const size_t srcCF = AlignLo(srcC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < srcCF; c += F)
+                WinogradKernel2x2Block2x2SetInput(src + c, srcS, srcC, rowB, rowE, colB, colE, dst + c, dstStride, body);
+            if (c < srcC)
+                WinogradKernel2x2Block2x2SetInput(src + c, srcS, srcC, rowB, rowE, colB, colE, dst + c, dstStride, svwhilelt_b32(c, srcC));
+        }
+
+        void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
+            size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans)
+        {
+            assert(padY == padX && padW == padH && (padY + padH == 0 || padY + padH == 1));
+            if (!trans)
+            {
+                Base::WinogradKernel2x2Block2x2SetInput(src, srcChannels, srcHeight, srcWidth, padY, padX, padH, padW, dst, dstStride, trans);
+                return;
+            }
+            size_t dstH = srcHeight - 1 + padY + padH;
+            size_t dstW = srcWidth - 1 + padX + padW;
+            size_t dstH2 = AlignLo(dstH, 2);
+            size_t dstW2 = AlignLo(dstW, 2);
+            size_t noseW = Simd::Min<size_t>(3, dstW + 1);
+            size_t noseH = Simd::Min<size_t>(3, dstH + 1);
+            size_t startY = padY ? 2 : 0;
+            size_t startX = padX ? 2 : 0;
+            if (padY || padH)
+            {
+                if (dstH == dstH2)
+                    dstH2 -= 2;
+                if (dstW == dstW2)
+                    dstW2 -= 2;
+                if (padY)
+                    src -= (srcWidth + 1) * srcChannels;
+            }
+            size_t tailW = dstW - dstW2 + (padW ? 0 : 1);
+            size_t tailH = dstH - dstH2 + (padH ? 0 : 1);
+            size_t row = 0, col = 0;
+            if (padY)
+            {
+                if (padX)
+                    WinogradKernel2x2Block2x2SetInput(src, srcWidth, srcChannels, 1, noseH, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = startX; col < dstW2; col += 2)
+                    WinogradKernel2x2Block2x2SetInput(src + col * srcChannels, srcWidth, srcChannels, 1, noseH, 0, 3, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel2x2Block2x2SetInput(src + col * srcChannels, srcWidth, srcChannels, 1, noseH, 0, tailW, dst, dstStride), dst += srcChannels;
+            }
+            for (row = startY; row < dstH2; row += 2)
+            {
+                if (padX)
+                    WinogradKernel2x2Block2x2SetInput(src + row * srcWidth * srcChannels, srcWidth, srcChannels, 0, 3, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = startX; col < dstW2; col += 2)
+                    WinogradKernel2x2Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel2x2Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, 3, 0, tailW, dst, dstStride), dst += srcChannels;
+            }
+            if (row < dstH)
+            {
+                if (padX)
+                    WinogradKernel2x2Block2x2SetInput(src + row * srcWidth * srcChannels, srcWidth, srcChannels, 0, tailH, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = startX; col < dstW2; col += 2)
+                    WinogradKernel2x2Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, tailH, 0, 3, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel2x2Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, tailH, 0, tailW, dst, dstStride), dst += srcChannels;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -553,6 +553,11 @@ namespace Test
             result = result && WinogradKernel2x2SetInputAutoTest(2, FUNC_WI(Simd::Neon::WinogradKernel2x2Block2x2SetInput), FUNC_WI(SimdWinogradKernel2x2Block2x2SetInput));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradKernel2x2SetInputAutoTest(2, FUNC_WI(Simd::Sve2::WinogradKernel2x2Block2x2SetInput), FUNC_WI(SimdWinogradKernel2x2Block2x2SetInput));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 vectorized `WinogradKernel2x2Block2x2SetInput` implementation for transposed input with scalable predicates and Base fallback for non-transposed input.
- Wire the implementation into the SVE2 header, public dispatcher, and Winograd autotests.
- Update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=WinogradKernel2x2Block2x2SetInput -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2Winograd2.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b044b56-facf-4430-8f62-d80371745268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b044b56-facf-4430-8f62-d80371745268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

