### PR TITLE
Add SVE2 AbsDifference optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -184,6 +184,7 @@
 <h5>New features</h5>
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
+ <li>SVE2 optimizations of function AbsDifference.</li>
  <li>SVE2 optimizations of function Float32ToBFloat16.</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function Float32ToUint8.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -21,6 +21,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifference.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AlphaBlending.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -149,6 +149,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifference.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -310,6 +310,11 @@ SIMD_API void SimdAbsDifference(const uint8_t *a, size_t aStride, const uint8_t 
         Sse41::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
     else
 #endif 
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::AbsDifference(a, aStride, b, bStride, c, cStride, width, height);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -31,6 +31,8 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        void AbsDifference(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, uint8_t* c, size_t cStride, size_t width, size_t height);
+
         void AddFeatureDifference(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride,
             uint16_t weight, uint8_t* difference, size_t differenceStride);

--- a/src/Simd/SimdSve2AbsDifference.cpp
+++ b/src/Simd/SimdSve2AbsDifference.cpp
@@ -1,0 +1,51 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void AbsDifference(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, uint8_t* c, size_t cStride, size_t width, size_t height)
+        {
+            const size_t A = svcntb();
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    svst1_u8(body, c + col, svabd_u8_x(body, svld1_u8(body, a + col), svld1_u8(body, b + col)));
+                if (widthA < width)
+                    svst1_u8(tail, c + col, svabd_u8_x(tail, svld1_u8(tail, a + col), svld1_u8(tail, b + col)));
+                a += aStride;
+                b += bStride;
+                c += cStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestAbsDifference.cpp
+++ b/src/Test/TestAbsDifference.cpp
@@ -119,6 +119,11 @@ namespace Test
 			result = result && AbsDifferenceAutoTest(FUNC1(Simd::Sve::AbsDifference), FUNC1(SimdAbsDifference), 1);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+		if (Simd::Sve2::Enable && TestSve2(options))
+			result = result && AbsDifferenceAutoTest(FUNC1(Simd::Sve2::AbsDifference), FUNC1(SimdAbsDifference), 1);
+#endif
+
 #ifdef SIMD_HVX_ENABLE
 		if (Simd::Hvx::Enable && TestHvx(options) && W >= Simd::Hvx::A)
 			result = result && AbsDifferenceAutoTest(FUNC1(Simd::Hvx::AbsDifference), FUNC1(SimdAbsDifference), 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch support for `SimdAbsDifference`.
- Cover `Simd::Sve2::AbsDifference` in the AbsDifference auto test.
- Register the new source in the VS2022 SVE2 project and update the 7.2.163 release notes.

### Testing
- `aarch64-linux-gnu-g++ -std=c++11 -O3 -fPIC -I src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2AbsDifference.cpp -o /tmp/SimdSve2AbsDifference.o`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AbsDifference -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b38d3ff-e9b1-4f4a-85fd-09cfcb200126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b38d3ff-e9b1-4f4a-85fd-09cfcb200126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

