### PR TITLE
Refactor NEON Synet pooling helpers

### DIFF
--- a/src/Simd/SimdNeonSynetPooling.cpp
+++ b/src/Simd/SimdNeonSynetPooling.cpp
@@ -297,6 +297,236 @@ namespace Simd
             Store<false>(dst + 7 * F, max7);
         }
 
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_1x1Max3x1Body(const float* src)
+        {
+            return vmaxq_f32(vmaxq_f32(Load<false>(src - 1), Load<false>(src)), Load<false>(src + 1));
+        }
+
+        SIMD_INLINE void SynetPoolingMax32fNchw_1x1Max3x3Body(const float* src, size_t stride, float* dst)
+        {
+            float32x4_t src0 = SynetPoolingMax32fNchw_1x1Max3x1Body(src - stride);
+            float32x4_t src1 = SynetPoolingMax32fNchw_1x1Max3x1Body(src);
+            float32x4_t src2 = SynetPoolingMax32fNchw_1x1Max3x1Body(src + stride);
+            Store<false>(dst, vmaxq_f32(vmaxq_f32(src0, src1), src2));
+        }
+
+        SIMD_INLINE void SynetPoolingMax32fNchw_1x1Max3x2Body(const float* src, size_t stride, float* dst)
+        {
+            float32x4_t src0 = SynetPoolingMax32fNchw_1x1Max3x1Body(src);
+            float32x4_t src1 = SynetPoolingMax32fNchw_1x1Max3x1Body(src + stride);
+            Store<false>(dst, vmaxq_f32(src0, src1));
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_1x1Max3x1Nose(const float* src)
+        {
+            float32x4_t src1 = Load<false>(src);
+            float32x4_t src0 = vextq_f32(vextq_f32(src1, src1, 1), src1, 3);
+            float32x4_t src2 = Load<false>(src + 1);
+            return vmaxq_f32(vmaxq_f32(src0, src1), src2);
+        }
+
+        SIMD_INLINE void SynetPoolingMax32fNchw_1x1Max3x3Nose(const float* src, size_t stride, float* dst)
+        {
+            float32x4_t src0 = SynetPoolingMax32fNchw_1x1Max3x1Nose(src - stride);
+            float32x4_t src1 = SynetPoolingMax32fNchw_1x1Max3x1Nose(src);
+            float32x4_t src2 = SynetPoolingMax32fNchw_1x1Max3x1Nose(src + stride);
+            Store<false>(dst, vmaxq_f32(vmaxq_f32(src0, src1), src2));
+        }
+
+        SIMD_INLINE void SynetPoolingMax32fNchw_1x1Max3x2Nose(const float* src, size_t stride, float* dst)
+        {
+            float32x4_t src0 = SynetPoolingMax32fNchw_1x1Max3x1Nose(src);
+            float32x4_t src1 = SynetPoolingMax32fNchw_1x1Max3x1Nose(src + stride);
+            Store<false>(dst, vmaxq_f32(src0, src1));
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_1x1Max3x1Tail(const float* src)
+        {
+            float32x4_t src0 = Load<false>(src - 1);
+            float32x4_t src1 = Load<false>(src);
+            float32x4_t src2 = vextq_f32(src1, vextq_f32(src1, src1, 3), 1);
+            return vmaxq_f32(vmaxq_f32(src0, src1), src2);
+        }
+
+        SIMD_INLINE void SynetPoolingMax32fNchw_1x1Max3x3Tail(const float* src, size_t stride, float* dst)
+        {
+            float32x4_t src0 = SynetPoolingMax32fNchw_1x1Max3x1Tail(src - stride);
+            float32x4_t src1 = SynetPoolingMax32fNchw_1x1Max3x1Tail(src);
+            float32x4_t src2 = SynetPoolingMax32fNchw_1x1Max3x1Tail(src + stride);
+            Store<false>(dst, vmaxq_f32(vmaxq_f32(src0, src1), src2));
+        }
+
+        SIMD_INLINE void SynetPoolingMax32fNchw_1x1Max3x2Tail(const float* src, size_t stride, float* dst)
+        {
+            float32x4_t src0 = SynetPoolingMax32fNchw_1x1Max3x1Tail(src);
+            float32x4_t src1 = SynetPoolingMax32fNchw_1x1Max3x1Tail(src + stride);
+            Store<false>(dst, vmaxq_f32(src0, src1));
+        }
+
+        void SynetPoolingMax32fNchw_1x1Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            assert(width > F && height > 1);
+
+            size_t alignedWidth = AlignHi(width, F) - F;
+            height -= 1;
+
+            SynetPoolingMax32fNchw_1x1Max3x2Nose(src, srcStride, dst);
+            for (size_t col = F; col < alignedWidth; col += F)
+                SynetPoolingMax32fNchw_1x1Max3x2Body(src + col, srcStride, dst + col);
+            SynetPoolingMax32fNchw_1x1Max3x2Tail(src + width - F, srcStride, dst + width - F);
+
+            for (size_t row = 1; row < height; ++row)
+            {
+                src += srcStride;
+                dst += dstStride;
+                SynetPoolingMax32fNchw_1x1Max3x3Nose(src, srcStride, dst);
+                for (size_t col = F; col < alignedWidth; col += F)
+                    SynetPoolingMax32fNchw_1x1Max3x3Body(src + col, srcStride, dst + col);
+                SynetPoolingMax32fNchw_1x1Max3x3Tail(src + width - F, srcStride, dst + width - F);
+            }
+
+            dst += dstStride;
+            SynetPoolingMax32fNchw_1x1Max3x2Nose(src, srcStride, dst);
+            for (size_t col = F; col < alignedWidth; col += F)
+                SynetPoolingMax32fNchw_1x1Max3x2Body(src + col, srcStride, dst + col);
+            SynetPoolingMax32fNchw_1x1Max3x2Tail(src + width - F, srcStride, dst + width - F);
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_2x2Max2x2(const float* src, size_t stride)
+        {
+            float32x4_t s0 = vmaxq_f32(Load<false>(src + 0), Load<false>(src + stride + 0));
+            float32x4_t s1 = vmaxq_f32(Load<false>(src + F), Load<false>(src + stride + F));
+            return vcombine_f32(vpmax_f32(vget_low_f32(s0), vget_high_f32(s0)), vpmax_f32(vget_low_f32(s1), vget_high_f32(s1)));
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_2x2Max2(const float* src)
+        {
+            float32x4_t s0 = Load<false>(src + 0);
+            float32x4_t s1 = Load<false>(src + F);
+            return vcombine_f32(vpmax_f32(vget_low_f32(s0), vget_high_f32(s0)), vpmax_f32(vget_low_f32(s1), vget_high_f32(s1)));
+        }
+
+        void SynetPoolingMax32fNchw_2x2Max2x2(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            size_t heightEven = Simd::AlignLo(height, 2);
+            size_t widthEven = Simd::AlignLo(width, 2);
+            size_t alignedWidth = AlignLo(width, DF);
+            for (size_t row = 0; row < heightEven; row += 2)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max2x2(src + col, srcStride));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max2x2(src + col, srcStride));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = Simd::Max(src[widthEven], src[widthEven + srcStride]);
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+            if (height - heightEven)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max2(src + col));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max2(src + col));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = src[widthEven];
+            }
+        }
+
+        SIMD_INLINE float Max2(const float* src)
+        {
+            return Simd::Max(src[0], src[1]);
+        }
+
+        SIMD_INLINE float Max2x2(const float* src, size_t stride)
+        {
+            return Simd::Max(Max2(src), Max2(src + stride));
+        }
+
+        SIMD_INLINE float Max2x3(const float* src, size_t stride)
+        {
+            return Simd::Max(Max2(src), Simd::Max(Max2(src + stride), Max2(src + 2 * stride)));
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_2x2Max1x3(const float* src, size_t stride)
+        {
+            return vmaxq_f32(vmaxq_f32(Load<false>(src), Load<false>(src + stride)), Load<false>(src + 2 * stride));
+        }
+
+        const uint8x8_t K8_TBL_BITS_LO = SIMD_VEC_SETR_PI8(0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B);
+        const uint8x8_t K8_TBL_BITS_HI = SIMD_VEC_SETR_PI8(0x04, 0x05, 0x06, 0x07, 0x0C, 0x0D, 0x0E, 0x0F);
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_CombineFor2x2(const float32x4_t& lo, const float32x4_t& hi)
+        {
+            return vcombine_f32((float32x2_t)vtbl2_u8((const uint8x8x2_t&)lo, K8_TBL_BITS_LO), (float32x2_t)vtbl2_u8((const uint8x8x2_t&)hi, K8_TBL_BITS_HI));
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_2x2Max3x3(const float* src, size_t stride)
+        {
+            float32x4_t _0123 = SynetPoolingMax32fNchw_2x2Max1x3(src, stride);
+            float32x4_t _4567 = SynetPoolingMax32fNchw_2x2Max1x3(src + F, stride);
+            float32x4_t _5678 = SynetPoolingMax32fNchw_2x2Max1x3(src + F + 1, stride);
+            float32x4x2_t _02461357 = vuzpq_f32(_0123, _4567);
+            float32x4_t _2468 = SynetPoolingMax32fNchw_CombineFor2x2(_02461357.val[0], _5678);
+            return vmaxq_f32(vmaxq_f32(_02461357.val[0], _02461357.val[1]), _2468);
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_2x2Max1x2(const float* src, size_t stride)
+        {
+            return vmaxq_f32(Load<false>(src), Load<false>(src + stride));
+        }
+
+        SIMD_INLINE float32x4_t SynetPoolingMax32fNchw_2x2Max3x2(const float* src, size_t stride)
+        {
+            float32x4_t _0123 = SynetPoolingMax32fNchw_2x2Max1x2(src, stride);
+            float32x4_t _4567 = SynetPoolingMax32fNchw_2x2Max1x2(src + F, stride);
+            float32x4_t _5678 = SynetPoolingMax32fNchw_2x2Max1x2(src + F + 1, stride);
+            float32x4x2_t _02461357 = vuzpq_f32(_0123, _4567);
+            float32x4_t _2468 = SynetPoolingMax32fNchw_CombineFor2x2(_02461357.val[0], _5678);
+            return vmaxq_f32(vmaxq_f32(_02461357.val[0], _02461357.val[1]), _2468);
+        }
+
+        void SynetPoolingMax32fNchw_2x2Max3x3(const float* src, size_t srcStride, size_t width, size_t height, float* dst, size_t dstStride)
+        {
+            height -= 1;
+            width -= 1;
+            size_t heightEven = Simd::AlignLo(height, 2);
+            size_t widthEven = Simd::AlignLo(width, 2);
+            size_t alignedWidth = AlignLo(width, DF);
+            for (size_t row = 0; row < heightEven; row += 2)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max3x3(src + col, srcStride));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max3x3(src + col, srcStride));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = Max2x3(src + widthEven, srcStride);
+                src += 2 * srcStride;
+                dst += dstStride;
+            }
+            if (height - heightEven)
+            {
+                for (size_t col = 0; col < alignedWidth; col += DF)
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max3x2(src + col, srcStride));
+                if (widthEven - alignedWidth)
+                {
+                    size_t col = widthEven - DF;
+                    Store<false>(dst + (col >> 1), SynetPoolingMax32fNchw_2x2Max3x2(src + col, srcStride));
+                }
+                if (width - widthEven)
+                    dst[widthEven >> 1] = Max2x2(src + widthEven, srcStride);
+            }
+        }
+
         void SynetPoolingMax32f2D(const float * src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
             size_t strideY, size_t strideX, size_t padY, size_t padX, float * dst, size_t dstH, size_t dstW, SimdTensorFormatType format)
         {
@@ -342,19 +572,19 @@ namespace Simd
                 if (strideY == 1 && strideX == 1 && kernelY == 3 && kernelX == 3 && srcH == dstH && srcW == dstW && dstW > F)
                 {
                     for (size_t c = 0; c < srcC; ++c, src += srcH * srcW, dst += dstH * dstW)
-                        Neon::NeuralPooling1x1Max3x3(src, srcW, srcW, srcH, dst, dstW);
+                        SynetPoolingMax32fNchw_1x1Max3x3(src, srcW, srcW, srcH, dst, dstW);
                     return;
                 }
                 if (strideY == 2 && strideX == 2 && kernelY == 2 && kernelX == 2 && padY == 0 && padX == 0 && dstW >= F)
                 {
                     for (size_t c = 0; c < srcC; ++c, src += srcH * srcW, dst += dstH * dstW)
-                        Neon::NeuralPooling2x2Max2x2(src, srcW, srcW, srcH, dst, dstW);
+                        SynetPoolingMax32fNchw_2x2Max2x2(src, srcW, srcW, srcH, dst, dstW);
                     return;
                 }
                 if (strideY == 2 && strideX == 2 && kernelY == 3 && kernelX == 3 && padY == 0 && padX == 0 && dstW > F)
                 {
                     for (size_t c = 0; c < srcC; ++c, src += srcH * srcW, dst += dstH * dstW)
-                        Neon::NeuralPooling2x2Max3x3(src, srcW, srcW, srcH, dst, dstW);
+                        SynetPoolingMax32fNchw_2x2Max3x3(src, srcW, srcW, srcH, dst, dstW);
                     return;
                 }
                 Base::SynetPoolingMax32f(src, srcC, srcH, srcW, 1, kernelY, kernelX, 1, strideY, strideX, 0, padY, padX, dst, srcC, dstH, dstW, format);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Copy the NEON max-pooling helper logic used by `SynetPoolingMax32f2D` into `SimdNeonSynetPooling.cpp` under `SynetPoolingMax32fNchw_*` names.
- Remove the copied helpers' `align` template dispatch by using unaligned loads/stores in the Synet-local implementation.
- Route NCHW fast paths to the new Synet-local helpers.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetPoolingMax32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I src -fsyntax-only src/Simd/SimdNeonSynetPooling.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c91d88a6-a6c4-419b-844b-4b9b48b3bb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c91d88a6-a6c4-419b-844b-4b9b48b3bb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

