### PR TITLE
Add SVE2 byte bilinear resizer

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -41,6 +41,7 @@
 <h4>Algorithms</h4>
 <h5>New features</h5>
 <ul>
+ <li>SVE2 optimizations of class ResizerByteBilinear.</li>
  <li>SVE2 optimizations of class ResizerNearest.</li>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBilinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerNearest.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ShiftBilinear.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -329,6 +329,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBilinear.cpp">
+      <Filter>Sve2\Resize</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerNearest.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>

--- a/src/Simd/SimdResizer.h
+++ b/src/Simd/SimdResizer.h
@@ -826,6 +826,30 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        class ResizerByteBilinear : public Base::ResizerByteBilinear
+        {
+        protected:
+            Array8u _ax, _bx[2];
+            size_t _blocks;
+            struct Idx
+            {
+                int32_t src, dst;
+                uint8_t shuffle[SIMD_SVE2_VECTOR_SIZE_MAX];
+            };
+            Array<Idx> _ixg;
+
+            size_t BlockCountMax(size_t align);
+            void EstimateParams();
+            template<size_t N> void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+            void RunG(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        public:
+            ResizerByteBilinear(const ResParam& param);
+
+            virtual void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
         void * ResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method);
     }
 #endif

--- a/src/Simd/SimdSve2Resizer.cpp
+++ b/src/Simd/SimdSve2Resizer.cpp
@@ -34,6 +34,8 @@ namespace Simd
             ResParam param(srcX, srcY, dstX, dstY, channels, type, method, svcntb());
             if (param.IsNearest())
                 return new ResizerNearest(param);
+            else if (param.IsByteBilinear() && dstX >= svcntb())
+                return new ResizerByteBilinear(param);
             else
 #ifdef SIMD_NEON_ENABLE
                 return Neon::ResizerInit(srcX, srcY, dstX, dstY, channels, type, method);

--- a/src/Simd/SimdSve2ResizerBilinear.cpp
+++ b/src/Simd/SimdSve2ResizerBilinear.cpp
@@ -143,18 +143,20 @@ namespace Simd
             return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
         }
 
-        SIMD_INLINE svuint16_t ResizerByteBilinearInterpolateY(const uint16_t* pbx0, const uint16_t* pbx1, const svuint16_t alpha[2], const svbool_t& mask)
+        SIMD_INLINE svuint16_t ResizerByteBilinearInterpolateY(const uint16_t* pbx0, const uint16_t* pbx1,
+            const svuint16_t& alpha0, const svuint16_t& alpha1, const svbool_t& mask)
         {
-            svuint16_t sum = svmul_u16_x(mask, svld1_u16(mask, pbx0), alpha[0]);
-            sum = svmla_u16_x(mask, sum, svld1_u16(mask, pbx1), alpha[1]);
+            svuint16_t sum = svmul_u16_x(mask, svld1_u16(mask, pbx0), alpha0);
+            sum = svmla_u16_x(mask, sum, svld1_u16(mask, pbx1), alpha1);
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, Base::BILINEAR_ROUND_TERM), Base::BILINEAR_SHIFT);
         }
 
-        SIMD_INLINE void ResizerByteBilinearInterpolateY(const uint8_t* bx0, const uint8_t* bx1, const svuint16_t alpha[2],
-            uint8_t* dst, const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi, size_t half)
+        SIMD_INLINE void ResizerByteBilinearInterpolateY(const uint8_t* bx0, const uint8_t* bx1,
+            const svuint16_t& alpha0, const svuint16_t& alpha1, uint8_t* dst,
+            const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi, size_t half)
         {
-            svuint16_t lo = ResizerByteBilinearInterpolateY((uint16_t*)bx0, (uint16_t*)bx1, alpha, maskLo);
-            svuint16_t hi = ResizerByteBilinearInterpolateY((uint16_t*)(bx0 + half * 2), (uint16_t*)(bx1 + half * 2), alpha, maskHi);
+            svuint16_t lo = ResizerByteBilinearInterpolateY((uint16_t*)bx0, (uint16_t*)bx1, alpha0, alpha1, maskLo);
+            svuint16_t hi = ResizerByteBilinearInterpolateY((uint16_t*)(bx0 + half * 2), (uint16_t*)(bx1 + half * 2), alpha0, alpha1, maskHi);
             svst1_u8(mask8, dst, PackU16ToU8(lo, hi));
         }
 
@@ -164,7 +166,6 @@ namespace Simd
             const size_t A = svcntb(), HA = svcnth(), DA = 2 * A;
             size_t aligned = AlignHi(size, DA) - DA;
             ptrdiff_t previous = -2;
-            svuint16_t a[2];
             uint8_t* bx[2] = { _bx[0].data, _bx[1].data };
             const uint8_t* ax = _ax.data;
             const int32_t* ix = _ix.data;
@@ -172,8 +173,8 @@ namespace Simd
 
             for (size_t yDst = 0; yDst < _param.dstH; yDst++, dst += dstStride)
             {
-                a[0] = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
-                a[1] = svdup_n_u16((uint16_t)_ay[yDst]);
+                svuint16_t a0 = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
+                svuint16_t a1 = svdup_n_u16((uint16_t)_ay[yDst]);
 
                 ptrdiff_t sy = _iy[yDst];
                 int k = 0;
@@ -208,9 +209,9 @@ namespace Simd
                 }
 
                 for (size_t ib = 0, id = 0; ib < aligned; ib += DA, id += A)
-                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
+                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a0, a1, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
                 size_t i = size - DA;
-                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
+                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a0, a1, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
                     svwhilelt_b16(i / 2, size / 2), svwhilelt_b16(i / 2 + HA, size / 2), HA);
             }
         }
@@ -232,15 +233,14 @@ namespace Simd
             size_t aligned = AlignHi(size, DA) - DA;
             size_t blocks = _blocks;
             ptrdiff_t previous = -2;
-            svuint16_t a[2];
             uint8_t* bx[2] = { _bx[0].data, _bx[1].data };
             const uint8_t* ax = _ax.data;
             const Idx* ixg = _ixg.data;
 
             for (size_t yDst = 0; yDst < _param.dstH; yDst++, dst += dstStride)
             {
-                a[0] = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
-                a[1] = svdup_n_u16((uint16_t)_ay[yDst]);
+                svuint16_t a0 = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
+                svuint16_t a1 = svdup_n_u16((uint16_t)_ay[yDst]);
 
                 ptrdiff_t sy = _iy[yDst];
                 int k = 0;
@@ -264,9 +264,9 @@ namespace Simd
                 }
 
                 for (size_t ib = 0, id = 0; ib < aligned; ib += DA, id += A)
-                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
+                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a0, a1, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
                 size_t i = size - DA;
-                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
+                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a0, a1, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
                     svwhilelt_b16(i / 2, size / 2), svwhilelt_b16(i / 2 + HA, size / 2), HA);
             }
         }

--- a/src/Simd/SimdSve2ResizerBilinear.cpp
+++ b/src/Simd/SimdSve2ResizerBilinear.cpp
@@ -1,0 +1,297 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdResizer.h"
+#include "Simd/SimdResizerCommon.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        ResizerByteBilinear::ResizerByteBilinear(const ResParam& param)
+            : Base::ResizerByteBilinear(param)
+            , _blocks(0)
+        {
+        }
+
+        size_t ResizerByteBilinear::BlockCountMax(size_t align)
+        {
+            return (size_t)Simd::Max(::ceil(float(_param.srcW) / (align - 1)), ::ceil(float(_param.dstW) * 2.0f / align));
+        }
+
+        void ResizerByteBilinear::EstimateParams()
+        {
+            if (_ax.data)
+                return;
+            const size_t A = svcntb();
+            if (_param.channels == 1 && _param.srcW < 4 * _param.dstW)
+                _blocks = BlockCountMax(A);
+            float scale = (float)_param.srcW / _param.dstW;
+            size_t size = _param.dstW * _param.channels * 2;
+            _ax.Resize(AlignHi(size, A), false, _param.align);
+            uint8_t* alphas = _ax.data;
+            if (_blocks)
+            {
+                _ixg.Resize(_blocks);
+                int block = 0;
+                _ixg[0].src = 0;
+                _ixg[0].dst = 0;
+                for (int dstIndex = 0; dstIndex < (int)_param.dstW; ++dstIndex)
+                {
+                    float alpha = (float)((dstIndex + 0.5) * scale - 0.5);
+                    int srcIndex = (int)::floor(alpha);
+                    alpha -= srcIndex;
+
+                    if (srcIndex < 0)
+                    {
+                        srcIndex = 0;
+                        alpha = 0;
+                    }
+
+                    if (srcIndex >(int)_param.srcW - 2)
+                    {
+                        srcIndex = (int)_param.srcW - 2;
+                        alpha = 1;
+                    }
+
+                    int dst = 2 * dstIndex - _ixg[block].dst;
+                    int src = srcIndex - _ixg[block].src;
+                    if (src >= (int)A - 1 || dst >= (int)A)
+                    {
+                        block++;
+                        _ixg[block].src = Simd::Min(srcIndex, int(_param.srcW - A));
+                        _ixg[block].dst = 2 * dstIndex;
+                        dst = 0;
+                        src = srcIndex - _ixg[block].src;
+                    }
+                    _ixg[block].shuffle[dst] = (uint8_t)src;
+                    _ixg[block].shuffle[dst + 1] = (uint8_t)src + 1;
+
+                    alphas[1] = (uint8_t)(alpha * Base::FRACTION_RANGE + 0.5);
+                    alphas[0] = (uint8_t)(Base::FRACTION_RANGE - alphas[1]);
+                    alphas += 2;
+                }
+                _blocks = block + 1;
+            }
+            else
+            {
+                _ix.Resize(_param.dstW);
+                for (size_t i = 0; i < _param.dstW; ++i)
+                {
+                    float alpha = (float)((i + 0.5) * scale - 0.5);
+                    ptrdiff_t index = (ptrdiff_t)::floor(alpha);
+                    alpha -= index;
+
+                    if (index < 0)
+                    {
+                        index = 0;
+                        alpha = 0;
+                    }
+
+                    if (index > (ptrdiff_t)_param.srcW - 2)
+                    {
+                        index = _param.srcW - 2;
+                        alpha = 1;
+                    }
+
+                    _ix[i] = (int)index;
+                    alphas[1] = (uint8_t)(alpha * Base::FRACTION_RANGE + 0.5);
+                    alphas[0] = (uint8_t)(Base::FRACTION_RANGE - alphas[1]);
+                    for (size_t channel = 1; channel < _param.channels; channel++)
+                        ((uint16_t*)alphas)[channel] = *(uint16_t*)alphas;
+                    alphas += 2 * _param.channels;
+                }
+            }
+            _bx[0].Resize(AlignHi(size, A), false, _param.align);
+            _bx[1].Resize(AlignHi(size, A), false, _param.align);
+        }
+
+        SIMD_INLINE void ResizerByteBilinearInterpolateX(const uint8_t* alpha, uint8_t* buffer)
+        {
+            const svbool_t mask8 = svptrue_b8(), mask16 = svptrue_b16();
+            svuint8_t _src = svld1_u8(mask8, buffer);
+            svuint8_t _alpha = svld1_u8(mask8, alpha);
+            svuint16_t lo = svmul_u16_x(mask16, svunpklo_u16(svuzp1_u8(_src, _src)), svunpklo_u16(svuzp1_u8(_alpha, _alpha)));
+            lo = svmla_u16_x(mask16, lo, svunpklo_u16(svuzp2_u8(_src, _src)), svunpklo_u16(svuzp2_u8(_alpha, _alpha)));
+            svst1_u16(mask16, (uint16_t*)buffer, lo);
+        }
+
+        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        {
+            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+        }
+
+        SIMD_INLINE svuint16_t ResizerByteBilinearInterpolateY(const uint16_t* pbx0, const uint16_t* pbx1, const svuint16_t alpha[2], const svbool_t& mask)
+        {
+            svuint16_t sum = svmul_u16_x(mask, svld1_u16(mask, pbx0), alpha[0]);
+            sum = svmla_u16_x(mask, sum, svld1_u16(mask, pbx1), alpha[1]);
+            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, Base::BILINEAR_ROUND_TERM), Base::BILINEAR_SHIFT);
+        }
+
+        SIMD_INLINE void ResizerByteBilinearInterpolateY(const uint8_t* bx0, const uint8_t* bx1, const svuint16_t alpha[2],
+            uint8_t* dst, const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi, size_t half)
+        {
+            svuint16_t lo = ResizerByteBilinearInterpolateY((uint16_t*)bx0, (uint16_t*)bx1, alpha, maskLo);
+            svuint16_t hi = ResizerByteBilinearInterpolateY((uint16_t*)(bx0 + half * 2), (uint16_t*)(bx1 + half * 2), alpha, maskHi);
+            svst1_u8(mask8, dst, PackU16ToU8(lo, hi));
+        }
+
+        template<size_t N> void ResizerByteBilinear::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            size_t size = 2 * _param.dstW * N;
+            const size_t A = svcntb(), HA = svcnth(), DA = 2 * A;
+            size_t aligned = AlignHi(size, DA) - DA;
+            ptrdiff_t previous = -2;
+            svuint16_t a[2];
+            uint8_t* bx[2] = { _bx[0].data, _bx[1].data };
+            const uint8_t* ax = _ax.data;
+            const int32_t* ix = _ix.data;
+            size_t dstW = _param.dstW;
+
+            for (size_t yDst = 0; yDst < _param.dstH; yDst++, dst += dstStride)
+            {
+                a[0] = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
+                a[1] = svdup_n_u16((uint16_t)_ay[yDst]);
+
+                ptrdiff_t sy = _iy[yDst];
+                int k = 0;
+
+                if (sy == previous)
+                    k = 2;
+                else if (sy == previous + 1)
+                {
+                    Swap(bx[0], bx[1]);
+                    k = 1;
+                }
+
+                previous = sy;
+
+                for (; k < 2; k++)
+                {
+                    uint8_t* pb = bx[k];
+                    const uint8_t* psrc = src + (sy + k) * srcStride;
+                    for (size_t x = 0; x < dstW; x++)
+                    {
+                        const uint8_t* ps = psrc + ix[x] * N;
+                        uint8_t* pd = pb + 2 * x * N;
+                        for (size_t c = 0; c < N; c++)
+                        {
+                            pd[2 * c + 0] = ps[c];
+                            pd[2 * c + 1] = ps[c + N];
+                        }
+                    }
+
+                    for (size_t i = 0; i < size; i += A)
+                        ResizerByteBilinearInterpolateX(ax + i, pb + i);
+                }
+
+                for (size_t ib = 0, id = 0; ib < aligned; ib += DA, id += A)
+                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
+                size_t i = size - DA;
+                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
+                    svwhilelt_b16(i / 2, size / 2), svwhilelt_b16(i / 2 + HA, size / 2), HA);
+            }
+        }
+
+        template <class Idx> SIMD_INLINE void ResizerByteBilinearLoadGrayInterpolated(const uint8_t* src, const Idx& index, const uint8_t* alpha, uint8_t* dst)
+        {
+            const svbool_t mask8 = svptrue_b8();
+            svuint8_t _src = svld1_u8(mask8, src + index.src);
+            svuint8_t _shuffle = svld1_u8(mask8, index.shuffle);
+            svuint8_t _buffer = svtbl_u8(_src, _shuffle);
+            svst1_u8(mask8, dst + index.dst, _buffer);
+            ResizerByteBilinearInterpolateX(alpha + index.dst, dst + index.dst);
+        }
+
+        void ResizerByteBilinear::RunG(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            size_t size = 2 * _param.dstW;
+            const size_t A = svcntb(), HA = svcnth(), DA = 2 * A;
+            size_t aligned = AlignHi(size, DA) - DA;
+            size_t blocks = _blocks;
+            ptrdiff_t previous = -2;
+            svuint16_t a[2];
+            uint8_t* bx[2] = { _bx[0].data, _bx[1].data };
+            const uint8_t* ax = _ax.data;
+            const Idx* ixg = _ixg.data;
+
+            for (size_t yDst = 0; yDst < _param.dstH; yDst++, dst += dstStride)
+            {
+                a[0] = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
+                a[1] = svdup_n_u16((uint16_t)_ay[yDst]);
+
+                ptrdiff_t sy = _iy[yDst];
+                int k = 0;
+
+                if (sy == previous)
+                    k = 2;
+                else if (sy == previous + 1)
+                {
+                    Swap(bx[0], bx[1]);
+                    k = 1;
+                }
+
+                previous = sy;
+
+                for (; k < 2; k++)
+                {
+                    const uint8_t* psrc = src + (sy + k) * srcStride;
+                    uint8_t* pdst = bx[k];
+                    for (size_t i = 0; i < blocks; ++i)
+                        ResizerByteBilinearLoadGrayInterpolated(psrc, ixg[i], ax, pdst);
+                }
+
+                for (size_t ib = 0, id = 0; ib < aligned; ib += DA, id += A)
+                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
+                size_t i = size - DA;
+                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
+                    svwhilelt_b16(i / 2, size / 2), svwhilelt_b16(i / 2 + HA, size / 2), HA);
+            }
+        }
+
+        void ResizerByteBilinear::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            assert(_param.dstW >= svcntb());
+
+            EstimateParams();
+            switch (_param.channels)
+            {
+            case 1:
+                if (_blocks)
+                    RunG(src, srcStride, dst, dstStride);
+                else
+                    Run<1>(src, srcStride, dst, dstStride);
+                break;
+            case 2: Run<2>(src, srcStride, dst, dstStride); break;
+            case 3: Run<3>(src, srcStride, dst, dstStride); break;
+            case 4: Run<4>(src, srcStride, dst, dstStride); break;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestResize.cpp
+++ b/src/Test/TestResize.cpp
@@ -298,6 +298,13 @@ namespace Test
         return result;
 #endif
 
+#if defined(SIMD_SVE2_ENABLE)
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelByte, 1, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
+#endif
+
 #if  0 
         {
             std::vector<SimdResizeMethodType> methods = { SimdResizeMethodNearest, SimdResizeMethodBilinear };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation for `ResizerByteBilinear` and dispatch byte bilinear resizer initialization to it.
- Add SVE2-specific byte bilinear coverage to resizer auto tests.
- Register the new SVE2 source in VS2022 project files and document it in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=Resizer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2ResizerBilinear.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1eae017-b322-4f11-8792-ff55bb7ea510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1eae017-b322-4f11-8792-ff55bb7ea510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

