### PR TITLE
Add SVE2 DeinterleaveBgra optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -245,6 +245,7 @@
  <li>SVE2 optimizations of function BgrToGray.</li>
  <li>SVE2 optimizations of function BgrToRgb.</li>
  <li>SVE2 optimizations of function DeinterleaveBgr.</li>
+ <li>SVE2 optimizations of function DeinterleaveBgra.</li>
  <li>SVE2 optimizations of function RgbToGray.</li>
  <li>SVE2 optimizations of function BgraToGray.</li>
  <li>SVE2 optimizations of function RgbaToGray.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2303,6 +2303,11 @@ SIMD_API void SimdDeinterleaveBgra(const uint8_t * bgra, size_t bgraStride, size
         Sse41::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -529,6 +529,9 @@ namespace Simd
         void DeinterleaveBgr(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride);
 
+        void DeinterleaveBgra(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride, uint8_t* a, size_t aStride);
+
         void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red);
 
         void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha);

--- a/src/Simd/SimdSve2Deinterleave.cpp
+++ b/src/Simd/SimdSve2Deinterleave.cpp
@@ -47,6 +47,25 @@ namespace Simd
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t DEINTERLEAVE_BGR_INDEX[3][2][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool DEINTERLEAVE_BGR_INDEX_INITED = InitDeinterleaveBgrIndex(DEINTERLEAVE_BGR_INDEX);
 
+        SIMD_INLINE bool InitDeinterleaveBgraIndex(uint8_t index[4][2][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t channel = 0; channel < 4; ++channel)
+            {
+                for (size_t i = 0; i < A; ++i)
+                {
+                    size_t src = 4 * i + channel;
+                    index[channel][0][i] = src < 2 * A ? (uint8_t)src : 0xFF;
+                    index[channel][1][i] = src >= 2 * A ? (uint8_t)(src - 2 * A) : 0xFF;
+                }
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t DEINTERLEAVE_BGRA_INDEX[4][2][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool DEINTERLEAVE_BGRA_INDEX_INITED = InitDeinterleaveBgraIndex(DEINTERLEAVE_BGRA_INDEX);
+
         template<int B, int G, int R> SIMD_INLINE void DeinterleaveBgr(const uint8_t* bgr, size_t A,
             const svbool_t& load0, const svbool_t& load1, const svbool_t& load2, const svbool_t& store,
             const svuint8_t& indexB0, const svuint8_t& indexB1, const svuint8_t& indexG0,
@@ -117,6 +136,104 @@ namespace Simd
                 DeinterleaveBgr<0, 1, 0>(bgr, bgrStride, width, height, b, bStride, g, gStride, r, rStride);
             else if (r)
                 DeinterleaveBgr<0, 0, 1>(bgr, bgrStride, width, height, b, bStride, g, gStride, r, rStride);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<int B, int G, int R, int A> SIMD_INLINE void DeinterleaveBgra(const uint8_t* bgra, size_t VL,
+            const svbool_t& load0, const svbool_t& load1, const svbool_t& load2, const svbool_t& load3, const svbool_t& store,
+            const svuint8_t& indexB0, const svuint8_t& indexB1, const svuint8_t& indexG0, const svuint8_t& indexG1,
+            const svuint8_t& indexR0, const svuint8_t& indexR1, const svuint8_t& indexA0, const svuint8_t& indexA1,
+            uint8_t* b, uint8_t* g, uint8_t* r, uint8_t* a)
+        {
+            svuint8_t bgra0 = svld1_u8(load0, bgra + 0 * VL);
+            svuint8_t bgra1 = svld1_u8(load1, bgra + 1 * VL);
+            svuint8_t bgra2 = svld1_u8(load2, bgra + 2 * VL);
+            svuint8_t bgra3 = svld1_u8(load3, bgra + 3 * VL);
+            svuint8x2_t bgra01 = svcreate2_u8(bgra0, bgra1);
+            svuint8x2_t bgra23 = svcreate2_u8(bgra2, bgra3);
+
+            if (B)
+                svst1_u8(store, b, svorr_u8_x(store, svtbl2_u8(bgra01, indexB0), svtbl2_u8(bgra23, indexB1)));
+            if (G)
+                svst1_u8(store, g, svorr_u8_x(store, svtbl2_u8(bgra01, indexG0), svtbl2_u8(bgra23, indexG1)));
+            if (R)
+                svst1_u8(store, r, svorr_u8_x(store, svtbl2_u8(bgra01, indexR0), svtbl2_u8(bgra23, indexR1)));
+            if (A)
+                svst1_u8(store, a, svorr_u8_x(store, svtbl2_u8(bgra01, indexA0), svtbl2_u8(bgra23, indexA1)));
+        }
+
+        template<int B, int G, int R, int A> void DeinterleaveBgra(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride, uint8_t* a, size_t aStride)
+        {
+            size_t VL = svlen(svuint8_t()), VL4 = VL * 4;
+            assert(VL <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t widthA = AlignLo(width, VL);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            size_t tailSize = (width - widthA) * 4;
+            const svbool_t tail0 = svwhilelt_b8(size_t(0) * VL, tailSize);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1) * VL, tailSize);
+            const svbool_t tail2 = svwhilelt_b8(size_t(2) * VL, tailSize);
+            const svbool_t tail3 = svwhilelt_b8(size_t(3) * VL, tailSize);
+            const svuint8_t indexB0 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[0][0]);
+            const svuint8_t indexB1 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[0][1]);
+            const svuint8_t indexG0 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[1][0]);
+            const svuint8_t indexG1 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[1][1]);
+            const svuint8_t indexR0 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[2][0]);
+            const svuint8_t indexR1 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[2][1]);
+            const svuint8_t indexA0 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[3][0]);
+            const svuint8_t indexA1 = svld1_u8(body, DEINTERLEAVE_BGRA_INDEX[3][1]);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += VL, offset += VL4)
+                    DeinterleaveBgra<B, G, R, A>(bgra + offset, VL, body, body, body, body, body, indexB0, indexB1, indexG0, indexG1, indexR0, indexR1, indexA0, indexA1,
+                        B ? b + col : NULL, G ? g + col : NULL, R ? r + col : NULL, A ? a + col : NULL);
+                if (widthA < width)
+                    DeinterleaveBgra<B, G, R, A>(bgra + offset, VL, tail0, tail1, tail2, tail3, tail, indexB0, indexB1, indexG0, indexG1, indexR0, indexR1, indexA0, indexA1,
+                        B ? b + col : NULL, G ? g + col : NULL, R ? r + col : NULL, A ? a + col : NULL);
+                bgra += bgraStride;
+                if (B) b += bStride;
+                if (G) g += gStride;
+                if (R) r += rStride;
+                if (A) a += aStride;
+            }
+        }
+
+        void DeinterleaveBgra(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
+            uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride, uint8_t* a, size_t aStride)
+        {
+            if (b && g && r && a)
+                DeinterleaveBgra<1, 1, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b && g && r)
+                DeinterleaveBgra<1, 1, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b && g && a)
+                DeinterleaveBgra<1, 1, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b && r && a)
+                DeinterleaveBgra<1, 0, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (g && r && a)
+                DeinterleaveBgra<0, 1, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b && g)
+                DeinterleaveBgra<1, 1, 0, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b && r)
+                DeinterleaveBgra<1, 0, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b && a)
+                DeinterleaveBgra<1, 0, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (g && r)
+                DeinterleaveBgra<0, 1, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (g && a)
+                DeinterleaveBgra<0, 1, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (r && a)
+                DeinterleaveBgra<0, 0, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (b)
+                DeinterleaveBgra<1, 0, 0, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (g)
+                DeinterleaveBgra<0, 1, 0, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (r)
+                DeinterleaveBgra<0, 0, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
+            else if (a)
+                DeinterleaveBgra<0, 0, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
         }
     }
 #endif

--- a/src/Test/TestDeinterleave.cpp
+++ b/src/Test/TestDeinterleave.cpp
@@ -409,6 +409,11 @@ namespace Test
             result = result && DeinterleaveBgraAutoTest(FUNC4(Simd::Sve::DeinterleaveBgra), FUNC4(SimdDeinterleaveBgra));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DeinterleaveBgraAutoTest(FUNC4(Simd::Sve2::DeinterleaveBgra), FUNC4(SimdDeinterleaveBgra));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 table-lookup implementation for `SimdDeinterleaveBgra`.
- Route BGRA deinterleave dispatch through SVE2 when available.
- Add SVE2 BGRA deinterleave auto-test coverage and release note entry.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=DeinterleaveBgra -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv9-a+sve2 -I./src -c src/Simd/SimdSve2Deinterleave.cpp -o /tmp/SimdSve2Deinterleave.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27f01eb4-c257-4f7f-b9bf-03abe6e7547c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27f01eb4-c257-4f7f-b9bf-03abe6e7547c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

