### PR TITLE
Add SVE2 Winograd 3x3 block2x2 input

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -58,6 +58,7 @@
  <li>SVE2 optimizations of function WinogradKernel2x2Block4x4SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel2x2Block4x4SetOutput.</li>
  <li>SVE2 optimizations of function WinogradKernel3x3Block2x2SetFilter.</li>
+ <li>SVE2 optimizations of function WinogradKernel3x3Block2x2SetInput.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8240,7 +8240,7 @@ SIMD_API void SimdWinogradKernel3x3Block2x2SetInput(const float* src, size_t src
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetInputPtr simdWinogradKernel3x3Block2x2SetInput = SIMD_FUNC4(WinogradKernel3x3Block2x2SetInput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetInputPtr simdWinogradKernel3x3Block2x2SetInput = SIMD_FUNC5(WinogradKernel3x3Block2x2SetInput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel3x3Block2x2SetInput(src, srcChannels, srcHeight, srcWidth, padY, padX, padH, padW, dst, dstStride, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -249,6 +249,9 @@ namespace Simd
 
         void WinogradKernel3x3Block2x2SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
 
+        void WinogradKernel3x3Block2x2SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
+            size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd3.cpp
+++ b/src/Simd/SimdSve2Winograd3.cpp
@@ -116,6 +116,155 @@ namespace Simd
                     WinogradKernel3x3Block2x2SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetInputStore(
+            const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2, const svfloat32_t& s3,
+            const svfloat32_t& s4, const svfloat32_t& s5, const svfloat32_t& s6, const svfloat32_t& s7,
+            const svfloat32_t& s8, const svfloat32_t& s9, const svfloat32_t& s10, const svfloat32_t& s11,
+            const svfloat32_t& s12, const svfloat32_t& s13, const svfloat32_t& s14, const svfloat32_t& s15,
+            float* dst, size_t stride, const svbool_t& pg)
+        {
+            svst1_f32(pg, dst + 0 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s0, s8), svsub_f32_x(pg, s2, s10)));
+            svst1_f32(pg, dst + 1 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s1, s9), svsub_f32_x(pg, s2, s10)));
+            svst1_f32(pg, dst + 2 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s2, s10), svsub_f32_x(pg, s1, s9)));
+            svst1_f32(pg, dst + 3 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s1, s9), svsub_f32_x(pg, s3, s11)));
+            svst1_f32(pg, dst + 4 * stride, svsub_f32_x(pg, svadd_f32_x(pg, s4, s8), svadd_f32_x(pg, s6, s10)));
+            svst1_f32(pg, dst + 5 * stride, svadd_f32_x(pg, svadd_f32_x(pg, s5, s9), svadd_f32_x(pg, s6, s10)));
+            svst1_f32(pg, dst + 6 * stride, svsub_f32_x(pg, svadd_f32_x(pg, s6, s10), svadd_f32_x(pg, s5, s9)));
+            svst1_f32(pg, dst + 7 * stride, svsub_f32_x(pg, svadd_f32_x(pg, s5, s9), svadd_f32_x(pg, s7, s11)));
+            svst1_f32(pg, dst + 8 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s8, s4), svsub_f32_x(pg, s10, s6)));
+            svst1_f32(pg, dst + 9 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s9, s5), svsub_f32_x(pg, s10, s6)));
+            svst1_f32(pg, dst + 10 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s10, s6), svsub_f32_x(pg, s9, s5)));
+            svst1_f32(pg, dst + 11 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s9, s5), svsub_f32_x(pg, s11, s7)));
+            svst1_f32(pg, dst + 12 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s4, s12), svsub_f32_x(pg, s6, s14)));
+            svst1_f32(pg, dst + 13 * stride, svadd_f32_x(pg, svsub_f32_x(pg, s5, s13), svsub_f32_x(pg, s6, s14)));
+            svst1_f32(pg, dst + 14 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s6, s14), svsub_f32_x(pg, s5, s13)));
+            svst1_f32(pg, dst + 15 * stride, svsub_f32_x(pg, svsub_f32_x(pg, s5, s13), svsub_f32_x(pg, s7, s15)));
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetInput(const float* src, size_t srcS, size_t srcC, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            WinogradKernel3x3Block2x2SetInputStore(
+                svld1_f32(pg, src + 0 * srcS + 0 * srcC), svld1_f32(pg, src + 0 * srcS + 1 * srcC), svld1_f32(pg, src + 0 * srcS + 2 * srcC), svld1_f32(pg, src + 0 * srcS + 3 * srcC),
+                svld1_f32(pg, src + 1 * srcS + 0 * srcC), svld1_f32(pg, src + 1 * srcS + 1 * srcC), svld1_f32(pg, src + 1 * srcS + 2 * srcC), svld1_f32(pg, src + 1 * srcS + 3 * srcC),
+                svld1_f32(pg, src + 2 * srcS + 0 * srcC), svld1_f32(pg, src + 2 * srcS + 1 * srcC), svld1_f32(pg, src + 2 * srcS + 2 * srcC), svld1_f32(pg, src + 2 * srcS + 3 * srcC),
+                svld1_f32(pg, src + 3 * srcS + 0 * srcC), svld1_f32(pg, src + 3 * srcS + 1 * srcC), svld1_f32(pg, src + 3 * srcS + 2 * srcC), svld1_f32(pg, src + 3 * srcS + 3 * srcC),
+                dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetInput(const float* src, size_t srcW, size_t srcC, float* dst, size_t dstStride)
+        {
+            const size_t F = svcntw();
+            const size_t srcS = srcW * srcC;
+            const size_t srcCF = AlignLo(srcC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < srcCF; c += F)
+                WinogradKernel3x3Block2x2SetInput(src + c, srcS, srcC, dst + c, dstStride, body);
+            if (c < srcC)
+                WinogradKernel3x3Block2x2SetInput(src + c, srcS, srcC, dst + c, dstStride, svwhilelt_b32(c, srcC));
+        }
+
+        SIMD_INLINE svfloat32_t WinogradKernel3x3Block2x2SetInputLoad(const float* src, size_t srcS, size_t srcC, size_t row,
+            size_t rowB, size_t rowE, size_t col, size_t colB, size_t colE, const svbool_t& pg)
+        {
+            return row >= rowB && row < rowE && col >= colB && col < colE ? svld1_f32(pg, src + row * srcS + col * srcC) : svdup_n_f32(0.0f);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetInput(const float* src, size_t srcS, size_t srcC, size_t rowB, size_t rowE,
+            size_t colB, size_t colE, float* dst, size_t dstStride, const svbool_t& pg)
+        {
+            WinogradKernel3x3Block2x2SetInputStore(
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 0, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 1, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 2, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 0, rowB, rowE, 3, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 0, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 1, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 2, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 1, rowB, rowE, 3, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 0, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 1, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 2, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 2, rowB, rowE, 3, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 3, rowB, rowE, 0, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 3, rowB, rowE, 1, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 3, rowB, rowE, 2, colB, colE, pg),
+                WinogradKernel3x3Block2x2SetInputLoad(src, srcS, srcC, 3, rowB, rowE, 3, colB, colE, pg),
+                dst, dstStride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block2x2SetInput(const float* src, size_t srcW, size_t srcC, size_t rowB, size_t rowE,
+            size_t colB, size_t colE, float* dst, size_t dstStride)
+        {
+            const size_t F = svcntw();
+            const size_t srcS = srcW * srcC;
+            const size_t srcCF = AlignLo(srcC, F);
+            const svbool_t body = svptrue_b32();
+            size_t c = 0;
+            for (; c < srcCF; c += F)
+                WinogradKernel3x3Block2x2SetInput(src + c, srcS, srcC, rowB, rowE, colB, colE, dst + c, dstStride, body);
+            if (c < srcC)
+                WinogradKernel3x3Block2x2SetInput(src + c, srcS, srcC, rowB, rowE, colB, colE, dst + c, dstStride, svwhilelt_b32(c, srcC));
+        }
+
+        void WinogradKernel3x3Block2x2SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
+            size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans)
+        {
+            assert(padY == padX && padY == padH && padY == padW && (padY == 0 || padY == 1));
+            if (!trans)
+            {
+                Base::WinogradKernel3x3Block2x2SetInput(src, srcChannels, srcHeight, srcWidth, padY, padX, padH, padW, dst, dstStride, trans);
+                return;
+            }
+            SimdBool pad = padY > 0 ? SimdTrue : SimdFalse;
+            size_t dstH = pad ? srcHeight : srcHeight - 2;
+            size_t dstW = pad ? srcWidth : srcWidth - 2;
+            size_t dstH2 = AlignLo(dstH, 2);
+            size_t dstW2 = AlignLo(dstW, 2);
+            size_t noseW = Simd::Min<size_t>(4, dstW + 1);
+            size_t noseH = Simd::Min<size_t>(4, dstH + 1);
+            size_t start = pad ? 2 : 0;
+            if (pad)
+            {
+                if (dstH == dstH2)
+                    dstH2 -= 2;
+                if (dstW == dstW2)
+                    dstW2 -= 2;
+                src -= (srcWidth + 1) * srcChannels;
+            }
+            size_t tailW = dstW - dstW2 + (pad ? 1 : 2);
+            size_t tailH = dstH - dstH2 + (pad ? 1 : 2);
+            size_t row = 0, col = 0;
+            if (pad)
+            {
+                WinogradKernel3x3Block2x2SetInput(src, srcWidth, srcChannels, 1, noseH, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = start; col < dstW2; col += 2)
+                    WinogradKernel3x3Block2x2SetInput(src + col * srcChannels, srcWidth, srcChannels, 1, noseH, 0, 4, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel3x3Block2x2SetInput(src + col * srcChannels, srcWidth, srcChannels, 1, noseH, 0, tailW, dst, dstStride), dst += srcChannels;
+            }
+            for (row = start; row < dstH2; row += 2)
+            {
+                if (pad)
+                    WinogradKernel3x3Block2x2SetInput(src + row * srcWidth * srcChannels, srcWidth, srcChannels, 0, 4, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = start; col < dstW2; col += 2)
+                    WinogradKernel3x3Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel3x3Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, 4, 0, tailW, dst, dstStride), dst += srcChannels;
+            }
+            if (row < dstH)
+            {
+                if (pad)
+                    WinogradKernel3x3Block2x2SetInput(src + row * srcWidth * srcChannels, srcWidth, srcChannels, 0, tailH, 1, noseW, dst, dstStride), dst += srcChannels;
+                for (col = start; col < dstW2; col += 2)
+                    WinogradKernel3x3Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, tailH, 0, 4, dst, dstStride), dst += srcChannels;
+                if (col < dstW)
+                    WinogradKernel3x3Block2x2SetInput(src + (row * srcWidth + col) * srcChannels, srcWidth, srcChannels, 0, tailH, 0, tailW, dst, dstStride), dst += srcChannels;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -664,6 +664,11 @@ namespace Test
             result = result && WinogradKernel3x3SetInputAutoTest(2, FUNC_WI(Simd::Neon::WinogradKernel3x3Block2x2SetInput), FUNC_WI(SimdWinogradKernel3x3Block2x2SetInput));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradKernel3x3SetInputAutoTest(2, FUNC_WI(Simd::Sve2::WinogradKernel3x3Block2x2SetInput), FUNC_WI(SimdWinogradKernel3x3Block2x2SetInput));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdWinogradKernel3x3Block2x2SetInput`.
- Cover the SVE2 function in `WinogradKernel3x3Block2x2SetInputAutoTest`.
- Document the SVE2 optimization in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=WinogradKernel3x3Block2x2SetInput -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Winograd3.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb51528-d228-48e0-96b0-d0b1d4382d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb51528-d228-48e0-96b0-d0b1d4382d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

