### PR TITLE
Add SVE2 AbsDifferenceSum optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -184,6 +184,7 @@
 <h5>New features</h5>
 <ul>
  <li>Support of SVE2 extension (ARM/ARM64 platform).</li>
+ <li>SVE2 optimizations of function AbsDifferenceSum.</li>
  <li>SVE2 optimizations of function Float32ToBFloat16.</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function Float32ToUint8.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -21,6 +21,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifferenceSum.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AlphaBlending.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -149,6 +149,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifferenceSum.cpp">
+      <Filter>Sve2\Statistics</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -347,6 +347,11 @@ SIMD_API void SimdAbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8
         Sse41::AbsDifferenceSum(a, aStride, b, bStride, width, height, sum);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AbsDifferenceSum(a, aStride, b, bStride, width, height, sum);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::AbsDifferenceSum(a, aStride, b, bStride, width, height, sum);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -31,6 +31,9 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        void AbsDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint64_t* sum);
+
         void AddFeatureDifference(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride,
             uint16_t weight, uint8_t* difference, size_t differenceStride);

--- a/src/Simd/SimdSve2AbsDifferenceSum.cpp
+++ b/src/Simd/SimdSve2AbsDifferenceSum.cpp
@@ -1,0 +1,62 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void AbsDifferenceSum(const uint8_t* a, const uint8_t* b, const svbool_t& mask, const svuint8_t& _1, const svuint8_t& zero, svuint32_t& sum)
+        {
+            svuint8_t diff = svabd_u8_x(mask, svld1_u8(mask, a), svld1_u8(mask, b));
+            sum = svdot_u32(sum, svsel_u8(mask, diff, zero), _1);
+        }
+
+        void AbsDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint64_t* sum)
+        {
+            const size_t A = svlen(svuint8_t());
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _1 = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+            *sum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                svuint32_t rowSum = svdup_n_u32(0);
+                for (; col < widthA; col += A)
+                    AbsDifferenceSum(a + col, b + col, body, _1, zero, rowSum);
+                if (widthA < width)
+                    AbsDifferenceSum(a + col, b + col, tail, _1, zero, rowSum);
+                *sum += svaddv_u32(svptrue_b32(), rowSum);
+                a += aStride;
+                b += bStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -280,6 +280,11 @@ namespace Test
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Avx512bw::AbsDifferenceSum), FUNC_S(SimdAbsDifferenceSum), 1);
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Sve2::AbsDifferenceSum), FUNC_S(SimdAbsDifferenceSum), 1);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A)
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Neon::AbsDifferenceSum), FUNC_S(SimdAbsDifferenceSum), 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `AbsDifferenceSum` with predicated vector tails and dot-product accumulation.
- Wire `Sve2::AbsDifferenceSum` into API dispatch and auto-tests.
- Add VS2022 project entries and release note for 7.2.163.
- Merge latest `origin/dev`; conflicts were simple additive/order conflicts with upstream SVE2 `AbsDifference` additions and were resolved by keeping both entries.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AbsDifference -tt=1 -ts=1 && ./Test "-r=.." -fi=AbsDifferenceSum -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2AbsDifference.cpp src/Simd/SimdSve2AbsDifferenceSum.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91eae8e4-a5e0-46aa-b282-355ce1f6afea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91eae8e4-a5e0-46aa-b282-355ce1f6afea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

