### PR TITLE
Add SVE2 OperationBinary16i optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function AbsDifferenceSums3x3Masked.</li>
  <li>SVE2 optimizations of function AbsGradientSaturatedSum.</li>
  <li>SVE2 optimizations of function Int16ToGray.</li>
+ <li>SVE2 optimizations of function OperationBinary16i.</li>
  <li>SVE2 optimizations of function DeinterleaveUv.</li>
  <li>SVE2 optimizations of function DeinterleaveBgr.</li>
  <li>SVE2 optimizations of function DeinterleaveBgra.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4722,6 +4722,11 @@ SIMD_API void SimdOperationBinary16i(const uint8_t * a, size_t aStride, const ui
         Sse41::OperationBinary16i(a, aStride, b, bStride, width, height, dst, dstStride, type);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcnth())
+        Sve2::OperationBinary16i(a, aStride, b, bStride, width, height, dst, dstStride, type);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::OperationBinary16i(a, aStride, b, bStride, width, height, dst, dstStride, type);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -401,6 +401,9 @@ namespace Simd
 
         void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
 
+        void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdOperationBinary16iType type);
+
         void VectorProduct(const uint8_t* vertical, const uint8_t* horizontal, uint8_t* dst, size_t stride, size_t width, size_t height);
       
         void BgraToBgr(const uint8_t* bgra, size_t width, size_t height, size_t bgraStride, uint8_t* bgr, size_t bgrStride);

--- a/src/Simd/SimdSve2Operation.cpp
+++ b/src/Simd/SimdSve2Operation.cpp
@@ -28,6 +28,65 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        template <SimdOperationBinary16iType type> SIMD_INLINE svint16_t OperationBinary16i(const svbool_t& mask, const svint16_t& a, const svint16_t& b);
+
+        template <> SIMD_INLINE svint16_t OperationBinary16i<SimdOperationBinary16iAddition>(const svbool_t& mask, const svint16_t& a, const svint16_t& b)
+        {
+            return svadd_s16_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svint16_t OperationBinary16i<SimdOperationBinary16iSubtraction>(const svbool_t& mask, const svint16_t& a, const svint16_t& b)
+        {
+            return svsub_s16_x(mask, a, b);
+        }
+
+        template <SimdOperationBinary16iType type> void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svlen(svint16_t());
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b16();
+            const svbool_t tail = svwhilelt_b16(widthA, width);
+            for (size_t row = 0; row < height; ++row)
+            {
+                const int16_t* pa = (const int16_t*)a;
+                const int16_t* pb = (const int16_t*)b;
+                int16_t* pd = (int16_t*)dst;
+                size_t col = 0;
+                for (; col < widthA; col += A)
+                {
+                    svint16_t _a = svld1_s16(body, pa + col);
+                    svint16_t _b = svld1_s16(body, pb + col);
+                    svst1_s16(body, pd + col, OperationBinary16i<type>(body, _a, _b));
+                }
+                if (widthA < width)
+                {
+                    svint16_t _a = svld1_s16(tail, pa + col);
+                    svint16_t _b = svld1_s16(tail, pb + col);
+                    svst1_s16(tail, pd + col, OperationBinary16i<type>(tail, _a, _b));
+                }
+                a += aStride;
+                b += bStride;
+                dst += dstStride;
+            }
+        }
+
+        void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdOperationBinary16iType type)
+        {
+            switch (type)
+            {
+            case SimdOperationBinary16iAddition:
+                return OperationBinary16i<SimdOperationBinary16iAddition>(a, aStride, b, bStride, width, height, dst, dstStride);
+            case SimdOperationBinary16iSubtraction:
+                return OperationBinary16i<SimdOperationBinary16iSubtraction>(a, aStride, b, bStride, width, height, dst, dstStride);
+            default:
+                assert(0);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE svuint8_t DivideI16By255(const svuint16_t & value)
         {
             const svbool_t full = svptrue_b16();

--- a/src/Test/TestOperation.cpp
+++ b/src/Test/TestOperation.cpp
@@ -268,6 +268,11 @@ namespace Test
             result = result && OperationBinary16iAutoTest(FUNC_OB16I(Simd::Sve::OperationBinary16i), FUNC_OB16I(SimdOperationBinary16i));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && OperationBinary16iAutoTest(FUNC_OB16I(Simd::Sve2::OperationBinary16i), FUNC_OB16I(SimdOperationBinary16i));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdOperationBinary16i`.
- Extend `OperationBinary16iAutoTest` coverage to the SVE2 implementation.
- Document the new SVE2 optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=OperationBinary16i -tt=1 -ts=1`
- `clang++ -fsyntax-only -target aarch64-linux-gnu -march=armv8.5-a+sve2 -I src -DSIMD_SVE2_ENABLE -DSIMD_SVE_ENABLE -DSIMD_ARM_ENABLE -DSIMD_STATIC src/Simd/SimdSve2Operation.cpp` was attempted but blocked by the missing AArch64 sysroot headers in this VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ae897f3-5f46-4945-aa75-27e45cc9031c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ae897f3-5f46-4945-aa75-27e45cc9031c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

