### PR TITLE
Add SVE2 RecursiveBilateralFilterPrecize optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -50,6 +50,7 @@
  <li>SVE2 optimizations of class ResizerFloatBilinear.</li>
  <li>SVE2 optimizations of class ResizerNearest.</li>
  <li>NEON optimizations of class RecursiveBilateralFilterPrecize.</li>
+ <li>SVE2 optimizations of class RecursiveBilateralFilterPrecize.</li>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -77,6 +77,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray4x4.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Reorder.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2RecursiveBilateralFilter.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerArea.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ResizerBicubic.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -326,6 +326,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2ReduceGray5x5.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2RecursiveBilateralFilter.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Resizer.cpp">
       <Filter>Sve2\Resize</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4706,7 +4706,7 @@ SIMD_API void* SimdRecursiveBilateralFilterInit(size_t width, size_t height, siz
 {
     SIMD_EMPTY();
     typedef void* (*SimdRecursiveBilateralFilterInitPtr) (size_t width, size_t height, size_t channels, const float* sigmaSpatial, const float* sigmaRange, SimdRecursiveBilateralFilterFlags flags);
-    const static SimdRecursiveBilateralFilterInitPtr simdRecursiveBilateralFilterInit = SIMD_FUNC3(RecursiveBilateralFilterInit, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);// , SIMD_AVX512BW_FUNC);
+    const static SimdRecursiveBilateralFilterInitPtr simdRecursiveBilateralFilterInit = SIMD_FUNC4(RecursiveBilateralFilterInit, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);// , SIMD_AVX512BW_FUNC);
     return simdRecursiveBilateralFilterInit(width, height, channels, sigmaSpatial, sigmaRange, flags);
 }
 

--- a/src/Simd/SimdRecursiveBilateralFilter.h
+++ b/src/Simd/SimdRecursiveBilateralFilter.h
@@ -215,5 +215,18 @@ namespace Simd
         void* RecursiveBilateralFilterInit(size_t width, size_t height, size_t channels, const float* sigmaSpatial, const float* sigmaRange, SimdRecursiveBilateralFilterFlags flags);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        class RecursiveBilateralFilterPrecize : public Base::RecursiveBilateralFilterPrecize
+        {
+        public:
+            RecursiveBilateralFilterPrecize(const RbfParam& param);
+        };
+
+        void* RecursiveBilateralFilterInit(size_t width, size_t height, size_t channels, const float* sigmaSpatial, const float* sigmaRange, SimdRecursiveBilateralFilterFlags flags);
+    }
+#endif
 }
 #endif

--- a/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
+++ b/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
@@ -1,0 +1,303 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdRecursiveBilateralFilter.h"
+#include "Simd/SimdPerformance.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        typedef RecursiveBilateralFilter::FilterPtr FilterPtr;
+
+        SIMD_INLINE svuint32_t Load8u(const uint8_t* src, const svuint32_t& offsets, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src, offsets);
+        }
+
+        SIMD_INLINE svuint32_t AbsDiff8u(const uint8_t* src0, const uint8_t* src1, const svuint32_t& offsets, const svbool_t& mask)
+        {
+            svuint32_t s0 = Load8u(src0, offsets, mask);
+            svuint32_t s1 = Load8u(src1, offsets, mask);
+            return svsub_u32_x(mask, svmax_u32_x(mask, s0, s1), svmin_u32_x(mask, s0, s1));
+        }
+
+        template<RbfDiffType type> SIMD_INLINE svuint32_t Diff(const svuint32_t& ch0, const svuint32_t& ch1, const svbool_t& mask)
+        {
+            switch (type)
+            {
+            case RbfDiffAvg: return svlsr_n_u32_x(mask, svadd_n_u32_x(mask, svadd_u32_x(mask, ch0, ch1), 1), 1);
+            case RbfDiffMax: return svmax_u32_x(mask, ch0, ch1);
+            case RbfDiffSum: return svmin_n_u32_x(mask, svadd_u32_x(mask, ch0, ch1), 255);
+            default:
+                assert(0); return svdup_n_u32(0);
+            }
+        }
+
+        template<RbfDiffType type> SIMD_INLINE svuint32_t Diff(const svuint32_t& ch0, const svuint32_t& ch1, const svuint32_t& ch2, const svbool_t& mask)
+        {
+            switch (type)
+            {
+            case RbfDiffAvg: return Diff<RbfDiffAvg>(ch1, Diff<RbfDiffAvg>(ch0, ch2, mask), mask);
+            case RbfDiffMax: return svmax_u32_x(mask, svmax_u32_x(mask, ch0, ch1), ch2);
+            case RbfDiffSum: return svmin_n_u32_x(mask, svadd_u32_x(mask, svadd_u32_x(mask, ch0, ch1), ch2), 255);
+            default:
+                assert(0); return svdup_n_u32(0);
+            }
+        }
+
+        template<int channels, RbfDiffType type> SIMD_INLINE void RowRanges(const uint8_t* src0, const uint8_t* src1, size_t width, const float* ranges, float* dst)
+        {
+            size_t F = svcntw(), x = 0;
+            const svbool_t body = svptrue_b32();
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), channels);
+            for (; x < width; x += F)
+            {
+                svbool_t mask = svwhilelt_b32(x, width);
+                const uint8_t* ps0 = src0 + x * channels;
+                const uint8_t* ps1 = src1 + x * channels;
+                svuint32_t diff = AbsDiff8u(ps0, ps1, offsets, mask);
+                if (channels == 2)
+                    diff = Diff<type>(diff, AbsDiff8u(ps0 + 1, ps1 + 1, offsets, mask), mask);
+                if (channels >= 3)
+                    diff = Diff<type>(diff, AbsDiff8u(ps0 + 1, ps1 + 1, offsets, mask), AbsDiff8u(ps0 + 2, ps1 + 2, offsets, mask), mask);
+                svst1_f32(mask, dst + x, svld1_gather_u32index_f32(mask, ranges, diff));
+            }
+        }
+
+        SIMD_INLINE svuint32_t Float32ToUint8(const svfloat32_t& value, const svbool_t& mask)
+        {
+            return svcvt_u32_f32_x(mask, value);
+        }
+
+        template<int channels> SIMD_INLINE void SetOut(const float* bc, const float* bf, const float* ec, const float* ef, size_t width, uint8_t* dst)
+        {
+            size_t F = svcntw(), x = 0;
+            const svbool_t body = svptrue_b32();
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), channels);
+            const svfloat32_t _1 = svdup_n_f32(1.0f);
+            for (; x < width; x += F)
+            {
+                svbool_t mask = svwhilelt_b32(x, width);
+                svfloat32_t factor = svdiv_f32_x(mask, _1, svadd_f32_x(mask, svld1_f32(mask, bf + x), svld1_f32(mask, ef + x)));
+                size_t o = x * channels;
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t colors = svadd_f32_x(mask,
+                        svld1_gather_u32index_f32(mask, bc + o + c, offsets),
+                        svld1_gather_u32index_f32(mask, ec + o + c, offsets));
+                    svst1b_scatter_u32offset_u32(mask, dst + o + c, offsets, Float32ToUint8(svmul_f32_x(mask, factor, colors), mask));
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        namespace Prec
+        {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsequenced"
+#endif
+            template<int channels, RbfDiffType type> void HorFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            {
+                //SIMD_PERF_FUNC();
+                size_t size = p.width * channels, cLast = size - 1, fLast = p.width - 1;
+                float* cb0 = buf, * cb1 = cb0 + size, * fb0 = cb1 + size, * fb1 = fb0 + p.width, * rb0 = fb1 + p.width;
+                for (size_t y = 0; y < p.height; y++)
+                {
+                    const uint8_t* sl = src, * sr = src + cLast;
+                    float* lc = cb0, * rc = cb1 + cLast;
+                    float* lf = fb0, * rf = fb1 + fLast;
+                    *lf++ = 1.f;
+                    *rf-- = 1.f;
+                    for (int c = 0; c < channels; c++)
+                    {
+                        *lc++ = *sl++;
+                        *rc-- = *sr--;
+                    }
+                    RowRanges<channels, type>(src, src + channels, p.width - 1, p.ranges, rb0 + 1);
+                    for (size_t x = 1; x < p.width; x++)
+                    {
+                        float la = rb0[x];
+                        float ra = rb0[p.width - x];
+                        *lf++ = p.alpha + la * lf[-1];
+                        *rf-- = p.alpha + ra * rf[+1];
+                        for (int c = 0; c < channels; c++)
+                        {
+                            *lc++ = (p.alpha * (*sl++) + la * lc[-channels]);
+                            *rc-- = (p.alpha * (*sr--) + ra * rc[+channels]);
+                        }
+                    }
+                    SetOut<channels>(cb0, fb0, cb1, fb1, p.width, dst);
+                    src += srcStride;
+                    dst += dstStride;
+                }
+            }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+            //-----------------------------------------------------------------------------------------
+
+            template<int channels> void VerSetEdge(const uint8_t* src, size_t width, float* factor, float* colors)
+            {
+                size_t F = svcntw(), size = width * channels, x = 0, i = 0;
+                const svbool_t body = svptrue_b32();
+                const svfloat32_t _1 = svdup_n_f32(1.0f);
+                for (; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    svst1_f32(mask, factor + x, _1);
+                }
+                for (; i < size; i += F)
+                {
+                    svbool_t mask = svwhilelt_b32(i, size);
+                    svst1_f32(mask, colors + i, svcvt_f32_u32_x(mask, svld1ub_u32(mask, src + i)));
+                }
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template<int channels> void VerSetMain(const uint8_t* hor, size_t width,
+                float alpha, const float* ranges, const float* pf, const float* pc, float* cf, float* cc)
+            {
+                size_t F = svcntw(), x = 0;
+                const svbool_t body = svptrue_b32();
+                const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), channels);
+                const svfloat32_t _alpha = svdup_n_f32(alpha);
+                for (; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    svfloat32_t _ranges = svld1_f32(mask, ranges + x);
+                    svst1_f32(mask, cf + x, svmla_f32_x(mask, _alpha, _ranges, svld1_f32(mask, pf + x)));
+                    size_t o = x * channels;
+                    for (size_t c = 0; c < channels; ++c)
+                    {
+                        svfloat32_t color = svmla_f32_x(mask,
+                            svmul_f32_x(mask, _alpha, svcvt_f32_u32_x(mask, Load8u(hor + o + c, offsets, mask))),
+                            _ranges, svld1_gather_u32index_f32(mask, pc + o + c, offsets));
+                        svst1_scatter_u32index_f32(mask, cc + o + c, offsets, color);
+                    }
+                }
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template<int channels, RbfDiffType type> void VerFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            {
+                //SIMD_PERF_FUNC();
+                size_t size = p.width * channels;
+                float* rb0 = buf, * dcb = rb0 + p.width, * dfb = dcb + size * 2, * ucb = dfb + p.width * 2, * ufb = ucb + size * p.height;
+
+                const uint8_t* suc = src + srcStride * (p.height - 1);
+                const uint8_t* duc = dst + dstStride * (p.height - 1);
+                float* uf = ufb + p.width * (p.height - 1);
+                float* uc = ucb + size * (p.height - 1);
+                VerSetEdge<channels>(duc, p.width, uf, uc);
+                for (size_t y = 1; y < p.height; y++)
+                {
+                    duc -= dstStride;
+                    suc -= srcStride;
+                    uf -= p.width;
+                    uc -= size;
+                    RowRanges<channels, type>(suc, suc + srcStride, p.width, p.ranges, rb0);
+                    VerSetMain<channels>(duc, p.width, p.alpha, rb0, uf + p.width, uc + size, uf, uc);
+                }
+
+                VerSetEdge<channels>(dst, p.width, dfb, dcb);
+                SetOut<channels>(dcb, dfb, ucb, ufb, p.width, dst);
+                for (size_t y = 1; y < p.height; y++)
+                {
+                    src += srcStride;
+                    dst += dstStride;
+                    float* dc = dcb + (y & 1) * size;
+                    float* df = dfb + (y & 1) * p.width;
+                    const float* dpc = dcb + ((y - 1) & 1) * size;
+                    const float* dpf = dfb + ((y - 1) & 1) * p.width;
+                    RowRanges<channels, type>(src, src - srcStride, p.width, p.ranges, rb0);
+                    VerSetMain<channels>(dst, p.width, p.alpha, rb0, dpf, dpc, df, dc);
+                    SetOut<channels>(dc, df, ucb + y * size, ufb + y * p.width, p.width, dst);
+                }
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template <int channels, RbfDiffType type> void Set(FilterPtr& horFilter, FilterPtr& verFilter)
+            {
+                horFilter = HorFilter<channels, type>;
+                verFilter = VerFilter<channels, type>;
+            }
+
+            template <RbfDiffType type> void Set(size_t channels, FilterPtr& horFilter, FilterPtr& verFilter)
+            {
+                switch (channels)
+                {
+                case 1: Set<1, type>(horFilter, verFilter); break;
+                case 2: Set<2, type>(horFilter, verFilter); break;
+                case 3: Set<3, type>(horFilter, verFilter); break;
+                case 4: Set<4, type>(horFilter, verFilter); break;
+                default:
+                    assert(0);
+                }
+            }
+
+            void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
+            {
+                switch (DiffType(param.flags))
+                {
+                case RbfDiffAvg: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                case RbfDiffMax: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                case RbfDiffSum: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                default:
+                    assert(0);
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        RecursiveBilateralFilterPrecize::RecursiveBilateralFilterPrecize(const RbfParam& param)
+            : Base::RecursiveBilateralFilterPrecize(param)
+        {
+            Prec::Set(_param, _hFilter, _vFilter);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        void* RecursiveBilateralFilterInit(size_t width, size_t height, size_t channels,
+            const float* sigmaSpatial, const float* sigmaRange, SimdRecursiveBilateralFilterFlags flags)
+        {
+            RbfParam param(width, height, channels, sigmaSpatial, sigmaRange, flags, svcntb());
+            if (!param.Valid())
+                return NULL;
+            if (Precise(flags))
+                return new RecursiveBilateralFilterPrecize(param);
+            else
+                return new Base::RecursiveBilateralFilterFast(param);
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -1338,6 +1338,11 @@ namespace
             result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Avx2::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Sve2::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Neon::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `RecursiveBilateralFilterPrecize` for ARM/ARM64.
- Route `SimdRecursiveBilateralFilterInit` through the SVE2 initializer before NEON when available.
- Add SVE2 coverage to `RecursiveBilateralFilterAutoTest`, VS2022 project entries, and 7.2.164 release notes.

### Testing
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -DSIMD_SVE2 -I./src -fsyntax-only src/Simd/SimdSve2RecursiveBilateralFilter.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv9-a+sve2 -msve-vector-bits=scalable -DSIMD_SVE2 -I./src -c src/Simd/SimdSve2RecursiveBilateralFilter.cpp -o /tmp/SimdSve2RecursiveBilateralFilter.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=RecursiveBilateralFilter -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78b1bb89-9543-463d-b70d-2195e6e7abf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78b1bb89-9543-463d-b70d-2195e6e7abf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

