### PR TITLE
Add SVE2 SynetHswish32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -79,6 +79,7 @@
  <li>SVE2 optimizations of function SynetElu32f.</li>
  <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
+ <li>SVE2 optimizations of function SynetHswish32f.</li>
  <li>NEON, SVE2 optimizations of class SynetGridSample2d32fBlZ.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6763,7 +6763,7 @@ SIMD_API void SimdSynetHswish32f(const float * src, size_t size, const float * s
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetHswish32fPtr) (const float * src, size_t size, const float * shift, const float * scale, float * dst);
-    const static SimdSynetHswish32fPtr simdSynetHswish32f = SIMD_FUNC4(SynetHswish32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetHswish32fPtr simdSynetHswish32f = SIMD_FUNC5(SynetHswish32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetHswish32f(src, size, shift, scale, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -609,6 +609,8 @@ namespace Simd
 
         void SynetHardSigmoid32f(const float* src, size_t size, const float* scale, const float* shift, float* dst);
 
+        void SynetHswish32f(const float* src, size_t size, const float* shift, const float* scale, float* dst);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -165,6 +165,39 @@ namespace Simd
             if (i < size)
                 SynetHardSigmoid32f(src + i, svwhilelt_b32(i, size), _scale, _shift, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetHswish32f(const svbool_t& mask, svfloat32_t value, svfloat32_t shift, svfloat32_t scale)
+        {
+            svfloat32_t upper = svmin_f32_x(mask, value, shift);
+            svfloat32_t positive = svmax_f32_x(mask, svadd_f32_x(mask, upper, shift), svdup_n_f32(0.0f));
+            return svmul_f32_x(mask, svmul_f32_x(mask, positive, scale), value);
+        }
+
+        SIMD_INLINE void SynetHswish32f(const float* src, const svbool_t& mask, svfloat32_t shift, svfloat32_t scale, float* dst)
+        {
+            svst1_f32(mask, dst, SynetHswish32f(mask, svld1_f32(mask, src), shift, scale));
+        }
+
+        void SynetHswish32f(const float* src, size_t size, const float* shift, const float* scale, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _shift = svdup_n_f32(shift[0]);
+            const svfloat32_t _scale = svdup_n_f32(scale[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetHswish32f(src + i + 0 * F, body, _shift, _scale, dst + i + 0 * F);
+                SynetHswish32f(src + i + 1 * F, body, _shift, _scale, dst + i + 1 * F);
+                SynetHswish32f(src + i + 2 * F, body, _shift, _scale, dst + i + 2 * F);
+                SynetHswish32f(src + i + 3 * F, body, _shift, _scale, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetHswish32f(src + i, body, _shift, _scale, dst + i);
+            if (i < size)
+                SynetHswish32f(src + i, svwhilelt_b32(i, size), _shift, _scale, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -384,6 +384,11 @@ namespace Test
             result = result && SynetHswish32fAutoTest(FUNC_HSWISH32F(Simd::Avx512bw::SynetHswish32f), FUNC_HSWISH32F(SimdSynetHswish32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetHswish32fAutoTest(FUNC_HSWISH32F(Simd::Sve2::SynetHswish32f), FUNC_HSWISH32F(SimdSynetHswish32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetHswish32fAutoTest(FUNC_HSWISH32F(Simd::Neon::SynetHswish32f), FUNC_HSWISH32F(SimdSynetHswish32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdSynetHswish32f`.
- Add SVE2 coverage to `Test::SynetHswish32fAutoTest`.
- Update 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=SynetHswish32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2SynetActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eebbe623-8a1d-4241-9ec6-f3d62ce74917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eebbe623-8a1d-4241-9ec6-f3d62ce74917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

