### PR TITLE
Add SVE2 optimization for SynetLrnLayerCrossChannels

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,7 @@
  <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
+ <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>
  <li>NEON, SVE2 optimizations of class SynetGridSample2d32fBlZ.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6929,7 +6929,7 @@ SIMD_API void SimdSynetLrnLayerCrossChannels(const float * src, size_t half, siz
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetLrnLayerCrossChannelsPtr) (const float * src, size_t half, size_t channels, size_t spatial, const float * k, float * dst, SimdTensorFormatType format);
-    const static SimdSynetLrnLayerCrossChannelsPtr simdSynetLrnLayerCrossChannels = SIMD_FUNC4(SynetLrnLayerCrossChannels, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetLrnLayerCrossChannelsPtr simdSynetLrnLayerCrossChannels = SIMD_FUNC5(SynetLrnLayerCrossChannels, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetLrnLayerCrossChannels(src, half, channels, spatial, k, dst, format);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -611,6 +611,8 @@ namespace Simd
 
         void SynetHswish32f(const float* src, size_t size, const float* shift, const float* scale, float* dst);
 
+        void SynetLrnLayerCrossChannels(const float* src, size_t half, size_t channels, size_t spatial, const float* k, float* dst, SimdTensorFormatType format);
+
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
 
         void GetRowSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums);

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -25,6 +25,7 @@
 #include "Simd/SimdSynet.h"
 #include "Simd/SimdSve2.h"
 #include "Simd/SimdBase.h"
+#include "Simd/SimdPow.h"
 
 namespace Simd
 {
@@ -244,6 +245,113 @@ namespace Simd
             default:
                 assert(0);
             }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t Square(const svbool_t& mask, const float* src)
+        {
+            svfloat32_t _src = svld1_f32(mask, src);
+            return svmul_f32_x(mask, _src, _src);
+        }
+
+        void SynetLrnLayerCrossChannelsNchw(const float* src, size_t half, size_t channels, size_t spatial, const float* k, float* dst)
+        {
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            svfloat32_t k0 = svdup_n_f32(k[0]);
+            svfloat32_t k1 = svdup_n_f32(k[1]);
+            svfloat32_t k2 = svdup_n_f32(k[2]);
+            Sve2::Pow pow;
+            Array32f sum(spatial, true), zero(spatial, true);
+            for (size_t c = 0; c < half; ++c)
+            {
+                const float* pos = src + c * spatial;
+                size_t s = 0;
+                for (; s + F <= spatial; s += F)
+                    svst1_f32(body, sum.data + s, svadd_f32_x(body, svld1_f32(body, sum.data + s), Square(body, pos + s)));
+                if (s < spatial)
+                {
+                    svbool_t tail = svwhilelt_b32(s, spatial);
+                    svst1_f32(tail, sum.data + s, svadd_f32_x(tail, svld1_f32(tail, sum.data + s), Square(tail, pos + s)));
+                }
+            }
+            for (size_t c = 0; c < channels; ++c)
+            {
+                const float* pos = (c < channels - half) ? src + half * spatial : zero.data;
+                const float* neg = (c > half) ? src - (half + 1) * spatial : zero.data;
+                size_t s = 0;
+                for (; s + F <= spatial; s += F)
+                {
+                    svfloat32_t _sum = svld1_f32(body, sum.data + s);
+                    _sum = svsub_f32_x(body, svadd_f32_x(body, _sum, Square(body, pos + s)), Square(body, neg + s));
+                    svst1_f32(body, sum.data + s, _sum);
+                    svst1_f32(body, dst + s, svmul_f32_x(body, svld1_f32(body, src + s), pow(body, svmla_f32_x(body, k0, k1, _sum), k2)));
+                }
+                if (s < spatial)
+                {
+                    svbool_t tail = svwhilelt_b32(s, spatial);
+                    svfloat32_t _sum = svld1_f32(tail, sum.data + s);
+                    _sum = svsub_f32_x(tail, svadd_f32_x(tail, _sum, Square(tail, pos + s)), Square(tail, neg + s));
+                    svst1_f32(tail, sum.data + s, _sum);
+                    svst1_f32(tail, dst + s, svmul_f32_x(tail, svld1_f32(tail, src + s), pow(tail, svmla_f32_x(tail, k0, k1, _sum), k2)));
+                }
+                src += spatial;
+                dst += spatial;
+            }
+        }
+
+        SIMD_INLINE float SynetLrnLayerCrossChannelsNhwc(const float* src, size_t half, size_t channels, size_t c, const float* k)
+        {
+            float sum = 0.0f;
+            size_t beg = c > half ? c - half : 0;
+            size_t end = Simd::Min(c + half + 1, channels);
+            for (size_t i = beg; i < end; ++i)
+                sum += Simd::Square(src[i]);
+            return src[c] * Base::Pow(k[0] + k[1] * sum, k[2]);
+        }
+
+        void SynetLrnLayerCrossChannelsNhwc2h(const float* src, size_t channels, size_t spatial, const float* k, float* dst)
+        {
+            const size_t F = svcntw(), half = 2, end = channels - half;
+            svfloat32_t k0 = svdup_n_f32(k[0]);
+            svfloat32_t k1 = svdup_n_f32(k[1]);
+            svfloat32_t k2 = svdup_n_f32(k[2]);
+            Sve2::Pow pow;
+            for (size_t s = 0; s < spatial; ++s)
+            {
+                for (size_t c = 0; c < half; ++c)
+                    dst[c] = SynetLrnLayerCrossChannelsNhwc(src, half, channels, c, k);
+                for (size_t c = half; c < end; c += F)
+                {
+                    svbool_t mask = svwhilelt_b32(c, end);
+                    svfloat32_t sum = Square(mask, src + c - 2);
+                    sum = svadd_f32_x(mask, sum, Square(mask, src + c - 1));
+                    sum = svadd_f32_x(mask, sum, Square(mask, src + c + 0));
+                    sum = svadd_f32_x(mask, sum, Square(mask, src + c + 1));
+                    sum = svadd_f32_x(mask, sum, Square(mask, src + c + 2));
+                    svst1_f32(mask, dst + c, svmul_f32_x(mask, svld1_f32(mask, src + c), pow(mask, svmla_f32_x(mask, k0, k1, sum), k2)));
+                }
+                for (size_t c = end; c < channels; ++c)
+                    dst[c] = SynetLrnLayerCrossChannelsNhwc(src, half, channels, c, k);
+                src += channels;
+                dst += channels;
+            }
+        }
+
+        void SynetLrnLayerCrossChannels(const float* src, size_t half, size_t channels, size_t spatial, const float* k, float* dst, SimdTensorFormatType format)
+        {
+            if (format == SimdTensorFormatNchw)
+                SynetLrnLayerCrossChannelsNchw(src, half, channels, spatial, k, dst);
+            else if (format == SimdTensorFormatNhwc)
+            {
+                if (half == 2 && channels > 2 * half)
+                    SynetLrnLayerCrossChannelsNhwc2h(src, channels, spatial, k, dst);
+                else
+                    Base::SynetLrnLayerCrossChannels(src, half, channels, spatial, k, dst, format);
+            }
+            else
+                assert(0);
         }
     }
 #endif

--- a/src/Test/TestSynet.cpp
+++ b/src/Test/TestSynet.cpp
@@ -354,6 +354,11 @@ namespace Test
             result = result && SynetLrnLayerCrossChannelsAutoTest(FUNC_LLCC(Simd::Neon::SynetLrnLayerCrossChannels), FUNC_LLCC(SimdSynetLrnLayerCrossChannels));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetLrnLayerCrossChannelsAutoTest(FUNC_LLCC(Simd::Sve2::SynetLrnLayerCrossChannels), FUNC_LLCC(SimdSynetLrnLayerCrossChannels));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetLrnLayerCrossChannels` in `SimdSve2Synet.cpp` for NCHW and NHWC half=2 paths.
- Wire SVE2 dispatch/header declarations and add SVE2 auto-test coverage.
- Update release 7.2.164 notes for the new SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetLrnLayerCrossChannels -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Synet.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6baaa89f-3f6f-4145-92d8-692d9e9b4068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6baaa89f-3f6f-4145-92d8-692d9e9b4068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

