### PR TITLE
Add SVE2 SynetAddBias optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -69,6 +69,7 @@
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
  <li>SVE2 optimizations of function SynetAdd8i.</li>
+ <li>SVE2 optimizations of function SynetAddBias.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6204,7 +6204,7 @@ SIMD_API void SimdSynetAddBias(const float * bias, size_t channels, size_t spati
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetAddBiasPtr) (const float * bias, size_t channels, size_t spatial, float * dst, SimdTensorFormatType format);
-    const static SimdSynetAddBiasPtr simdSynetAddBias = SIMD_FUNC4(SynetAddBias, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetAddBiasPtr simdSynetAddBias = SIMD_FUNC5(SynetAddBias, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetAddBias(bias, channels, spatial, dst, format);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -589,6 +589,8 @@ namespace Simd
         void SynetAdd8i(const uint8_t* aData, const float* aScale, const float* aShift, const uint8_t* bData, const float* bScale, const float* bShift,
             uint8_t* cData, const float* cScale, const float* cShift, size_t batch, size_t channels, size_t spatial, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);
 
+        void SynetAddBias(const float* bias, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetAdd.cpp
+++ b/src/Simd/SimdSve2SynetAdd.cpp
@@ -31,6 +31,73 @@ namespace Simd
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Sve2
     {
+        SIMD_INLINE void SynetAddBias(const svfloat32_t& bias, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), bias));
+        }
+
+        SIMD_INLINE void SynetAddBias(const float* bias, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, svadd_f32_x(mask, svld1_f32(mask, dst), svld1_f32(mask, bias)));
+        }
+
+        void SynetAddBiasNchw(const float* bias, size_t channels, size_t spatial, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            for (size_t c = 0; c < channels; ++c)
+            {
+                size_t s = 0;
+                svfloat32_t _bias = svdup_n_f32(bias[c]);
+                for (; s + QF <= spatial; s += QF)
+                {
+                    SynetAddBias(_bias, dst + s + 0 * F, body);
+                    SynetAddBias(_bias, dst + s + 1 * F, body);
+                    SynetAddBias(_bias, dst + s + 2 * F, body);
+                    SynetAddBias(_bias, dst + s + 3 * F, body);
+                }
+                for (; s + F <= spatial; s += F)
+                    SynetAddBias(_bias, dst + s, body);
+                if (s < spatial)
+                    SynetAddBias(_bias, dst + s, svwhilelt_b32(s, spatial));
+                dst += spatial;
+            }
+        }
+
+        void SynetAddBiasNhwc(const float* bias, size_t channels, size_t spatial, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            for (size_t s = 0; s < spatial; ++s)
+            {
+                size_t c = 0;
+                for (; c + QF <= channels; c += QF)
+                {
+                    SynetAddBias(bias + c + 0 * F, dst + c + 0 * F, body);
+                    SynetAddBias(bias + c + 1 * F, dst + c + 1 * F, body);
+                    SynetAddBias(bias + c + 2 * F, dst + c + 2 * F, body);
+                    SynetAddBias(bias + c + 3 * F, dst + c + 3 * F, body);
+                }
+                for (; c + F <= channels; c += F)
+                    SynetAddBias(bias + c, dst + c, body);
+                if (c < channels)
+                    SynetAddBias(bias + c, dst + c, svwhilelt_b32(c, channels));
+                dst += channels;
+            }
+        }
+
+        void SynetAddBias(const float* bias, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format)
+        {
+            if (Base::NchwCompatible(channels, spatial, format))
+                SynetAddBiasNchw(bias, channels, spatial, dst);
+            else if (Base::NhwcCompatible(channels, spatial, format))
+                SynetAddBiasNhwc(bias, channels, spatial, dst);
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE svfloat32_t SynetAdd8iLoad(const uint8_t* src, const svbool_t& mask)
         {
             return svcvt_f32_u32_x(mask, svld1ub_u32(mask, src));

--- a/src/Test/TestSynetAdd.cpp
+++ b/src/Test/TestSynetAdd.cpp
@@ -130,6 +130,11 @@ namespace Test
             result = result && SynetAddBiasAutoTest(FUNC_AB(Simd::Neon::SynetAddBias), FUNC_AB(SimdSynetAddBias));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetAddBiasAutoTest(FUNC_AB(Simd::Sve2::SynetAddBias), FUNC_AB(SimdSynetAddBias));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SimdSynetAddBias` for NCHW and NHWC tensor layouts.
- Route `SimdSynetAddBias` dispatch through the SVE2 backend and include SVE2 in the auto-test coverage.
- Document the new SVE2 optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetAddBias -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.2-a+sve2 -I src src/Simd/SimdSve2SynetAdd.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceb0b5bd-6508-4d41-9cad-3c2b5c3d9e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb0b5bd-6508-4d41-9cad-3c2b5c3d9e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

