### PR TITLE
Add SVE2 fast recursive bilateral filter

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of class ResizerNearest.</li>
  <li>NEON optimizations of class RecursiveBilateralFilterFast.</li>
  <li>NEON optimizations of class RecursiveBilateralFilterPrecize.</li>
+ <li>SVE2 optimizations of class RecursiveBilateralFilterFast.</li>
  <li>SVE2 optimizations of class RecursiveBilateralFilterPrecize.</li>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>

--- a/src/Simd/SimdRecursiveBilateralFilter.h
+++ b/src/Simd/SimdRecursiveBilateralFilter.h
@@ -231,6 +231,12 @@ namespace Simd
             RecursiveBilateralFilterPrecize(const RbfParam& param);
         };
 
+        class RecursiveBilateralFilterFast : public Base::RecursiveBilateralFilterFast
+        {
+        public:
+            RecursiveBilateralFilterFast(const RbfParam& param);
+        };
+
         void* RecursiveBilateralFilterInit(size_t width, size_t height, size_t channels, const float* sigmaSpatial, const float* sigmaRange, SimdRecursiveBilateralFilterFlags flags);
     }
 #endif

--- a/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
+++ b/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
@@ -289,54 +289,6 @@ namespace Simd
 
         namespace Fast
         {
-            template<bool nofma> SIMD_INLINE float Fmadd(float a, float b, float c);
-
-#if defined(__GNUC__) && !defined(__clang__)
-            __attribute__((noinline, optimize("fp-contract=off")))
-#else
-            SIMD_NOINLINE
-#endif
-            float FmaddNoFma(float a, float b, float c)
-            {
-                return a * b + c;
-            }
-
-            template<> SIMD_INLINE float Fmadd<true>(float a, float b, float c)
-            {
-                return FmaddNoFma(a, b, c);
-            }
-
-            template<> SIMD_INLINE float Fmadd<false>(float a, float b, float c)
-            {
-                return a * b + c;
-            }
-
-            //-----------------------------------------------------------------------------------------
-
-            template<bool nofma> SIMD_INLINE svfloat32_t Fmadd(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c);
-
-#if defined(__GNUC__) && !defined(__clang__)
-            __attribute__((noinline, optimize("fp-contract=off")))
-#else
-            SIMD_NOINLINE
-#endif
-            svfloat32_t FmaddNoFma(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c)
-            {
-                return svadd_f32_x(mask, svmul_f32_x(mask, a, b), c);
-            }
-
-            template<> SIMD_INLINE svfloat32_t Fmadd<true>(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c)
-            {
-                return FmaddNoFma(mask, a, b, c);
-            }
-
-            template<> SIMD_INLINE svfloat32_t Fmadd<false>(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c)
-            {
-                return svmla_f32_x(mask, c, a, b);
-            }
-
-            //-----------------------------------------------------------------------------------------
-
             template<int dir> SIMD_INLINE void Set(int value, uint8_t* dst);
 
             template<> SIMD_INLINE void Set<+1>(int value, uint8_t* dst)
@@ -409,7 +361,7 @@ namespace Simd
 
             //-----------------------------------------------------------------------------------------
 
-            template<int channels, int dir, bool nofma> void HorRow(const uint8_t* src, size_t width, float alpha, const float* ranges, uint8_t* diff, uint8_t* dst)
+            template<int channels, int dir> void HorRow(const uint8_t* src, size_t width, float alpha, const float* ranges, uint8_t* diff, uint8_t* dst)
             {
                 if (dir == -1 && width > 1)
                     diff += width - 2;
@@ -424,17 +376,17 @@ namespace Simd
                     src += channels * dir;
                     dst += channels * dir;
                     float range = ranges[diff[0]];
-                    factor = Fmadd<nofma>(range, factor, alpha);
+                    factor = alpha + range * factor;
                     for (int c = 0; c < channels; c++)
                     {
-                        colors[c] = Fmadd<nofma>(alpha, src[c], range * colors[c]);
+                        colors[c] = alpha * src[c] + range * colors[c];
                         Set<dir>(int(colors[c] / factor), dst + c);
                     }
                     diff += dir;
                 }
             }
 
-            template<int channels, RbfDiffType type, bool nofma> void HorFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            template<int channels, RbfDiffType type> void HorFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
             {
                 size_t last = (p.width - 1) * channels, height4 = AlignLo(p.height, 4), y = 0;
                 uint8_t* diff = (uint8_t*)buf;
@@ -443,8 +395,8 @@ namespace Simd
                     RowDiff4x<channels, type>(src, src + channels, srcStride, p.width - 1, diff, dstStride);
                     for (size_t i = 0; i < 4; ++i)
                     {
-                        HorRow<channels, +1, nofma>(src + i * srcStride, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride);
-                        HorRow<channels, -1, nofma>(src + i * srcStride + last, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride + last);
+                        HorRow<channels, +1>(src + i * srcStride, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride);
+                        HorRow<channels, -1>(src + i * srcStride + last, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride + last);
                     }
                     src += 4 * srcStride;
                     dst += 4 * dstStride;
@@ -452,8 +404,8 @@ namespace Simd
                 for (; y < p.height; y++)
                 {
                     RowDiff<channels, type>(src, src + channels, p.width - 1, diff);
-                    HorRow<channels, +1, nofma>(src, p.width, p.alpha, p.ranges, diff, dst);
-                    HorRow<channels, -1, nofma>(src + last, p.width, p.alpha, p.ranges, diff, dst + last);
+                    HorRow<channels, +1>(src, p.width, p.alpha, p.ranges, diff, dst);
+                    HorRow<channels, -1>(src + last, p.width, p.alpha, p.ranges, diff, dst + last);
                     src += srcStride;
                     dst += dstStride;
                 }
@@ -479,7 +431,7 @@ namespace Simd
                 }
             }
 
-            template<int channels, int dir, bool nofma> void VerMain(const uint8_t* src, const uint8_t* diff, size_t width, float alpha,
+            template<int channels, int dir> void VerMain(const uint8_t* src, const uint8_t* diff, size_t width, float alpha,
                 const float* ranges, float* factor, float* colors, uint8_t* dst)
             {
                 size_t F = svcntw(), x = 0;
@@ -490,20 +442,21 @@ namespace Simd
                 {
                     svbool_t mask = svwhilelt_b32(x, width);
                     svfloat32_t _range = svld1_gather_u32index_f32(mask, ranges, svld1ub_u32(mask, diff + x));
-                    svfloat32_t _factor = Fmadd<nofma>(mask, _range, svld1_f32(mask, factor + x), _alpha);
+                    svfloat32_t _factor = svmla_f32_x(mask, _alpha, _range, svld1_f32(mask, factor + x));
                     svst1_f32(mask, factor + x, _factor);
                     size_t o = x * channels;
                     for (size_t c = 0; c < channels; ++c)
                     {
-                        svfloat32_t _color = Fmadd<nofma>(mask, _alpha, svcvt_f32_u32_x(mask, Load8u(src + o + c, offsets, mask)),
-                            svmul_f32_x(mask, _range, svld1_gather_u32index_f32(mask, colors + o + c, offsets)));
+                        svfloat32_t _color = svmla_f32_x(mask,
+                            svmul_f32_x(mask, _alpha, svcvt_f32_u32_x(mask, Load8u(src + o + c, offsets, mask))),
+                            _range, svld1_gather_u32index_f32(mask, colors + o + c, offsets));
                         svst1_scatter_u32index_f32(mask, colors + o + c, offsets, _color);
                         Set<dir>(mask, offsets, Float32ToUint8(svdiv_f32_x(mask, _color, _factor), mask), dst + o + c);
                     }
                 }
             }
 
-            template<int channels, RbfDiffType type, bool nofma> void VerFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            template<int channels, RbfDiffType type> void VerFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
             {
                 size_t size = p.width * channels;
                 uint8_t* diff = (uint8_t*)(buf + size + p.width);
@@ -513,7 +466,7 @@ namespace Simd
                     src += srcStride;
                     dst += dstStride;
                     RowDiff<channels, type>(src, src - srcStride, p.width, diff);
-                    VerMain<channels, +1, nofma>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
+                    VerMain<channels, +1>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
                 }
                 VerEdge<channels, -1>(src, p.width, buf + size, buf, dst);
                 for (size_t y = 1; y < p.height; y++)
@@ -521,7 +474,7 @@ namespace Simd
                     src -= srcStride;
                     dst -= dstStride;
                     RowDiff<channels, type>(src, src + srcStride, p.width, diff);
-                    VerMain<channels, -1, nofma>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
+                    VerMain<channels, -1>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
                 }
             }
 
@@ -529,8 +482,8 @@ namespace Simd
 
             template <int channels, RbfDiffType type> void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
             {
-                horFilter = FmaAvoid(param.flags) ? HorFilter<channels, type, true> : HorFilter<channels, type, false>;
-                verFilter = FmaAvoid(param.flags) ? VerFilter<channels, type, true> : VerFilter<channels, type, false>;
+                horFilter = HorFilter<channels, type>;
+                verFilter = VerFilter<channels, type>;
             }
 
             template <RbfDiffType type> void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
@@ -564,7 +517,8 @@ namespace Simd
         RecursiveBilateralFilterFast::RecursiveBilateralFilterFast(const RbfParam& param)
             : Base::RecursiveBilateralFilterFast(param)
         {
-            Fast::Set(_param, _hFilter, _vFilter);
+            if (!FmaAvoid(_param.flags))
+                Fast::Set(_param, _hFilter, _vFilter);
         }
 
         //-----------------------------------------------------------------------------------------

--- a/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
+++ b/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
@@ -289,6 +289,30 @@ namespace Simd
 
         namespace Fast
         {
+            template<bool nofma> SIMD_INLINE float Fmadd(float a, float b, float c);
+
+#if defined(__GNUC__) && !defined(__clang__)
+            __attribute__((noinline, optimize("fp-contract=off")))
+#else
+            SIMD_NOINLINE
+#endif
+            float FmaddNoFma(float a, float b, float c)
+            {
+                return a * b + c;
+            }
+
+            template<> SIMD_INLINE float Fmadd<true>(float a, float b, float c)
+            {
+                return FmaddNoFma(a, b, c);
+            }
+
+            template<> SIMD_INLINE float Fmadd<false>(float a, float b, float c)
+            {
+                return a * b + c;
+            }
+
+            //-----------------------------------------------------------------------------------------
+
             template<bool nofma> SIMD_INLINE svfloat32_t Fmadd(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c);
 
 #if defined(__GNUC__) && !defined(__clang__)
@@ -385,7 +409,7 @@ namespace Simd
 
             //-----------------------------------------------------------------------------------------
 
-            template<int channels, int dir> void HorRow(const uint8_t* src, size_t width, float alpha, const float* ranges, uint8_t* diff, uint8_t* dst)
+            template<int channels, int dir, bool nofma> void HorRow(const uint8_t* src, size_t width, float alpha, const float* ranges, uint8_t* diff, uint8_t* dst)
             {
                 if (dir == -1 && width > 1)
                     diff += width - 2;
@@ -400,17 +424,17 @@ namespace Simd
                     src += channels * dir;
                     dst += channels * dir;
                     float range = ranges[diff[0]];
-                    factor = alpha + range * factor;
+                    factor = Fmadd<nofma>(range, factor, alpha);
                     for (int c = 0; c < channels; c++)
                     {
-                        colors[c] = alpha * src[c] + range * colors[c];
+                        colors[c] = Fmadd<nofma>(alpha, src[c], range * colors[c]);
                         Set<dir>(int(colors[c] / factor), dst + c);
                     }
                     diff += dir;
                 }
             }
 
-            template<int channels, RbfDiffType type> void HorFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            template<int channels, RbfDiffType type, bool nofma> void HorFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
             {
                 size_t last = (p.width - 1) * channels, height4 = AlignLo(p.height, 4), y = 0;
                 uint8_t* diff = (uint8_t*)buf;
@@ -419,8 +443,8 @@ namespace Simd
                     RowDiff4x<channels, type>(src, src + channels, srcStride, p.width - 1, diff, dstStride);
                     for (size_t i = 0; i < 4; ++i)
                     {
-                        HorRow<channels, +1>(src + i * srcStride, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride);
-                        HorRow<channels, -1>(src + i * srcStride + last, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride + last);
+                        HorRow<channels, +1, nofma>(src + i * srcStride, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride);
+                        HorRow<channels, -1, nofma>(src + i * srcStride + last, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride + last);
                     }
                     src += 4 * srcStride;
                     dst += 4 * dstStride;
@@ -428,8 +452,8 @@ namespace Simd
                 for (; y < p.height; y++)
                 {
                     RowDiff<channels, type>(src, src + channels, p.width - 1, diff);
-                    HorRow<channels, +1>(src, p.width, p.alpha, p.ranges, diff, dst);
-                    HorRow<channels, -1>(src + last, p.width, p.alpha, p.ranges, diff, dst + last);
+                    HorRow<channels, +1, nofma>(src, p.width, p.alpha, p.ranges, diff, dst);
+                    HorRow<channels, -1, nofma>(src + last, p.width, p.alpha, p.ranges, diff, dst + last);
                     src += srcStride;
                     dst += dstStride;
                 }
@@ -505,7 +529,7 @@ namespace Simd
 
             template <int channels, RbfDiffType type> void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
             {
-                horFilter = HorFilter<channels, type>;
+                horFilter = FmaAvoid(param.flags) ? HorFilter<channels, type, true> : HorFilter<channels, type, false>;
                 verFilter = FmaAvoid(param.flags) ? VerFilter<channels, type, true> : VerFilter<channels, type, false>;
             }
 

--- a/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
+++ b/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
@@ -287,6 +287,241 @@ namespace Simd
 
         //-----------------------------------------------------------------------------------------
 
+        namespace Fast
+        {
+            template<int dir> SIMD_INLINE void Set(int value, uint8_t* dst);
+
+            template<> SIMD_INLINE void Set<+1>(int value, uint8_t* dst)
+            {
+                dst[0] = uint8_t(value);
+            }
+
+            template<> SIMD_INLINE void Set<-1>(int value, uint8_t* dst)
+            {
+                dst[0] = uint8_t((value + dst[0] + 1) / 2);
+            }
+
+            template<int dir> SIMD_INLINE void Set(const svbool_t& mask, const svuint32_t& value, uint8_t* dst);
+
+            template<> SIMD_INLINE void Set<+1>(const svbool_t& mask, const svuint32_t& value, uint8_t* dst)
+            {
+                svst1b_u32(mask, dst, value);
+            }
+
+            template<> SIMD_INLINE void Set<-1>(const svbool_t& mask, const svuint32_t& value, uint8_t* dst)
+            {
+                svuint32_t sum = svadd_u32_x(mask, svld1ub_u32(mask, dst), value);
+                svst1b_u32(mask, dst, svlsr_n_u32_x(mask, svadd_n_u32_x(mask, sum, 1), 1));
+            }
+
+            template<int dir> SIMD_INLINE void Set(const svbool_t& mask, const svuint32_t& offsets, const svuint32_t& value, uint8_t* dst);
+
+            template<> SIMD_INLINE void Set<+1>(const svbool_t& mask, const svuint32_t& offsets, const svuint32_t& value, uint8_t* dst)
+            {
+                svst1b_scatter_u32offset_u32(mask, dst, offsets, value);
+            }
+
+            template<> SIMD_INLINE void Set<-1>(const svbool_t& mask, const svuint32_t& offsets, const svuint32_t& value, uint8_t* dst)
+            {
+                svuint32_t sum = svadd_u32_x(mask, svld1ub_gather_u32offset_u32(mask, dst, offsets), value);
+                svst1b_scatter_u32offset_u32(mask, dst, offsets, svlsr_n_u32_x(mask, svadd_n_u32_x(mask, sum, 1), 1));
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template<int channels, RbfDiffType type> SIMD_INLINE void RowDiff(const uint8_t* src0, const uint8_t* src1, size_t width, uint8_t* dst)
+            {
+                size_t F = svcntw(), x = 0;
+                const svbool_t body = svptrue_b32();
+                const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), channels);
+                for (; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    const uint8_t* ps0 = src0 + x * channels;
+                    const uint8_t* ps1 = src1 + x * channels;
+                    svuint32_t diff = AbsDiff8u(ps0, ps1, offsets, mask);
+                    if (channels == 2)
+                        diff = Diff<type>(diff, AbsDiff8u(ps0 + 1, ps1 + 1, offsets, mask), mask);
+                    if (channels >= 3)
+                        diff = Diff<type>(diff, AbsDiff8u(ps0 + 1, ps1 + 1, offsets, mask), AbsDiff8u(ps0 + 2, ps1 + 2, offsets, mask), mask);
+                    svst1b_u32(mask, dst + x, diff);
+                }
+            }
+
+            template<int channels, RbfDiffType type> void RowDiff4x(const uint8_t* src0, const uint8_t* src1, size_t srcStride, size_t width, uint8_t* dst, size_t dstStride)
+            {
+                for (size_t i = 0; i < 4; ++i)
+                {
+                    RowDiff<channels, type>(src0, src1, width, dst);
+                    src0 += srcStride;
+                    src1 += srcStride;
+                    dst += dstStride;
+                }
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template<int channels, int dir> void HorRow(const uint8_t* src, size_t width, float alpha, const float* ranges, uint8_t* diff, uint8_t* dst)
+            {
+                if (dir == -1 && width > 1)
+                    diff += width - 2;
+                float factor = 1.0f, colors[channels];
+                for (int c = 0; c < channels; c++)
+                {
+                    colors[c] = src[c];
+                    Set<dir>(src[c], dst + c);
+                }
+                for (size_t x = 1; x < width; x += 1)
+                {
+                    src += channels * dir;
+                    dst += channels * dir;
+                    float range = ranges[diff[0]];
+                    factor = alpha + range * factor;
+                    for (int c = 0; c < channels; c++)
+                    {
+                        colors[c] = alpha * src[c] + range * colors[c];
+                        Set<dir>(int(colors[c] / factor), dst + c);
+                    }
+                    diff += dir;
+                }
+            }
+
+            template<int channels, RbfDiffType type> void HorFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            {
+                size_t last = (p.width - 1) * channels, height4 = AlignLo(p.height, 4), y = 0;
+                uint8_t* diff = (uint8_t*)buf;
+                for (; y < height4; y += 4)
+                {
+                    RowDiff4x<channels, type>(src, src + channels, srcStride, p.width - 1, diff, dstStride);
+                    for (size_t i = 0; i < 4; ++i)
+                    {
+                        HorRow<channels, +1>(src + i * srcStride, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride);
+                        HorRow<channels, -1>(src + i * srcStride + last, p.width, p.alpha, p.ranges, diff + i * dstStride, dst + i * dstStride + last);
+                    }
+                    src += 4 * srcStride;
+                    dst += 4 * dstStride;
+                }
+                for (; y < p.height; y++)
+                {
+                    RowDiff<channels, type>(src, src + channels, p.width - 1, diff);
+                    HorRow<channels, +1>(src, p.width, p.alpha, p.ranges, diff, dst);
+                    HorRow<channels, -1>(src + last, p.width, p.alpha, p.ranges, diff, dst + last);
+                    src += srcStride;
+                    dst += dstStride;
+                }
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template<int channels, int dir> void VerEdge(const uint8_t* src, size_t width, float* factor, float* colors, uint8_t* dst)
+            {
+                size_t F = svcntw(), size = width * channels, x = 0, i = 0;
+                const svfloat32_t _1 = svdup_n_f32(1.0f);
+                for (; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    svst1_f32(mask, factor + x, _1);
+                }
+                for (; i < size; i += F)
+                {
+                    svbool_t mask = svwhilelt_b32(i, size);
+                    svuint32_t src8 = svld1ub_u32(mask, src + i);
+                    svst1_f32(mask, colors + i, svcvt_f32_u32_x(mask, src8));
+                    Set<dir>(mask, src8, dst + i);
+                }
+            }
+
+            template<int channels, int dir> void VerMain(const uint8_t* src, const uint8_t* diff, size_t width, float alpha,
+                const float* ranges, float* factor, float* colors, uint8_t* dst)
+            {
+                size_t F = svcntw(), x = 0;
+                const svbool_t body = svptrue_b32();
+                const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), channels);
+                const svfloat32_t _alpha = svdup_n_f32(alpha);
+                for (; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    svfloat32_t _range = svld1_gather_u32index_f32(mask, ranges, svld1ub_u32(mask, diff + x));
+                    svfloat32_t _factor = svmla_f32_x(mask, _alpha, _range, svld1_f32(mask, factor + x));
+                    svst1_f32(mask, factor + x, _factor);
+                    size_t o = x * channels;
+                    for (size_t c = 0; c < channels; ++c)
+                    {
+                        svfloat32_t _color = svmla_f32_x(mask,
+                            svmul_f32_x(mask, _alpha, svcvt_f32_u32_x(mask, Load8u(src + o + c, offsets, mask))),
+                            _range, svld1_gather_u32index_f32(mask, colors + o + c, offsets));
+                        svst1_scatter_u32index_f32(mask, colors + o + c, offsets, _color);
+                        Set<dir>(mask, offsets, Float32ToUint8(svdiv_f32_x(mask, _color, _factor), mask), dst + o + c);
+                    }
+                }
+            }
+
+            template<int channels, RbfDiffType type> void VerFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            {
+                size_t size = p.width * channels;
+                uint8_t* diff = (uint8_t*)(buf + size + p.width);
+                VerEdge<channels, +1>(src, p.width, buf + size, buf, dst);
+                for (size_t y = 1; y < p.height; y++)
+                {
+                    src += srcStride;
+                    dst += dstStride;
+                    RowDiff<channels, type>(src, src - srcStride, p.width, diff);
+                    VerMain<channels, +1>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
+                }
+                VerEdge<channels, -1>(src, p.width, buf + size, buf, dst);
+                for (size_t y = 1; y < p.height; y++)
+                {
+                    src -= srcStride;
+                    dst -= dstStride;
+                    RowDiff<channels, type>(src, src + srcStride, p.width, diff);
+                    VerMain<channels, -1>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
+                }
+            }
+
+            //-----------------------------------------------------------------------------------------
+
+            template <int channels, RbfDiffType type> void Set(FilterPtr& horFilter, FilterPtr& verFilter)
+            {
+                horFilter = HorFilter<channels, type>;
+                verFilter = VerFilter<channels, type>;
+            }
+
+            template <RbfDiffType type> void Set(size_t channels, FilterPtr& horFilter, FilterPtr& verFilter)
+            {
+                switch (channels)
+                {
+                case 1: Set<1, type>(horFilter, verFilter); break;
+                case 2: Set<2, type>(horFilter, verFilter); break;
+                case 3: Set<3, type>(horFilter, verFilter); break;
+                case 4: Set<4, type>(horFilter, verFilter); break;
+                default:
+                    assert(0);
+                }
+            }
+
+            void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
+            {
+                switch (DiffType(param.flags))
+                {
+                case RbfDiffAvg: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                case RbfDiffMax: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                case RbfDiffSum: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                default:
+                    assert(0);
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        RecursiveBilateralFilterFast::RecursiveBilateralFilterFast(const RbfParam& param)
+            : Base::RecursiveBilateralFilterFast(param)
+        {
+            Fast::Set(_param, _hFilter, _vFilter);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
         void* RecursiveBilateralFilterInit(size_t width, size_t height, size_t channels,
             const float* sigmaSpatial, const float* sigmaRange, SimdRecursiveBilateralFilterFlags flags)
         {
@@ -296,7 +531,7 @@ namespace Simd
             if (Precise(flags))
                 return new RecursiveBilateralFilterPrecize(param);
             else
-                return new Base::RecursiveBilateralFilterFast(param);
+                return new RecursiveBilateralFilterFast(param);
         }
     }
 #endif

--- a/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
+++ b/src/Simd/SimdSve2RecursiveBilateralFilter.cpp
@@ -289,6 +289,30 @@ namespace Simd
 
         namespace Fast
         {
+            template<bool nofma> SIMD_INLINE svfloat32_t Fmadd(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c);
+
+#if defined(__GNUC__) && !defined(__clang__)
+            __attribute__((noinline, optimize("fp-contract=off")))
+#else
+            SIMD_NOINLINE
+#endif
+            svfloat32_t FmaddNoFma(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c)
+            {
+                return svadd_f32_x(mask, svmul_f32_x(mask, a, b), c);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Fmadd<true>(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c)
+            {
+                return FmaddNoFma(mask, a, b, c);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Fmadd<false>(const svbool_t& mask, const svfloat32_t& a, const svfloat32_t& b, const svfloat32_t& c)
+            {
+                return svmla_f32_x(mask, c, a, b);
+            }
+
+            //-----------------------------------------------------------------------------------------
+
             template<int dir> SIMD_INLINE void Set(int value, uint8_t* dst);
 
             template<> SIMD_INLINE void Set<+1>(int value, uint8_t* dst)
@@ -431,7 +455,7 @@ namespace Simd
                 }
             }
 
-            template<int channels, int dir> void VerMain(const uint8_t* src, const uint8_t* diff, size_t width, float alpha,
+            template<int channels, int dir, bool nofma> void VerMain(const uint8_t* src, const uint8_t* diff, size_t width, float alpha,
                 const float* ranges, float* factor, float* colors, uint8_t* dst)
             {
                 size_t F = svcntw(), x = 0;
@@ -442,21 +466,20 @@ namespace Simd
                 {
                     svbool_t mask = svwhilelt_b32(x, width);
                     svfloat32_t _range = svld1_gather_u32index_f32(mask, ranges, svld1ub_u32(mask, diff + x));
-                    svfloat32_t _factor = svmla_f32_x(mask, _alpha, _range, svld1_f32(mask, factor + x));
+                    svfloat32_t _factor = Fmadd<nofma>(mask, _range, svld1_f32(mask, factor + x), _alpha);
                     svst1_f32(mask, factor + x, _factor);
                     size_t o = x * channels;
                     for (size_t c = 0; c < channels; ++c)
                     {
-                        svfloat32_t _color = svmla_f32_x(mask,
-                            svmul_f32_x(mask, _alpha, svcvt_f32_u32_x(mask, Load8u(src + o + c, offsets, mask))),
-                            _range, svld1_gather_u32index_f32(mask, colors + o + c, offsets));
+                        svfloat32_t _color = Fmadd<nofma>(mask, _alpha, svcvt_f32_u32_x(mask, Load8u(src + o + c, offsets, mask)),
+                            svmul_f32_x(mask, _range, svld1_gather_u32index_f32(mask, colors + o + c, offsets)));
                         svst1_scatter_u32index_f32(mask, colors + o + c, offsets, _color);
                         Set<dir>(mask, offsets, Float32ToUint8(svdiv_f32_x(mask, _color, _factor), mask), dst + o + c);
                     }
                 }
             }
 
-            template<int channels, RbfDiffType type> void VerFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
+            template<int channels, RbfDiffType type, bool nofma> void VerFilter(const RbfParam& p, float* buf, const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
             {
                 size_t size = p.width * channels;
                 uint8_t* diff = (uint8_t*)(buf + size + p.width);
@@ -466,7 +489,7 @@ namespace Simd
                     src += srcStride;
                     dst += dstStride;
                     RowDiff<channels, type>(src, src - srcStride, p.width, diff);
-                    VerMain<channels, +1>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
+                    VerMain<channels, +1, nofma>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
                 }
                 VerEdge<channels, -1>(src, p.width, buf + size, buf, dst);
                 for (size_t y = 1; y < p.height; y++)
@@ -474,26 +497,26 @@ namespace Simd
                     src -= srcStride;
                     dst -= dstStride;
                     RowDiff<channels, type>(src, src + srcStride, p.width, diff);
-                    VerMain<channels, -1>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
+                    VerMain<channels, -1, nofma>(src, diff, p.width, p.alpha, p.ranges, buf + size, buf, dst);
                 }
             }
 
             //-----------------------------------------------------------------------------------------
 
-            template <int channels, RbfDiffType type> void Set(FilterPtr& horFilter, FilterPtr& verFilter)
+            template <int channels, RbfDiffType type> void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
             {
                 horFilter = HorFilter<channels, type>;
-                verFilter = VerFilter<channels, type>;
+                verFilter = FmaAvoid(param.flags) ? VerFilter<channels, type, true> : VerFilter<channels, type, false>;
             }
 
-            template <RbfDiffType type> void Set(size_t channels, FilterPtr& horFilter, FilterPtr& verFilter)
+            template <RbfDiffType type> void Set(const RbfParam& param, FilterPtr& horFilter, FilterPtr& verFilter)
             {
-                switch (channels)
+                switch (param.channels)
                 {
-                case 1: Set<1, type>(horFilter, verFilter); break;
-                case 2: Set<2, type>(horFilter, verFilter); break;
-                case 3: Set<3, type>(horFilter, verFilter); break;
-                case 4: Set<4, type>(horFilter, verFilter); break;
+                case 1: Set<1, type>(param, horFilter, verFilter); break;
+                case 2: Set<2, type>(param, horFilter, verFilter); break;
+                case 3: Set<3, type>(param, horFilter, verFilter); break;
+                case 4: Set<4, type>(param, horFilter, verFilter); break;
                 default:
                     assert(0);
                 }
@@ -503,9 +526,9 @@ namespace Simd
             {
                 switch (DiffType(param.flags))
                 {
-                case RbfDiffAvg: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
-                case RbfDiffMax: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
-                case RbfDiffSum: Set<RbfDiffAvg>(param.channels, horFilter, verFilter); break;
+                case RbfDiffAvg: Set<RbfDiffAvg>(param, horFilter, verFilter); break;
+                case RbfDiffMax: Set<RbfDiffAvg>(param, horFilter, verFilter); break;
+                case RbfDiffSum: Set<RbfDiffAvg>(param, horFilter, verFilter); break;
                 default:
                     assert(0);
                 }

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -1340,7 +1340,7 @@ namespace
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Sve2::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Base::RecursiveBilateralFilterInit), FUNC_RBF(Simd::Sve2::RecursiveBilateralFilterInit));
 #endif
 
 #ifdef SIMD_NEON_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 optimized fast recursive bilateral filter kernels and dispatch for normal fast mode.
- Keep `SimdRecursiveBilateralFilterFmaAvoid` exact-comparison mode on the base fast filters to preserve bit-exact test behavior.
- Compare the SVE2 recursive bilateral filter backend directly against the base reference in auto tests.
- Document the new SVE2 RecursiveBilateralFilterFast optimization in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build . --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=RecursiveBilateralFilter -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -O2 -march=armv8.2-a+sve2 -I/workspace/src /workspace/src/Simd/SimdSve2RecursiveBilateralFilter.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c1a8994-d2bc-47ca-8f79-ae1ca8930764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c1a8994-d2bc-47ca-8f79-ae1ca8930764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

