### PR TITLE
Add SVE2 SynetDequantizeLinear optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -74,6 +74,7 @@
  <li>NEON, SVE2 optimizations of function SynetChannelSum16b.</li>
  <li>SVE2 optimizations of function SynetConvert32fTo8u.</li>
  <li>SVE2 optimizations of function SynetConvert8uTo32f.</li>
+ <li>SVE2 optimizations of function SynetDequantizeLinear.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -386,6 +386,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp">
       <Filter>Sve2\Motion</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6616,7 +6616,7 @@ SIMD_API void SimdSynetDequantizeLinear(const uint8_t* src, size_t size, int32_t
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetDequantizeLinearPtr) (const uint8_t* src, size_t size, int32_t bias, const float* norm, float* dst);
-    const static SimdSynetDequantizeLinearPtr simdSynetDequantizeLinear = SIMD_FUNC4(SynetDequantizeLinear, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetDequantizeLinearPtr simdSynetDequantizeLinear = SIMD_FUNC5(SynetDequantizeLinear, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetDequantizeLinear(src, size, bias, norm, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -599,6 +599,8 @@ namespace Simd
         void SynetConvert8uTo32f(const uint8_t* src, size_t batch, size_t channels, size_t height, size_t width,
             SimdTensorFormatType format, const float* scale, const float* shift, float* dst, SimdSynetCompatibilityType compatibility);
 
+        void SynetDequantizeLinear(const uint8_t* src, size_t size, int32_t bias, const float* norm, float* dst);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetQuantizeLinear.cpp
+++ b/src/Simd/SimdSve2SynetQuantizeLinear.cpp
@@ -1,0 +1,57 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void SynetDequantizeLinear(const uint8_t* src, const svint32_t& bias, const svfloat32_t& norm, float* dst, const svbool_t& mask)
+        {
+            svint32_t value = svadd_s32_x(mask, svreinterpret_s32_u32(svld1ub_u32(mask, src)), bias);
+            svst1_f32(mask, dst, svmul_f32_x(mask, svcvt_f32_s32_x(mask, value), norm));
+        }
+
+        void SynetDequantizeLinear(const uint8_t* src, size_t size, int32_t bias, const float* norm, float* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            svint32_t _bias = svdup_n_s32(bias);
+            svfloat32_t _norm = svdup_n_f32(norm[0]);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                SynetDequantizeLinear(src + i + 0 * F, _bias, _norm, dst + i + 0 * F, body);
+                SynetDequantizeLinear(src + i + 1 * F, _bias, _norm, dst + i + 1 * F, body);
+                SynetDequantizeLinear(src + i + 2 * F, _bias, _norm, dst + i + 2 * F, body);
+                SynetDequantizeLinear(src + i + 3 * F, _bias, _norm, dst + i + 3 * F, body);
+            }
+            for (; i < size; i += F)
+                SynetDequantizeLinear(src + i, _bias, _norm, dst + i, svwhilelt_b32(i, size));
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetQuantizeLinear.cpp
+++ b/src/Test/TestSynetQuantizeLinear.cpp
@@ -119,6 +119,11 @@ namespace Test
             result = result && SynetDequantizeLinearAutoTest(FUNC_DL(Simd::Neon::SynetDequantizeLinear), FUNC_DL(SimdSynetDequantizeLinear));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetDequantizeLinearAutoTest(FUNC_DL(Simd::Sve2::SynetDequantizeLinear), FUNC_DL(SimdSynetDequantizeLinear));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `SynetDequantizeLinear` and wire it into runtime dispatch.
- Extend the autotest coverage to compare the SVE2 path when available.
- Add the new SVE2 source to VS2022 project files and document the release note for 7.2.164.

### Testing
- Passed: `aarch64-linux-gnu-g++ -std=c++11 -fsyntax-only -I src -march=armv9-a+sve2 -msve-vector-bits=scalable src/Simd/SimdSve2SynetQuantizeLinear.cpp`
- Passed: `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- Passed: `cmake --build build --parallel$(nproc)`
- Passed: `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetDequantizeLinear -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f12430e-9b1b-4935-aaf4-1d45d53eb75a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f12430e-9b1b-4935-aaf4-1d45d53eb75a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

