### PR TITLE
Add SVE2 float bilinear resizer

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>SVE2 optimizations of class ResizerByteBilinearOpenCv.</li>
  <li>SVE2 optimizations of class ResizerByteBilinear.</li>
+ <li>SVE2 optimizations of class ResizerFloatBilinear.</li>
  <li>SVE2 optimizations of class ResizerNearest.</li>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>

--- a/src/Simd/SimdResizer.h
+++ b/src/Simd/SimdResizer.h
@@ -865,6 +865,16 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        class ResizerFloatBilinear : public Base::ResizerFloatBilinear
+        {
+        protected:
+            virtual void Run(const float* src, size_t srcStride, float* dst, size_t dstStride);
+        public:
+            ResizerFloatBilinear(const ResParam& param);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
         void * ResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method);
     }
 #endif

--- a/src/Simd/SimdSve2Resizer.cpp
+++ b/src/Simd/SimdSve2Resizer.cpp
@@ -38,6 +38,8 @@ namespace Simd
                 return new ResizerByteBilinear(param);
             else if (param.IsByteBilinearOpenCv() && dstX >= svcntb())
                 return new ResizerByteBilinearOpenCv(param);
+            else if (param.IsFloatBilinear())
+                return new ResizerFloatBilinear(param);
             else
 #ifdef SIMD_NEON_ENABLE
                 return Neon::ResizerInit(srcX, srcY, dstX, dstY, channels, type, method);

--- a/src/Simd/SimdSve2ResizerBilinear.cpp
+++ b/src/Simd/SimdSve2ResizerBilinear.cpp
@@ -417,6 +417,77 @@ namespace Simd
                 assert(0);
             }
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        ResizerFloatBilinear::ResizerFloatBilinear(const ResParam& param)
+            : Base::ResizerFloatBilinear(param)
+        {
+        }
+
+        SIMD_INLINE void ResizerFloatBilinearInterpolateX(const float* src, size_t channels, const int32_t* ix, const float* ax, float* dst, size_t offset, size_t size)
+        {
+            svbool_t pg = svwhilelt_b32(offset, size);
+            svuint32_t idx = svreinterpret_u32_s32(svld1_s32(pg, ix + offset));
+            svfloat32_t fx1 = svld1_f32(pg, ax + offset);
+            svfloat32_t fx0 = svsub_f32_x(pg, svdup_n_f32(1.0f), fx1);
+            svfloat32_t s0 = svld1_gather_u32index_f32(pg, src, idx);
+            svfloat32_t s1 = svld1_gather_u32index_f32(pg, src + channels, idx);
+            svst1_f32(pg, dst + offset, svmla_f32_x(pg, svmul_f32_x(pg, s0, fx0), s1, fx1));
+        }
+
+        SIMD_INLINE void ResizerFloatBilinearInterpolateY(const float* bx0, const float* bx1, const svfloat32_t& fy0, const svfloat32_t& fy1, float* dst, size_t offset, size_t size)
+        {
+            svbool_t pg = svwhilelt_b32(offset, size);
+            svfloat32_t b0 = svld1_f32(pg, bx0 + offset);
+            svfloat32_t b1 = svld1_f32(pg, bx1 + offset);
+            svst1_f32(pg, dst + offset, svmla_f32_x(pg, svmul_f32_x(pg, b0, fy0), b1, fy1));
+        }
+
+        void ResizerFloatBilinear::Run(const float* src, size_t srcStride, float* dst, size_t dstStride)
+        {
+            assert(_rowBuf);
+
+            size_t cn = _param.channels;
+            size_t rs = _param.dstW * cn;
+            size_t F = svcntw(), rsF = AlignLo(rs, F);
+            float* pbx[2] = { _bx[0].data, _bx[1].data };
+            int32_t prev = -2;
+            for (size_t dy = 0; dy < _param.dstH; dy++, dst += dstStride)
+            {
+                svfloat32_t fy1 = svdup_n_f32(_ay[dy]);
+                svfloat32_t fy0 = svdup_n_f32(1.0f - _ay[dy]);
+                int32_t sy = _iy[dy];
+                int32_t k = 0;
+
+                if (sy == prev)
+                    k = 2;
+                else if (sy == prev + 1)
+                {
+                    Swap(pbx[0], pbx[1]);
+                    k = 1;
+                }
+
+                prev = sy;
+
+                for (; k < 2; k++)
+                {
+                    float* pb = pbx[k];
+                    const float* ps = src + (sy + k) * srcStride;
+                    size_t dx = 0;
+                    for (; dx < rsF; dx += F)
+                        ResizerFloatBilinearInterpolateX(ps, cn, _ix.data, _ax.data, pb, dx, rs);
+                    if (dx < rs)
+                        ResizerFloatBilinearInterpolateX(ps, cn, _ix.data, _ax.data, pb, dx, rs);
+                }
+
+                size_t dx = 0;
+                for (; dx < rsF; dx += F)
+                    ResizerFloatBilinearInterpolateY(pbx[0], pbx[1], fy0, fy1, dst, dx, rs);
+                if (dx < rs)
+                    ResizerFloatBilinearInterpolateY(pbx[0], pbx[1], fy0, fy1, dst, dx, rs);
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestResize.cpp
+++ b/src/Test/TestResize.cpp
@@ -307,6 +307,9 @@ namespace Test
         result = result && ResizerAutoTest(SimdResizeMethodBilinearOpenCv, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinearOpenCv, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinearOpenCv, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 1, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 3, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 8, 333, 257, 577, 431, f1, f2);
 #endif
 
 #if  0 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Sve2::ResizerFloatBilinear` and route float bilinear resizer initialization through the SVE2 implementation.
- Add SVE2-specific float bilinear resize cases to the resize autotest coverage.
- Document the new SVE2 `ResizerFloatBilinear` optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Resize -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I/workspace/src -c /workspace/src/Simd/SimdSve2ResizerBilinear.cpp -o /tmp/SimdSve2ResizerBilinear.o && aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I/workspace/src -c /workspace/src/Simd/SimdSve2Resizer.cpp -o /tmp/SimdSve2Resizer.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57b5becf-3174-49d7-b83c-b62d394c6c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b5becf-3174-49d7-b83c-b62d394c6c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

