### PR TITLE
Fix Frame::Clone: qualify Copy call to avoid member-function name lookup

### DIFF
--- a/src/Simd/SimdFrame.hpp
+++ b/src/Simd/SimdFrame.hpp
@@ -669,7 +669,7 @@ namespace Simd
     template <template<class> class A> SIMD_INLINE Frame<A> * Frame<A>::Clone() const
     {
         Frame<A> * clone = new Frame<A>(width, height, format, flipped, timestamp, yuvType);
-        Copy(*this, *clone);
+        Simd::Copy(*this, *clone);
         return clone;
     }
 
@@ -691,7 +691,7 @@ namespace Simd
                                         buffer.planes[1].data, buffer.planes[1].stride,
                                         buffer.planes[2].data, buffer.planes[2].stride,
                                         flipped, timestamp, yuvType);
-        Copy(*this, *clone);
+        Simd::Copy(*this, *clone);
         return clone;
     }
 


### PR DESCRIPTION
After `Frame::Copy()` was added (returning by value), `Frame::Clone()` fails to compile.

`Frame<A>::Clone()` calls unqualified `Copy(*this, *clone)`. Unqualified lookup inside a member function finds the member `Frame::Copy()` (0/1 args) and stops before reaching the free `Simd::Copy(src, dst)`, so the 2-argument call has no viable candidate:

```
SimdFrame.hpp: error: no matching function for call to
  ('Simd::Frame<Simd::Allocator>::Copy(const Frame&, Frame&) const'
  candidate expects 0 arguments, 2 provided
```

Qualify the calls in both `Clone()` overloads as `Simd::Copy`, matching how `Frame::Copy()` already calls it.