### PR TITLE
Add SVE2 InterleaveBgr optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -51,6 +51,7 @@
  <li>SVE2 optimizations of function DeinterleaveUv.</li>
  <li>SVE2 optimizations of function DeinterleaveBgr.</li>
  <li>SVE2 optimizations of function DeinterleaveBgra.</li>
+ <li>SVE2 optimizations of function InterleaveBgr.</li>
  <li>SVE2 optimizations of function GetStatistic.</li>
  <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
  <li>SVE2 optimizations of class ResizerByteArea2x2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3635,6 +3635,11 @@ SIMD_API void SimdInterleaveBgr(const uint8_t * b, size_t bStride, const uint8_t
         Sse41::InterleaveBgr(b, bStride, g, gStride, r, rStride, width, height, bgr, bgrStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::InterleaveBgr(b, bStride, g, gStride, r, rStride, width, height, bgr, bgrStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::InterleaveBgr(b, bStride, g, gStride, r, rStride, width, height, bgr, bgrStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -542,6 +542,9 @@ namespace Simd
         void InterleaveUv(const uint8_t* u, size_t uStride, const uint8_t* v, size_t vStride,
             size_t width, size_t height, uint8_t* uv, size_t uvStride);
 
+        void InterleaveBgr(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride);
+
         void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red);
 
         void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha);

--- a/src/Simd/SimdSve2Interleave.cpp
+++ b/src/Simd/SimdSve2Interleave.cpp
@@ -28,6 +28,27 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        SIMD_INLINE bool InitInterleaveBgrIndex(uint8_t index[3][3][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t part = 0; part < 3; ++part)
+            {
+                for (size_t channel = 0; channel < 3; ++channel)
+                {
+                    for (size_t i = 0; i < A; ++i)
+                    {
+                        size_t dst = part * A + i;
+                        index[part][channel][i] = dst % 3 == channel ? (uint8_t)(dst / 3) : 0xFF;
+                    }
+                }
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t INTERLEAVE_BGR_INDEX[3][3][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool INTERLEAVE_BGR_INDEX_INITED = InitInterleaveBgrIndex(INTERLEAVE_BGR_INDEX);
+
         SIMD_INLINE void InterleaveUv(const uint8_t* u, const uint8_t* v, uint8_t* uv,
             const svbool_t& load, const svbool_t& store0, const svbool_t& store1)
         {
@@ -57,6 +78,65 @@ namespace Simd
                 u += uStride;
                 v += vStride;
                 uv += uvStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint8_t InterleaveBgr(const svuint8_t& b, const svuint8_t& g, const svuint8_t& r,
+            const svuint8_t& indexB, const svuint8_t& indexG, const svuint8_t& indexR, const svbool_t& mask)
+        {
+            return svorr_u8_x(mask, svorr_u8_x(mask, svtbl_u8(b, indexB), svtbl_u8(g, indexG)), svtbl_u8(r, indexR));
+        }
+
+        SIMD_INLINE void InterleaveBgr(const uint8_t* b, const uint8_t* g, const uint8_t* r, uint8_t* bgr, size_t A,
+            const svuint8_t& indexB0, const svuint8_t& indexG0, const svuint8_t& indexR0,
+            const svuint8_t& indexB1, const svuint8_t& indexG1, const svuint8_t& indexR1,
+            const svuint8_t& indexB2, const svuint8_t& indexG2, const svuint8_t& indexR2,
+            const svbool_t& load, const svbool_t& store0, const svbool_t& store1, const svbool_t& store2)
+        {
+            svuint8_t _b = svld1_u8(load, b);
+            svuint8_t _g = svld1_u8(load, g);
+            svuint8_t _r = svld1_u8(load, r);
+            svst1_u8(store0, bgr + 0 * A, InterleaveBgr(_b, _g, _r, indexB0, indexG0, indexR0, store0));
+            svst1_u8(store1, bgr + 1 * A, InterleaveBgr(_b, _g, _r, indexB1, indexG1, indexR1, store1));
+            svst1_u8(store2, bgr + 2 * A, InterleaveBgr(_b, _g, _r, indexB2, indexG2, indexR2, store2));
+        }
+
+        void InterleaveBgr(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride)
+        {
+            size_t A = svcntb(), A3 = A * 3;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            size_t tailSize = (width - widthA) * 3;
+            const svbool_t tail0 = svwhilelt_b8(size_t(0) * A, tailSize);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1) * A, tailSize);
+            const svbool_t tail2 = svwhilelt_b8(size_t(2) * A, tailSize);
+            const svuint8_t indexB0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][0]);
+            const svuint8_t indexG0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][1]);
+            const svuint8_t indexR0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][2]);
+            const svuint8_t indexB1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][0]);
+            const svuint8_t indexG1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][1]);
+            const svuint8_t indexR1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][2]);
+            const svuint8_t indexB2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][0]);
+            const svuint8_t indexG2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][1]);
+            const svuint8_t indexR2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][2]);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    InterleaveBgr(b + col, g + col, r + col, bgr + offset, A,
+                        indexB0, indexG0, indexR0, indexB1, indexG1, indexR1, indexB2, indexG2, indexR2, body, body, body, body);
+                if (widthA < width)
+                    InterleaveBgr(b + col, g + col, r + col, bgr + offset, A,
+                        indexB0, indexG0, indexR0, indexB1, indexG1, indexR1, indexB2, indexG2, indexR2, tail, tail0, tail1, tail2);
+                b += bStride;
+                g += gStride;
+                r += rStride;
+                bgr += bgrStride;
             }
         }
     }

--- a/src/Test/TestInterleave.cpp
+++ b/src/Test/TestInterleave.cpp
@@ -212,6 +212,11 @@ namespace Test
             result = result && InterleaveBgrAutoTest(FUNC3(Simd::Sve::InterleaveBgr), FUNC3(SimdInterleaveBgr));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && InterleaveBgrAutoTest(FUNC3(Simd::Sve2::InterleaveBgr), FUNC3(SimdInterleaveBgr));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 `InterleaveBgr` implementation using table-based byte interleaving and predicated tail stores.
* Dispatch `SimdInterleaveBgr` through SVE2 and add SVE2 coverage to `InterleaveBgrAutoTest`.
* Document the new optimization in release 7.2.164 notes.

### Testing
* `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++11 -I/workspace/src -DSIMD_AVX512BW_DISABLE -DSIMD_AVX512VNNI_DISABLE -DSIMD_AMXBF16_DISABLE -fsyntax-only /workspace/src/Simd/SimdSve2Interleave.cpp`
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=InterleaveBgr -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-242f6c23-46ed-4fb2-a360-4052fcc516f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-242f6c23-46ed-4fb2-a360-4052fcc516f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

