### PR TITLE
Add SVE2 GetStatistic optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -287,6 +287,7 @@
  <li>SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GetAbsDyRowSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>
+ <li>SVE2 optimizations of function GetStatistic.</li>
  <li>SVE2 optimizations of function GetMoments.</li>
  <li>SVE2 optimizations of function GetObjectMoments.</li>
  <li>SVE2 optimizations of function ValueSum.</li>
@@ -399,6 +400,7 @@
 <h5>New features</h5>
 <ul>
  <li>Tests for verifying functionality of SVE2 version of function DeinterleaveBgr.</li>
+ <li>Tests for verifying functionality of SVE2 version of function GetStatistic.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -5700,6 +5700,11 @@ SIMD_API void SimdGetStatistic(const uint8_t * src, size_t stride, size_t width,
         Sse41::GetStatistic(src, stride, width, height, min, max, average);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::GetStatistic(src, stride, width, height, min, max, average);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::GetStatistic(src, stride, width, height, min, max, average);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -569,6 +569,8 @@ namespace Simd
             const uint8_t* bkg, size_t bkgStride, const double* shiftX, const double* shiftY,
             size_t cropLeft, size_t cropTop, size_t cropRight, size_t cropBottom, uint8_t* dst, size_t dstStride);
 
+        void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
+
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);
 
         void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -33,6 +33,46 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE    
     namespace Sve2
     {
+        SIMD_INLINE void UpdateStatistic(const uint8_t* src, svbool_t mask, svuint8_t _1, svuint8_t& min, svuint8_t& max, svuint32_t& sum)
+        {
+            svuint8_t val = svld1_u8(mask, src);
+            min = svmin_u8_m(mask, min, val);
+            max = svmax_u8_m(mask, max, val);
+            sum = svdot_u32(sum, val, _1);
+        }
+
+        void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average)
+        {
+            assert(width * height);
+
+            size_t A = svlen(svuint8_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+
+            svuint8_t _1 = svdup_n_u8(1);
+            svuint8_t _min = svdup_n_u8(255);
+            svuint8_t _max = svdup_n_u8(0);
+            uint64_t sum = 0;
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0;
+                svuint32_t _sum = svdup_n_u32(0);
+                for (; col < widthA; col += A)
+                    UpdateStatistic(src + col, body, _1, _min, _max, _sum);
+                if (widthA < width)
+                    UpdateStatistic(src + col, tail, _1, _min, _max, _sum);
+                sum += svaddv_u32(svptrue_b32(), _sum);
+                src += stride;
+            }
+
+            *min = svminv_u8(svptrue_b8(), _min);
+            *max = svmaxv_u8(svptrue_b8(), _max);
+            *average = (uint8_t)((sum + width * height / 2) / (width * height));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         namespace
         {
             struct Buffer

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -108,6 +108,11 @@ namespace Test
             result = result && GetStatisticAutoTest(FUNC1(Simd::Avx512bw::GetStatistic), FUNC1(SimdGetStatistic));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && GetStatisticAutoTest(FUNC1(Simd::Sve2::GetStatistic), FUNC1(SimdGetStatistic));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && GetStatisticAutoTest(FUNC1(Simd::Neon::GetStatistic), FUNC1(SimdGetStatistic));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 implementation and dispatch for `SimdGetStatistic`.
* Add SVE2 coverage to `GetStatisticAutoTest`.
* Update 7.2.163 release notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=GetStatistic -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I./src ./src/Simd/SimdSve2Statistic.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acdc73f9-4c09-479d-9739-ffe5ee86942b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acdc73f9-4c09-479d-9739-ffe5ee86942b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

