### PR TITLE
Add SVE2 optimization for InterleaveUv

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -367,6 +367,7 @@
  <li>SVE2 optimizations of function FillBgr.</li>
  <li>SVE2 optimizations of function FillBgra.</li>
  <li>SVE2 optimizations of function FillPixel.</li>
+ <li>SVE2 optimizations of function InterleaveUv.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcSpecV1.</li>
@@ -403,6 +404,7 @@
 <h5>New features</h5>
 <ul>
  <li>Tests for verifying functionality of SVE2 version of function DeinterleaveBgr.</li>
+ <li>Tests for verifying functionality of SVE2 version of function InterleaveUv.</li>
  <li>Tests for verifying functionality of SVE2 version of function GetStatistic.</li>
 </ul>
 <h5>Bug fixing</h5>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -64,6 +64,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToY.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Int16ToGray.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Interleave.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Laplace.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -239,6 +239,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Deinterleave.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Interleave.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Fill.cpp">
       <Filter>Sve2\Image</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3598,6 +3598,11 @@ SIMD_API void SimdInterleaveUv(const uint8_t * u, size_t uStride, const uint8_t 
         Sse41::InterleaveUv(u, uStride, v, vStride, width, height, uv, uvStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::InterleaveUv(u, uStride, v, vStride, width, height, uv, uvStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::InterleaveUv(u, uStride, v, vStride, width, height, uv, uvStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -539,6 +539,9 @@ namespace Simd
         void DeinterleaveBgra(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
             uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride, uint8_t* a, size_t aStride);
 
+        void InterleaveUv(const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* uv, size_t uvStride);
+
         void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red);
 
         void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha);

--- a/src/Simd/SimdSve2Interleave.cpp
+++ b/src/Simd/SimdSve2Interleave.cpp
@@ -1,0 +1,64 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE void InterleaveUv(const uint8_t* u, const uint8_t* v, uint8_t* uv,
+            const svbool_t& load, const svbool_t& store0, const svbool_t& store1)
+        {
+            svuint8_t _u = svld1_u8(load, u);
+            svuint8_t _v = svld1_u8(load, v);
+            svst1_u8(store0, uv, svzip1_u8(_u, _v));
+            svst1_u8(store1, uv + svcntb(), svzip2_u8(_u, _v));
+        }
+
+        void InterleaveUv(const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
+            size_t width, size_t height, uint8_t* uv, size_t uvStride)
+        {
+            size_t A = svcntb(), A2 = A * 2;
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            size_t tailSize = (width - widthA) * 2;
+            const svbool_t tail0 = svwhilelt_b8(size_t(0) * A, tailSize);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1) * A, tailSize);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A2)
+                    InterleaveUv(u + col, v + col, uv + offset, body, body, body);
+                if (widthA < width)
+                    InterleaveUv(u + col, v + col, uv + offset, tail, tail0, tail1);
+                u += uStride;
+                v += vStride;
+                uv += uvStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestInterleave.cpp
+++ b/src/Test/TestInterleave.cpp
@@ -115,6 +115,11 @@ namespace Test
             result = result && InterleaveUvAutoTest(FUNC2(Simd::Sve::InterleaveUv), FUNC2(SimdInterleaveUv));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && InterleaveUvAutoTest(FUNC2(Simd::Sve2::InterleaveUv), FUNC2(SimdInterleaveUv));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `InterleaveUv` implementation and runtime dispatch.
- Extend `InterleaveUvAutoTest` coverage for SVE2.
- Register the new SVE2 source in VS2022 project files and document release notes for 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=InterleaveUv -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O3 -DNDEBUG -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2Interleave.cpp -o /tmp/SimdSve2Interleave.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O3 -DNDEBUG -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdLib.cpp -o /tmp/SimdLib.aarch64.o`
- `aarch64-linux-gnu-g++ -std=c++17 -O3 -DNDEBUG -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Test/TestInterleave.cpp -o /tmp/TestInterleave.aarch64.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f15c9bd-c555-4131-91a8-06a4eae70dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f15c9bd-c555-4131-91a8-06a4eae70dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

