### PR TITLE
Add SVE2 WinogradKernel3x3Block2x2SetFilter optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -57,6 +57,7 @@
  <li>SVE2 optimizations of function WinogradKernel2x2Block4x4SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block4x4SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block4x4SetOutput.</li>
+ <li>SVE2 optimizations of function WinogradKernel3x3Block2x2SetFilter.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>
@@ -152,6 +153,7 @@
  <li>Tests for verifying functionality of function Yuv444pToHue.</li>
  <li>Tests for verifying functionality of function WinogradKernel1x3Block1x4SetFilter.</li>
  <li>Tests for verifying functionality of function WinogradKernel1x3Block1x4SetOutput.</li>
+ <li>Tests for verifying functionality of function WinogradKernel3x3Block2x2SetFilter.</li>
  <li>Tests for verifying functionality of function Yuv420pToUyvy422.</li>
  <li>Tests for verifying functionality of function Yuva422pToBgraV2.</li>
  <li>Tests for verifying functionality of function Yuva444pToBgraV2.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -90,6 +90,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToYuv.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Winograd1.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Winograd2.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Winograd3.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgraV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2YuvToBgrV2.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -356,6 +356,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Winograd2.cpp">
       <Filter>Sve2\Math</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Winograd3.cpp">
+      <Filter>Sve2\Math</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2YToGray.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8227,7 +8227,7 @@ SIMD_API void SimdWinogradKernel3x3Block2x2SetFilter(const float * src, size_t s
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetFilterPtr simdWinogradKernel3x3Block2x2SetFilter = SIMD_FUNC4(WinogradKernel3x3Block2x2SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetFilterPtr simdWinogradKernel3x3Block2x2SetFilter = SIMD_FUNC5(WinogradKernel3x3Block2x2SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel3x3Block2x2SetFilter(src, size, dst, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -247,6 +247,8 @@ namespace Simd
 
         void WinogradKernel2x2Block4x4SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
 
+        void WinogradKernel3x3Block2x2SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd3.cpp
+++ b/src/Simd/SimdSve2Winograd3.cpp
@@ -1,0 +1,121 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdWinograd.h"
+#include "Simd/SimdBase.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetFilter(const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2,
+            const svfloat32_t& s3, const svfloat32_t& s4, const svfloat32_t& s5, const svfloat32_t& s6, const svfloat32_t& s7,
+            const svfloat32_t& s8, float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r2 = svdup_n_f32(1.0f / 2.0f);
+            const svfloat32_t r4 = svdup_n_f32(1.0f / 4.0f);
+
+            svst1_f32(pg, dst + 0 * stride, s0);
+            svfloat32_t a02 = svadd_f32_x(pg, s0, s2);
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, svadd_f32_x(pg, a02, s1), r2));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, svsub_f32_x(pg, a02, s1), r2));
+            svst1_f32(pg, dst + 3 * stride, s2);
+
+            svfloat32_t a063 = svadd_f32_x(pg, svadd_f32_x(pg, s0, s6), s3);
+            svst1_f32(pg, dst + 4 * stride, svmul_f32_x(pg, a063, r2));
+            svfloat32_t a285 = svadd_f32_x(pg, svadd_f32_x(pg, s2, s8), s5);
+            svfloat32_t a174 = svadd_f32_x(pg, svadd_f32_x(pg, s1, s7), s4);
+            svst1_f32(pg, dst + 5 * stride, svmul_f32_x(pg, svadd_f32_x(pg, svadd_f32_x(pg, a063, a285), a174), r4));
+            svst1_f32(pg, dst + 6 * stride, svmul_f32_x(pg, svsub_f32_x(pg, svadd_f32_x(pg, a063, a285), a174), r4));
+            svst1_f32(pg, dst + 7 * stride, svmul_f32_x(pg, a285, r2));
+
+            svfloat32_t a06m3 = svsub_f32_x(pg, svadd_f32_x(pg, s0, s6), s3);
+            svst1_f32(pg, dst + 8 * stride, svmul_f32_x(pg, a06m3, r2));
+            svfloat32_t a28m5 = svsub_f32_x(pg, svadd_f32_x(pg, s2, s8), s5);
+            svfloat32_t a17m4 = svsub_f32_x(pg, svadd_f32_x(pg, s1, s7), s4);
+            svst1_f32(pg, dst + 9 * stride, svmul_f32_x(pg, svadd_f32_x(pg, svadd_f32_x(pg, a06m3, a28m5), a17m4), r4));
+            svst1_f32(pg, dst + 10 * stride, svmul_f32_x(pg, svsub_f32_x(pg, svadd_f32_x(pg, a06m3, a28m5), a17m4), r4));
+            svst1_f32(pg, dst + 11 * stride, svmul_f32_x(pg, a28m5, r2));
+
+            svst1_f32(pg, dst + 12 * stride, s6);
+            svfloat32_t a68 = svadd_f32_x(pg, s6, s8);
+            svst1_f32(pg, dst + 13 * stride, svmul_f32_x(pg, svadd_f32_x(pg, a68, s7), r2));
+            svst1_f32(pg, dst + 14 * stride, svmul_f32_x(pg, svsub_f32_x(pg, a68, s7), r2));
+            svst1_f32(pg, dst + 15 * stride, s8);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetFilterVt(const float* src, size_t srcStride, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * srcStride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * srcStride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * srcStride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * srcStride);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * srcStride);
+            svfloat32_t s5 = svld1_f32(pg, src + 5 * srcStride);
+            svfloat32_t s6 = svld1_f32(pg, src + 6 * srcStride);
+            svfloat32_t s7 = svld1_f32(pg, src + 7 * srcStride);
+            svfloat32_t s8 = svld1_f32(pg, src + 8 * srcStride);
+            WinogradKernel3x3Block2x2SetFilter(s0, s1, s2, s3, s4, s5, s6, s7, s8, dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetFilterVn(const float* src, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            svuint32_t offsets = svindex_u32(0, 9);
+            svfloat32_t s0 = svld1_gather_u32index_f32(pg, src + 0, offsets);
+            svfloat32_t s1 = svld1_gather_u32index_f32(pg, src + 1, offsets);
+            svfloat32_t s2 = svld1_gather_u32index_f32(pg, src + 2, offsets);
+            svfloat32_t s3 = svld1_gather_u32index_f32(pg, src + 3, offsets);
+            svfloat32_t s4 = svld1_gather_u32index_f32(pg, src + 4, offsets);
+            svfloat32_t s5 = svld1_gather_u32index_f32(pg, src + 5, offsets);
+            svfloat32_t s6 = svld1_gather_u32index_f32(pg, src + 6, offsets);
+            svfloat32_t s7 = svld1_gather_u32index_f32(pg, src + 7, offsets);
+            svfloat32_t s8 = svld1_gather_u32index_f32(pg, src + 8, offsets);
+            WinogradKernel3x3Block2x2SetFilter(s0, s1, s2, s3, s4, s5, s6, s7, s8, dst, dstStride, pg);
+        }
+
+        void WinogradKernel3x3Block2x2SetFilter(const float* src, size_t size, float* dst, SimdBool trans)
+        {
+            const size_t F = svcntw();
+            const size_t sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            if (trans)
+            {
+                for (; i < sizeF; i += F)
+                    WinogradKernel3x3Block2x2SetFilterVt(src + i, size, dst + i, size, body);
+                if (i < size)
+                    WinogradKernel3x3Block2x2SetFilterVt(src + i, size, dst + i, size, svwhilelt_b32(i, size));
+            }
+            else
+            {
+                for (; i < sizeF; i += F, src += 9 * F, dst += F)
+                    WinogradKernel3x3Block2x2SetFilterVn(src, dst, size, body);
+                if (i < size)
+                    WinogradKernel3x3Block2x2SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -266,6 +266,11 @@ namespace Test
             result = result && WinogradSetFilterAutoTest(_2x2, _3x3, FUNC_WF(Simd::Neon::WinogradKernel3x3Block2x2SetFilter), FUNC_WF(SimdWinogradKernel3x3Block2x2SetFilter));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradSetFilterAutoTest(_2x2, _3x3, FUNC_WF(Simd::Sve2::WinogradKernel3x3Block2x2SetFilter), FUNC_WF(SimdWinogradKernel3x3Block2x2SetFilter));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add SVE2 implementation of `WinogradKernel3x3Block2x2SetFilter` in a new source file `src/Simd/SimdSve2Winograd3.cpp`.
- enable SVE2 dispatch for `SimdWinogradKernel3x3Block2x2SetFilter` in `src/Simd/SimdLib.cpp`.
- add missing declaration of `Simd::Sve2::WinogradKernel3x3Block2x2SetFilter` in `src/Simd/SimdSve2.h` (fixes CI compile error in `SimdLib.cpp`).
- extend `WinogradKernel3x3Block2x2SetFilterAutoTest` to validate `Simd::Sve2::WinogradKernel3x3Block2x2SetFilter`.
- register `SimdSve2Winograd3.cpp` in `prj/vs2022/Sve2.vcxproj` and `prj/vs2022/Sve2.vcxproj.filters`.
- update release notes in `docs/2026.html` for version `7.2.164`.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cmake --build build --target Test --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." "-fi=WinogradKernel3x3Block2x2SetFilter" -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6822fbe-c071-43ec-ae10-b9c48babc78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6822fbe-c071-43ec-ae10-b9c48babc78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

