### PR TITLE
Add SVE2 masked 3x3 abs difference sums

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -188,6 +188,7 @@
  <li>SVE2 optimizations of function AbsDifferenceSum.</li>
  <li>SVE2 optimizations of function AbsDifferenceSumMasked.</li>
  <li>SVE2 optimizations of function AbsDifferenceSums3x3.</li>
+ <li>SVE2 optimizations of function AbsDifferenceSums3x3Masked.</li>
  <li>SVE2 optimizations of function Float32ToBFloat16.</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function Float32ToUint8.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -468,6 +468,11 @@ SIMD_API void SimdAbsDifferenceSums3x3Masked(const uint8_t *current, size_t curr
         Sse41::AbsDifferenceSums3x3Masked(current, currentStride, background, backgroundStride, mask, maskStride, index, width, height, sums);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AbsDifferenceSums3x3Masked(current, currentStride, background, backgroundStride, mask, maskStride, index, width, height, sums);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::AbsDifferenceSums3x3Masked(current, currentStride, background, backgroundStride, mask, maskStride, index, width, height, sums);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -42,6 +42,9 @@ namespace Simd
         void AbsDifferenceSums3x3(const uint8_t* current, size_t currentStride, const uint8_t* background, size_t backgroundStride,
             size_t width, size_t height, uint64_t* sums);
 
+        void AbsDifferenceSums3x3Masked(const uint8_t* current, size_t currentStride, const uint8_t* background, size_t backgroundStride,
+            const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sums);
+
         void AddFeatureDifference(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride,
             uint16_t weight, uint8_t* difference, size_t differenceStride);

--- a/src/Simd/SimdSve2AbsDifferenceSum.cpp
+++ b/src/Simd/SimdSve2AbsDifferenceSum.cpp
@@ -218,6 +218,71 @@ namespace Simd
                 background += backgroundStride;
             }
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void AbsDifferenceSums3Masked(const svuint8_t& current, const uint8_t* background, const svbool_t& mask, const svuint8_t& _1,
+            const svuint8_t& zero, svuint32_t& sum0, svuint32_t& sum1, svuint32_t& sum2)
+        {
+            svuint8_t diff0 = svabd_u8_x(mask, current, svld1_u8(mask, background - 1));
+            svuint8_t diff1 = svabd_u8_x(mask, current, svld1_u8(mask, background));
+            svuint8_t diff2 = svabd_u8_x(mask, current, svld1_u8(mask, background + 1));
+            sum0 = svdot_u32(sum0, svsel_u8(mask, diff0, zero), _1);
+            sum1 = svdot_u32(sum1, svsel_u8(mask, diff1, zero), _1);
+            sum2 = svdot_u32(sum2, svsel_u8(mask, diff2, zero), _1);
+        }
+
+        SIMD_INLINE void AbsDifferenceSums3x3Masked(const uint8_t* current, const uint8_t* background, size_t stride, const uint8_t* mask,
+            const svbool_t& tail, const svuint8_t& index, const svuint8_t& _1, const svuint8_t& zero,
+            svuint32_t& s0, svuint32_t& s1, svuint32_t& s2, svuint32_t& s3, svuint32_t& s4, svuint32_t& s5, svuint32_t& s6, svuint32_t& s7, svuint32_t& s8)
+        {
+            svbool_t equal = svcmpeq_u8(tail, svld1_u8(tail, mask), index);
+            svuint8_t _current = svld1_u8(equal, current);
+            AbsDifferenceSums3Masked(_current, background - stride, equal, _1, zero, s0, s1, s2);
+            AbsDifferenceSums3Masked(_current, background, equal, _1, zero, s3, s4, s5);
+            AbsDifferenceSums3Masked(_current, background + stride, equal, _1, zero, s6, s7, s8);
+        }
+
+        void AbsDifferenceSums3x3Masked(const uint8_t* current, size_t currentStride, const uint8_t* background, size_t backgroundStride,
+            const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sums)
+        {
+            assert(height > 2 && width > 2);
+
+            width -= 2;
+            height -= 2;
+            current += 1 + currentStride;
+            background += 1 + backgroundStride;
+            mask += 1 + maskStride;
+
+            const size_t A = svlen(svuint8_t());
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            const svuint8_t _index = svdup_n_u8(index);
+            const svuint8_t _1 = svdup_n_u8(1);
+            const svuint8_t zero = svdup_n_u8(0);
+
+            for (size_t i = 0; i < 9; ++i)
+                sums[i] = 0;
+            svuint32_t s0, s1, s2, s3, s4, s5, s6, s7, s8;
+            for (size_t row = 0; row < height; ++row)
+            {
+                ClearSums(s0, s1, s2);
+                ClearSums(s3, s4, s5);
+                ClearSums(s6, s7, s8);
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    AbsDifferenceSums3x3Masked(current + col, background + col, backgroundStride, mask + col, body, _index, _1, zero, s0, s1, s2, s3, s4, s5, s6, s7, s8);
+                if (widthA < width)
+                    AbsDifferenceSums3x3Masked(current + col, background + col, backgroundStride, mask + col, tail, _index, _1, zero, s0, s1, s2, s3, s4, s5, s6, s7, s8);
+                AddSums(s0, s1, s2, sums + 0);
+                AddSums(s3, s4, s5, sums + 3);
+                AddSums(s6, s7, s8, sums + 6);
+                current += currentStride;
+                background += backgroundStride;
+                mask += maskStride;
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -405,6 +405,11 @@ namespace Test
             result = result && DifferenceSumsMaskedAutoTest(FUNC_M(Simd::Avx512bw::AbsDifferenceSums3x3Masked), FUNC_M(SimdAbsDifferenceSums3x3Masked), 9);
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DifferenceSumsMaskedAutoTest(FUNC_M(Simd::Sve2::AbsDifferenceSums3x3Masked), FUNC_M(SimdAbsDifferenceSums3x3Masked), 9);
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options) && W >= Simd::Neon::A + 2)
             result = result && DifferenceSumsMaskedAutoTest(FUNC_M(Simd::Neon::AbsDifferenceSums3x3Masked), FUNC_M(SimdAbsDifferenceSums3x3Masked), 9);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `AbsDifferenceSums3x3Masked`.
- Extend the masked 3x3 auto-test to cover SVE2.
- Document the SVE2 optimization in release 7.2.163.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=AbsDifferenceSums3x3Masked -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdSve2AbsDifferenceSum.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15aae4a6-2f9c-4fc5-8ab0-228f83ba5606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15aae4a6-2f9c-4fc5-8ab0-228f83ba5606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

