### PR TITLE
Add SVE2 SynetAdd16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -68,7 +68,7 @@
  <li>NEON, SVE2 optimizations of class RecursiveBilateralFilterPrecize.</li>
  <li>SVE2 optimizations of function StretchGray2x2.</li>
  <li>SVE2 optimizations of function ShiftBilinear.</li>
- <li>NEON optimizations of function SynetAdd16b.</li>
+ <li>NEON, SVE2 optimizations of function SynetAdd16b.</li>
  <li>SVE2 optimizations of function SynetAdd8i.</li>
  <li>SVE2 optimizations of function SynetAddBias.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -97,6 +97,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -377,6 +377,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6179,7 +6179,7 @@ SIMD_API void* SimdSynetAdd16bInit(const size_t* aShape, size_t aCount, SimdTens
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetAdd16bInitPtr) (const size_t* aShape, size_t aCount, SimdTensorDataType aType, const size_t* bShape, size_t bCount, SimdTensorDataType bType, SimdTensorDataType dstType, SimdTensorFormatType format);
-    const static SimdSynetAdd16bInitPtr simdSynetAdd16bInit = SIMD_FUNC4(SynetAdd16bInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetAdd16bInitPtr simdSynetAdd16bInit = SIMD_FUNC5(SynetAdd16bInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetAdd16bInit(aShape, aCount, aType, bShape, bCount, bType, dstType, format);
 #else

--- a/src/Simd/SimdSve2SynetAdd16b.cpp
+++ b/src/Simd/SimdSve2SynetAdd16b.cpp
@@ -1,0 +1,142 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetAdd16b.h"
+#include "Simd/SimdSynetAdd16bCommon.h"
+#include "Simd/SimdBFloat16.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Sve2
+    {
+        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
+        {
+            svuint32_t bits = svreinterpret_u32_f32(value);
+            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+        }
+
+        SIMD_INLINE svfloat32_t BFloat16ToFloat32(svuint32_t value, const svbool_t& mask)
+        {
+            return svreinterpret_f32_u32(svlsl_n_u32_x(mask, value, Base::Bf16::SHIFT));
+        }
+
+        template <typename A> SIMD_INLINE svfloat32_t LoadAdd16b(const A* src, const svbool_t& mask);
+
+        template <> SIMD_INLINE svfloat32_t LoadAdd16b(const float* src, const svbool_t& mask)
+        {
+            return svld1_f32(mask, src);
+        }
+
+        template <> SIMD_INLINE svfloat32_t LoadAdd16b(const uint16_t* src, const svbool_t& mask)
+        {
+            return BFloat16ToFloat32(svld1uh_u32(mask, src), mask);
+        }
+
+        template <typename D> SIMD_INLINE void StoreAdd16b(D* dst, const svbool_t& mask, const svfloat32_t& value);
+
+        template <> SIMD_INLINE void StoreAdd16b(float* dst, const svbool_t& mask, const svfloat32_t& value)
+        {
+            svst1_f32(mask, dst, value);
+        }
+
+        template <> SIMD_INLINE void StoreAdd16b(uint16_t* dst, const svbool_t& mask, const svfloat32_t& value)
+        {
+            svst1h_u32(mask, dst, Float32ToBFloat16(value, mask));
+        }
+
+        template <typename A, typename B, typename D> SIMD_INLINE void Add16bF(const A* a, const B* b, D* dst, const svbool_t& mask)
+        {
+            StoreAdd16b(dst, mask, svadd_f32_x(mask, LoadAdd16b(a, mask), LoadAdd16b(b, mask)));
+        }
+
+        template <typename A, typename B, typename D> static void Add16bUniform(const uint8_t* a8, const uint8_t* b8, size_t size, uint8_t* dst8)
+        {
+            const A* a = (const A*)a8;
+            const B* b = (const B*)b8;
+            D* dst = (D*)dst8;
+            size_t F = svcntw(), sizeF = AlignLo(size, F), i = 0;
+            const svbool_t body = svptrue_b32();
+
+            for (; i < sizeF; i += F)
+                Add16bF(a + i, b + i, dst + i, body);
+            if (i < size)
+                Add16bF(a + i, b + i, dst + i, svwhilelt_b32(i, size));
+        }
+
+        template<class A, class B> static SynetAdd16bUniform::UniformPtr GetAdd16bUniform(SimdTensorDataType dType)
+        {
+            switch (dType)
+            {
+            case SimdTensorData32f: return Add16bUniform<A, B, float>;
+            case SimdTensorData16b: return Add16bUniform<A, B, uint16_t>;
+            default:
+                return NULL;
+            }
+        }
+
+        template<class A> static SynetAdd16bUniform::UniformPtr GetAdd16bUniform(SimdTensorDataType bType, SimdTensorDataType dType)
+        {
+            switch (bType)
+            {
+            case SimdTensorData32f: return GetAdd16bUniform<A, float>(dType);
+            case SimdTensorData16b: return GetAdd16bUniform<A, uint16_t>(dType);
+            default:
+                return NULL;
+            }
+        }
+
+        static SynetAdd16bUniform::UniformPtr GetAdd16bUniform(SimdTensorDataType aType, SimdTensorDataType bType, SimdTensorDataType dType)
+        {
+            switch (aType)
+            {
+            case SimdTensorData32f: return GetAdd16bUniform<float>(bType, dType);
+            case SimdTensorData16b: return GetAdd16bUniform<uint16_t>(bType, dType);
+            default:
+                return NULL;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetAdd16bUniform::SynetAdd16bUniform(const Add16bParam& p)
+            : Base::SynetAdd16bUniform(p)
+        {
+            _uniform = GetAdd16bUniform(p.aType, p.bType, p.dType);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetAdd16bInit(const size_t* aShape, size_t aCount, SimdTensorDataType aType, const size_t* bShape, size_t bCount, SimdTensorDataType bType, SimdTensorDataType dstType, SimdTensorFormatType format)
+        {
+            Add16bParam param(aShape, aCount, aType, bShape, bCount, bType, dstType, format);
+            if (!param.Valid())
+                return NULL;
+            if (Base::SynetAdd16bUniform::Preferable(param))
+                return new SynetAdd16bUniform(param);
+            return NULL;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetAdd16b.h
+++ b/src/Simd/SimdSynetAdd16b.h
@@ -111,6 +111,21 @@ namespace Simd
     }
 #endif
 
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        class SynetAdd16bUniform : public Base::SynetAdd16bUniform
+        {
+        public:
+            SynetAdd16bUniform(const Add16bParam& p);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetAdd16bInit(const size_t* aShape, size_t aCount, SimdTensorDataType aType, const size_t* bShape, size_t bCount, SimdTensorDataType bType, SimdTensorDataType dstType, SimdTensorFormatType format);
+    }
+#endif
+
 #ifdef SIMD_SSE41_ENABLE    
     namespace Sse41
     {

--- a/src/Test/TestSynetAdd.cpp
+++ b/src/Test/TestSynetAdd.cpp
@@ -423,6 +423,11 @@ namespace Test
             result = result && SynetAdd16bAutoTest(FUNC_A16B(Simd::Neon::SynetAdd16bInit), FUNC_A16B(SimdSynetAdd16bInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetAdd16bAutoTest(FUNC_A16B(Simd::Sve2::SynetAdd16bInit), FUNC_A16B(SimdSynetAdd16bInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 vectorized SynetAdd16b implementation for FP32/BF16 tensor addition.
* Route public SynetAdd16b init and auto-tests through the SVE2 path when available.
* Register the new SVE2 source in VS2022 project files and update release 7.2.164 notes.

### Testing
* `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.5-a+sve2 -I src src/Simd/SimdSve2SynetAdd16b.cpp`
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetAdd16b -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfe8d3b1-7dc5-402a-abe5-f3cc52ce791b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfe8d3b1-7dc5-402a-abe5-f3cc52ce791b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

