### PR TITLE
Refactor Sse41 Synet max pooling helpers

### DIFF
--- a/src/Simd/SimdSse41SynetPooling.cpp
+++ b/src/Simd/SimdSse41SynetPooling.cpp
@@ -344,6 +344,232 @@ namespace Simd
             _mm_storeu_ps(dst + 7 * F, max7);
         }
 
+        SIMD_INLINE __m128 Pooling1x1Max3x1Body(const float* src)
+        {
+            return _mm_max_ps(_mm_max_ps(Load<false>(src - 1), Load<false>(src)), Load<false>(src + 1));
+        }
+
+        SIMD_INLINE void Pooling1x1Max3x3Body(const float* src, size_t stride, float* dst)
+        {
+            __m128 src0 = Pooling1x1Max3x1Body(src - stride);
+            __m128 src1 = Pooling1x1Max3x1Body(src);
+            __m128 src2 = Pooling1x1Max3x1Body(src + stride);
+            Store<false>(dst, _mm_max_ps(_mm_max_ps(src0, src1), src2));
+        }
+
+        SIMD_INLINE void Pooling1x1Max3x2Body(const float* src, size_t stride, float* dst)
+        {
+            __m128 src0 = Pooling1x1Max3x1Body(src);
+            __m128 src1 = Pooling1x1Max3x1Body(src + stride);
+            Store<false>(dst, _mm_max_ps(src0, src1));
+        }
+
+        SIMD_INLINE __m128 Pooling1x1Max3x1Nose(const float* src)
+        {
+            __m128 src1 = Load<false>(src);
+            __m128 src0 = _mm_shuffle_ps(src1, src1, 0x90);
+            __m128 src2 = Load<false>(src + 1);
+            return _mm_max_ps(_mm_max_ps(src0, src1), src2);
+        }
+
+        SIMD_INLINE void Pooling1x1Max3x3Nose(const float* src, size_t stride, float* dst)
+        {
+            __m128 src0 = Pooling1x1Max3x1Nose(src - stride);
+            __m128 src1 = Pooling1x1Max3x1Nose(src);
+            __m128 src2 = Pooling1x1Max3x1Nose(src + stride);
+            Store<false>(dst, _mm_max_ps(_mm_max_ps(src0, src1), src2));
+        }
+        SIMD_INLINE void Pooling1x1Max3x2Nose(const float* src, size_t stride, float* dst)
+        {
+            __m128 src0 = Pooling1x1Max3x1Nose(src);
+            __m128 src1 = Pooling1x1Max3x1Nose(src + stride);
+            Store<false>(dst, _mm_max_ps(src0, src1));
+        }
+
+        SIMD_INLINE __m128 Pooling1x1Max3x1Tail(const float* src)
+        {
+            __m128 src0 = Load<false>(src - 1);
+            __m128 src1 = Load<false>(src);
+            __m128 src2 = _mm_shuffle_ps(src1, src1, 0xF9);
+            return _mm_max_ps(_mm_max_ps(src0, src1), src2);
+        }
+
+        SIMD_INLINE void Pooling1x1Max3x3Tail(const float* src, size_t stride, float* dst)
+        {
+            __m128 src0 = Pooling1x1Max3x1Tail(src - stride);
+            __m128 src1 = Pooling1x1Max3x1Tail(src);
+            __m128 src2 = Pooling1x1Max3x1Tail(src + stride);
+            Store<false>(dst, _mm_max_ps(_mm_max_ps(src0, src1), src2));
+        }
+        SIMD_INLINE void Pooling1x1Max3x2Tail(const float* src, size_t stride, float* dst)
+        {
+            __m128 src0 = Pooling1x1Max3x1Tail(src);
+            __m128 src1 = Pooling1x1Max3x1Tail(src + stride);
+            Store<false>(dst, _mm_max_ps(src0, src1));
+        }
+
+        void SynetPoolingMax32fNchw_1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            assert(width > F && height > 1);
+
+            size_t alignedWidth = AlignHi(width, F) - F;
+            height -= 1;
+
+            Pooling1x1Max3x2Nose(src, srcStride, dst);
+            for (size_t col = F; col < alignedWidth; col += F)
+                Pooling1x1Max3x2Body(src + col, srcStride, dst + col);
+            Pooling1x1Max3x2Tail(src + width - F, srcStride, dst + width - F);
+
+            for (size_t row = 1; row < height; ++row)
+            {
+                src += srcStride;
+                dst += dstStride;
+                Pooling1x1Max3x3Nose(src, srcStride, dst);
+                for (size_t col = F; col < alignedWidth; col += F)
+                    Pooling1x1Max3x3Body(src + col, srcStride, dst + col);
+                Pooling1x1Max3x3Tail(src + width - F, srcStride, dst + width - F);
+            }
+
+            dst += dstStride;
+            Pooling1x1Max3x2Nose(src, srcStride, dst);
+            for (size_t col = F; col < alignedWidth; col += F)
+                Pooling1x1Max3x2Body(src + col, srcStride, dst + col);
+            Pooling1x1Max3x2Tail(src + width - F, srcStride, dst + width - F);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE __m128 Pooling2x2Max2x2(const float* src, size_t stride)
+        {
+            __m128 _src0 = _mm_max_ps(Load<false>(src + 0), Load<false>(src + stride + 0));
+            __m128 _src1 = _mm_max_ps(Load<false>(src + F), Load<false>(src + stride + F));
+            return _mm_max_ps(_mm_shuffle_ps(_src0, _src1, 0x88), _mm_shuffle_ps(_src0, _src1, 0xDD));
+        }
+
+        SIMD_INLINE __m128 Pooling2x2Max2(const float* src)
+        {
+            __m128 _src0 = Load<false>(src + 0);
+            __m128 _src1 = Load<false>(src + F);
+            return _mm_max_ps(_mm_shuffle_ps(_src0, _src1, 0x88), _mm_shuffle_ps(_src0, _src1, 0xDD));
+        }
+
+        void SynetPoolingMax32fNchw_2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            size_t heightEven = Simd::AlignLo(height, 2);
+            size_t widthEven = Simd::AlignLo(width, 2);
+            size_t alignedWidth = AlignLo(width, DF);
+            for (size_t row = 0; row < heightEven; row += 2)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), Pooling2x2Max2x2(src + col, srcStride));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), Pooling2x2Max2x2(src + col, srcStride));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = Simd::Max(src[widthEven], src[widthEven + srcStride]);
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+            if (height - heightEven)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), Pooling2x2Max2(src + col));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), Pooling2x2Max2(src + col));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = src[widthEven];
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE float Max2(const float* src)
+        {
+            return Simd::Max(src[0], src[1]);
+        }
+
+        SIMD_INLINE float Max2x2(const float* src, size_t stride)
+        {
+            return Simd::Max(Max2(src), Max2(src + stride));
+        }
+
+        SIMD_INLINE float Max2x3(const float* src, size_t stride)
+        {
+            return Simd::Max(Max2(src), Simd::Max(Max2(src + stride), Max2(src + 2 * stride)));
+        }
+
+        SIMD_INLINE __m128 Pooling2x2Max1x3(const float* src, size_t stride)
+        {
+            return _mm_max_ps(_mm_max_ps(Load<false>(src), Load<false>(src + stride)), Load<false>(src + 2 * stride));
+        }
+
+        SIMD_INLINE __m128 Pooling2x2Max3x3(const float* src, size_t stride)
+        {
+            __m128 _0123 = Pooling2x2Max1x3(src, stride);
+            __m128 _4567 = Pooling2x2Max1x3(src + F, stride);
+            __m128 _5678 = Pooling2x2Max1x3(src + F + 1, stride);
+            __m128 _0246 = _mm_shuffle_ps(_0123, _4567, 0x88);
+            __m128 _1357 = _mm_shuffle_ps(_0123, _4567, 0xDD);
+            __m128 _2468 = _mm_shuffle_ps(_0246, _5678, 0xD9);
+            return _mm_max_ps(_mm_max_ps(_0246, _1357), _2468);
+        }
+
+        SIMD_INLINE __m128 Pooling2x2Max1x2(const float* src, size_t stride)
+        {
+            return _mm_max_ps(Load<false>(src), Load<false>(src + stride));
+        }
+
+        SIMD_INLINE __m128 Pooling2x2Max3x2(const float* src, size_t stride)
+        {
+            __m128 _0123 = Pooling2x2Max1x2(src, stride);
+            __m128 _4567 = Pooling2x2Max1x2(src + F, stride);
+            __m128 _5678 = Pooling2x2Max1x2(src + F + 1, stride);
+            __m128 _0246 = _mm_shuffle_ps(_0123, _4567, 0x88);
+            __m128 _1357 = _mm_shuffle_ps(_0123, _4567, 0xDD);
+            __m128 _2468 = _mm_shuffle_ps(_0246, _5678, 0xD9);
+            return _mm_max_ps(_mm_max_ps(_0246, _1357), _2468);
+        }
+
+        void SynetPoolingMax32fNchw_2x2Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            height -= 1;
+            width -= 1;
+            size_t heightEven = Simd::AlignLo(height, 2);
+            size_t widthEven = Simd::AlignLo(width, 2);
+            size_t alignedWidth = AlignLo(width, DF);
+            for (size_t row = 0; row < heightEven; row += 2)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), Pooling2x2Max3x3(src + col, srcStride));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), Pooling2x2Max3x3(src + col, srcStride));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = Max2x3(src + widthEven, srcStride);
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+            if (height - heightEven)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), Pooling2x2Max3x2(src + col, srcStride));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), Pooling2x2Max3x2(src + col, srcStride));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = Max2x2(src + widthEven, srcStride);
+            }
+        }
+
         void SynetPoolingMax32f2D(const float* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
             size_t strideY, size_t strideX, size_t padY, size_t padX, float* dst, size_t dstH, size_t dstW, SimdTensorFormatType format)
         {
@@ -389,19 +615,19 @@ namespace Simd
                 if (strideY == 1 && strideX == 1 && kernelY == 3 && kernelX == 3 && srcH == dstH && srcW == dstW && dstW > F)
                 {
                     for (size_t c = 0; c < srcC; ++c, src += srcH * srcW, dst += dstH * dstW)
-                        Sse41::NeuralPooling1x1Max3x3(src, srcW, srcW, srcH, dst, dstW);
+                        SynetPoolingMax32fNchw_1x1Max3x3(src, srcW, srcW, srcH, dst, dstW);
                     return;
                 }
                 if (strideY == 2 && strideX == 2 && kernelY == 2 && kernelX == 2 && padY == 0 && padX == 0 && dstW >= F)
                 {
                     for (size_t c = 0; c < srcC; ++c, src += srcH * srcW, dst += dstH * dstW)
-                        Sse41::NeuralPooling2x2Max2x2(src, srcW, srcW, srcH, dst, dstW);
+                        SynetPoolingMax32fNchw_2x2Max2x2(src, srcW, srcW, srcH, dst, dstW);
                     return;
                 }
                 if (strideY == 2 && strideX == 2 && kernelY == 3 && kernelX == 3 && padY == 0 && padX == 0 && dstW > F)
                 {
                     for (size_t c = 0; c < srcC; ++c, src += srcH * srcW, dst += dstH * dstW)
-                        Sse41::NeuralPooling2x2Max3x3(src, srcW, srcW, srcH, dst, dstW);
+                        SynetPoolingMax32fNchw_2x2Max3x3(src, srcW, srcW, srcH, dst, dstW);
                     return;
                 }
                 Base::SynetPoolingMax32f(src, srcC, srcH, srcW, 1, kernelY, kernelX, 1, strideY, strideX, 0, padY, padX, dst, srcC, dstH, dstW, format);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Move the Sse41 NCHW max pooling helper implementations used by `SynetPoolingMax32f2D` into `SimdSse41SynetPooling.cpp`.
- Rename the local helpers to `SynetPoolingMax32fNchw_*` and remove their `align` template dispatch.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && cd build && ./Test "-r=.." -fi=SynetPoolingMax32f -tt=1 -ts=1`
- Direct throwaway harness comparing `Simd::Sse41::SynetPoolingMax32f` against `Simd::Base::SynetPoolingMax32f` for the three NCHW fast paths: `1x1Max3x3`, `2x2Max2x2`, and `2x2Max3x3`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dcd2e8b-dd03-4cdd-b92c-091967317aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dcd2e8b-dd03-4cdd-b92c-091967317aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

