### PR TITLE
Add SVE2 SynetConvert32fTo8u optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -72,6 +72,7 @@
  <li>SVE2 optimizations of function SynetAdd8i.</li>
  <li>SVE2 optimizations of function SynetAddBias.</li>
  <li>NEON, SVE2 optimizations of function SynetChannelSum16b.</li>
+ <li>SVE2 optimizations of function SynetConvert32fTo8u.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Synet.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -383,6 +383,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6245,7 +6245,7 @@ SIMD_API void SimdSynetConvert32fTo8u(const float* src, size_t batch, size_t cha
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetConvert32fTo8uPtr) (const float* src, size_t batch, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* scale, const float* shift, uint8_t* dst, SimdSynetCompatibilityType compatibility);
-    const static SimdSynetConvert32fTo8uPtr simdSynetConvert32fTo8u = SIMD_FUNC4(SynetConvert32fTo8u, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetConvert32fTo8uPtr simdSynetConvert32fTo8u = SIMD_FUNC5(SynetConvert32fTo8u, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetConvert32fTo8u(src, batch, channels, height, width, format, scale, shift, dst, compatibility);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -593,6 +593,9 @@ namespace Simd
 
         void SynetChannelSum16b(const uint16_t* src, size_t channels, size_t spatial, SimdTensorFormatType format, float* sum);
 
+        void SynetConvert32fTo8u(const float* src, size_t batch, size_t channels, size_t height, size_t width,
+            SimdTensorFormatType format, const float* scale, const float* shift, uint8_t* dst, SimdSynetCompatibilityType compatibility);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetConversion.cpp
+++ b/src/Simd/SimdSve2SynetConversion.cpp
@@ -1,0 +1,166 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdBase.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        template <bool nofma> SIMD_INLINE svfloat32_t Fmadd(const svfloat32_t& src, const svfloat32_t& scale, const svfloat32_t& shift, const svbool_t& mask)
+        {
+            if (nofma)
+                return svadd_f32_x(mask, svmul_f32_x(mask, src, scale), shift);
+            else
+                return svmla_f32_x(mask, shift, src, scale);
+        }
+
+        SIMD_INLINE svint32_t Round(const svfloat32_t& value, const svbool_t& mask)
+        {
+            svfloat32_t round = svsel_f32(svcmpgt_n_f32(mask, value, 0.0f), svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
+            return svcvt_s32_f32_x(mask, svadd_f32_x(mask, value, round));
+        }
+
+        template <bool nofma> SIMD_INLINE svuint32_t SynetConvert32fTo8u(const svfloat32_t& src, const svfloat32_t& scale, const svfloat32_t& shift, int upper, const svbool_t& mask)
+        {
+            svint32_t dst = Round(Fmadd<nofma>(src, scale, shift, mask), mask);
+            dst = svmin_n_s32_x(mask, svmax_n_s32_x(mask, dst, 0), upper);
+            return svreinterpret_u32_s32(dst);
+        }
+
+        template <bool nofma> SIMD_INLINE void SynetConvert32fTo8u(const float* src, const svfloat32_t& scale, const svfloat32_t& shift, int upper, uint8_t* dst, const svbool_t& mask)
+        {
+            svst1b_u32(mask, dst, SynetConvert32fTo8u<nofma>(svld1_f32(mask, src), scale, shift, upper, mask));
+        }
+
+        template <bool nofma> void SynetConvert32fTo8uNchw(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale, const float* shift, int upper, uint8_t* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _scale = svdup_n_f32(scale[c]);
+                    svfloat32_t _shift = svdup_n_f32(shift[c]);
+                    size_t s = 0;
+                    for (; s + QF <= spatial; s += QF)
+                    {
+                        SynetConvert32fTo8u<nofma>(src + s + 0 * F, _scale, _shift, upper, dst + s + 0 * F, body);
+                        SynetConvert32fTo8u<nofma>(src + s + 1 * F, _scale, _shift, upper, dst + s + 1 * F, body);
+                        SynetConvert32fTo8u<nofma>(src + s + 2 * F, _scale, _shift, upper, dst + s + 2 * F, body);
+                        SynetConvert32fTo8u<nofma>(src + s + 3 * F, _scale, _shift, upper, dst + s + 3 * F, body);
+                    }
+                    for (; s + F <= spatial; s += F)
+                        SynetConvert32fTo8u<nofma>(src + s, _scale, _shift, upper, dst + s, body);
+                    if (s < spatial)
+                        SynetConvert32fTo8u<nofma>(src + s, _scale, _shift, upper, dst + s, svwhilelt_b32(s, spatial));
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+        }
+
+        template <bool nofma> void SynetConvert32fTo8uNhwc(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale, const float* shift, int upper, uint8_t* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    size_t c = 0;
+                    for (; c + QF <= channels; c += QF)
+                    {
+                        SynetConvert32fTo8u<nofma>(src + c + 0 * F, svld1_f32(body, scale + c + 0 * F), svld1_f32(body, shift + c + 0 * F), upper, dst + c + 0 * F, body);
+                        SynetConvert32fTo8u<nofma>(src + c + 1 * F, svld1_f32(body, scale + c + 1 * F), svld1_f32(body, shift + c + 1 * F), upper, dst + c + 1 * F, body);
+                        SynetConvert32fTo8u<nofma>(src + c + 2 * F, svld1_f32(body, scale + c + 2 * F), svld1_f32(body, shift + c + 2 * F), upper, dst + c + 2 * F, body);
+                        SynetConvert32fTo8u<nofma>(src + c + 3 * F, svld1_f32(body, scale + c + 3 * F), svld1_f32(body, shift + c + 3 * F), upper, dst + c + 3 * F, body);
+                    }
+                    for (; c + F <= channels; c += F)
+                        SynetConvert32fTo8u<nofma>(src + c, svld1_f32(body, scale + c), svld1_f32(body, shift + c), upper, dst + c, body);
+                    if (c < channels)
+                    {
+                        svbool_t tail = svwhilelt_b32(c, channels);
+                        SynetConvert32fTo8u<nofma>(src + c, svld1_f32(tail, scale + c), svld1_f32(tail, shift + c), upper, dst + c, tail);
+                    }
+                    src += channels;
+                    dst += channels;
+                }
+            }
+        }
+
+        template <bool nofma> void SynetConvert32fTo8uNhwc3(const float* src, size_t batch, size_t spatial, const float* scale, const float* shift, int upper, uint8_t* dst)
+        {
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), 3);
+            svfloat32_t scale0 = svdup_n_f32(scale[0]), scale1 = svdup_n_f32(scale[1]), scale2 = svdup_n_f32(scale[2]);
+            svfloat32_t shift0 = svdup_n_f32(shift[0]), shift1 = svdup_n_f32(shift[1]), shift2 = svdup_n_f32(shift[2]);
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    const float* ps = src + 3 * s;
+                    uint8_t* pd = dst + 3 * s;
+                    svst1b_scatter_u32offset_u32(mask, pd + 0, offsets, SynetConvert32fTo8u<nofma>(svld1_gather_u32index_f32(mask, ps + 0, offsets), scale0, shift0, upper, mask));
+                    svst1b_scatter_u32offset_u32(mask, pd + 1, offsets, SynetConvert32fTo8u<nofma>(svld1_gather_u32index_f32(mask, ps + 1, offsets), scale1, shift1, upper, mask));
+                    svst1b_scatter_u32offset_u32(mask, pd + 2, offsets, SynetConvert32fTo8u<nofma>(svld1_gather_u32index_f32(mask, ps + 2, offsets), scale2, shift2, upper, mask));
+                }
+                src += 3 * spatial;
+                dst += 3 * spatial;
+            }
+        }
+
+        template <bool nofma> void SynetConvert32fTo8u(const float* src, size_t batch, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* scale, const float* shift, int upper, uint8_t* dst)
+        {
+            size_t spatial = height * width;
+            if (Base::NchwCompatible(channels, spatial, format))
+                SynetConvert32fTo8uNchw<nofma>(src, batch, channels, spatial, scale, shift, upper, dst);
+            else if (Base::NhwcCompatible(channels, spatial, format))
+            {
+                if (channels == 3)
+                    SynetConvert32fTo8uNhwc3<nofma>(src, batch, spatial, scale, shift, upper, dst);
+                else
+                    SynetConvert32fTo8uNhwc<nofma>(src, batch, channels, spatial, scale, shift, upper, dst);
+            }
+            else
+                assert(0);
+        }
+
+        void SynetConvert32fTo8u(const float* src, size_t batch, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* scale, const float* shift, uint8_t* dst, SimdSynetCompatibilityType compatibility)
+        {
+            int upper = Base::Narrowed(compatibility) ? Base::U8_NARROWED_MAX : Base::U8_PRECISE_MAX;
+            if (Base::FmaAvoid(compatibility))
+                SynetConvert32fTo8u<true>(src, batch, channels, height, width, format, scale, shift, upper, dst);
+            else
+                SynetConvert32fTo8u<false>(src, batch, channels, height, width, format, scale, shift, upper, dst);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetConversion.cpp
+++ b/src/Test/TestSynetConversion.cpp
@@ -135,6 +135,11 @@ namespace Test
             result = result && SynetConvert32fTo8uAutoTest(FUNC_C_32F_8U(Simd::Avx512bw::SynetConvert32fTo8u), FUNC_C_32F_8U(SimdSynetConvert32fTo8u));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetConvert32fTo8uAutoTest(FUNC_C_32F_8U(Simd::Sve2::SynetConvert32fTo8u), FUNC_C_32F_8U(SimdSynetConvert32fTo8u));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetConvert32fTo8uAutoTest(FUNC_C_32F_8U(Simd::Neon::SynetConvert32fTo8u), FUNC_C_32F_8U(SimdSynetConvert32fTo8u));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetConvert32fTo8u` for NCHW, NHWC, and NHWC3 tensors.
- Route `SimdSynetConvert32fTo8u` through SVE2 dispatch and add SVE2 auto-test coverage.
- Add the new SVE2 source to VS2022 project files and document the change in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetConvert32fTo8u -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2SynetConversion.cpp -o /tmp/SimdSve2SynetConversion.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce8cbf49-23d8-45d6-9eb3-735c1812af0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce8cbf49-23d8-45d6-9eb3-735c1812af0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

