### PR TITLE
Add SVE2 optimization for inner product layer forward

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,7 @@
  <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
+ <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>
  <li>NEON, SVE2 optimizations of class SynetGridSample2d32fBlZ.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6834,7 +6834,7 @@ SIMD_API void SimdSynetInnerProductLayerForward(const float * src, const float *
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetInnerProductLayerForwardPtr) (const float * src, const float * weight, const float * bias, size_t count, size_t size, float * dst);
-    const static SimdSynetInnerProductLayerForwardPtr simdSynetInnerProductLayerForward = SIMD_FUNC4(SynetInnerProductLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetInnerProductLayerForwardPtr simdSynetInnerProductLayerForward = SIMD_FUNC5(SynetInnerProductLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetInnerProductLayerForward(src, weight, bias, count, size, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -611,6 +611,8 @@ namespace Simd
 
         void SynetHswish32f(const float* src, size_t size, const float* shift, const float* scale, float* dst);
 
+        void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);
+
         void SynetLrnLayerCrossChannels(const float* src, size_t half, size_t channels, size_t spatial, const float* k, float* dst, SimdTensorFormatType format);
 
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -249,6 +249,63 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void SynetInnerProductLayerForward(const float* src, const float* weight, size_t offset, const svbool_t& mask, svfloat32_t& sum)
+        {
+            sum = svmla_f32_m(mask, sum, svld1_f32(mask, src + offset), svld1_f32(mask, weight + offset));
+        }
+
+        SIMD_INLINE void SynetInnerProductLayerForward(const float* src, const float* weight0, const float* weight1, size_t offset, const svbool_t& mask, svfloat32_t* sum)
+        {
+            svfloat32_t _src = svld1_f32(mask, src + offset);
+            sum[0] = svmla_f32_m(mask, sum[0], _src, svld1_f32(mask, weight0 + offset));
+            sum[1] = svmla_f32_m(mask, sum[1], _src, svld1_f32(mask, weight1 + offset));
+        }
+
+        void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst)
+        {
+            const size_t F = svcntw(), DF = 2 * F, QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            size_t i = 0, count2 = AlignLo(count, 2);
+            for (; i < count2; i += 2)
+            {
+                size_t j = 0;
+                const float* weight0 = weight + 0 * size;
+                const float* weight1 = weight + 1 * size;
+                svfloat32_t sums[4] = { svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f) };
+                for (; j + DF <= size; j += DF)
+                {
+                    SynetInnerProductLayerForward(src, weight0, weight1, j + 0 * F, body, sums + 0);
+                    SynetInnerProductLayerForward(src, weight0, weight1, j + 1 * F, body, sums + 2);
+                }
+                sums[0] = svadd_f32_x(body, sums[0], sums[2]);
+                sums[1] = svadd_f32_x(body, sums[1], sums[3]);
+                if (j < size)
+                    SynetInnerProductLayerForward(src, weight0, weight1, j, svwhilelt_b32(j, size), sums);
+                dst[i + 0] = svaddv_f32(body, sums[0]) + (bias ? bias[i + 0] : 0);
+                dst[i + 1] = svaddv_f32(body, sums[1]) + (bias ? bias[i + 1] : 0);
+                weight += 2 * size;
+            }
+            for (; i < count; ++i)
+            {
+                size_t j = 0;
+                svfloat32_t sums[4] = { svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f) };
+                for (; j + QF <= size; j += QF)
+                {
+                    SynetInnerProductLayerForward(src, weight, j + 0 * F, body, sums[0]);
+                    SynetInnerProductLayerForward(src, weight, j + 1 * F, body, sums[1]);
+                    SynetInnerProductLayerForward(src, weight, j + 2 * F, body, sums[2]);
+                    SynetInnerProductLayerForward(src, weight, j + 3 * F, body, sums[3]);
+                }
+                sums[0] = svadd_f32_x(body, svadd_f32_x(body, sums[0], sums[1]), svadd_f32_x(body, sums[2], sums[3]));
+                for (; j < size; j += F)
+                    SynetInnerProductLayerForward(src, weight, j, svwhilelt_b32(j, size), sums[0]);
+                dst[i] = svaddv_f32(body, sums[0]) + (bias ? bias[i] : 0);
+                weight += size;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE svfloat32_t Square(const svbool_t& mask, const float* src)
         {
             svfloat32_t _src = svld1_f32(mask, src);

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -254,11 +254,11 @@ namespace Simd
             sum = svmla_f32_m(mask, sum, svld1_f32(mask, src + offset), svld1_f32(mask, weight + offset));
         }
 
-        SIMD_INLINE void SynetInnerProductLayerForward(const float* src, const float* weight0, const float* weight1, size_t offset, const svbool_t& mask, svfloat32_t* sum)
+        SIMD_INLINE void SynetInnerProductLayerForward(const float* src, const float* weight0, const float* weight1, size_t offset, const svbool_t& mask, svfloat32_t& sum0, svfloat32_t& sum1)
         {
             svfloat32_t _src = svld1_f32(mask, src + offset);
-            sum[0] = svmla_f32_m(mask, sum[0], _src, svld1_f32(mask, weight0 + offset));
-            sum[1] = svmla_f32_m(mask, sum[1], _src, svld1_f32(mask, weight1 + offset));
+            sum0 = svmla_f32_m(mask, sum0, _src, svld1_f32(mask, weight0 + offset));
+            sum1 = svmla_f32_m(mask, sum1, _src, svld1_f32(mask, weight1 + offset));
         }
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst)
@@ -271,35 +271,37 @@ namespace Simd
                 size_t j = 0;
                 const float* weight0 = weight + 0 * size;
                 const float* weight1 = weight + 1 * size;
-                svfloat32_t sums[4] = { svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f) };
+                svfloat32_t sum00 = svdup_n_f32(0.0f), sum01 = svdup_n_f32(0.0f);
+                svfloat32_t sum10 = svdup_n_f32(0.0f), sum11 = svdup_n_f32(0.0f);
                 for (; j + DF <= size; j += DF)
                 {
-                    SynetInnerProductLayerForward(src, weight0, weight1, j + 0 * F, body, sums + 0);
-                    SynetInnerProductLayerForward(src, weight0, weight1, j + 1 * F, body, sums + 2);
+                    SynetInnerProductLayerForward(src, weight0, weight1, j + 0 * F, body, sum00, sum01);
+                    SynetInnerProductLayerForward(src, weight0, weight1, j + 1 * F, body, sum10, sum11);
                 }
-                sums[0] = svadd_f32_x(body, sums[0], sums[2]);
-                sums[1] = svadd_f32_x(body, sums[1], sums[3]);
+                sum00 = svadd_f32_x(body, sum00, sum10);
+                sum01 = svadd_f32_x(body, sum01, sum11);
                 if (j < size)
-                    SynetInnerProductLayerForward(src, weight0, weight1, j, svwhilelt_b32(j, size), sums);
-                dst[i + 0] = svaddv_f32(body, sums[0]) + (bias ? bias[i + 0] : 0);
-                dst[i + 1] = svaddv_f32(body, sums[1]) + (bias ? bias[i + 1] : 0);
+                    SynetInnerProductLayerForward(src, weight0, weight1, j, svwhilelt_b32(j, size), sum00, sum01);
+                dst[i + 0] = svaddv_f32(body, sum00) + (bias ? bias[i + 0] : 0);
+                dst[i + 1] = svaddv_f32(body, sum01) + (bias ? bias[i + 1] : 0);
                 weight += 2 * size;
             }
             for (; i < count; ++i)
             {
                 size_t j = 0;
-                svfloat32_t sums[4] = { svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f), svdup_n_f32(0.0f) };
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+                svfloat32_t sum2 = svdup_n_f32(0.0f), sum3 = svdup_n_f32(0.0f);
                 for (; j + QF <= size; j += QF)
                 {
-                    SynetInnerProductLayerForward(src, weight, j + 0 * F, body, sums[0]);
-                    SynetInnerProductLayerForward(src, weight, j + 1 * F, body, sums[1]);
-                    SynetInnerProductLayerForward(src, weight, j + 2 * F, body, sums[2]);
-                    SynetInnerProductLayerForward(src, weight, j + 3 * F, body, sums[3]);
+                    SynetInnerProductLayerForward(src, weight, j + 0 * F, body, sum0);
+                    SynetInnerProductLayerForward(src, weight, j + 1 * F, body, sum1);
+                    SynetInnerProductLayerForward(src, weight, j + 2 * F, body, sum2);
+                    SynetInnerProductLayerForward(src, weight, j + 3 * F, body, sum3);
                 }
-                sums[0] = svadd_f32_x(body, svadd_f32_x(body, sums[0], sums[1]), svadd_f32_x(body, sums[2], sums[3]));
+                sum0 = svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), svadd_f32_x(body, sum2, sum3));
                 for (; j < size; j += F)
-                    SynetInnerProductLayerForward(src, weight, j, svwhilelt_b32(j, size), sums[0]);
-                dst[i] = svaddv_f32(body, sums[0]) + (bias ? bias[i] : 0);
+                    SynetInnerProductLayerForward(src, weight, j, svwhilelt_b32(j, size), sum0);
+                dst[i] = svaddv_f32(body, sum0) + (bias ? bias[i] : 0);
                 weight += size;
             }
         }

--- a/src/Test/TestSynetInnerProduct.cpp
+++ b/src/Test/TestSynetInnerProduct.cpp
@@ -272,6 +272,11 @@ namespace Test
             result = result && SynetInnerProductLayerForwardAutoTest(FUNC_IPLF(Simd::Neon::SynetInnerProductLayerForward), FUNC_IPLF(SimdSynetInnerProductLayerForward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetInnerProductLayerForwardAutoTest(FUNC_IPLF(Simd::Sve2::SynetInnerProductLayerForward), FUNC_IPLF(SimdSynetInnerProductLayerForward));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `SimdSynetInnerProductLayerForward` in `SimdSve2Synet.cpp`.
- Wire SVE2 dispatch and auto-test coverage for `SynetInnerProductLayerForward`.
- Document the new optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetInnerProductLayerForward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -O2 -DNDEBUG -I./src -c ./src/Simd/SimdSve2Synet.cpp -o /tmp/SimdSve2Synet.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad32aaab-7354-4fdd-8843-522bca2b0b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad32aaab-7354-4fdd-8843-522bca2b0b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

