### PR TITLE
Add NEON SynetChannelSum16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -71,6 +71,7 @@
  <li>NEON, SVE2 optimizations of function SynetAdd16b.</li>
  <li>SVE2 optimizations of function SynetAdd8i.</li>
  <li>SVE2 optimizations of function SynetAddBias.</li>
+ <li>NEON optimizations of function SynetChannelSum16b.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6232,7 +6232,7 @@ SIMD_API void SimdSynetChannelSum16b(const uint16_t* src, size_t channels, size_
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetChannelSum16bPtr) (const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum);
-    const static SimdSynetChannelSum16bPtr simdSynetChannelSum16b = SIMD_FUNC3(SynetChannelSum16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetChannelSum16bPtr simdSynetChannelSum16b = SIMD_FUNC4(SynetChannelSum16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     simdSynetChannelSum16b(src, channels, spatial, format, sum);
 #else

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -506,6 +506,8 @@ namespace Simd
 
         void SynetAddBias(const float * bias, size_t channels, size_t spatial, float * dst, SimdTensorFormatType format);
 
+        void SynetChannelSum16b(const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum);
+
         void SynetConvert32fTo8u(const float* src, size_t batch, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* scale, const float* shift, uint8_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetConvert8uTo32f(const uint8_t* src, size_t batch, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* scale, const float* shift, float* dst, SimdSynetCompatibilityType compatibility);

--- a/src/Simd/SimdNeonSynet.cpp
+++ b/src/Simd/SimdNeonSynet.cpp
@@ -29,12 +29,116 @@
 #include "Simd/SimdExtract.h"
 #include "Simd/SimdPow.h"
 #include "Simd/SimdExp.h"
+#include "Simd/SimdBFloat16.h"
 
 namespace Simd
 {
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE) 
     namespace Neon
     {
+        SIMD_INLINE float32x4_t BFloat16ToFloat32(const uint16_t* src)
+        {
+            return BFloat16ToFloat32(vmovl_u16(vld1_u16(src)));
+        }
+
+        SIMD_INLINE void AddBFloat16ToSum(const uint16_t* src, float32x4_t& sum0, float32x4_t& sum1)
+        {
+            uint16x8_t _src = vld1q_u16(src);
+            sum0 = vaddq_f32(sum0, BFloat16ToFloat32(vmovl_u16(vget_low_u16(_src))));
+            sum1 = vaddq_f32(sum1, BFloat16ToFloat32(vmovl_u16(vget_high_u16(_src))));
+        }
+
+        void SynetChannelSum16b(const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum)
+        {
+            if (format == SimdTensorFormatNhwc)
+            {
+                size_t channels4 = AlignLo(channels, 4), channels8 = AlignLo(channels, 8);
+                size_t spatial4 = AlignLo(spatial, 4);
+                size_t c = 0;
+                for (; c < channels4; c += 4)
+                    vst1q_f32(sum + c, vdupq_n_f32(0.0f));
+                for (; c < channels; ++c)
+                    sum[c] = 0.0f;
+
+                size_t s = 0;
+                for (; s < spatial4; s += 4)
+                {
+                    const uint16_t* src0 = src + 0 * channels;
+                    const uint16_t* src1 = src + 1 * channels;
+                    const uint16_t* src2 = src + 2 * channels;
+                    const uint16_t* src3 = src + 3 * channels;
+                    size_t c = 0;
+                    for (; c < channels8; c += 8)
+                    {
+                        float32x4_t sum0 = vld1q_f32(sum + c + 0);
+                        float32x4_t sum1 = vld1q_f32(sum + c + 4);
+                        AddBFloat16ToSum(src0 + c, sum0, sum1);
+                        AddBFloat16ToSum(src1 + c, sum0, sum1);
+                        AddBFloat16ToSum(src2 + c, sum0, sum1);
+                        AddBFloat16ToSum(src3 + c, sum0, sum1);
+                        vst1q_f32(sum + c + 0, sum0);
+                        vst1q_f32(sum + c + 4, sum1);
+                    }
+                    for (; c < channels4; c += 4)
+                    {
+                        float32x4_t _sum = vld1q_f32(sum + c);
+                        _sum = vaddq_f32(_sum, BFloat16ToFloat32(src0 + c));
+                        _sum = vaddq_f32(_sum, BFloat16ToFloat32(src1 + c));
+                        _sum = vaddq_f32(_sum, BFloat16ToFloat32(src2 + c));
+                        _sum = vaddq_f32(_sum, BFloat16ToFloat32(src3 + c));
+                        vst1q_f32(sum + c, _sum);
+                    }
+                    for (; c < channels; ++c)
+                    {
+                        sum[c] += Base::BFloat16ToFloat32(src0[c]);
+                        sum[c] += Base::BFloat16ToFloat32(src1[c]);
+                        sum[c] += Base::BFloat16ToFloat32(src2[c]);
+                        sum[c] += Base::BFloat16ToFloat32(src3[c]);
+                    }
+                    src += channels * 4;
+                }
+                for (; s < spatial; ++s)
+                {
+                    c = 0;
+                    for (; c < channels8; c += 8)
+                    {
+                        float32x4_t sum0 = vld1q_f32(sum + c + 0);
+                        float32x4_t sum1 = vld1q_f32(sum + c + 4);
+                        AddBFloat16ToSum(src + c, sum0, sum1);
+                        vst1q_f32(sum + c + 0, sum0);
+                        vst1q_f32(sum + c + 4, sum1);
+                    }
+                    for (; c < channels4; c += 4)
+                        vst1q_f32(sum + c, vaddq_f32(vld1q_f32(sum + c), BFloat16ToFloat32(src + c)));
+                    for (; c < channels; ++c)
+                        sum[c] += Base::BFloat16ToFloat32(src[c]);
+                    src += channels;
+                }
+            }
+            else if (format == SimdTensorFormatNchw)
+            {
+                size_t spatial4 = AlignLo(spatial, 4), spatial8 = AlignLo(spatial, 8);
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f);
+                    size_t s = 0;
+                    for (; s < spatial8; s += 8)
+                        AddBFloat16ToSum(src + s, sum0, sum1);
+                    sum0 = vaddq_f32(sum0, sum1);
+                    for (; s < spatial4; s += 4)
+                        sum0 = vaddq_f32(sum0, BFloat16ToFloat32(src + s));
+                    sum[c] = ExtractSum32f(sum0);
+                    for (; s < spatial; ++s)
+                        sum[c] += Base::BFloat16ToFloat32(src[s]);
+                    src += spatial;
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         template <SimdSynetEltwiseOperationType type> float32x4_t SynetEltwiseLayerForward(float32x4_t src0, float32x4_t src1);
 
         template <> SIMD_INLINE float32x4_t SynetEltwiseLayerForward<SimdSynetEltwiseOperationProduct>(float32x4_t src0, float32x4_t src1)

--- a/src/Test/TestSynet.cpp
+++ b/src/Test/TestSynet.cpp
@@ -128,6 +128,11 @@ namespace Test
             result = result && SynetChannelSum16bAutoTest(FUNC_SCS16B(Simd::Avx512bw::SynetChannelSum16b), FUNC_SCS16B(SimdSynetChannelSum16b));
 #endif
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetChannelSum16bAutoTest(FUNC_SCS16B(Simd::Neon::SynetChannelSum16b), FUNC_SCS16B(SimdSynetChannelSum16b));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add NEON implementation and dispatch for `SynetChannelSum16b`.
* Add NEON coverage in `SynetChannelSum16bAutoTest`.
* Update release 7.2.164 notes.

### Validation
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetChannelSum16b -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -c src/Simd/SimdNeonSynet.cpp -o /tmp/SimdNeonSynet.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-834dabbc-0edd-43b6-9d73-f5b34db95355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-834dabbc-0edd-43b6-9d73-f5b34db95355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

