### PR TITLE
Add SVE2 Winograd 2x2 output optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -53,6 +53,7 @@
  <li>SVE2 optimizations of function WinogradKernel1x5Block1x4SetOutput.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetInput.</li>
+ <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetOutput.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8178,7 +8178,7 @@ SIMD_API void SimdWinogradKernel2x2Block2x2SetOutput(const float* src, size_t sr
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetOutputPtr simdWinogradKernel2x2Block2x2SetOutput = SIMD_FUNC4(WinogradKernel2x2Block2x2SetOutput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetOutputPtr simdWinogradKernel2x2Block2x2SetOutput = SIMD_FUNC5(WinogradKernel2x2Block2x2SetOutput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel2x2Block2x2SetOutput(src, srcStride, dst, dstChannels, dstHeight, dstWidth, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -238,6 +238,8 @@ namespace Simd
         void WinogradKernel2x2Block2x2SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
             size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans);
 
+        void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd2.cpp
+++ b/src/Simd/SimdSve2Winograd2.cpp
@@ -223,6 +223,115 @@ namespace Simd
                     WinogradKernel2x2Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, tailH, 0, tailW, dst, dstStride), dst += srcChannels;
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputLoad9(const float* src, size_t stride, svfloat32_t dst[4], const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * stride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * stride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * stride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * stride);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * stride);
+            svfloat32_t s5 = svld1_f32(pg, src + 5 * stride);
+            svfloat32_t s6 = svld1_f32(pg, src + 6 * stride);
+            svfloat32_t s7 = svld1_f32(pg, src + 7 * stride);
+            svfloat32_t s8 = svld1_f32(pg, src + 8 * stride);
+            dst[0] = svadd_f32_x(pg, svadd_f32_x(pg, s0, s1), svadd_f32_x(pg, s3, s4));
+            dst[1] = svadd_f32_x(pg, svadd_f32_x(pg, s1, s2), svadd_f32_x(pg, s4, s5));
+            dst[2] = svadd_f32_x(pg, svadd_f32_x(pg, s3, s4), svadd_f32_x(pg, s6, s7));
+            dst[3] = svadd_f32_x(pg, svadd_f32_x(pg, s4, s5), svadd_f32_x(pg, s7, s8));
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputStore(const svfloat32_t src[4], float* dst, size_t dstS, size_t dstC, const svbool_t& pg)
+        {
+            svst1_f32(pg, dst + 0 * dstS + 0 * dstC, src[0]);
+            svst1_f32(pg, dst + 0 * dstS + 1 * dstC, src[1]);
+            svst1_f32(pg, dst + 1 * dstS + 0 * dstC, src[2]);
+            svst1_f32(pg, dst + 1 * dstS + 1 * dstC, src[3]);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstW, size_t dstC)
+        {
+            const size_t F = svcntw();
+            const size_t dstS = dstW * dstC;
+            const size_t dstCF = AlignLo(dstC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < dstCF; c += F)
+            {
+                svfloat32_t tmp[4];
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, body);
+                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, body);
+            }
+            if (c < dstC)
+            {
+                svfloat32_t tmp[4];
+                svbool_t tail = svwhilelt_b32(c, dstC);
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, tail);
+                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, tail);
+            }
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputStore(const svfloat32_t src[4], float* dst, size_t dstS, size_t dstC, size_t rowE, size_t colE, const svbool_t& pg)
+        {
+            if (0 < rowE && 0 < colE)
+                svst1_f32(pg, dst + 0 * dstS + 0 * dstC, src[0]);
+            if (0 < rowE && 1 < colE)
+                svst1_f32(pg, dst + 0 * dstS + 1 * dstC, src[1]);
+            if (1 < rowE && 0 < colE)
+                svst1_f32(pg, dst + 1 * dstS + 0 * dstC, src[2]);
+            if (1 < rowE && 1 < colE)
+                svst1_f32(pg, dst + 1 * dstS + 1 * dstC, src[3]);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstW, size_t dstC, size_t rowE, size_t colE)
+        {
+            const size_t F = svcntw();
+            const size_t dstS = dstW * dstC;
+            const size_t dstCF = AlignLo(dstC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < dstCF; c += F)
+            {
+                svfloat32_t tmp[4];
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, body);
+                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, rowE, colE, body);
+            }
+            if (c < dstC)
+            {
+                svfloat32_t tmp[4];
+                svbool_t tail = svwhilelt_b32(c, dstC);
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, tail);
+                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, rowE, colE, tail);
+            }
+        }
+
+        void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans)
+        {
+            if (!trans)
+            {
+                Base::WinogradKernel2x2Block2x2SetOutput(src, srcStride, dst, dstChannels, dstHeight, dstWidth, trans);
+                return;
+            }
+            size_t dstH2 = AlignLo(dstHeight, 2);
+            size_t dstW2 = AlignLo(dstWidth, 2);
+            size_t row, col;
+            for (row = 0; row < dstH2; row += 2)
+            {
+                for (col = 0; col < dstW2; col += 2)
+                    WinogradKernel2x2Block2x2SetOutput(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels), src += dstChannels;
+                if (col < dstWidth)
+                    WinogradKernel2x2Block2x2SetOutput(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, 2, dstWidth - col), src += dstChannels;
+            }
+            if (row < dstHeight)
+            {
+                for (col = 0; col < dstW2; col += 2)
+                    WinogradKernel2x2Block2x2SetOutput(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, dstHeight - row, 2), src += dstChannels;
+                if (col < dstWidth)
+                    WinogradKernel2x2Block2x2SetOutput(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, dstHeight - row, dstWidth - col), src += dstChannels;
+            }
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSve2Winograd2.cpp
+++ b/src/Simd/SimdSve2Winograd2.cpp
@@ -226,7 +226,7 @@ namespace Simd
 
         //-----------------------------------------------------------------------
 
-        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputLoad9(const float* src, size_t stride, svfloat32_t dst[4], const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputLoad9(const float* src, size_t stride, svfloat32_t& d0, svfloat32_t& d1, svfloat32_t& d2, svfloat32_t& d3, const svbool_t& pg)
         {
             svfloat32_t s0 = svld1_f32(pg, src + 0 * stride);
             svfloat32_t s1 = svld1_f32(pg, src + 1 * stride);
@@ -237,18 +237,18 @@ namespace Simd
             svfloat32_t s6 = svld1_f32(pg, src + 6 * stride);
             svfloat32_t s7 = svld1_f32(pg, src + 7 * stride);
             svfloat32_t s8 = svld1_f32(pg, src + 8 * stride);
-            dst[0] = svadd_f32_x(pg, svadd_f32_x(pg, s0, s1), svadd_f32_x(pg, s3, s4));
-            dst[1] = svadd_f32_x(pg, svadd_f32_x(pg, s1, s2), svadd_f32_x(pg, s4, s5));
-            dst[2] = svadd_f32_x(pg, svadd_f32_x(pg, s3, s4), svadd_f32_x(pg, s6, s7));
-            dst[3] = svadd_f32_x(pg, svadd_f32_x(pg, s4, s5), svadd_f32_x(pg, s7, s8));
+            d0 = svadd_f32_x(pg, svadd_f32_x(pg, s0, s1), svadd_f32_x(pg, s3, s4));
+            d1 = svadd_f32_x(pg, svadd_f32_x(pg, s1, s2), svadd_f32_x(pg, s4, s5));
+            d2 = svadd_f32_x(pg, svadd_f32_x(pg, s3, s4), svadd_f32_x(pg, s6, s7));
+            d3 = svadd_f32_x(pg, svadd_f32_x(pg, s4, s5), svadd_f32_x(pg, s7, s8));
         }
 
-        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputStore(const svfloat32_t src[4], float* dst, size_t dstS, size_t dstC, const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputStore(const svfloat32_t& d0, const svfloat32_t& d1, const svfloat32_t& d2, const svfloat32_t& d3, float* dst, size_t dstS, size_t dstC, const svbool_t& pg)
         {
-            svst1_f32(pg, dst + 0 * dstS + 0 * dstC, src[0]);
-            svst1_f32(pg, dst + 0 * dstS + 1 * dstC, src[1]);
-            svst1_f32(pg, dst + 1 * dstS + 0 * dstC, src[2]);
-            svst1_f32(pg, dst + 1 * dstS + 1 * dstC, src[3]);
+            svst1_f32(pg, dst + 0 * dstS + 0 * dstC, d0);
+            svst1_f32(pg, dst + 0 * dstS + 1 * dstC, d1);
+            svst1_f32(pg, dst + 1 * dstS + 0 * dstC, d2);
+            svst1_f32(pg, dst + 1 * dstS + 1 * dstC, d3);
         }
 
         SIMD_INLINE void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstW, size_t dstC)
@@ -260,29 +260,29 @@ namespace Simd
             size_t c = 0;
             for (; c < dstCF; c += F)
             {
-                svfloat32_t tmp[4];
-                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, body);
-                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, body);
+                svfloat32_t d0, d1, d2, d3;
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, d0, d1, d2, d3, body);
+                WinogradKernel2x2Block2x2SetOutputStore(d0, d1, d2, d3, dst + c, dstS, dstC, body);
             }
             if (c < dstC)
             {
-                svfloat32_t tmp[4];
+                svfloat32_t d0, d1, d2, d3;
                 svbool_t tail = svwhilelt_b32(c, dstC);
-                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, tail);
-                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, tail);
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, d0, d1, d2, d3, tail);
+                WinogradKernel2x2Block2x2SetOutputStore(d0, d1, d2, d3, dst + c, dstS, dstC, tail);
             }
         }
 
-        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputStore(const svfloat32_t src[4], float* dst, size_t dstS, size_t dstC, size_t rowE, size_t colE, const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel2x2Block2x2SetOutputStore(const svfloat32_t& d0, const svfloat32_t& d1, const svfloat32_t& d2, const svfloat32_t& d3, float* dst, size_t dstS, size_t dstC, size_t rowE, size_t colE, const svbool_t& pg)
         {
             if (0 < rowE && 0 < colE)
-                svst1_f32(pg, dst + 0 * dstS + 0 * dstC, src[0]);
+                svst1_f32(pg, dst + 0 * dstS + 0 * dstC, d0);
             if (0 < rowE && 1 < colE)
-                svst1_f32(pg, dst + 0 * dstS + 1 * dstC, src[1]);
+                svst1_f32(pg, dst + 0 * dstS + 1 * dstC, d1);
             if (1 < rowE && 0 < colE)
-                svst1_f32(pg, dst + 1 * dstS + 0 * dstC, src[2]);
+                svst1_f32(pg, dst + 1 * dstS + 0 * dstC, d2);
             if (1 < rowE && 1 < colE)
-                svst1_f32(pg, dst + 1 * dstS + 1 * dstC, src[3]);
+                svst1_f32(pg, dst + 1 * dstS + 1 * dstC, d3);
         }
 
         SIMD_INLINE void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstW, size_t dstC, size_t rowE, size_t colE)
@@ -294,16 +294,16 @@ namespace Simd
             size_t c = 0;
             for (; c < dstCF; c += F)
             {
-                svfloat32_t tmp[4];
-                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, body);
-                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, rowE, colE, body);
+                svfloat32_t d0, d1, d2, d3;
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, d0, d1, d2, d3, body);
+                WinogradKernel2x2Block2x2SetOutputStore(d0, d1, d2, d3, dst + c, dstS, dstC, rowE, colE, body);
             }
             if (c < dstC)
             {
-                svfloat32_t tmp[4];
+                svfloat32_t d0, d1, d2, d3;
                 svbool_t tail = svwhilelt_b32(c, dstC);
-                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, tmp, tail);
-                WinogradKernel2x2Block2x2SetOutputStore(tmp, dst + c, dstS, dstC, rowE, colE, tail);
+                WinogradKernel2x2Block2x2SetOutputLoad9(src + c, srcStride, d0, d1, d2, d3, tail);
+                WinogradKernel2x2Block2x2SetOutputStore(d0, d1, d2, d3, dst + c, dstS, dstC, rowE, colE, tail);
             }
         }
 

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -925,6 +925,11 @@ namespace Test
             result = result && WinogradKernel2x2SetOutputAutoTest(2, FUNC_WO(Simd::Neon::WinogradKernel2x2Block2x2SetOutput), FUNC_WO(SimdWinogradKernel2x2Block2x2SetOutput));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradKernel2x2SetOutputAutoTest(2, FUNC_WO(Simd::Sve2::WinogradKernel2x2Block2x2SetOutput), FUNC_WO(SimdWinogradKernel2x2Block2x2SetOutput));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and public dispatch for `SimdWinogradKernel2x2Block2x2SetOutput`.
- Cover the SVE2 implementation in the Winograd output auto-test.
- Document the new SVE2 optimization in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=WinogradKernel2x2Block2x2SetOutput -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -I./src -std=c++17 -fsyntax-only src/Simd/SimdSve2Winograd2.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8dd367d-d0b1-4dc9-ae80-701b56acf327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8dd367d-d0b1-4dc9-ae80-701b56acf327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

