### PR TITLE
Add SVE2 Winograd 2x2 block 4x4 filter

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -54,6 +54,7 @@
  <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block2x2SetOutput.</li>
+ <li>SVE2 optimizations of function WinogradKernel2x2Block4x4SetFilter.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8190,7 +8190,7 @@ SIMD_API void SimdWinogradKernel2x2Block4x4SetFilter(const float* src, size_t si
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetFilterPtr simdWinogradKernel2x2Block4x4SetFilter = SIMD_FUNC4(WinogradKernel2x2Block4x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetFilterPtr simdWinogradKernel2x2Block4x4SetFilter = SIMD_FUNC5(WinogradKernel2x2Block4x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel2x2Block4x4SetFilter(src, size, dst, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -240,6 +240,8 @@ namespace Simd
 
         void WinogradKernel2x2Block2x2SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
 
+        void WinogradKernel2x2Block4x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd2.cpp
+++ b/src/Simd/SimdSve2Winograd2.cpp
@@ -332,6 +332,94 @@ namespace Simd
                     WinogradKernel2x2Block2x2SetOutput(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, dstHeight - row, dstWidth - col), src += dstChannels;
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterRow(const svfloat32_t* t, float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r2 = svdup_n_f32(1.0f / 2.0f);
+            const svfloat32_t r3 = svdup_n_f32(1.0f / 3.0f);
+            const svfloat32_t r6 = svdup_n_f32(1.0f / 6.0f);
+            const svfloat32_t mr2 = svdup_n_f32(-1.0f / 2.0f);
+
+            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r2, t[0]));
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr2, svadd_f32_x(pg, t[0], t[1])));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, r6, svsub_f32_x(pg, t[1], t[0])));
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, svmul_f32_x(pg, r6, t[0]), svmul_f32_x(pg, r3, t[1])));
+            svst1_f32(pg, dst + 4 * stride, t[1]);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilter(const svfloat32_t src[4], float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r2 = svdup_n_f32(1.0f / 2.0f);
+            const svfloat32_t r3 = svdup_n_f32(1.0f / 3.0f);
+            const svfloat32_t r6 = svdup_n_f32(1.0f / 6.0f);
+            const svfloat32_t mr2 = svdup_n_f32(-1.0f / 2.0f);
+
+            svfloat32_t t[2];
+            t[0] = svmul_f32_x(pg, r2, src[0]);
+            t[1] = svmul_f32_x(pg, r2, src[1]);
+            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 0 * stride, stride, pg);
+
+            t[0] = svmul_f32_x(pg, mr2, svadd_f32_x(pg, src[0], src[2]));
+            t[1] = svmul_f32_x(pg, mr2, svadd_f32_x(pg, src[1], src[3]));
+            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 5 * stride, stride, pg);
+
+            t[0] = svmul_f32_x(pg, r6, svsub_f32_x(pg, src[2], src[0]));
+            t[1] = svmul_f32_x(pg, r6, svsub_f32_x(pg, src[3], src[1]));
+            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 10 * stride, stride, pg);
+
+            t[0] = svadd_f32_x(pg, svmul_f32_x(pg, r6, src[0]), svmul_f32_x(pg, r3, src[2]));
+            t[1] = svadd_f32_x(pg, svmul_f32_x(pg, r6, src[1]), svmul_f32_x(pg, r3, src[3]));
+            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 15 * stride, stride, pg);
+
+            t[0] = src[2];
+            t[1] = src[3];
+            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 20 * stride, stride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t _src[4];
+            _src[0] = svld1_f32(pg, src + 0 * srcStride);
+            _src[1] = svld1_f32(pg, src + 1 * srcStride);
+            _src[2] = svld1_f32(pg, src + 2 * srcStride);
+            _src[3] = svld1_f32(pg, src + 3 * srcStride);
+            WinogradKernel2x2Block4x4SetFilter(_src, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svuint32_t offsets = svindex_u32(0, 4);
+            svfloat32_t _src[4];
+            _src[0] = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            _src[1] = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            _src[2] = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            _src[3] = svld1_gather_u32index_f32(pg, src + 3, offsets);
+            WinogradKernel2x2Block4x4SetFilter(_src, dst, dstStride, pg);
+        }
+
+        void WinogradKernel2x2Block4x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans)
+        {
+            const size_t F = svcntw();
+            const size_t sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            if (trans)
+            {
+                for (; i < sizeF; i += F)
+                    WinogradKernel2x2Block4x4SetFilterVt(src + i, size, dst + i, size, body);
+                if (i < size)
+                    WinogradKernel2x2Block4x4SetFilterVt(src + i, size, dst + i, size, svwhilelt_b32(i, size));
+            }
+            else
+            {
+                for (; i < sizeF; i += F, src += 4 * F, dst += F)
+                    WinogradKernel2x2Block4x4SetFilterVn(src, dst, size, body);
+                if (i < size)
+                    WinogradKernel2x2Block4x4SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSve2Winograd2.cpp
+++ b/src/Simd/SimdSve2Winograd2.cpp
@@ -335,68 +335,64 @@ namespace Simd
 
         //-----------------------------------------------------------------------
 
-        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterRow(const svfloat32_t* t, float* dst, size_t stride, const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterRow(const svfloat32_t& t0, const svfloat32_t& t1, float* dst, size_t stride, const svbool_t& pg)
         {
             const svfloat32_t r2 = svdup_n_f32(1.0f / 2.0f);
             const svfloat32_t r3 = svdup_n_f32(1.0f / 3.0f);
             const svfloat32_t r6 = svdup_n_f32(1.0f / 6.0f);
             const svfloat32_t mr2 = svdup_n_f32(-1.0f / 2.0f);
 
-            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r2, t[0]));
-            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr2, svadd_f32_x(pg, t[0], t[1])));
-            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, r6, svsub_f32_x(pg, t[1], t[0])));
-            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, svmul_f32_x(pg, r6, t[0]), svmul_f32_x(pg, r3, t[1])));
-            svst1_f32(pg, dst + 4 * stride, t[1]);
+            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r2, t0));
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr2, svadd_f32_x(pg, t0, t1)));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, r6, svsub_f32_x(pg, t1, t0)));
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, svmul_f32_x(pg, r6, t0), svmul_f32_x(pg, r3, t1)));
+            svst1_f32(pg, dst + 4 * stride, t1);
         }
 
-        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilter(const svfloat32_t src[4], float* dst, size_t stride, const svbool_t& pg)
+        SIMD_INLINE void WinogradKernel2x2Block4x4SetFilter(const svfloat32_t& src0, const svfloat32_t& src1,
+            const svfloat32_t& src2, const svfloat32_t& src3, float* dst, size_t stride, const svbool_t& pg)
         {
             const svfloat32_t r2 = svdup_n_f32(1.0f / 2.0f);
             const svfloat32_t r3 = svdup_n_f32(1.0f / 3.0f);
             const svfloat32_t r6 = svdup_n_f32(1.0f / 6.0f);
             const svfloat32_t mr2 = svdup_n_f32(-1.0f / 2.0f);
 
-            svfloat32_t t[2];
-            t[0] = svmul_f32_x(pg, r2, src[0]);
-            t[1] = svmul_f32_x(pg, r2, src[1]);
-            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 0 * stride, stride, pg);
+            svfloat32_t t0 = svmul_f32_x(pg, r2, src0);
+            svfloat32_t t1 = svmul_f32_x(pg, r2, src1);
+            WinogradKernel2x2Block4x4SetFilterRow(t0, t1, dst + 0 * stride, stride, pg);
 
-            t[0] = svmul_f32_x(pg, mr2, svadd_f32_x(pg, src[0], src[2]));
-            t[1] = svmul_f32_x(pg, mr2, svadd_f32_x(pg, src[1], src[3]));
-            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 5 * stride, stride, pg);
+            t0 = svmul_f32_x(pg, mr2, svadd_f32_x(pg, src0, src2));
+            t1 = svmul_f32_x(pg, mr2, svadd_f32_x(pg, src1, src3));
+            WinogradKernel2x2Block4x4SetFilterRow(t0, t1, dst + 5 * stride, stride, pg);
 
-            t[0] = svmul_f32_x(pg, r6, svsub_f32_x(pg, src[2], src[0]));
-            t[1] = svmul_f32_x(pg, r6, svsub_f32_x(pg, src[3], src[1]));
-            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 10 * stride, stride, pg);
+            t0 = svmul_f32_x(pg, r6, svsub_f32_x(pg, src2, src0));
+            t1 = svmul_f32_x(pg, r6, svsub_f32_x(pg, src3, src1));
+            WinogradKernel2x2Block4x4SetFilterRow(t0, t1, dst + 10 * stride, stride, pg);
 
-            t[0] = svadd_f32_x(pg, svmul_f32_x(pg, r6, src[0]), svmul_f32_x(pg, r3, src[2]));
-            t[1] = svadd_f32_x(pg, svmul_f32_x(pg, r6, src[1]), svmul_f32_x(pg, r3, src[3]));
-            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 15 * stride, stride, pg);
+            t0 = svadd_f32_x(pg, svmul_f32_x(pg, r6, src0), svmul_f32_x(pg, r3, src2));
+            t1 = svadd_f32_x(pg, svmul_f32_x(pg, r6, src1), svmul_f32_x(pg, r3, src3));
+            WinogradKernel2x2Block4x4SetFilterRow(t0, t1, dst + 15 * stride, stride, pg);
 
-            t[0] = src[2];
-            t[1] = src[3];
-            WinogradKernel2x2Block4x4SetFilterRow(t, dst + 20 * stride, stride, pg);
+            WinogradKernel2x2Block4x4SetFilterRow(src2, src3, dst + 20 * stride, stride, pg);
         }
 
         SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
         {
-            svfloat32_t _src[4];
-            _src[0] = svld1_f32(pg, src + 0 * srcStride);
-            _src[1] = svld1_f32(pg, src + 1 * srcStride);
-            _src[2] = svld1_f32(pg, src + 2 * srcStride);
-            _src[3] = svld1_f32(pg, src + 3 * srcStride);
-            WinogradKernel2x2Block4x4SetFilter(_src, dst, dstStride, pg);
+            svfloat32_t src0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t src1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t src2 = svld1_f32(pg, src + 2 * srcStride);
+            svfloat32_t src3 = svld1_f32(pg, src + 3 * srcStride);
+            WinogradKernel2x2Block4x4SetFilter(src0, src1, src2, src3, dst, dstStride, pg);
         }
 
         SIMD_INLINE void WinogradKernel2x2Block4x4SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
         {
             svuint32_t offsets = svindex_u32(0, 4);
-            svfloat32_t _src[4];
-            _src[0] = svld1_gather_u32index_f32(pg, src + 0, offsets);
-            _src[1] = svld1_gather_u32index_f32(pg, src + 1, offsets);
-            _src[2] = svld1_gather_u32index_f32(pg, src + 2, offsets);
-            _src[3] = svld1_gather_u32index_f32(pg, src + 3, offsets);
-            WinogradKernel2x2Block4x4SetFilter(_src, dst, dstStride, pg);
+            svfloat32_t src0 = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            svfloat32_t src1 = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            svfloat32_t src2 = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            svfloat32_t src3 = svld1_gather_u32index_f32(pg, src + 3, offsets);
+            WinogradKernel2x2Block4x4SetFilter(src0, src1, src2, src3, dst, dstStride, pg);
         }
 
         void WinogradKernel2x2Block4x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans)

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -230,6 +230,11 @@ namespace Test
             result = result && WinogradSetFilterAutoTest(_4x4, _2x2, FUNC_WF(Simd::Neon::WinogradKernel2x2Block4x4SetFilter), FUNC_WF(SimdWinogradKernel2x2Block4x4SetFilter));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradSetFilterAutoTest(_4x4, _2x2, FUNC_WF(Simd::Sve2::WinogradKernel2x2Block4x4SetFilter), FUNC_WF(SimdWinogradKernel2x2Block4x4SetFilter));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `WinogradKernel2x2Block4x4SetFilter`.
- Extend Winograd auto-tests with direct SVE2 coverage.
- Document the new SVE2 optimization in release 7.2.164.

### Testing
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2Winograd2.cpp`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=WinogradKernel2x2Block4x4SetFilter -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f0c62b8-8dfa-49ae-b2a2-12c6e7acb232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f0c62b8-8dfa-49ae-b2a2-12c6e7acb232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

