### PR TITLE
Add SVE2 optimization for DeinterleaveUv

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -244,6 +244,7 @@
  <li>SVE2 optimizations of function BgraToRgba.</li>
  <li>SVE2 optimizations of function BgrToGray.</li>
  <li>SVE2 optimizations of function BgrToRgb.</li>
+ <li>SVE2 optimizations of function DeinterleaveUv.</li>
  <li>SVE2 optimizations of function DeinterleaveBgr.</li>
  <li>SVE2 optimizations of function DeinterleaveBgra.</li>
  <li>SVE2 optimizations of function RgbToGray.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2224,6 +2224,11 @@ SIMD_API void SimdDeinterleaveUv(const uint8_t * uv, size_t uvStride, size_t wid
         Sse41::DeinterleaveUv(uv, uvStride, width, height, u, uStride, v, vStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::DeinterleaveUv(uv, uvStride, width, height, u, uStride, v, vStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::DeinterleaveUv(uv, uvStride, width, height, u, uStride, v, vStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -526,6 +526,9 @@ namespace Simd
         void DetectionLbpDetect16ii(const void* hid, const uint8_t* mask, size_t maskStride,
             ptrdiff_t left, ptrdiff_t top, ptrdiff_t right, ptrdiff_t bottom, uint8_t* dst, size_t dstStride);
 
+        void DeinterleaveUv(const uint8_t* uv, size_t uvStride, size_t width, size_t height,
+            uint8_t* u, size_t uStride, uint8_t* v, size_t vStride);
+
         void DeinterleaveBgr(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride);
 

--- a/src/Simd/SimdSve2Deinterleave.cpp
+++ b/src/Simd/SimdSve2Deinterleave.cpp
@@ -28,6 +28,54 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        template <int U, int V> SIMD_INLINE void DeinterleaveUv(const uint8_t* uv, size_t A,
+            const svbool_t& load0, const svbool_t& load1, const svbool_t& store, uint8_t* u, uint8_t* v)
+        {
+            svuint8_t uv0 = svld1_u8(load0, uv + 0 * A);
+            svuint8_t uv1 = svld1_u8(load1, uv + 1 * A);
+
+            if (U)
+                svst1_u8(store, u, svuzp1_u8(uv0, uv1));
+            if (V)
+                svst1_u8(store, v, svuzp2_u8(uv0, uv1));
+        }
+
+        template <int U, int V> void DeinterleaveUv(const uint8_t* uv, size_t uvStride, size_t width, size_t height,
+            uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            size_t A = svlen(svuint8_t()), A2 = A * 2;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            size_t tailSize = (width - widthA) * 2;
+            const svbool_t tail0 = svwhilelt_b8(size_t(0) * A, tailSize);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1) * A, tailSize);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A2)
+                    DeinterleaveUv<U, V>(uv + offset, A, body, body, body, U ? u + col : NULL, V ? v + col : NULL);
+                if (widthA < width)
+                    DeinterleaveUv<U, V>(uv + offset, A, tail0, tail1, tail, U ? u + col : NULL, V ? v + col : NULL);
+                uv += uvStride;
+                if (U) u += uStride;
+                if (V) v += vStride;
+            }
+        }
+
+        void DeinterleaveUv(const uint8_t* uv, size_t uvStride, size_t width, size_t height,
+            uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
+        {
+            if (u && v)
+                DeinterleaveUv<1, 1>(uv, uvStride, width, height, u, uStride, v, vStride);
+            else if (u)
+                DeinterleaveUv<1, 0>(uv, uvStride, width, height, u, uStride, v, vStride);
+            else if (v)
+                DeinterleaveUv<0, 1>(uv, uvStride, width, height, u, uStride, v, vStride);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE bool InitDeinterleaveBgrIndex(uint8_t index[3][2][SIMD_SVE2_VECTOR_SIZE_MAX])
         {
             size_t A = svlen(svuint8_t());

--- a/src/Test/TestDeinterleave.cpp
+++ b/src/Test/TestDeinterleave.cpp
@@ -141,6 +141,11 @@ namespace Test
             result = result && DeinterleaveUvAutoTest(FUNC2(Simd::Sve::DeinterleaveUv), FUNC2(SimdDeinterleaveUv));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && DeinterleaveUvAutoTest(FUNC2(Simd::Sve2::DeinterleaveUv), FUNC2(SimdDeinterleaveUv));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `DeinterleaveUv` implementation using predicated SVE loads and unzip operations.
- Route `SimdDeinterleaveUv` through SVE2 when available.
- Add SVE2 coverage to `DeinterleaveUvAutoTest` and document the release note for 7.2.163.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `LD_LIBRARY_PATH=/workspace/build:$LD_LIBRARY_PATH ./Test "-r=.." -fi=DeinterleaveUv -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I src -march=armv8.5-a+sve2 -fsyntax-only src/Simd/SimdSve2Deinterleave.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64422982-f017-4860-baea-af2c90e7e5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64422982-f017-4860-baea-af2c90e7e5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

