### PR TITLE
Add SVE2 Winograd 3x3 block4x4 filter

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -63,6 +63,7 @@
  <li>SVE2 optimizations of function WinogradKernel3x3Block3x3SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel3x3Block3x3SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel3x3Block3x3SetOutput.</li>
+ <li>SVE2 optimizations of function WinogradKernel3x3Block4x4SetFilter.</li>
  <li>SVE2 optimizations of function TextureGetDifferenceSum.</li>
  <li>SVE2 optimizations of function TexturePerformCompensation.</li>
  <li>SVE2 optimizations of function TransformImage.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8301,7 +8301,7 @@ SIMD_API void SimdWinogradKernel3x3Block4x4SetFilter(const float * src, size_t s
 {
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
-    const static SimdWinogradSetFilterPtr simdWinogradKernel3x3Block4x4SetFilter = SIMD_FUNC4(WinogradKernel3x3Block4x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdWinogradSetFilterPtr simdWinogradKernel3x3Block4x4SetFilter = SIMD_FUNC5(WinogradKernel3x3Block4x4SetFilter, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdWinogradKernel3x3Block4x4SetFilter(src, size, dst, trans);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -261,6 +261,8 @@ namespace Simd
 
         void WinogradKernel3x3Block3x3SetOutput(const float* src, size_t srcStride, float* dst, size_t dstChannels, size_t dstHeight, size_t dstWidth, SimdBool trans);
 
+        void WinogradKernel3x3Block4x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans);
+
         void Yuv420pToBgrV2(const uint8_t* y, size_t yStride, const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride, SimdYuvType yuvType);
 

--- a/src/Simd/SimdSve2Winograd3.cpp
+++ b/src/Simd/SimdSve2Winograd3.cpp
@@ -213,6 +213,111 @@ namespace Simd
 
         //-----------------------------------------------------------------------
 
+        SIMD_INLINE void WinogradKernel3x3Block4x4SetFilterRow(const svfloat32_t& t0, const svfloat32_t& t1, const svfloat32_t& t2,
+            float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r4 = svdup_n_f32(1.0f / 4.0f);
+            const svfloat32_t mr6 = svdup_n_f32(-1.0f / 6.0f);
+            const svfloat32_t r6 = svdup_n_f32(1.0f / 6.0f);
+            const svfloat32_t r12 = svdup_n_f32(1.0f / 12.0f);
+            const svfloat32_t r24 = svdup_n_f32(1.0f / 24.0f);
+
+            svst1_f32(pg, dst + 0 * stride, svmul_f32_x(pg, r4, t0));
+            svfloat32_t sum02 = svadd_f32_x(pg, t0, t2);
+            svst1_f32(pg, dst + 1 * stride, svmul_f32_x(pg, mr6, svadd_f32_x(pg, sum02, t1)));
+            svst1_f32(pg, dst + 2 * stride, svmul_f32_x(pg, mr6, svsub_f32_x(pg, sum02, t1)));
+            svfloat32_t term02 = svadd_f32_x(pg, svmul_f32_x(pg, r24, t0), svmul_f32_x(pg, r6, t2));
+            svfloat32_t term1 = svmul_f32_x(pg, r12, t1);
+            svst1_f32(pg, dst + 3 * stride, svadd_f32_x(pg, term02, term1));
+            svst1_f32(pg, dst + 4 * stride, svsub_f32_x(pg, term02, term1));
+            svst1_f32(pg, dst + 5 * stride, t2);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block4x4SetFilterAll(
+            const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2, const svfloat32_t& s3, const svfloat32_t& s4,
+            const svfloat32_t& s5, const svfloat32_t& s6, const svfloat32_t& s7, const svfloat32_t& s8,
+            float* dst, size_t stride, const svbool_t& pg)
+        {
+            const svfloat32_t r4 = svdup_n_f32(1.0f / 4.0f);
+            const svfloat32_t mr6 = svdup_n_f32(-1.0f / 6.0f);
+            const svfloat32_t r6 = svdup_n_f32(1.0f / 6.0f);
+            const svfloat32_t r12 = svdup_n_f32(1.0f / 12.0f);
+            const svfloat32_t r24 = svdup_n_f32(1.0f / 24.0f);
+
+            WinogradKernel3x3Block4x4SetFilterRow(
+                svmul_f32_x(pg, r4, s0), svmul_f32_x(pg, r4, s1), svmul_f32_x(pg, r4, s2),
+                dst + 0 * stride, stride, pg);
+
+            WinogradKernel3x3Block4x4SetFilterRow(
+                svmul_f32_x(pg, mr6, svadd_f32_x(pg, svadd_f32_x(pg, s0, s3), s6)),
+                svmul_f32_x(pg, mr6, svadd_f32_x(pg, svadd_f32_x(pg, s1, s4), s7)),
+                svmul_f32_x(pg, mr6, svadd_f32_x(pg, svadd_f32_x(pg, s2, s5), s8)),
+                dst + 6 * stride, stride, pg);
+
+            WinogradKernel3x3Block4x4SetFilterRow(
+                svmul_f32_x(pg, mr6, svadd_f32_x(pg, svsub_f32_x(pg, s0, s3), s6)),
+                svmul_f32_x(pg, mr6, svadd_f32_x(pg, svsub_f32_x(pg, s1, s4), s7)),
+                svmul_f32_x(pg, mr6, svadd_f32_x(pg, svsub_f32_x(pg, s2, s5), s8)),
+                dst + 12 * stride, stride, pg);
+
+            WinogradKernel3x3Block4x4SetFilterRow(
+                svadd_f32_x(pg, svadd_f32_x(pg, svmul_f32_x(pg, r24, s0), svmul_f32_x(pg, r12, s3)), svmul_f32_x(pg, r6, s6)),
+                svadd_f32_x(pg, svadd_f32_x(pg, svmul_f32_x(pg, r24, s1), svmul_f32_x(pg, r12, s4)), svmul_f32_x(pg, r6, s7)),
+                svadd_f32_x(pg, svadd_f32_x(pg, svmul_f32_x(pg, r24, s2), svmul_f32_x(pg, r12, s5)), svmul_f32_x(pg, r6, s8)),
+                dst + 18 * stride, stride, pg);
+
+            WinogradKernel3x3Block4x4SetFilterRow(
+                svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, r24, s0), svmul_f32_x(pg, r12, s3)), svmul_f32_x(pg, r6, s6)),
+                svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, r24, s1), svmul_f32_x(pg, r12, s4)), svmul_f32_x(pg, r6, s7)),
+                svadd_f32_x(pg, svsub_f32_x(pg, svmul_f32_x(pg, r24, s2), svmul_f32_x(pg, r12, s5)), svmul_f32_x(pg, r6, s8)),
+                dst + 24 * stride, stride, pg);
+
+            WinogradKernel3x3Block4x4SetFilterRow(s6, s7, s8, dst + 30 * stride, stride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block4x4SetFilterVt(const float* src, float* dst, size_t stride, const svbool_t& pg)
+        {
+            WinogradKernel3x3Block4x4SetFilterAll(
+                svld1_f32(pg, src + 0 * stride), svld1_f32(pg, src + 1 * stride), svld1_f32(pg, src + 2 * stride),
+                svld1_f32(pg, src + 3 * stride), svld1_f32(pg, src + 4 * stride), svld1_f32(pg, src + 5 * stride),
+                svld1_f32(pg, src + 6 * stride), svld1_f32(pg, src + 7 * stride), svld1_f32(pg, src + 8 * stride),
+                dst + 0 * stride, stride, pg);
+        }
+
+        SIMD_INLINE void WinogradKernel3x3Block4x4SetFilterVn(const float* src, float* dst, size_t stride, const svbool_t& pg)
+        {
+            svuint32_t offsets = svindex_u32(0, 9);
+            WinogradKernel3x3Block4x4SetFilterAll(
+                svld1_gather_u32index_f32(pg, src + 0, offsets), svld1_gather_u32index_f32(pg, src + 1, offsets), svld1_gather_u32index_f32(pg, src + 2, offsets),
+                svld1_gather_u32index_f32(pg, src + 3, offsets), svld1_gather_u32index_f32(pg, src + 4, offsets), svld1_gather_u32index_f32(pg, src + 5, offsets),
+                svld1_gather_u32index_f32(pg, src + 6, offsets), svld1_gather_u32index_f32(pg, src + 7, offsets), svld1_gather_u32index_f32(pg, src + 8, offsets),
+                dst + 0 * stride, stride, pg);
+        }
+
+        void WinogradKernel3x3Block4x4SetFilter(const float* src, size_t size, float* dst, SimdBool trans)
+        {
+            const size_t F = svcntw();
+            const size_t sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            if (trans)
+            {
+                for (; i < sizeF; i += F)
+                    WinogradKernel3x3Block4x4SetFilterVt(src + i, dst + i, size, body);
+                if (i < size)
+                    WinogradKernel3x3Block4x4SetFilterVt(src + i, dst + i, size, svwhilelt_b32(i, size));
+            }
+            else
+            {
+                for (; i < sizeF; i += F, src += 9 * F, dst += F)
+                    WinogradKernel3x3Block4x4SetFilterVn(src, dst, size, body);
+                if (i < size)
+                    WinogradKernel3x3Block4x4SetFilterVn(src, dst, size, svwhilelt_b32(i, size));
+            }
+        }
+
+        //-----------------------------------------------------------------------
+
         SIMD_INLINE void WinogradKernel3x3Block2x2SetInputStore(
             const svfloat32_t& s0, const svfloat32_t& s1, const svfloat32_t& s2, const svfloat32_t& s3,
             const svfloat32_t& s4, const svfloat32_t& s5, const svfloat32_t& s6, const svfloat32_t& s7,

--- a/src/Test/TestWinograd.cpp
+++ b/src/Test/TestWinograd.cpp
@@ -338,6 +338,11 @@ namespace Test
             result = result && WinogradSetFilterAutoTest(_4x4, _3x3, FUNC_WF(Simd::Neon::WinogradKernel3x3Block4x4SetFilter), FUNC_WF(SimdWinogradKernel3x3Block4x4SetFilter));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && WinogradSetFilterAutoTest(_4x4, _3x3, FUNC_WF(Simd::Sve2::WinogradKernel3x3Block4x4SetFilter), FUNC_WF(SimdWinogradKernel3x3Block4x4SetFilter));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation and dispatch for `WinogradKernel3x3Block4x4SetFilter`.
* Extend the Winograd SetFilter autotest to cover the SVE2 optimized function.
* Document the new SVE2 optimization in release 7.2.164.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=WinogradKernel3x3Block4x4SetFilter -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -fsyntax-only -I/workspace/src /workspace/src/Simd/SimdSve2Winograd3.cpp`

[winograd_block4x4_setfilter_test.log](https://cursor.com/agents/bc-d7dc00d5-e4a5-450f-97a5-2bca221feb73/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwinograd_block4x4_setfilter_test.log)
[sve2_winograd3_syntax_check.log](https://cursor.com/agents/bc-d7dc00d5-e4a5-450f-97a5-2bca221feb73/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsve2_winograd3_syntax_check.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7dc00d5-e4a5-450f-97a5-2bca221feb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7dc00d5-e4a5-450f-97a5-2bca221feb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

