### PR TITLE
fix out-of-bounds read when growing zlib buffer in ParseHuffmanBlock

### DIFF
--- a/src/Simd/SimdBaseImageLoadPng.cpp
+++ b/src/Simd/SimdBaseImageLoadPng.cpp
@@ -162,6 +162,7 @@ namespace Simd
                             return CorruptPngError("bad huffman code");
                         if (dst >= end)
                         {
+                            os.Seek(dst - beg);
                             os.Reserve(end - beg + 1);
                             beg = os.Data();
                             dst = os.Current();
@@ -191,6 +192,7 @@ namespace Simd
                             return CorruptPngError("bad dist");
                         if (dst + len > end)
                         {
+                            os.Seek(dst - beg);
                             os.Reserve(dst - beg + len);
                             beg = os.Data();
                             dst = os.Current();


### PR DESCRIPTION
**Out-of-bounds read when the zlib output buffer grows**

`Zlib::ParseHuffmanBlock` walks the inflate output with a raw `beg`/`dst`/`end` cursor and only writes the stream position back at the end of a block, so a mid-block `Reserve` reloads `dst` from a stale `_pos`: the growth resets the cursor to the block start and a following distance copy reads from `dst - dist`, before the allocation. The decoded buffer is pre-sized comfortably above any valid image, so only a crafted PNG whose IDAT inflates past it reaches this path; syncing with `os.Seek(dst - beg)` before each grow (the same call already used at end-of-block) keeps `_pos` and the preserved bytes consistent and leaves the normal decode untouched.
