### PR TITLE
guard jpeg gray fast path against subsampled first component

### DIFF
--- a/src/Simd/SimdBaseImageLoadJpeg.cpp
+++ b/src/Simd/SimdBaseImageLoadJpeg.cpp
@@ -1325,7 +1325,11 @@ namespace Simd
 
         SIMD_INLINE bool CanCopyGray(const JpegContext& jc)
         {
-            return !(jc.img_n == 3 && (jc.rgb == 3 || (jc.app14_color_transform == 0 && !jc.jfif)));
+            // The gray fast path copies the full img_x by img_y image straight out of the first
+            // component plane, so it is only valid when that plane is full resolution. A subsampled
+            // first component leaves w2 by h2 smaller than the image and would be read out of bounds.
+            return !(jc.img_n == 3 && (jc.rgb == 3 || (jc.app14_color_transform == 0 && !jc.jfif))) &&
+                jc.img_comp[0].w2 >= jc.img_x && jc.img_comp[0].h2 >= jc.img_y;
         }
 
         SIMD_INLINE bool IsYuv444(const JpegContext & jc)


### PR DESCRIPTION
**Grayscale fast path over-reads a subsampled first component.**
`ImageJpegLoader::FromStream` has a fast path, gated by `CanCopyGray`, that returns a grayscale image by copying the first component plane straight into the output. It copies `img_x` by `img_y` bytes out of `img_comp[0].data`, which `JpegProcessFrameHeader` sizes only to that component's own `w2` by `h2` (`img_mcu_x * h * 8` by `img_mcu_y * v * 8`).

**The frame header never requires the first component to be full resolution.**
It checks only that each sampling factor divides the maximum, so a JPEG whose first component is subsampled (for example a JFIF three-component image with component 0 at 1x1 and component 1 at 2x2, or any four-component image) passes validation while leaving `w2` by `h2` smaller than the image. Decoding it as `SimdPixelFormatGray8` then reads past the end of the component buffer and copies the out-of-bounds heap bytes into the returned image.

**Fix: gate the fast path on the first component covering the image.**
`CanCopyGray` now also requires `img_comp[0].w2 >= img_x` and `img_comp[0].h2 >= img_y`, so a subsampled first component falls through to the general `JpegToRgba` path that resamples every plane to full resolution before converting. This matches the neighbouring `IsYuv420` and `IsYuv444` fast paths, which already gate on plane size, and it leaves single-component and full-resolution images on the fast path so decode performance is unchanged.
