### PR TITLE
Add SVE2 bicubic resizer

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>SVE2 optimizations of class ResizerByteBilinearOpenCv.</li>
  <li>SVE2 optimizations of class ResizerByteBilinear.</li>
+ <li>SVE2 optimizations of class ResizerByteBicubic.</li>
  <li>SVE2 optimizations of class ResizerBf16Bilinear.</li>
  <li>SVE2 optimizations of class ResizerFloatBilinear.</li>
  <li>SVE2 optimizations of class ResizerNearest.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBicubic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBilinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerNearest.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Segmentation.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -329,6 +329,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBicubic.cpp">
+      <Filter>Sve2\Resize</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBilinear.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>

--- a/src/Simd/SimdResizer.h
+++ b/src/Simd/SimdResizer.h
@@ -885,6 +885,18 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        class ResizerByteBicubic : public Base::ResizerByteBicubic
+        {
+        protected:
+            template<int N> void RunB(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        public:
+            ResizerByteBicubic(const ResParam& param);
+
+            virtual void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
         void * ResizerInit(size_t srcX, size_t srcY, size_t dstX, size_t dstY, size_t channels, SimdResizeChannelType type, SimdResizeMethodType method);
     }
 #endif

--- a/src/Simd/SimdSve2Resizer.cpp
+++ b/src/Simd/SimdSve2Resizer.cpp
@@ -42,6 +42,8 @@ namespace Simd
                 return new ResizerFloatBilinear(param);
             else if (param.IsBf16Bilinear())
                 return new ResizerBf16Bilinear(param);
+            else if (param.IsByteBicubic())
+                return new ResizerByteBicubic(param);
             else
 #ifdef SIMD_NEON_ENABLE
                 return Neon::ResizerInit(srcX, srcY, dstX, dstY, channels, type, method);

--- a/src/Simd/SimdSve2ResizerBicubic.cpp
+++ b/src/Simd/SimdSve2ResizerBicubic.cpp
@@ -1,0 +1,123 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdResizer.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        ResizerByteBicubic::ResizerByteBicubic(const ResParam& param)
+            : Base::ResizerByteBicubic(param)
+        {
+        }
+
+        template<int N, int F, int L> SIMD_INLINE int32_t CubicSumX(const uint8_t* src, const int32_t* ax)
+        {
+            return ax[0] * src[F * N] + ax[1] * src[0 * N] + ax[2] * src[1 * N] + ax[3] * src[L * N];
+        }
+
+        template<int N, int F, int L> SIMD_INLINE void PixelCubicSumX(const uint8_t* src, const int32_t* ax, int32_t* dst)
+        {
+            for (size_t c = 0; c < N; ++c)
+                dst[c] = CubicSumX<N, F, L>(src + c, ax);
+        }
+
+        template<int N> SIMD_INLINE void RowCubicSumX(const uint8_t* src, size_t nose, size_t body, size_t tail, const int32_t* ix, const int32_t* ax, int32_t* dst)
+        {
+            size_t dx = 0;
+            for (; dx < nose; dx++, ax += 4, dst += N)
+                PixelCubicSumX<N, 0, 2>(src + ix[dx], ax, dst);
+            for (; dx < body; dx++, ax += 4, dst += N)
+                PixelCubicSumX<N, -1, 2>(src + ix[dx], ax, dst);
+            for (; dx < tail; dx++, ax += 4, dst += N)
+                PixelCubicSumX<N, -1, 1>(src + ix[dx], ax, dst);
+        }
+
+        SIMD_INLINE void BicubicRowInt(const int32_t* src0, const int32_t* src1, const int32_t* src2, const int32_t* src3, size_t size, const int32_t* ay, uint8_t* dst)
+        {
+            size_t i = 0, F = svcntw();
+            svint32_t ay0 = svdup_n_s32(ay[0]);
+            svint32_t ay1 = svdup_n_s32(ay[1]);
+            svint32_t ay2 = svdup_n_s32(ay[2]);
+            svint32_t ay3 = svdup_n_s32(ay[3]);
+            svint32_t round = svdup_n_s32(Base::BICUBIC_ROUND);
+            for (; i < size; i += F)
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                svint32_t sum = svmul_s32_x(mask, svld1_s32(mask, src0 + i), ay0);
+                sum = svmla_s32_x(mask, sum, svld1_s32(mask, src1 + i), ay1);
+                sum = svmla_s32_x(mask, sum, svld1_s32(mask, src2 + i), ay2);
+                sum = svmla_s32_x(mask, sum, svld1_s32(mask, src3 + i), ay3);
+                sum = svasr_n_s32_x(mask, svadd_s32_x(mask, sum, round), Base::BICUBIC_SHIFT);
+                sum = svmin_n_s32_x(mask, svmax_n_s32_x(mask, sum, 0), 255);
+                svst1b_u32(mask, dst + i, svreinterpret_u32_s32(sum));
+            }
+        }
+
+        template<int N> void ResizerByteBicubic::RunB(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            int32_t prev = -1;
+            for (size_t dy = 0; dy < _param.dstH; dy++, dst += dstStride)
+            {
+                int32_t sy = _iy[dy], next = prev;
+                for (int32_t curr = sy - 1, end = sy + 3; curr < end; ++curr)
+                {
+                    if (curr < prev)
+                        continue;
+                    const uint8_t* ps = src + RestrictRange(curr, 0, (int)_param.srcH - 1) * srcStride;
+                    int32_t* pb = _bx[(curr + 1) & 3].data;
+                    RowCubicSumX<N>(ps, _xn, _xt, _param.dstW, _ix.data, _ax.data, pb);
+                    next++;
+                }
+                prev = next;
+
+                const int32_t* ay = _ay.data + dy * 4;
+                int32_t* pb0 = _bx[(sy + 0) & 3].data;
+                int32_t* pb1 = _bx[(sy + 1) & 3].data;
+                int32_t* pb2 = _bx[(sy + 2) & 3].data;
+                int32_t* pb3 = _bx[(sy + 3) & 3].data;
+                BicubicRowInt(pb0, pb1, pb2, pb3, _bx[0].size, ay, dst);
+            }
+        }
+
+        void ResizerByteBicubic::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            bool sparse = _param.dstH * 4.0 <= _param.srcH;
+            Init(sparse);
+            switch (_param.channels)
+            {
+            case 1: sparse ? Base::ResizerByteBicubic::RunS<1>(src, srcStride, dst, dstStride) : RunB<1>(src, srcStride, dst, dstStride); return;
+            case 2: sparse ? Base::ResizerByteBicubic::RunS<2>(src, srcStride, dst, dstStride) : RunB<2>(src, srcStride, dst, dstStride); return;
+            case 3: sparse ? Base::ResizerByteBicubic::RunS<3>(src, srcStride, dst, dstStride) : RunB<3>(src, srcStride, dst, dstStride); return;
+            case 4: sparse ? Base::ResizerByteBicubic::RunS<4>(src, srcStride, dst, dstStride) : RunB<4>(src, srcStride, dst, dstStride); return;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestResize.cpp
+++ b/src/Test/TestResize.cpp
@@ -307,6 +307,10 @@ namespace Test
         result = result && ResizerAutoTest(SimdResizeMethodBilinearOpenCv, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinearOpenCv, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinearOpenCv, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 1, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 1, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 8, 333, 257, 577, 431, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Sve2::ResizerByteBicubic` and dispatch byte bicubic resize to it on SVE2 builds.
- Add SVE2-specific bicubic resize coverage to `TestResize`.
- Register the new SVE2 source in VS2022 project files and document the 7.2.164 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=Resizer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2ResizerBicubic.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2Resizer.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8077b077-d83a-4ad9-89e3-e9276a1ddc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8077b077-d83a-4ad9-89e3-e9276a1ddc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

