### PR TITLE
Add SVE2 Synet eltwise optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -75,6 +75,7 @@
  <li>SVE2 optimizations of function SynetConvert32fTo8u.</li>
  <li>SVE2 optimizations of function SynetConvert8uTo32f.</li>
  <li>SVE2 optimizations of function SynetDequantizeLinear.</li>
+ <li>SVE2 optimizations of function SynetEltwiseLayerForward.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6629,7 +6629,7 @@ SIMD_API void SimdSynetEltwiseLayerForward(float const * const * src, const floa
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetEltwiseLayerForwardPtr) (float const * const * src, const float * weight, size_t count, size_t size, SimdSynetEltwiseOperationType type, float * dst);
-    const static SimdSynetEltwiseLayerForwardPtr simdSynetEltwiseLayerForward = SIMD_FUNC4(SynetEltwiseLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetEltwiseLayerForwardPtr simdSynetEltwiseLayerForward = SIMD_FUNC5(SynetEltwiseLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetEltwiseLayerForward(src, weight, count, size, type, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -601,6 +601,8 @@ namespace Simd
 
         void SynetDequantizeLinear(const uint8_t* src, size_t size, int32_t bias, const float* norm, float* dst);
 
+        void SynetEltwiseLayerForward(float const* const* src, const float* weight, size_t count, size_t size, SimdSynetEltwiseOperationType type, float* dst);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -121,6 +121,130 @@ namespace Simd
             else
                 assert(0);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <SimdSynetEltwiseOperationType type> svfloat32_t SynetEltwiseLayerForward(const svfloat32_t& src0, const svfloat32_t& src1, const svbool_t& mask);
+
+        template <> SIMD_INLINE svfloat32_t SynetEltwiseLayerForward<SimdSynetEltwiseOperationProduct>(const svfloat32_t& src0, const svfloat32_t& src1, const svbool_t& mask)
+        {
+            return svmul_f32_x(mask, src0, src1);
+        }
+
+        template <> SIMD_INLINE svfloat32_t SynetEltwiseLayerForward<SimdSynetEltwiseOperationMax>(const svfloat32_t& src0, const svfloat32_t& src1, const svbool_t& mask)
+        {
+            return svmax_f32_x(mask, src0, src1);
+        }
+
+        template <> SIMD_INLINE svfloat32_t SynetEltwiseLayerForward<SimdSynetEltwiseOperationMin>(const svfloat32_t& src0, const svfloat32_t& src1, const svbool_t& mask)
+        {
+            return svmin_f32_x(mask, src0, src1);
+        }
+
+        template <SimdSynetEltwiseOperationType type> SIMD_INLINE void SynetEltwiseLayerForward(const float* src0, const float* src1, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, SynetEltwiseLayerForward<type>(svld1_f32(mask, src0), svld1_f32(mask, src1), mask));
+        }
+
+        template <SimdSynetEltwiseOperationType type> void SynetEltwiseLayerForward(float const* const* src, size_t count, size_t size, float* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const float* src0 = src[0];
+            const float* src1 = src[1];
+            size_t j = 0;
+            for (; j + QF <= size; j += QF)
+            {
+                SynetEltwiseLayerForward<type>(src0 + j + 0 * F, src1 + j + 0 * F, dst + j + 0 * F, body);
+                SynetEltwiseLayerForward<type>(src0 + j + 1 * F, src1 + j + 1 * F, dst + j + 1 * F, body);
+                SynetEltwiseLayerForward<type>(src0 + j + 2 * F, src1 + j + 2 * F, dst + j + 2 * F, body);
+                SynetEltwiseLayerForward<type>(src0 + j + 3 * F, src1 + j + 3 * F, dst + j + 3 * F, body);
+            }
+            for (; j < size; j += F)
+                SynetEltwiseLayerForward<type>(src0 + j, src1 + j, dst + j, svwhilelt_b32(j, size));
+            for (size_t i = 2; i < count; ++i)
+            {
+                const float* srci = src[i];
+                j = 0;
+                for (; j + QF <= size; j += QF)
+                {
+                    SynetEltwiseLayerForward<type>(dst + j + 0 * F, srci + j + 0 * F, dst + j + 0 * F, body);
+                    SynetEltwiseLayerForward<type>(dst + j + 1 * F, srci + j + 1 * F, dst + j + 1 * F, body);
+                    SynetEltwiseLayerForward<type>(dst + j + 2 * F, srci + j + 2 * F, dst + j + 2 * F, body);
+                    SynetEltwiseLayerForward<type>(dst + j + 3 * F, srci + j + 3 * F, dst + j + 3 * F, body);
+                }
+                for (; j < size; j += F)
+                    SynetEltwiseLayerForward<type>(dst + j, srci + j, dst + j, svwhilelt_b32(j, size));
+            }
+        }
+
+        SIMD_INLINE void SynetEltwiseLayerForwardSum(const float* src0, const svfloat32_t& weight0, const float* src1, const svfloat32_t& weight1, float* dst, const svbool_t& mask)
+        {
+            svfloat32_t sum = svmul_f32_x(mask, svld1_f32(mask, src0), weight0);
+            svst1_f32(mask, dst, svmla_f32_x(mask, sum, svld1_f32(mask, src1), weight1));
+        }
+
+        SIMD_INLINE void SynetEltwiseLayerForwardSum(const float* src, const svfloat32_t& weight, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, svmla_f32_x(mask, svld1_f32(mask, dst), svld1_f32(mask, src), weight));
+        }
+
+        void SynetEltwiseLayerForwardSum(float const* const* src, const float* weight, size_t count, size_t size, float* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const float* src0 = src[0];
+            const float* src1 = src[1];
+            svfloat32_t weight0 = svdup_n_f32(weight[0]);
+            svfloat32_t weight1 = svdup_n_f32(weight[1]);
+            size_t j = 0;
+            for (; j + QF <= size; j += QF)
+            {
+                SynetEltwiseLayerForwardSum(src0 + j + 0 * F, weight0, src1 + j + 0 * F, weight1, dst + j + 0 * F, body);
+                SynetEltwiseLayerForwardSum(src0 + j + 1 * F, weight0, src1 + j + 1 * F, weight1, dst + j + 1 * F, body);
+                SynetEltwiseLayerForwardSum(src0 + j + 2 * F, weight0, src1 + j + 2 * F, weight1, dst + j + 2 * F, body);
+                SynetEltwiseLayerForwardSum(src0 + j + 3 * F, weight0, src1 + j + 3 * F, weight1, dst + j + 3 * F, body);
+            }
+            for (; j < size; j += F)
+                SynetEltwiseLayerForwardSum(src0 + j, weight0, src1 + j, weight1, dst + j, svwhilelt_b32(j, size));
+            for (size_t i = 2; i < count; ++i)
+            {
+                const float* srci = src[i];
+                svfloat32_t weighti = svdup_n_f32(weight[i]);
+                j = 0;
+                for (; j + QF <= size; j += QF)
+                {
+                    SynetEltwiseLayerForwardSum(srci + j + 0 * F, weighti, dst + j + 0 * F, body);
+                    SynetEltwiseLayerForwardSum(srci + j + 1 * F, weighti, dst + j + 1 * F, body);
+                    SynetEltwiseLayerForwardSum(srci + j + 2 * F, weighti, dst + j + 2 * F, body);
+                    SynetEltwiseLayerForwardSum(srci + j + 3 * F, weighti, dst + j + 3 * F, body);
+                }
+                for (; j < size; j += F)
+                    SynetEltwiseLayerForwardSum(srci + j, weighti, dst + j, svwhilelt_b32(j, size));
+            }
+        }
+
+        void SynetEltwiseLayerForward(float const* const* src, const float* weight, size_t count, size_t size, SimdSynetEltwiseOperationType type, float* dst)
+        {
+            assert(count >= 2);
+            switch (type)
+            {
+            case SimdSynetEltwiseOperationProduct:
+                SynetEltwiseLayerForward<SimdSynetEltwiseOperationProduct>(src, count, size, dst);
+                break;
+            case SimdSynetEltwiseOperationSum:
+                SynetEltwiseLayerForwardSum(src, weight, count, size, dst);
+                break;
+            case SimdSynetEltwiseOperationMax:
+                SynetEltwiseLayerForward<SimdSynetEltwiseOperationMax>(src, count, size, dst);
+                break;
+            case SimdSynetEltwiseOperationMin:
+                SynetEltwiseLayerForward<SimdSynetEltwiseOperationMin>(src, count, size, dst);
+                break;
+            default:
+                assert(0);
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestSynet.cpp
+++ b/src/Test/TestSynet.cpp
@@ -251,6 +251,11 @@ namespace Test
             result = result && SynetEltwiseLayerForwardAutoTest(FUNC_ELF(Simd::Neon::SynetEltwiseLayerForward), FUNC_ELF(SimdSynetEltwiseLayerForward));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetEltwiseLayerForwardAutoTest(FUNC_ELF(Simd::Sve2::SynetEltwiseLayerForward), FUNC_ELF(SimdSynetEltwiseLayerForward));
+#endif 
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetEltwiseLayerForward` for product, weighted sum, max, and min operations.
- Wire SVE2 dispatch and auto-test coverage for `SimdSynetEltwiseLayerForward`.
- Document the release note for version 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetEltwiseLayerForward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.6-a+sve2 -I src -c src/Simd/SimdSve2Synet.cpp -o /tmp/SimdSve2Synet.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe87c36e-aa9b-41c0-9552-27f4cda98a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe87c36e-aa9b-41c0-9552-27f4cda98a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

