### PR TITLE
Add SVE2 InterleaveBgra optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -52,6 +52,7 @@
  <li>SVE2 optimizations of function DeinterleaveBgr.</li>
  <li>SVE2 optimizations of function DeinterleaveBgra.</li>
  <li>SVE2 optimizations of function InterleaveBgr.</li>
+ <li>SVE2 optimizations of function InterleaveBgra.</li>
  <li>SVE2 optimizations of function GetStatistic.</li>
  <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
  <li>SVE2 optimizations of class ResizerByteArea2x2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3672,6 +3672,11 @@ SIMD_API void SimdInterleaveBgra(const uint8_t * b, size_t bStride, const uint8_
         Sse41::InterleaveBgra(b, bStride, g, gStride, r, rStride, a, aStride, width, height, bgra, bgraStride);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::InterleaveBgra(b, bStride, g, gStride, r, rStride, a, aStride, width, height, bgra, bgraStride);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::InterleaveBgra(b, bStride, g, gStride, r, rStride, a, aStride, width, height, bgra, bgraStride);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -545,6 +545,9 @@ namespace Simd
         void InterleaveBgr(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride,
             size_t width, size_t height, uint8_t* bgr, size_t bgrStride);
 
+        void InterleaveBgra(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride, const uint8_t* a, size_t aStride,
+            size_t width, size_t height, uint8_t* bgra, size_t bgraStride);
+
         void FillBgr(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red);
 
         void FillBgra(uint8_t* dst, size_t stride, size_t width, size_t height, uint8_t blue, uint8_t green, uint8_t red, uint8_t alpha);

--- a/src/Simd/SimdSve2Interleave.cpp
+++ b/src/Simd/SimdSve2Interleave.cpp
@@ -46,8 +46,29 @@ namespace Simd
             return true;
         }
 
+        SIMD_INLINE bool InitInterleaveBgraIndex(uint8_t index[4][4][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t part = 0; part < 4; ++part)
+            {
+                for (size_t channel = 0; channel < 4; ++channel)
+                {
+                    for (size_t i = 0; i < A; ++i)
+                    {
+                        size_t dst = part * A + i;
+                        index[part][channel][i] = dst % 4 == channel ? (uint8_t)(dst / 4) : 0xFF;
+                    }
+                }
+            }
+            return true;
+        }
+
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t INTERLEAVE_BGR_INDEX[3][3][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool INTERLEAVE_BGR_INDEX_INITED = InitInterleaveBgrIndex(INTERLEAVE_BGR_INDEX);
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t INTERLEAVE_BGRA_INDEX[4][4][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool INTERLEAVE_BGRA_INDEX_INITED = InitInterleaveBgraIndex(INTERLEAVE_BGRA_INDEX);
 
         SIMD_INLINE void InterleaveUv(const uint8_t* u, const uint8_t* v, uint8_t* uv,
             const svbool_t& load, const svbool_t& store0, const svbool_t& store1)
@@ -137,6 +158,82 @@ namespace Simd
                 g += gStride;
                 r += rStride;
                 bgr += bgrStride;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svuint8_t InterleaveBgra(const svuint8_t& b, const svuint8_t& g, const svuint8_t& r, const svuint8_t& a,
+            const svuint8_t& indexB, const svuint8_t& indexG, const svuint8_t& indexR, const svuint8_t& indexA, const svbool_t& mask)
+        {
+            return svorr_u8_x(mask, svorr_u8_x(mask, svtbl_u8(b, indexB), svtbl_u8(g, indexG)),
+                svorr_u8_x(mask, svtbl_u8(r, indexR), svtbl_u8(a, indexA)));
+        }
+
+        SIMD_INLINE void InterleaveBgra(const uint8_t* b, const uint8_t* g, const uint8_t* r, const uint8_t* a, uint8_t* bgra, size_t A,
+            const svuint8_t& indexB0, const svuint8_t& indexG0, const svuint8_t& indexR0, const svuint8_t& indexA0,
+            const svuint8_t& indexB1, const svuint8_t& indexG1, const svuint8_t& indexR1, const svuint8_t& indexA1,
+            const svuint8_t& indexB2, const svuint8_t& indexG2, const svuint8_t& indexR2, const svuint8_t& indexA2,
+            const svuint8_t& indexB3, const svuint8_t& indexG3, const svuint8_t& indexR3, const svuint8_t& indexA3,
+            const svbool_t& load, const svbool_t& store0, const svbool_t& store1, const svbool_t& store2, const svbool_t& store3)
+        {
+            svuint8_t _b = svld1_u8(load, b);
+            svuint8_t _g = svld1_u8(load, g);
+            svuint8_t _r = svld1_u8(load, r);
+            svuint8_t _a = svld1_u8(load, a);
+            svst1_u8(store0, bgra + 0 * A, InterleaveBgra(_b, _g, _r, _a, indexB0, indexG0, indexR0, indexA0, store0));
+            svst1_u8(store1, bgra + 1 * A, InterleaveBgra(_b, _g, _r, _a, indexB1, indexG1, indexR1, indexA1, store1));
+            svst1_u8(store2, bgra + 2 * A, InterleaveBgra(_b, _g, _r, _a, indexB2, indexG2, indexR2, indexA2, store2));
+            svst1_u8(store3, bgra + 3 * A, InterleaveBgra(_b, _g, _r, _a, indexB3, indexG3, indexR3, indexA3, store3));
+        }
+
+        void InterleaveBgra(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride, const uint8_t* a, size_t aStride,
+            size_t width, size_t height, uint8_t* bgra, size_t bgraStride)
+        {
+            size_t A = svcntb(), A4 = A * 4;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            size_t tailSize = (width - widthA) * 4;
+            const svbool_t tail0 = svwhilelt_b8(size_t(0) * A, tailSize);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1) * A, tailSize);
+            const svbool_t tail2 = svwhilelt_b8(size_t(2) * A, tailSize);
+            const svbool_t tail3 = svwhilelt_b8(size_t(3) * A, tailSize);
+            const svuint8_t indexB0 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[0][0]);
+            const svuint8_t indexG0 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[0][1]);
+            const svuint8_t indexR0 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[0][2]);
+            const svuint8_t indexA0 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[0][3]);
+            const svuint8_t indexB1 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[1][0]);
+            const svuint8_t indexG1 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[1][1]);
+            const svuint8_t indexR1 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[1][2]);
+            const svuint8_t indexA1 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[1][3]);
+            const svuint8_t indexB2 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[2][0]);
+            const svuint8_t indexG2 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[2][1]);
+            const svuint8_t indexR2 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[2][2]);
+            const svuint8_t indexA2 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[2][3]);
+            const svuint8_t indexB3 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[3][0]);
+            const svuint8_t indexG3 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[3][1]);
+            const svuint8_t indexR3 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[3][2]);
+            const svuint8_t indexA3 = svld1_u8(body, INTERLEAVE_BGRA_INDEX[3][3]);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A4)
+                    InterleaveBgra(b + col, g + col, r + col, a + col, bgra + offset, A,
+                        indexB0, indexG0, indexR0, indexA0, indexB1, indexG1, indexR1, indexA1,
+                        indexB2, indexG2, indexR2, indexA2, indexB3, indexG3, indexR3, indexA3,
+                        body, body, body, body, body);
+                if (widthA < width)
+                    InterleaveBgra(b + col, g + col, r + col, a + col, bgra + offset, A,
+                        indexB0, indexG0, indexR0, indexA0, indexB1, indexG1, indexR1, indexA1,
+                        indexB2, indexG2, indexR2, indexA2, indexB3, indexG3, indexR3, indexA3,
+                        tail, tail0, tail1, tail2, tail3);
+                b += bStride;
+                g += gStride;
+                r += rStride;
+                a += aStride;
+                bgra += bgraStride;
             }
         }
     }

--- a/src/Test/TestInterleave.cpp
+++ b/src/Test/TestInterleave.cpp
@@ -311,6 +311,11 @@ namespace Test
             result = result && InterleaveBgraAutoTest(FUNC4(Simd::Sve::InterleaveBgra), FUNC4(SimdInterleaveBgra));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && InterleaveBgraAutoTest(FUNC4(Simd::Sve2::InterleaveBgra), FUNC4(SimdInterleaveBgra));
+#endif
+
         return result;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 table-based optimization for `SimdInterleaveBgra`.
* Wire SVE2 BGRA interleave into the public dispatcher and auto-test coverage.
* Document the optimization in the 7.2.164 release notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=InterleaveBgra -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Interleave.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d891bb7a-ae4b-428b-a556-2a3541cb4392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d891bb7a-ae4b-428b-a556-2a3541cb4392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

