### PR TITLE
Add SVE2 OperationBinary8u optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of function AbsDifferenceSums3x3Masked.</li>
  <li>SVE2 optimizations of function AbsGradientSaturatedSum.</li>
  <li>SVE2 optimizations of function Int16ToGray.</li>
+ <li>SVE2 optimizations of function OperationBinary8u.</li>
  <li>SVE2 optimizations of function OperationBinary16i.</li>
  <li>SVE2 optimizations of function DeinterleaveUv.</li>
  <li>SVE2 optimizations of function DeinterleaveBgr.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4685,6 +4685,11 @@ SIMD_API void SimdOperationBinary8u(const uint8_t * a, size_t aStride, const uin
         Sse41::OperationBinary8u(a, aStride, b, bStride, width, height, channelCount, dst, dstStride, type);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable)
+        Sve2::OperationBinary8u(a, aStride, b, bStride, width, height, channelCount, dst, dstStride, type);
+    else
+#endif
 #ifdef SIMD_SVE_ENABLE
     if (Sve::Enable)
         Sve::OperationBinary8u(a, aStride, b, bStride, width, height, channelCount, dst, dstStride, type);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -401,6 +401,9 @@ namespace Simd
 
         void CosineDistance32f(const float* a, const float* b, size_t size, float* distance);
 
+        void OperationBinary8u(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride, SimdOperationBinary8uType type);
+
         void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
             size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdOperationBinary16iType type);
 

--- a/src/Simd/SimdSve2Operation.cpp
+++ b/src/Simd/SimdSve2Operation.cpp
@@ -28,6 +28,98 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
+        template <SimdOperationBinary8uType type> SIMD_INLINE svuint8_t OperationBinary8u(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b);
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uAverage>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svrhadd_u8_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uAnd>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svand_u8_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uOr>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svorr_u8_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uMaximum>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svmax_u8_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uMinimum>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svmin_u8_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uSaturatedSubtraction>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svqsub_u8_x(mask, a, b);
+        }
+
+        template <> SIMD_INLINE svuint8_t OperationBinary8u<SimdOperationBinary8uSaturatedAddition>(const svbool_t& mask, const svuint8_t& a, const svuint8_t& b)
+        {
+            return svqadd_u8_x(mask, a, b);
+        }
+
+        template <SimdOperationBinary8uType type> void OperationBinary8u(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride)
+        {
+            size_t A = svcntb();
+            size_t size = width * channelCount;
+            size_t sizeA = AlignLo(size, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(sizeA, size);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t offset = 0;
+                for (; offset < sizeA; offset += A)
+                {
+                    svuint8_t _a = svld1_u8(body, a + offset);
+                    svuint8_t _b = svld1_u8(body, b + offset);
+                    svst1_u8(body, dst + offset, OperationBinary8u<type>(body, _a, _b));
+                }
+                if (sizeA < size)
+                {
+                    svuint8_t _a = svld1_u8(tail, a + offset);
+                    svuint8_t _b = svld1_u8(tail, b + offset);
+                    svst1_u8(tail, dst + offset, OperationBinary8u<type>(tail, _a, _b));
+                }
+                a += aStride;
+                b += bStride;
+                dst += dstStride;
+            }
+        }
+
+        void OperationBinary8u(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
+            size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride, SimdOperationBinary8uType type)
+        {
+            switch (type)
+            {
+            case SimdOperationBinary8uAverage:
+                return OperationBinary8u<SimdOperationBinary8uAverage>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            case SimdOperationBinary8uAnd:
+                return OperationBinary8u<SimdOperationBinary8uAnd>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            case SimdOperationBinary8uOr:
+                return OperationBinary8u<SimdOperationBinary8uOr>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            case SimdOperationBinary8uMaximum:
+                return OperationBinary8u<SimdOperationBinary8uMaximum>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            case SimdOperationBinary8uMinimum:
+                return OperationBinary8u<SimdOperationBinary8uMinimum>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            case SimdOperationBinary8uSaturatedSubtraction:
+                return OperationBinary8u<SimdOperationBinary8uSaturatedSubtraction>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            case SimdOperationBinary8uSaturatedAddition:
+                return OperationBinary8u<SimdOperationBinary8uSaturatedAddition>(a, aStride, b, bStride, width, height, channelCount, dst, dstStride);
+            default:
+                assert(0);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         template <SimdOperationBinary16iType type> SIMD_INLINE svint16_t OperationBinary16i(const svbool_t& mask, const svint16_t& a, const svint16_t& b);
 
         template <> SIMD_INLINE svint16_t OperationBinary16i<SimdOperationBinary16iAddition>(const svbool_t& mask, const svint16_t& a, const svint16_t& b)

--- a/src/Test/TestOperation.cpp
+++ b/src/Test/TestOperation.cpp
@@ -191,6 +191,11 @@ namespace Test
             result = result && OperationBinary8uAutoTest(FUNC_OB8U(Simd::Sve::OperationBinary8u), FUNC_OB8U(SimdOperationBinary8u));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && OperationBinary8uAutoTest(FUNC_OB8U(Simd::Sve2::OperationBinary8u), FUNC_OB8U(SimdOperationBinary8u));
+#endif
+
 #ifdef SIMD_HVX_ENABLE
         if (Simd::Hvx::Enable && TestHvx(options) && W >= Simd::Hvx::A)
             result = result && OperationBinary8uAutoTest(FUNC_OB8U(Simd::Hvx::OperationBinary8u), FUNC_OB8U(SimdOperationBinary8u));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `OperationBinary8u` for average, bitwise, min/max, and saturated arithmetic operations.
- Route `SimdOperationBinary8u` through SVE2 before SVE/NEON when SVE2 is available.
- Extend `OperationBinary8uAutoTest` coverage and update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=OperationBinary8u -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++11 -fsyntax-only -I./src ./src/Simd/SimdSve2Operation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a234b31-c46e-4021-ab5e-1c7ad5813398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a234b31-c46e-4021-ab5e-1c7ad5813398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

