### PR TITLE
Add SVE2 ResizerByteArea1x1 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -41,6 +41,7 @@
 <h4>Algorithms</h4>
 <h5>New features</h5>
 <ul>
+ <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
  <li>SVE2 optimizations of class ResizerByteBilinearOpenCv.</li>
  <li>SVE2 optimizations of class ResizerByteBilinear.</li>
  <li>SVE2 optimizations of class ResizerByteBicubic.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerArea.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBicubic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBilinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerNearest.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -329,6 +329,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ResizerArea.cpp">
+      <Filter>Sve2\Resize</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBicubic.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>

--- a/src/Simd/SimdResizer.h
+++ b/src/Simd/SimdResizer.h
@@ -826,6 +826,18 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        class ResizerByteArea1x1 : public Base::ResizerByteArea1x1
+        {
+        protected:
+            template<size_t N> void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        public:
+            ResizerByteArea1x1(const ResParam& param);
+
+            virtual void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
         class ResizerByteBilinear : public Base::ResizerByteBilinear
         {
         protected:

--- a/src/Simd/SimdSve2Resizer.cpp
+++ b/src/Simd/SimdSve2Resizer.cpp
@@ -44,6 +44,8 @@ namespace Simd
                 return new ResizerBf16Bilinear(param);
             else if (param.IsByteBicubic())
                 return new ResizerByteBicubic(param);
+            else if (param.IsByteArea1x1())
+                return new ResizerByteArea1x1(param);
             else
 #ifdef SIMD_NEON_ENABLE
                 return Neon::ResizerInit(srcX, srcY, dstX, dstY, channels, type, method);

--- a/src/Simd/SimdSve2ResizerArea.cpp
+++ b/src/Simd/SimdSve2ResizerArea.cpp
@@ -1,0 +1,124 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdResizer.h"
+#include "Simd/SimdResizerCommon.h"
+#include "Simd/SimdUpdate.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        ResizerByteArea1x1::ResizerByteArea1x1(const ResParam& param)
+            : Base::ResizerByteArea1x1(param)
+        {
+        }
+
+        template<UpdateType update> SIMD_INLINE void ResizerByteArea1x1Update(const svbool_t& mask, int32_t* dst, const svint32_t& value)
+        {
+            svst1_s32(mask, dst, value);
+        }
+
+        template<> SIMD_INLINE void ResizerByteArea1x1Update<UpdateAdd>(const svbool_t& mask, int32_t* dst, const svint32_t& value)
+        {
+            svst1_s32(mask, dst, svadd_s32_x(mask, svld1_s32(mask, dst), value));
+        }
+
+        template<UpdateType update> SIMD_INLINE void ResizerByteArea1x1RowUpdate(const uint8_t* src0, size_t size, int32_t a0, int32_t* dst)
+        {
+            svint32_t _a0 = svdup_n_s32(a0);
+            size_t F = svcntw();
+            for (size_t i = 0; i < size; i += F)
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                svint32_t sum = svmul_s32_x(mask, svld1ub_s32(mask, src0 + i), _a0);
+                ResizerByteArea1x1Update<update>(mask, dst + i, sum);
+            }
+        }
+
+        template<UpdateType update> SIMD_INLINE void ResizerByteArea1x1RowUpdate(const uint8_t* src0, size_t stride, size_t size, int32_t a0, int32_t a1, int32_t* dst)
+        {
+            svint32_t _a0 = svdup_n_s32(a0);
+            svint32_t _a1 = svdup_n_s32(a1);
+            const uint8_t* src1 = src0 + stride;
+            size_t F = svcntw();
+            for (size_t i = 0; i < size; i += F)
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                svint32_t sum = svmul_s32_x(mask, svld1ub_s32(mask, src0 + i), _a0);
+                sum = svmla_s32_x(mask, sum, svld1ub_s32(mask, src1 + i), _a1);
+                ResizerByteArea1x1Update<update>(mask, dst + i, sum);
+            }
+        }
+
+        SIMD_INLINE void ResizerByteArea1x1RowSum(const uint8_t* src, size_t stride, size_t count, size_t size, int32_t curr, int32_t zero, int32_t next, int32_t* dst)
+        {
+            if (count)
+            {
+                size_t i = 0;
+                ResizerByteArea1x1RowUpdate<UpdateSet>(src, stride, size, curr, count == 1 ? zero - next : zero, dst), src += 2 * stride, i += 2;
+                for (; i < count; i += 2, src += 2 * stride)
+                    ResizerByteArea1x1RowUpdate<UpdateAdd>(src, stride, size, zero, i == count - 1 ? zero - next : zero, dst);
+                if (i == count)
+                    ResizerByteArea1x1RowUpdate<UpdateAdd>(src, size, zero - next, dst);
+            }
+            else
+                ResizerByteArea1x1RowUpdate<UpdateSet>(src, size, curr - next, dst);
+        }
+
+        template<size_t N> void ResizerByteArea1x1::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            size_t dstW = _param.dstW, rowSize = _param.srcW * N, rowRest = dstStride - dstW * N;
+            const int32_t* iy = _iy.data, * ix = _ix.data, * ay = _ay.data, * ax = _ax.data;
+            int32_t ay0 = ay[0], ax0 = ax[0];
+            for (size_t dy = 0; dy < _param.dstH; dy++, dst += rowRest)
+            {
+                int32_t* buf = _by.data;
+                size_t yn = iy[dy + 1] - iy[dy];
+                ResizerByteArea1x1RowSum(src, srcStride, yn, rowSize, ay[dy], ay0, ay[dy + 1], buf), src += yn * srcStride;
+                for (size_t dx = 0; dx < dstW; dx++, dst += N)
+                {
+                    size_t xn = ix[dx + 1] - ix[dx];
+                    Base::ResizerByteAreaResult<N>(buf, xn, ax[dx], ax0, ax[dx + 1], dst), buf += xn * N;
+                }
+            }
+        }
+
+        void ResizerByteArea1x1::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            switch (_param.channels)
+            {
+            case 1: Run<1>(src, srcStride, dst, dstStride); return;
+            case 2: Run<2>(src, srcStride, dst, dstStride); return;
+            case 3: Run<3>(src, srcStride, dst, dstStride); return;
+            case 4: Run<4>(src, srcStride, dst, dstStride); return;
+            default:
+                assert(0);
+            }
+        }
+    }
+#endif
+}
+

--- a/src/Test/TestResize.cpp
+++ b/src/Test/TestResize.cpp
@@ -311,6 +311,14 @@ namespace Test
         result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBicubic, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodArea, SimdResizeChannelByte, 1, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodArea, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodArea, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodArea, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 1, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 1, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 8, 333, 257, 577, 431, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `ResizerByteArea1x1`.
- Extend SVE2 resizer tests with Area and AreaFast byte cases.
- Register the new SVE2 source in VS2022 project files and document the release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Resizer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -DNDEBUG -I/workspace/src -march=armv9-a+sve2 -msve-vector-bits=scalable -c /workspace/src/Simd/SimdSve2ResizerArea.cpp -o /tmp/SimdSve2ResizerArea.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -DNDEBUG -I/workspace/src -march=armv9-a+sve2 -msve-vector-bits=scalable -c /workspace/src/Simd/SimdSve2Resizer.cpp -o /tmp/SimdSve2Resizer.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7522d996-96b9-4d30-adc6-482361662882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7522d996-96b9-4d30-adc6-482361662882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

