### PR TITLE
Add SVE2 SynetAdd8i optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -68,6 +68,7 @@
  <li>NEON, SVE2 optimizations of class RecursiveBilateralFilterPrecize.</li>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
+ <li>SVE2 optimizations of function SynetAdd8i.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -374,6 +374,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6219,7 +6219,7 @@ SIMD_API void SimdSynetAdd8i(const uint8_t* aData, const float* aScale, const fl
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetAdd8iPtr) (const uint8_t* aData, const float* aScale, const float* aShift, const uint8_t* bData, const float* bScale, const float* bShift,
         uint8_t* cData, const float* cScale, const float* cShift, size_t batch, size_t channels, size_t spatial, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);
-    const static SimdSynetAdd8iPtr simdSynetAdd8i = SIMD_FUNC4(SynetAdd8i, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetAdd8iPtr simdSynetAdd8i = SIMD_FUNC5(SynetAdd8i, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetAdd8i(aData, aScale, aShift, bData, bScale, bShift, cData, cScale, cShift, batch, channels, spatial, format, compatibility);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -586,6 +586,9 @@ namespace Simd
             const uint8_t* bkg, size_t bkgStride, const double* shiftX, const double* shiftY,
             size_t cropLeft, size_t cropTop, size_t cropRight, size_t cropBottom, uint8_t* dst, size_t dstStride);
 
+        void SynetAdd8i(const uint8_t* aData, const float* aScale, const float* aShift, const uint8_t* bData, const float* bScale, const float* bShift,
+            uint8_t* cData, const float* cScale, const float* cShift, size_t batch, size_t channels, size_t spatial, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetAdd.cpp
+++ b/src/Simd/SimdSve2SynetAdd.cpp
@@ -1,0 +1,117 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdBase.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE svfloat32_t SynetAdd8iLoad(const uint8_t* src, const svbool_t& mask)
+        {
+            return svcvt_f32_u32_x(mask, svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE svuint32_t SynetAdd8iConvert(const svfloat32_t& value, const svfloat32_t& scale,
+            const svfloat32_t& shift, float upper, const svbool_t& mask)
+        {
+            svfloat32_t dst = svmla_f32_x(mask, shift, value, scale);
+            dst = svmin_n_f32_x(mask, svmax_n_f32_x(mask, dst, 0.0f), upper);
+            return svcvt_u32_f32_x(mask, svadd_n_f32_x(mask, dst, 0.5f));
+        }
+
+        SIMD_INLINE void SynetAdd8i(const uint8_t* a, const svfloat32_t& aScale, const svfloat32_t& aShift,
+            const uint8_t* b, const svfloat32_t& bScale, const svfloat32_t& bShift, uint8_t* c,
+            const svfloat32_t& cScale, const svfloat32_t& cShift, float upper, const svbool_t& mask)
+        {
+            svfloat32_t _a = svmla_f32_x(mask, aShift, SynetAdd8iLoad(a, mask), aScale);
+            svfloat32_t _b = svmla_f32_x(mask, bShift, SynetAdd8iLoad(b, mask), bScale);
+            svst1b_u32(mask, c, SynetAdd8iConvert(svadd_f32_x(mask, _a, _b), cScale, cShift, upper, mask));
+        }
+
+        void SynetAdd8iNchw(const uint8_t* aData, const float* aScale, const float* aShift, const uint8_t* bData, const float* bScale, const float* bShift,
+            uint8_t* cData, const float* cScale, const float* cShift, size_t batch, size_t channels, size_t spatial, float upper)
+        {
+            const size_t F = svcntw();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _aScale = svdup_n_f32(aScale[c]);
+                    svfloat32_t _aShift = svdup_n_f32(aShift[c]);
+                    svfloat32_t _bScale = svdup_n_f32(bScale[c]);
+                    svfloat32_t _bShift = svdup_n_f32(bShift[c]);
+                    svfloat32_t _cScale = svdup_n_f32(cScale[c]);
+                    svfloat32_t _cShift = svdup_n_f32(cShift[c]);
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        SynetAdd8i(aData + s, _aScale, _aShift, bData + s, _bScale, _bShift, cData + s, _cScale, _cShift, upper, mask);
+                    }
+                    aData += spatial;
+                    bData += spatial;
+                    cData += spatial;
+                }
+            }
+        }
+
+        void SynetAdd8iNhwc(const uint8_t* aData, const float* aScale, const float* aShift, const uint8_t* bData, const float* bScale, const float* bShift,
+            uint8_t* cData, const float* cScale, const float* cShift, size_t batch, size_t channels, size_t spatial, float upper)
+        {
+            const size_t F = svcntw();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        SynetAdd8i(aData + c, svld1_f32(mask, aScale + c), svld1_f32(mask, aShift + c),
+                            bData + c, svld1_f32(mask, bScale + c), svld1_f32(mask, bShift + c),
+                            cData + c, svld1_f32(mask, cScale + c), svld1_f32(mask, cShift + c), upper, mask);
+                    }
+                    aData += channels;
+                    bData += channels;
+                    cData += channels;
+                }
+            }
+        }
+
+        void SynetAdd8i(const uint8_t* aData, const float* aScale, const float* aShift, const uint8_t* bData, const float* bScale, const float* bShift,
+            uint8_t* cData, const float* cScale, const float* cShift, size_t batch, size_t channels, size_t spatial, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility)
+        {
+            float upper = (float)(Base::Narrowed(compatibility) ? Base::U8_NARROWED_MAX : Base::U8_PRECISE_MAX);
+            if (format == SimdTensorFormatNchw)
+                SynetAdd8iNchw(aData, aScale, aShift, bData, bScale, bShift, cData, cScale, cShift, batch, channels, spatial, upper);
+            else if (format == SimdTensorFormatNhwc)
+                SynetAdd8iNhwc(aData, aScale, aShift, bData, bScale, bShift, cData, cScale, cShift, batch, channels, spatial, upper);
+            else
+                Base::SynetAdd8i(aData, aScale, aShift, bData, bScale, bShift, cData, cScale, cShift, batch, channels, spatial, format, compatibility);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetAdd.cpp
+++ b/src/Test/TestSynetAdd.cpp
@@ -263,6 +263,11 @@ namespace Test
             result = result && SynetAdd8iAutoTest(FUNC_A8I(Simd::Neon::SynetAdd8i), FUNC_A8I(SimdSynetAdd8i));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetAdd8iAutoTest(FUNC_A8I(Simd::Sve2::SynetAdd8i), FUNC_A8I(SimdSynetAdd8i));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetAdd8i` for NCHW and NHWC tensors.
- Wire SVE2 dispatch and direct auto-test coverage.
- Add VS2022 project entries and release 7.2.164 documentation note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetAdd8i -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -I./src -fsyntax-only ./src/Simd/SimdSve2SynetAdd.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70ad29b8-b5fb-4e98-8cf7-a233a7c70a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70ad29b8-b5fb-4e98-8cf7-a233a7c70a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

