### PR TITLE
Add SVE2 SynetGelu32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -381,6 +381,7 @@
  <li>SVE2 optimizations of function FillBgra.</li>
  <li>SVE2 optimizations of function FillPixel.</li>
  <li>SVE2 optimizations of function InterleaveUv.</li>
+ <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>Support of RISCV/RISCV64 platform.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcGemmV1.</li>
  <li>Base implementation, AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcSpecV1.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6700,7 +6700,7 @@ SIMD_API void SimdSynetGelu32f(const float* src, size_t size, float* dst)
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetGelu32fPtr) (const float* src, size_t size, float* dst);
-    const static SimdSynetGelu32fPtr simdSynetGelu32f = SIMD_FUNC4(SynetGelu32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetGelu32fPtr simdSynetGelu32f = SIMD_FUNC5(SynetGelu32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetGelu32f(src, size, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -605,6 +605,8 @@ namespace Simd
 
         void SynetElu32f(const float* src, size_t size, const float* alpha, float* dst);
 
+        void SynetGelu32f(const float* src, size_t size, float* dst);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -85,6 +85,55 @@ namespace Simd
             if (i < size)
                 SynetElu32f(src + i, svwhilelt_b32(i, size), _alpha, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
+        {
+            const svfloat32_t _1 = svdup_n_f32(1.0f);
+            svfloat32_t a = svmin_f32_x(mask, svabs_f32_x(mask, x), svdup_n_f32(9.0f));
+            svfloat32_t p = svdup_n_f32(0.0000430638f);
+            p = svmla_f32_x(mask, svdup_n_f32(0.0002765672f), a, p);
+            p = svmla_f32_x(mask, svdup_n_f32(0.0001520143f), a, p);
+            p = svmla_f32_x(mask, svdup_n_f32(0.0092705272f), a, p);
+            p = svmla_f32_x(mask, svdup_n_f32(0.0422820123f), a, p);
+            p = svmla_f32_x(mask, svdup_n_f32(0.0705230784f), a, p);
+            p = svmla_f32_x(mask, _1, a, p);
+            p = svmul_f32_x(mask, p, p);
+            p = svmul_f32_x(mask, p, p);
+            p = svmul_f32_x(mask, p, p);
+            p = svmul_f32_x(mask, p, p);
+            svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
+            return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
+        }
+
+        SIMD_INLINE svfloat32_t Gelu(const svbool_t& mask, svfloat32_t x)
+        {
+            svfloat32_t t = svmul_n_f32_x(mask, x, float(M_SQRT1_2));
+            return svmul_f32_x(mask, svmul_n_f32_x(mask, t, float(M_SQRT1_2)), svadd_n_f32_x(mask, Erf(mask, t), 1.0f));
+        }
+
+        SIMD_INLINE void SynetGelu32f(const float* src, const svbool_t& mask, float* dst)
+        {
+            svst1_f32(mask, dst, Gelu(mask, svld1_f32(mask, src)));
+        }
+
+        void SynetGelu32f(const float* src, size_t size, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            for (; i + QF <= size; i += QF)
+            {
+                SynetGelu32f(src + i + 0 * F, body, dst + i + 0 * F);
+                SynetGelu32f(src + i + 1 * F, body, dst + i + 1 * F);
+                SynetGelu32f(src + i + 2 * F, body, dst + i + 2 * F);
+                SynetGelu32f(src + i + 3 * F, body, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetGelu32f(src + i, body, dst + i);
+            if (i < size)
+                SynetGelu32f(src + i, svwhilelt_b32(i, size), dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -198,6 +198,11 @@ namespace Test
             result = result && SynetGelu32fAutoTest(FUNC_GELU32F(Simd::Avx512bw::SynetGelu32f), FUNC_GELU32F(SimdSynetGelu32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetGelu32fAutoTest(FUNC_GELU32F(Simd::Sve2::SynetGelu32f), FUNC_GELU32F(SimdSynetGelu32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetGelu32fAutoTest(FUNC_GELU32F(Simd::Neon::SynetGelu32f), FUNC_GELU32F(SimdSynetGelu32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatcher wiring for `SimdSynetGelu32f`.
- Add SVE2 coverage to `Test::SynetGelu32fAutoTest`.
- Update release 7.2.163 notes for the new SVE2 optimization.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetGelu32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -march=armv8.2-a+sve2 -I src -c src/Simd/SimdSve2SynetActivation.cpp -o /tmp/SimdSve2SynetActivation.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-181c13de-70b0-467a-beac-30f3ffe81590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-181c13de-70b0-467a-beac-30f3ffe81590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

