### PR TITLE
Add SVE2 AbsGradientSaturatedSum optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -189,6 +189,7 @@
  <li>SVE2 optimizations of function AbsDifferenceSumMasked.</li>
  <li>SVE2 optimizations of function AbsDifferenceSums3x3.</li>
  <li>SVE2 optimizations of function AbsDifferenceSums3x3Masked.</li>
+ <li>SVE2 optimizations of function AbsGradientSaturatedSum.</li>
  <li>SVE2 optimizations of function Float32ToBFloat16.</li>
  <li>SVE2 optimizations of function BFloat16ToFloat32.</li>
  <li>SVE2 optimizations of function Float32ToUint8.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifference.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifferenceSum.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2AbsGradientSaturatedSum.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2AlphaBlending.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Background.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -155,6 +155,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2AbsDifferenceSum.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2AbsGradientSaturatedSum.cpp">
+      <Filter>Sve2\Filter</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2AddFeatureDifference.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -505,6 +505,11 @@ SIMD_API void SimdAbsGradientSaturatedSum(const uint8_t * src, size_t srcStride,
         Sse41::AbsGradientSaturatedSum(src, srcStride, width, height, dst, dstStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::AbsGradientSaturatedSum(src, srcStride, width, height, dst, dstStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::AbsGradientSaturatedSum(src, srcStride, width, height, dst, dstStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -45,6 +45,8 @@ namespace Simd
         void AbsDifferenceSums3x3Masked(const uint8_t* current, size_t currentStride, const uint8_t* background, size_t backgroundStride,
             const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sums);
 
+        void AbsGradientSaturatedSum(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride);
+
         void AddFeatureDifference(const uint8_t* value, size_t valueStride, size_t width, size_t height,
             const uint8_t* lo, size_t loStride, const uint8_t* hi, size_t hiStride,
             uint16_t weight, uint8_t* difference, size_t differenceStride);

--- a/src/Simd/SimdSve2AbsGradientSaturatedSum.cpp
+++ b/src/Simd/SimdSve2AbsGradientSaturatedSum.cpp
@@ -1,0 +1,63 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void AbsGradientSaturatedSum(const uint8_t* src, size_t stride, uint8_t* dst, const svbool_t& mask)
+        {
+            const svuint8_t dx = svabd_u8_x(mask, svld1_u8(mask, src + 1), svld1_u8(mask, src - 1));
+            const svuint8_t dy = svabd_u8_x(mask, svld1_u8(mask, src + stride), svld1_u8(mask, src - stride));
+            svst1_u8(mask, dst, svqadd_u8(dx, dy));
+        }
+
+        void AbsGradientSaturatedSum(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            const size_t A = svcntb();
+            const size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            memset(dst, 0, width);
+            src += srcStride;
+            dst += dstStride;
+            for (size_t row = 2; row < height; ++row)
+            {
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                    AbsGradientSaturatedSum(src + col, srcStride, dst + col, body);
+                if (widthA < width)
+                    AbsGradientSaturatedSum(src + col, srcStride, dst + col, tail);
+                dst[0] = 0;
+                dst[width - 1] = 0;
+                src += srcStride;
+                dst += dstStride;
+            }
+            memset(dst, 0, width);
+        }
+    }
+#endif
+}

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -713,6 +713,11 @@ namespace
             result = result && GrayFilterAutoTest(View::Gray8, FUNC_G(Simd::Neon::AbsGradientSaturatedSum), FUNC_G(SimdAbsGradientSaturatedSum));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GrayFilterAutoTest(View::Gray8, FUNC_G(Simd::Sve2::AbsGradientSaturatedSum), FUNC_G(SimdAbsGradientSaturatedSum));
+#endif
+
 #ifdef SIMD_SVE_ENABLE
         if (Simd::Sve::Enable && TestSve(options))
             result = result && GrayFilterAutoTest(View::Gray8, FUNC_G(Simd::Sve::AbsGradientSaturatedSum), FUNC_G(SimdAbsGradientSaturatedSum));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `AbsGradientSaturatedSum` and dispatch it before SVE1 on ARM/ARM64.
- Extend the auto-test matrix with SVE2 coverage.
- Add Visual Studio project entries and update the 7.2.163 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=AbsGradientSaturatedSum -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -fsyntax-only src/Simd/SimdSve2AbsGradientSaturatedSum.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3592ff1a-27fc-4221-a534-0aef0666ebfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3592ff1a-27fc-4221-a534-0aef0666ebfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

