### PR TITLE
Add SVE2 ResizerByteArea2x2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
+ <li>SVE2 optimizations of class ResizerByteArea2x2.</li>
  <li>SVE2 optimizations of class ResizerByteBilinearOpenCv.</li>
  <li>SVE2 optimizations of class ResizerByteBilinear.</li>
  <li>SVE2 optimizations of class ResizerByteBicubic.</li>

--- a/src/Simd/SimdResizer.h
+++ b/src/Simd/SimdResizer.h
@@ -838,6 +838,18 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        class ResizerByteArea2x2 : public Base::ResizerByteArea2x2
+        {
+        protected:
+            template<size_t N> void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        public:
+            ResizerByteArea2x2(const ResParam& param);
+
+            virtual void Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
         class ResizerByteBilinear : public Base::ResizerByteBilinear
         {
         protected:

--- a/src/Simd/SimdSve2Resizer.cpp
+++ b/src/Simd/SimdSve2Resizer.cpp
@@ -44,6 +44,8 @@ namespace Simd
                 return new ResizerBf16Bilinear(param);
             else if (param.IsByteBicubic())
                 return new ResizerByteBicubic(param);
+            else if (param.IsByteArea2x2())
+                return new ResizerByteArea2x2(param);
             else if (param.IsByteArea1x1())
                 return new ResizerByteArea1x1(param);
             else

--- a/src/Simd/SimdSve2ResizerArea.cpp
+++ b/src/Simd/SimdSve2ResizerArea.cpp
@@ -118,6 +118,107 @@ namespace Simd
                 assert(0);
             }
         }
+
+        //---------------------------------------------------------------------------------------------
+
+        ResizerByteArea2x2::ResizerByteArea2x2(const ResParam& param)
+            : Base::ResizerByteArea2x2(param)
+        {
+        }
+
+        template<size_t N> SIMD_INLINE svuint8_t ResizerByteArea2x2Index(size_t count)
+        {
+            uint8_t index[SIMD_SVE2_VECTOR_SIZE_MAX] = { 0 };
+            for (size_t i = 0; i < count; ++i)
+                index[i] = uint8_t(2 * N * (i / N) + i % N);
+            return svld1_u8(svptrue_b8(), index);
+        }
+
+        SIMD_INLINE svuint32_t ResizerByteArea2x2Load(const uint8_t* src, const svuint8_t& index, size_t count)
+        {
+            svuint8_t bytes = svld1_u8(svwhilelt_b8((size_t)0, 2 * count), src);
+            return svunpklo_u32(svunpklo_u16(svtbl_u8(bytes, index)));
+        }
+
+        template<UpdateType update> SIMD_INLINE void ResizerByteArea2x2Update(const svbool_t& mask, int32_t* dst, const svint32_t& value)
+        {
+            svst1_s32(mask, dst, value);
+        }
+
+        template<> SIMD_INLINE void ResizerByteArea2x2Update<UpdateAdd>(const svbool_t& mask, int32_t* dst, const svint32_t& value)
+        {
+            svst1_s32(mask, dst, svadd_s32_x(mask, svld1_s32(mask, dst), value));
+        }
+
+        template<size_t N, UpdateType update> SIMD_INLINE void ResizerByteArea2x2RowUpdate(const uint8_t* src0, const uint8_t* src1, size_t size, int32_t val, int32_t* dst)
+        {
+            if (update == UpdateAdd && val == 0)
+                return;
+            size_t size2N = AlignLoAny(size, 2 * N);
+            size_t F = svcntw(), step = AlignLoAny(F, N), dstSize = size2N / 2;
+            svuint8_t index = ResizerByteArea2x2Index<N>(step);
+            svint32_t _val = svdup_n_s32(val);
+            size_t j = 0;
+            for (; j < dstSize; j += step)
+            {
+                size_t count = dstSize - j < step ? dstSize - j : step;
+                svbool_t mask = svwhilelt_b32((size_t)0, count);
+                const uint8_t* s0 = src0 + 2 * j;
+                const uint8_t* s1 = src1 + 2 * j;
+                svuint32_t sum = svadd_u32_x(mask, ResizerByteArea2x2Load(s0, index, count), ResizerByteArea2x2Load(s0 + N, index, count));
+                sum = svadd_u32_x(mask, sum, ResizerByteArea2x2Load(s1, index, count));
+                sum = svadd_u32_x(mask, sum, ResizerByteArea2x2Load(s1 + N, index, count));
+                ResizerByteArea2x2Update<update>(mask, dst + j, svmul_s32_x(mask, svreinterpret_s32_u32(sum), _val));
+            }
+            if (size2N < size)
+                Base::ResizerByteArea2x2RowUpdate<N, 0, update>(src0 + size2N, src1 + size2N, val, dst + dstSize);
+        }
+
+        template<size_t N> SIMD_INLINE void ResizerByteArea2x2RowSum(const uint8_t* src, size_t stride, size_t count, size_t size, int32_t curr, int32_t zero, int32_t next, bool tail, int32_t* dst)
+        {
+            size_t c = 0;
+            if (count)
+            {
+                ResizerByteArea2x2RowUpdate<N, UpdateSet>(src, src + stride, size, curr, dst), src += 2 * stride, c += 2;
+                for (; c < count; c += 2, src += 2 * stride)
+                    ResizerByteArea2x2RowUpdate<N, UpdateAdd>(src, src + stride, size, zero, dst);
+                ResizerByteArea2x2RowUpdate<N, UpdateAdd>(src, tail ? src : src + stride, size, zero - next, dst);
+            }
+            else
+                ResizerByteArea2x2RowUpdate<N, UpdateSet>(src, tail ? src : src + stride, size, curr - next, dst);
+        }
+
+        template<size_t N> void ResizerByteArea2x2::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            size_t dstW = _param.dstW, rowSize = _param.srcW * N, rowRest = dstStride - dstW * N;
+            const int32_t* iy = _iy.data, * ix = _ix.data, * ay = _ay.data, * ax = _ax.data;
+            int32_t ay0 = ay[0], ax0 = ax[0];
+            for (size_t dy = 0; dy < _param.dstH; dy++, dst += rowRest)
+            {
+                int32_t* buf = _by.data;
+                size_t yn = (iy[dy + 1] - iy[dy]) * 2;
+                bool tail = (dy == _param.dstH - 1) && (_param.srcH & 1);
+                ResizerByteArea2x2RowSum<N>(src, srcStride, yn, rowSize, ay[dy], ay0, ay[dy + 1], tail, buf), src += yn * srcStride;
+                for (size_t dx = 0; dx < dstW; dx++, dst += N)
+                {
+                    size_t xn = ix[dx + 1] - ix[dx];
+                    Base::ResizerByteAreaResult<N>(buf, xn, ax[dx], ax0, ax[dx + 1], dst), buf += xn * N;
+                }
+            }
+        }
+
+        void ResizerByteArea2x2::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+        {
+            switch (_param.channels)
+            {
+            case 1: Run<1>(src, srcStride, dst, dstStride); return;
+            case 2: Run<2>(src, srcStride, dst, dstStride); return;
+            case 3: Run<3>(src, srcStride, dst, dstStride); return;
+            case 4: Run<4>(src, srcStride, dst, dstStride); return;
+            default:
+                assert(0);
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestResize.cpp
+++ b/src/Test/TestResize.cpp
@@ -319,6 +319,10 @@ namespace Test
         result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 2, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 4, 333, 257, 577, 431, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 1, 641, 479, 160, 119, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 2, 641, 479, 160, 119, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 3, 641, 479, 160, 119, f1, f2);
+        result = result && ResizerAutoTest(SimdResizeMethodAreaFast, SimdResizeChannelByte, 4, 641, 479, 160, 119, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 1, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 3, 333, 257, 577, 431, f1, f2);
         result = result && ResizerAutoTest(SimdResizeMethodBilinear, SimdResizeChannelFloat, 8, 333, 257, 577, 431, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `ResizerByteArea2x2` dispatch and implementation for byte `AreaFast` resizing.
- Extend Resizer tests with explicit 2x2 downscale coverage for SVE2.
- Update 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=Resizer -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdSve2ResizerArea.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b362c687-26c2-429b-ad74-a12135f6ce43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b362c687-26c2-429b-ad74-a12135f6ce43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

