### PR TITLE
Add SVE2 Winograd 3x3 output optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -62,6 +62,7 @@
  <li>SVE2 optimizations of function WinogradKernel3x3Block2x2SetOutput.</li>
  <li>SVE2 optimizations of function WinogradKernel3x3Block3x3SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel3x3Block3x3SetInput.</li>
+ <li>SVE2 optimizations of function WinogradKernel3x3Block3x3SetOutput.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8289,7 +8289,7 @@ SIMD_API void SimdWinogradKernel3x3Block3x3SetOutput(const float * src, size_t s
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetOutputPtr simdWinogradKernel3x3Block3x3SetOutput = SIMD_FUNC4(WinogradKernel3x3Block3x3SetOutput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetOutputPtr simdWinogradKernel3x3Block3x3SetOutput = SIMD_FUNC5(WinogradKernel3x3Block3x3SetOutput, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel3x3Block3x3SetOutput(src, srcStride, dst, dstChannels, dstHeight, dstWidth, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -259,6 +259,8 @@ namespace Simd
         void WinogradKernel3x3Block3x3SetInput(const float* src, size_t srcChannels, size_t srcHeight, size_t srcWidth,
             size_t padY, size_t padX, size_t padH, size_t padW, float* dst, size_t dstStride, SimdBool trans);
 
+        void WinogradKernel3x3Block3x3SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd3.cpp
+++ b/src/Simd/SimdSve2Winograd3.cpp
@@ -738,6 +738,181 @@ namespace Simd
                 }
             }
         }
+
+        //-----------------------------------------------------------------------
+
+        SIMD_INLINE void WinogradKernel3x3Block3x3SetOutputLoad25(const float* src, size_t stride,
+            svfloat32_t& dst0, svfloat32_t& dst1, svfloat32_t& dst2, svfloat32_t& dst3, svfloat32_t& dst4,
+            svfloat32_t& dst5, svfloat32_t& dst6, svfloat32_t& dst7, svfloat32_t& dst8, const svbool_t& pg)
+        {
+            svfloat32_t s0 = svld1_f32(pg, src + 0 * stride);
+            svfloat32_t s1 = svld1_f32(pg, src + 1 * stride);
+            svfloat32_t s2 = svld1_f32(pg, src + 2 * stride);
+            svfloat32_t s3 = svld1_f32(pg, src + 3 * stride);
+            svfloat32_t s4 = svld1_f32(pg, src + 4 * stride);
+            svfloat32_t s5 = svld1_f32(pg, src + 5 * stride);
+            svfloat32_t s6 = svld1_f32(pg, src + 6 * stride);
+            svfloat32_t s7 = svld1_f32(pg, src + 7 * stride);
+            svfloat32_t s8 = svld1_f32(pg, src + 8 * stride);
+            svfloat32_t s9 = svld1_f32(pg, src + 9 * stride);
+            svfloat32_t s10 = svld1_f32(pg, src + 10 * stride);
+            svfloat32_t s11 = svld1_f32(pg, src + 11 * stride);
+            svfloat32_t s12 = svld1_f32(pg, src + 12 * stride);
+            svfloat32_t s13 = svld1_f32(pg, src + 13 * stride);
+            svfloat32_t s14 = svld1_f32(pg, src + 14 * stride);
+            svfloat32_t s15 = svld1_f32(pg, src + 15 * stride);
+            svfloat32_t s16 = svld1_f32(pg, src + 16 * stride);
+            svfloat32_t s17 = svld1_f32(pg, src + 17 * stride);
+            svfloat32_t s18 = svld1_f32(pg, src + 18 * stride);
+            svfloat32_t s19 = svld1_f32(pg, src + 19 * stride);
+            svfloat32_t s20 = svld1_f32(pg, src + 20 * stride);
+            svfloat32_t s21 = svld1_f32(pg, src + 21 * stride);
+            svfloat32_t s22 = svld1_f32(pg, src + 22 * stride);
+            svfloat32_t s23 = svld1_f32(pg, src + 23 * stride);
+            svfloat32_t s24 = svld1_f32(pg, src + 24 * stride);
+
+            svfloat32_t _2 = svdup_n_f32(2.0f);
+            svfloat32_t _4 = svdup_n_f32(4.0f);
+            svfloat32_t t0, t1, t2, t3, t4;
+
+            t0 = svadd_f32_x(pg, svadd_f32_x(pg, s0, s5), svadd_f32_x(pg, s10, s15));
+            t1 = svadd_f32_x(pg, svadd_f32_x(pg, s1, s6), svadd_f32_x(pg, s11, s16));
+            t2 = svadd_f32_x(pg, svadd_f32_x(pg, s2, s7), svadd_f32_x(pg, s12, s17));
+            t3 = svadd_f32_x(pg, svadd_f32_x(pg, s3, s8), svadd_f32_x(pg, s13, s18));
+            t4 = svadd_f32_x(pg, svadd_f32_x(pg, s4, s9), svadd_f32_x(pg, s14, s19));
+            dst0 = svadd_f32_x(pg, svadd_f32_x(pg, t0, t1), svadd_f32_x(pg, t2, t3));
+            dst1 = svadd_f32_x(pg, svsub_f32_x(pg, t1, t2), svmul_f32_x(pg, _2, t3));
+            dst2 = svadd_f32_x(pg, svadd_f32_x(pg, t1, t2), svadd_f32_x(pg, svmul_f32_x(pg, _4, t3), t4));
+
+            t0 = svadd_f32_x(pg, svsub_f32_x(pg, s5, s10), svmul_f32_x(pg, _2, s15));
+            t1 = svadd_f32_x(pg, svsub_f32_x(pg, s6, s11), svmul_f32_x(pg, _2, s16));
+            t2 = svadd_f32_x(pg, svsub_f32_x(pg, s7, s12), svmul_f32_x(pg, _2, s17));
+            t3 = svadd_f32_x(pg, svsub_f32_x(pg, s8, s13), svmul_f32_x(pg, _2, s18));
+            t4 = svadd_f32_x(pg, svsub_f32_x(pg, s9, s14), svmul_f32_x(pg, _2, s19));
+            dst3 = svadd_f32_x(pg, svadd_f32_x(pg, t0, t1), svadd_f32_x(pg, t2, t3));
+            dst4 = svadd_f32_x(pg, svsub_f32_x(pg, t1, t2), svmul_f32_x(pg, _2, t3));
+            dst5 = svadd_f32_x(pg, svadd_f32_x(pg, t1, t2), svadd_f32_x(pg, svmul_f32_x(pg, _4, t3), t4));
+
+            t0 = svadd_f32_x(pg, svadd_f32_x(pg, s5, s10), svadd_f32_x(pg, svmul_f32_x(pg, _4, s15), s20));
+            t1 = svadd_f32_x(pg, svadd_f32_x(pg, s6, s11), svadd_f32_x(pg, svmul_f32_x(pg, _4, s16), s21));
+            t2 = svadd_f32_x(pg, svadd_f32_x(pg, s7, s12), svadd_f32_x(pg, svmul_f32_x(pg, _4, s17), s22));
+            t3 = svadd_f32_x(pg, svadd_f32_x(pg, s8, s13), svadd_f32_x(pg, svmul_f32_x(pg, _4, s18), s23));
+            t4 = svadd_f32_x(pg, svadd_f32_x(pg, s9, s14), svadd_f32_x(pg, svmul_f32_x(pg, _4, s19), s24));
+            dst6 = svadd_f32_x(pg, svadd_f32_x(pg, t0, t1), svadd_f32_x(pg, t2, t3));
+            dst7 = svadd_f32_x(pg, svsub_f32_x(pg, t1, t2), svmul_f32_x(pg, _2, t3));
+            dst8 = svadd_f32_x(pg, svadd_f32_x(pg, t1, t2), svadd_f32_x(pg, svmul_f32_x(pg, _4, t3), t4));
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block3x3SetOutputStore9(
+            const svfloat32_t& src0, const svfloat32_t& src1, const svfloat32_t& src2, const svfloat32_t& src3, const svfloat32_t& src4,
+            const svfloat32_t& src5, const svfloat32_t& src6, const svfloat32_t& src7, const svfloat32_t& src8,
+            float* dst, size_t dstS, size_t dstC, const svbool_t& pg)
+        {
+            svst1_f32(pg, dst + 0 * dstS + 0 * dstC, src0);
+            svst1_f32(pg, dst + 0 * dstS + 1 * dstC, src1);
+            svst1_f32(pg, dst + 0 * dstS + 2 * dstC, src2);
+            svst1_f32(pg, dst + 1 * dstS + 0 * dstC, src3);
+            svst1_f32(pg, dst + 1 * dstS + 1 * dstC, src4);
+            svst1_f32(pg, dst + 1 * dstS + 2 * dstC, src5);
+            svst1_f32(pg, dst + 2 * dstS + 0 * dstC, src6);
+            svst1_f32(pg, dst + 2 * dstS + 1 * dstC, src7);
+            svst1_f32(pg, dst + 2 * dstS + 2 * dstC, src8);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block3x3SetOutputStore9(
+            const svfloat32_t& src0, const svfloat32_t& src1, const svfloat32_t& src2, const svfloat32_t& src3, const svfloat32_t& src4,
+            const svfloat32_t& src5, const svfloat32_t& src6, const svfloat32_t& src7, const svfloat32_t& src8,
+            float* dst, size_t dstS, size_t dstC, size_t rowE, size_t colE, const svbool_t& pg)
+        {
+            if (rowE > 0 && colE > 0)
+                svst1_f32(pg, dst + 0 * dstS + 0 * dstC, src0);
+            if (rowE > 0 && colE > 1)
+                svst1_f32(pg, dst + 0 * dstS + 1 * dstC, src1);
+            if (rowE > 0 && colE > 2)
+                svst1_f32(pg, dst + 0 * dstS + 2 * dstC, src2);
+            if (rowE > 1 && colE > 0)
+                svst1_f32(pg, dst + 1 * dstS + 0 * dstC, src3);
+            if (rowE > 1 && colE > 1)
+                svst1_f32(pg, dst + 1 * dstS + 1 * dstC, src4);
+            if (rowE > 1 && colE > 2)
+                svst1_f32(pg, dst + 1 * dstS + 2 * dstC, src5);
+            if (rowE > 2 && colE > 0)
+                svst1_f32(pg, dst + 2 * dstS + 0 * dstC, src6);
+            if (rowE > 2 && colE > 1)
+                svst1_f32(pg, dst + 2 * dstS + 1 * dstC, src7);
+            if (rowE > 2 && colE > 2)
+                svst1_f32(pg, dst + 2 * dstS + 2 * dstC, src8);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block3x3SetOutputT(const float* src, size_t srcStride, float* dst, size_t dstW, size_t dstC)
+        {
+            const size_t F = svcntw();
+            const size_t dstCF = AlignLo(dstC, F);
+            const svbool_t body = svptrue_b32();
+            const size_t dstS = dstW * dstC;
+            size_t d = 0;
+            for (; d < dstCF; d += F)
+            {
+                svfloat32_t tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8;
+                WinogradKernel3x3Block3x3SetOutputLoad25(src + d, srcStride, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, body);
+                WinogradKernel3x3Block3x3SetOutputStore9(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, dst + d, dstS, dstC, body);
+            }
+            if (d < dstC)
+            {
+                svbool_t tail = svwhilelt_b32(d, dstC);
+                svfloat32_t tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8;
+                WinogradKernel3x3Block3x3SetOutputLoad25(src + d, srcStride, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tail);
+                WinogradKernel3x3Block3x3SetOutputStore9(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, dst + d, dstS, dstC, tail);
+            }
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block3x3SetOutputT(const float* src, size_t srcStride, float* dst, size_t dstW, size_t dstC, size_t rowE, size_t colE)
+        {
+            const size_t F = svcntw();
+            const size_t dstCF = AlignLo(dstC, F);
+            const svbool_t body = svptrue_b32();
+            const size_t dstS = dstW * dstC;
+            size_t d = 0;
+            for (; d < dstCF; d += F)
+            {
+                svfloat32_t tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8;
+                WinogradKernel3x3Block3x3SetOutputLoad25(src + d, srcStride, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, body);
+                WinogradKernel3x3Block3x3SetOutputStore9(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, dst + d, dstS, dstC, rowE, colE, body);
+            }
+            if (d < dstC)
+            {
+                svbool_t tail = svwhilelt_b32(d, dstC);
+                svfloat32_t tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8;
+                WinogradKernel3x3Block3x3SetOutputLoad25(src + d, srcStride, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, tail);
+                WinogradKernel3x3Block3x3SetOutputStore9(tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7, tmp8, dst + d, dstS, dstC, rowE, colE, tail);
+            }
+        }
+
+        void WinogradKernel3x3Block3x3SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans)
+        {
+            if (!trans)
+            {
+                Base::WinogradKernel3x3Block3x3SetOutput(src, srcStride, dst, dstChannels, dstHeight, dstWidth, trans);
+                return;
+            }
+            size_t dstH3 = AlignLoAny(dstHeight, 3);
+            size_t dstW3 = AlignLoAny(dstWidth, 3);
+            size_t row, col;
+            for (row = 0; row < dstH3; row += 3)
+            {
+                for (col = 0; col < dstW3; col += 3)
+                    WinogradKernel3x3Block3x3SetOutputT(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels), src += dstChannels;
+                if (col < dstWidth)
+                    WinogradKernel3x3Block3x3SetOutputT(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, 3, dstWidth - col), src += dstChannels;
+            }
+            if (row < dstHeight)
+            {
+                for (col = 0; col < dstW3; col += 3)
+                    WinogradKernel3x3Block3x3SetOutputT(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, dstHeight - row, 3), src += dstChannels;
+                if (col < dstWidth)
+                    WinogradKernel3x3Block3x3SetOutputT(src, srcStride, dst + (row * dstWidth + col) * dstChannels, dstWidth, dstChannels, dstHeight - row, dstWidth - col), src += dstChannels;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -1083,6 +1083,11 @@ namespace Test
             result = result && WinogradKernel3x3SetOutputAutoTest(3, FUNC_WO(Simd::Neon::WinogradKernel3x3Block3x3SetOutput), FUNC_WO(SimdWinogradKernel3x3Block3x3SetOutput));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradKernel3x3SetOutputAutoTest(3, FUNC_WO(Simd::Sve2::WinogradKernel3x3Block3x3SetOutput), FUNC_WO(SimdWinogradKernel3x3Block3x3SetOutput));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation for `WinogradKernel3x3Block3x3SetOutput` transposed output transform.
- Wire SVE2 dispatch and auto-test coverage for `WinogradKernel3x3Block3x3SetOutput`.
- Update 7.2.164 release notes with the new SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=WinogradKernel3x3Block3x3SetOutput -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -O2 -I/workspace/src -c /workspace/src/Simd/SimdSve2Winograd3.cpp -o /tmp/SimdSve2Winograd3.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-202ccef6-24a3-4aa9-bd42-4918bf6ef8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-202ccef6-24a3-4aa9-bd42-4918bf6ef8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

