### PR TITLE
Add SVE2 nearest resizer optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
+ <li>SVE2 optimizations of class ResizerNearest for functions SimdResizerInit and SimdResizerRun.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -77,6 +77,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerNearest.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ShiftBilinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -326,6 +326,12 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp">
+      <Filter>Sve2\Resize</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerNearest.cpp">
+      <Filter>Sve2\Resize</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4973,7 +4973,7 @@ SIMD_API void * SimdResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t ds
 {
     SIMD_EMPTY();
     typedef void*(*SimdResizerInitPtr) (size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method);
-    const static SimdResizerInitPtr simdResizerInit = SIMD_FUNC4(ResizerInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdResizerInitPtr simdResizerInit = SIMD_FUNC5(ResizerInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdResizerInit(srcX, srcY, dstX, dstY, channels, type, method);
 }

--- a/src/Simd/SimdResizer.h
+++ b/src/Simd/SimdResizer.h
@@ -799,5 +799,35 @@ namespace Simd
         void * ResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method);
     }
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class ResizerNearest : public Base::ResizerNearest
+        {
+        protected:
+            size_t _blocks, _tails;
+            struct IndexShuffle8x1
+            {
+                int32_t src, dst;
+                uint8_t shuffle[SIMD_SVE2_VECTOR_SIZE_MAX];
+            };
+            Array<IndexShuffle8x1> _ix8x1;
+            Array<size_t> _tail8x1;
+
+            size_t BlockCountMax(size_t align);
+            void EstimateParams();
+            void Shuffle8x1(const uint8_t* src, size_t srcStride, size_t dyBeg, size_t dyEnd, uint8_t* dst, size_t dstStride);
+        public:
+            ResizerNearest(const ResParam& param);
+
+            virtual void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void * ResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method);
+    }
+#endif
 }
 #endif

--- a/src/Simd/SimdSve2Resizer.cpp
+++ b/src/Simd/SimdSve2Resizer.cpp
@@ -1,0 +1,47 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdResizer.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void * ResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method)
+        {
+            ResParam param(srcX, srcY, dstX, dstY, channels, type, method, svcntb());
+            if (param.IsNearest())
+                return new ResizerNearest(param);
+            else
+#ifdef SIMD_NEON_ENABLE
+                return Neon::ResizerInit(srcX, srcY, dstX, dstY, channels, type, method);
+#else
+                return Base::ResizerInit(srcX, srcY, dstX, dstY, channels, type, method);
+#endif
+        }
+    }
+#endif
+}
+

--- a/src/Simd/SimdSve2ResizerNearest.cpp
+++ b/src/Simd/SimdSve2ResizerNearest.cpp
@@ -1,0 +1,134 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdResizer.h"
+#include "Simd/SimdResizerCommon.h"
+#include "Simd/SimdParallel.hpp"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        ResizerNearest::ResizerNearest(const ResParam& param)
+            : Base::ResizerNearest(param)
+            , _blocks(0)
+            , _tails(0)
+        {
+        }
+
+        size_t ResizerNearest::BlockCountMax(size_t align)
+        {
+            return (size_t)::ceil(float(Simd::Max(_param.srcW, _param.dstW) * _param.PixelSize()) / (align - _param.PixelSize()));
+        }
+
+        void ResizerNearest::EstimateParams()
+        {
+            if (_blocks)
+                return;
+            Base::ResizerNearest::EstimateParams();
+            const size_t A = svcntb();
+            const size_t pixelSize = _param.PixelSize();
+            if (pixelSize * _param.dstW < A || pixelSize * _param.srcW < A)
+                return;
+            if (pixelSize < 4 && _param.srcW < 4 * _param.dstW)
+                _blocks = BlockCountMax(A);
+            float scale = (float)_param.srcW / _param.dstW;
+            if (_blocks)
+            {
+                _tails = 0;
+                _ix8x1.Resize(_blocks);
+                _tail8x1.Resize((size_t)::ceil(A * scale / pixelSize));
+                size_t dstRowSize = _param.dstW * pixelSize;
+                int block = 0;
+                _ix8x1[0].src = 0;
+                _ix8x1[0].dst = 0;
+                for (int dstIndex = 0; dstIndex < (int)_param.dstW; ++dstIndex)
+                {
+                    int srcIndex = _ix[dstIndex] / (int)pixelSize;
+                    int dst = dstIndex * (int)pixelSize - _ix8x1[block].dst;
+                    int src = srcIndex * (int)pixelSize - _ix8x1[block].src;
+                    if (src >= int(A - pixelSize) || dst >= int(A - pixelSize))
+                    {
+                        block++;
+                        _ix8x1[block].src = srcIndex * (int)pixelSize;
+                        _ix8x1[block].dst = dstIndex * (int)pixelSize;
+                        if (_ix8x1[block].dst > int(dstRowSize - A))
+                        {
+                            _tail8x1[_tails] = dstRowSize - _ix8x1[block].dst;
+                            _tails++;
+                        }
+                        dst = 0;
+                        src = srcIndex * (int)pixelSize - _ix8x1[block].src;
+                    }
+                    for (size_t i = 0; i < pixelSize; ++i)
+                        _ix8x1[block].shuffle[dst + i] = uint8_t(src + i);
+                }
+                _blocks = block + 1;
+            }
+        }
+
+        void ResizerNearest::Shuffle8x1(const uint8_t* src, size_t srcStride, size_t dyBeg, size_t dyEnd, uint8_t* dst, size_t dstStride)
+        {
+            size_t body = _blocks - _tails;
+            const svbool_t full = svptrue_b8();
+            for (size_t dy = dyBeg; dy < dyEnd; dy++)
+            {
+                const uint8_t* srcRow = src + _iy[dy] * srcStride;
+                size_t i = 0, t = 0;
+                for (; i < body; ++i)
+                {
+                    const IndexShuffle8x1& index = _ix8x1[i];
+                    svuint8_t _src = svld1_u8(full, srcRow + index.src);
+                    svuint8_t _shuffle = svld1_u8(full, index.shuffle);
+                    svst1_u8(full, dst + index.dst, svtbl_u8(_src, _shuffle));
+                }
+                for (; i < _blocks; ++i, ++t)
+                {
+                    const IndexShuffle8x1& index = _ix8x1[i];
+                    svuint8_t _src = svld1_u8(full, srcRow + index.src);
+                    svuint8_t _shuffle = svld1_u8(full, index.shuffle);
+                    svst1_u8(svwhilelt_b8((size_t)0, _tail8x1[t]), dst + index.dst, svtbl_u8(_src, _shuffle));
+                }
+                dst += dstStride;
+            }
+        }
+
+        void ResizerNearest::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            EstimateParams();
+            if (_blocks)
+            {
+                Simd::Parallel(0, _param.dstH, [&](size_t thread, size_t dstBeg, size_t dstEnd)
+                {
+                    this->Shuffle8x1(src, srcStride, dstBeg, dstEnd, dst + dstBeg * dstStride, dstStride);
+                }, _threads, 1);
+            }
+            else
+                Base::ResizerNearest::Run(src, srcStride, dst, dstStride);
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestResize.cpp
+++ b/src/Test/TestResize.cpp
@@ -361,6 +361,11 @@ namespace Test
             result = result && ResizerAutoTest(FUNC_RS(Simd::Neon::ResizerInit), FUNC_RS(SimdResizerInit));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ResizerAutoTest(FUNC_RS(Simd::Sve2::ResizerInit), FUNC_RS(SimdResizerInit));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 `ResizerNearest` implementation for `SimdResizerInit` / `SimdResizerRun` nearest resize paths.
* Route public resizer dispatch through SVE2 before NEON and add SVE2 resizer auto-test coverage.
* Add SVE2 resizer sources to VS2022 project files and update release notes for 7.2.164.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && build/Test "-r=." -fi=Resizer -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++11 -fsyntax-only -I src src/Simd/SimdSve2Resizer.cpp src/Simd/SimdSve2ResizerNearest.cpp`
* `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="" -DSIMD_TARGET="aarch64" -DSIMD_SVE2=ON -DSIMD_TEST=OFF -DSIMD_PYTHON=OFF -DSIMD_SHARED=OFF`
* `cmake --build build-aarch64-sve2 --parallel$(nproc)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-761da8b5-4eee-43e7-9dc2-8bdf54757f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-761da8b5-4eee-43e7-9dc2-8bdf54757f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

