### PR TITLE
Add SVE2 SynetChannelSum16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -71,7 +71,7 @@
  <li>NEON, SVE2 optimizations of function SynetAdd16b.</li>
  <li>SVE2 optimizations of function SynetAdd8i.</li>
  <li>SVE2 optimizations of function SynetAddBias.</li>
- <li>NEON optimizations of function SynetChannelSum16b.</li>
+ <li>NEON, SVE2 optimizations of function SynetChannelSum16b.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Statistic.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StatisticMoments.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2StretchGray2x2.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2Synet.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -374,6 +374,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SquaredDifferenceSum.cpp">
       <Filter>Sve2\Statistics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2Synet.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6232,7 +6232,7 @@ SIMD_API void SimdSynetChannelSum16b(const uint16_t* src, size_t channels, size_
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetChannelSum16bPtr) (const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum);
-    const static SimdSynetChannelSum16bPtr simdSynetChannelSum16b = SIMD_FUNC4(SynetChannelSum16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetChannelSum16bPtr simdSynetChannelSum16b = SIMD_FUNC5(SynetChannelSum16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetChannelSum16b(src, channels, spatial, format, sum);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -591,6 +591,8 @@ namespace Simd
 
         void SynetAddBias(const float* bias, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
+        void SynetChannelSum16b(const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -1,0 +1,126 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdBase.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE svfloat32_t BFloat16ToFloat32(const uint16_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_f32_u32(svlsl_n_u32_x(mask, svld1uh_u32(mask, src), Base::Bf16::SHIFT));
+        }
+
+        SIMD_INLINE void AddBFloat16ToSum(const uint16_t* src, svfloat32_t& sum, const svbool_t& mask)
+        {
+            sum = svadd_f32_m(mask, sum, BFloat16ToFloat32(src, mask));
+        }
+
+        void SynetChannelSum16b(const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+
+            if (format == SimdTensorFormatNhwc)
+            {
+                size_t c = 0;
+                for (; c + QF <= channels; c += QF)
+                {
+                    svst1_f32(body, sum + c + 0 * F, svdup_n_f32(0.0f));
+                    svst1_f32(body, sum + c + 1 * F, svdup_n_f32(0.0f));
+                    svst1_f32(body, sum + c + 2 * F, svdup_n_f32(0.0f));
+                    svst1_f32(body, sum + c + 3 * F, svdup_n_f32(0.0f));
+                }
+                for (; c + F <= channels; c += F)
+                    svst1_f32(body, sum + c, svdup_n_f32(0.0f));
+                if (c < channels)
+                    svst1_f32(svwhilelt_b32(c, channels), sum + c, svdup_n_f32(0.0f));
+
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    c = 0;
+                    for (; c + QF <= channels; c += QF)
+                    {
+                        svfloat32_t sum0 = svld1_f32(body, sum + c + 0 * F);
+                        svfloat32_t sum1 = svld1_f32(body, sum + c + 1 * F);
+                        svfloat32_t sum2 = svld1_f32(body, sum + c + 2 * F);
+                        svfloat32_t sum3 = svld1_f32(body, sum + c + 3 * F);
+                        AddBFloat16ToSum(src + c + 0 * F, sum0, body);
+                        AddBFloat16ToSum(src + c + 1 * F, sum1, body);
+                        AddBFloat16ToSum(src + c + 2 * F, sum2, body);
+                        AddBFloat16ToSum(src + c + 3 * F, sum3, body);
+                        svst1_f32(body, sum + c + 0 * F, sum0);
+                        svst1_f32(body, sum + c + 1 * F, sum1);
+                        svst1_f32(body, sum + c + 2 * F, sum2);
+                        svst1_f32(body, sum + c + 3 * F, sum3);
+                    }
+                    for (; c + F <= channels; c += F)
+                    {
+                        svfloat32_t _sum = svld1_f32(body, sum + c);
+                        AddBFloat16ToSum(src + c, _sum, body);
+                        svst1_f32(body, sum + c, _sum);
+                    }
+                    if (c < channels)
+                    {
+                        svbool_t tail = svwhilelt_b32(c, channels);
+                        svfloat32_t _sum = svld1_f32(tail, sum + c);
+                        AddBFloat16ToSum(src + c, _sum, tail);
+                        svst1_f32(tail, sum + c, _sum);
+                    }
+                    src += channels;
+                }
+            }
+            else if (format == SimdTensorFormatNchw)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+                    svfloat32_t sum2 = svdup_n_f32(0.0f), sum3 = svdup_n_f32(0.0f);
+                    size_t s = 0;
+                    for (; s + QF <= spatial; s += QF)
+                    {
+                        AddBFloat16ToSum(src + s + 0 * F, sum0, body);
+                        AddBFloat16ToSum(src + s + 1 * F, sum1, body);
+                        AddBFloat16ToSum(src + s + 2 * F, sum2, body);
+                        AddBFloat16ToSum(src + s + 3 * F, sum3, body);
+                    }
+                    sum0 = svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), svadd_f32_x(body, sum2, sum3));
+                    for (; s + F <= spatial; s += F)
+                        AddBFloat16ToSum(src + s, sum0, body);
+                    if (s < spatial)
+                        AddBFloat16ToSum(src + s, sum0, svwhilelt_b32(s, spatial));
+                    sum[c] = svaddv_f32(body, sum0);
+                    src += spatial;
+                }
+            }
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynet.cpp
+++ b/src/Test/TestSynet.cpp
@@ -133,6 +133,11 @@ namespace Test
             result = result && SynetChannelSum16bAutoTest(FUNC_SCS16B(Simd::Neon::SynetChannelSum16b), FUNC_SCS16B(SimdSynetChannelSum16b));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetChannelSum16bAutoTest(FUNC_SCS16B(Simd::Sve2::SynetChannelSum16b), FUNC_SCS16B(SimdSynetChannelSum16b));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdSynetChannelSum16b`.
- Extend the auto-test to cover `Simd::Sve2::SynetChannelSum16b`.
- Register the new source in VS2022 SVE2 project files and update release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && cd build && ./Test "-r=.." -fi=SynetChannelSum16b -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdSve2Synet.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75cbc7bf-4342-4ebe-b4a6-5be6df79d232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75cbc7bf-4342-4ebe-b4a6-5be6df79d232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

