### PR TITLE
Add SVE2 SynetHardSigmoid32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -78,6 +78,7 @@
  <li>SVE2 optimizations of function SynetEltwiseLayerForward.</li>
  <li>SVE2 optimizations of function SynetElu32f.</li>
  <li>SVE2 optimizations of function SynetGelu32f.</li>
+ <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>NEON, SVE2 optimizations of class SynetGridSample2d32fBlZ.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6750,7 +6750,7 @@ SIMD_API void SimdSynetHardSigmoid32f(const float* src, size_t size, const float
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetHardSigmoid32fPtr) (const float* src, size_t size, const float* scale, const float* shift, float* dst);
-    const static SimdSynetHardSigmoid32fPtr simdSynetHardSigmoid32f = SIMD_FUNC4(SynetHardSigmoid32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetHardSigmoid32fPtr simdSynetHardSigmoid32f = SIMD_FUNC5(SynetHardSigmoid32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetHardSigmoid32f(src, size, scale, shift, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -607,6 +607,8 @@ namespace Simd
 
         void SynetGelu32f(const float* src, size_t size, float* dst);
 
+        void SynetHardSigmoid32f(const float* src, size_t size, const float* scale, const float* shift, float* dst);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -134,6 +134,37 @@ namespace Simd
             if (i < size)
                 SynetGelu32f(src + i, svwhilelt_b32(i, size), dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetHardSigmoid32f(const svbool_t& mask, svfloat32_t value, svfloat32_t scale, svfloat32_t shift)
+        {
+            return svmax_f32_x(mask, svmin_f32_x(mask, svmla_f32_x(mask, shift, value, scale), svdup_n_f32(1.0f)), svdup_n_f32(0.0f));
+        }
+
+        SIMD_INLINE void SynetHardSigmoid32f(const float* src, const svbool_t& mask, svfloat32_t scale, svfloat32_t shift, float* dst)
+        {
+            svst1_f32(mask, dst, SynetHardSigmoid32f(mask, svld1_f32(mask, src), scale, shift));
+        }
+
+        void SynetHardSigmoid32f(const float* src, size_t size, const float* scale, const float* shift, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _scale = svdup_n_f32(scale[0]);
+            const svfloat32_t _shift = svdup_n_f32(shift[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetHardSigmoid32f(src + i + 0 * F, body, _scale, _shift, dst + i + 0 * F);
+                SynetHardSigmoid32f(src + i + 1 * F, body, _scale, _shift, dst + i + 1 * F);
+                SynetHardSigmoid32f(src + i + 2 * F, body, _scale, _shift, dst + i + 2 * F);
+                SynetHardSigmoid32f(src + i + 3 * F, body, _scale, _shift, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetHardSigmoid32f(src + i, body, _scale, _shift, dst + i);
+            if (i < size)
+                SynetHardSigmoid32f(src + i, svwhilelt_b32(i, size), _scale, _shift, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -291,6 +291,11 @@ namespace Test
             result = result && SynetHardSigmoid32fAutoTest(FUNC_HARDSIGMOID32F(Simd::Avx512bw::SynetHardSigmoid32f), FUNC_HARDSIGMOID32F(SimdSynetHardSigmoid32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetHardSigmoid32fAutoTest(FUNC_HARDSIGMOID32F(Simd::Sve2::SynetHardSigmoid32f), FUNC_HARDSIGMOID32F(SimdSynetHardSigmoid32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetHardSigmoid32fAutoTest(FUNC_HARDSIGMOID32F(Simd::Neon::SynetHardSigmoid32f), FUNC_HARDSIGMOID32F(SimdSynetHardSigmoid32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdSynetHardSigmoid32f`.
- Extend `SynetHardSigmoid32fAutoTest` to cover the SVE2 implementation when available.
- Document the optimization in release 7.2.164 notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetHardSigmoid32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdSve2SynetActivation.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv9-a+sve2 -msve-vector-bits=scalable -I src src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-417edf50-3bcd-436f-abb2-d7df27f7742f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-417edf50-3bcd-436f-abb2-d7df27f7742f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

