### PR TITLE
Add NEON optimization for SynetInnerProduct8i

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,7 @@
  <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
+ <li>NEON optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>
  <li>NEON, SVE2 optimizations of class SynetGridSample2d32fBlZ.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetGridSample2d32fBlZ.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct32f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32fCd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32fCdc.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32fDc.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -334,6 +334,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct32f.cpp">
       <Filter>Neon\Synet\Other</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct8i.cpp">
+      <Filter>Neon\Synet\Other</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetPermute.cpp">
       <Filter>Neon\Synet\Other</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6916,7 +6916,7 @@ SIMD_API void SimdSynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetInnerProduct8iPtr) (size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
-    const static SimdSynetInnerProduct8iPtr simdSynetInnerProduct8i = SIMD_FUNC3(SynetInnerProduct8i, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetInnerProduct8iPtr simdSynetInnerProduct8i = SIMD_FUNC4(SynetInnerProduct8i, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     simdSynetInnerProduct8i(M, N, K, src, weight, dst, compatibility);
 #else

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -541,6 +541,8 @@ namespace Simd
 
         void SynetHswish32f(const float * src, size_t size, const float * shift, const float * scale, float * dst);
 
+        void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
+
         void SynetInnerProductLayerForward(const float * src, const float * weight, const float * bias, size_t count, size_t size, float * dst);
 
         void SynetLrnLayerCrossChannels(const float * src, size_t half, size_t channels, size_t spatial, const float * k, float * dst, SimdTensorFormatType format);

--- a/src/Simd/SimdNeonSynetInnerProduct8i.cpp
+++ b/src/Simd/SimdNeonSynetInnerProduct8i.cpp
@@ -1,0 +1,291 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdLoad.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdNeon.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Neon
+    {
+        SIMD_INLINE uint8x16_t LoadTail(const uint8_t* ptr, size_t tail)
+        {
+            uint8_t buf[A] = { 0 };
+            for (size_t i = 0; i < tail; ++i)
+                buf[i] = ptr[i];
+            return Load<false>(buf);
+        }
+
+        SIMD_INLINE int8x16_t LoadTail(const int8_t* ptr, size_t tail)
+        {
+            int8_t buf[A] = { 0 };
+            for (size_t i = 0; i < tail; ++i)
+                buf[i] = ptr[i];
+            return Load<false>(buf);
+        }
+
+        SIMD_INLINE int ExtractInt32Sum(int32x4_t value)
+        {
+            int32_t buf[4];
+            vst1q_s32(buf, value);
+            return buf[0] + buf[1] + buf[2] + buf[3];
+        }
+
+        template<bool overflow> SIMD_INLINE void Madd4(int32x4_t& sum, uint8x16_t u8, int8x16_t i8);
+
+        template<> SIMD_INLINE void Madd4<false>(int32x4_t& sum, uint8x16_t u8, int8x16_t i8)
+        {
+            uint16x8_t u16 = vmovl_u8(vget_low_u8(u8));
+            int16x8_t i16 = vmovl_s8(vget_low_s8(i8));
+            sum = vmlal_s16(sum, vget_low_s16(vreinterpretq_s16_u16(u16)), vget_low_s16(i16));
+            sum = vmlal_s16(sum, vget_high_s16(vreinterpretq_s16_u16(u16)), vget_high_s16(i16));
+
+            u16 = vmovl_u8(vget_high_u8(u8));
+            i16 = vmovl_s8(vget_high_s8(i8));
+            sum = vmlal_s16(sum, vget_low_s16(vreinterpretq_s16_u16(u16)), vget_low_s16(i16));
+            sum = vmlal_s16(sum, vget_high_s16(vreinterpretq_s16_u16(u16)), vget_high_s16(i16));
+        }
+
+        SIMD_INLINE int16x4_t Madd4PairSaturated(uint8x8_t u8, int8x8_t i8)
+        {
+            uint16x8_t u16 = vmovl_u8(u8);
+            int16x8_t i16 = vmovl_s8(i8);
+            int32x4_t lo = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(u16)), vget_low_s16(i16));
+            int32x4_t hi = vmull_s16(vget_high_s16(vreinterpretq_s16_u16(u16)), vget_high_s16(i16));
+            int32x4_t sums = vcombine_s32(vpadd_s32(vget_low_s32(lo), vget_high_s32(lo)), vpadd_s32(vget_low_s32(hi), vget_high_s32(hi)));
+            return vqmovn_s32(sums);
+        }
+
+        template<> SIMD_INLINE void Madd4<true>(int32x4_t& sum, uint8x16_t u8, int8x16_t i8)
+        {
+            int16x8_t pairs = vcombine_s16(
+                Madd4PairSaturated(vget_low_u8(u8), vget_low_s8(i8)),
+                Madd4PairSaturated(vget_high_u8(u8), vget_high_s8(i8)));
+            sum = vaddw_s16(sum, vget_low_s16(pairs));
+            sum = vaddw_s16(sum, vget_high_s16(pairs));
+        }
+
+        static SIMD_INLINE void Save4Sums(const int32x4_t& sum0, const int32x4_t& sum1, const int32x4_t& sum2, const int32x4_t& sum3, int32_t* dst)
+        {
+            dst[0] = ExtractInt32Sum(sum0);
+            dst[1] = ExtractInt32Sum(sum1);
+            dst[2] = ExtractInt32Sum(sum2);
+            dst[3] = ExtractInt32Sum(sum3);
+        }
+
+        template<bool overflow> static void SynetInnerProduct8i1x1(size_t K, const uint8_t* S, size_t lds, const int8_t* W, size_t ldw, int32_t* D, size_t ldd)
+        {
+            size_t KA = AlignLo(K, A);
+            const uint8_t* S0 = S + 0 * lds;
+            const int8_t* W0 = W + 0 * ldw;
+            int32x4_t d00 = vdupq_n_s32(0);
+            uint8x16_t s0;
+            int8x16_t w0;
+            for (size_t k = 0; k < KA; k += A)
+            {
+                s0 = Load<false>(S0 + k);
+                w0 = Load<false>(W0 + k);
+                Madd4<overflow>(d00, s0, w0);
+            }
+            if (KA < K)
+            {
+                size_t tail = K - KA;
+                s0 = LoadTail(S0 + KA, tail);
+                w0 = LoadTail(W0 + KA, tail);
+                Madd4<overflow>(d00, s0, w0);
+            }
+            D[0] = ExtractInt32Sum(d00);
+        }
+
+        template<bool overflow> static void SynetInnerProduct8i1x4(size_t K, const uint8_t* S, size_t lds, const int8_t* W, size_t ldw, int32_t* D, size_t ldd)
+        {
+            size_t KA = AlignLo(K, A);
+            const uint8_t* S0 = S + 0 * lds;
+            const int8_t* W0 = W + 0 * ldw;
+            const int8_t* W1 = W + 1 * ldw;
+            const int8_t* W2 = W + 2 * ldw;
+            const int8_t* W3 = W + 3 * ldw;
+            int32x4_t d00 = vdupq_n_s32(0);
+            int32x4_t d01 = vdupq_n_s32(0);
+            int32x4_t d02 = vdupq_n_s32(0);
+            int32x4_t d03 = vdupq_n_s32(0);
+            uint8x16_t s0;
+            int8x16_t w0;
+            for (size_t k = 0; k < KA; k += A)
+            {
+                s0 = Load<false>(S0 + k);
+                w0 = Load<false>(W0 + k);
+                Madd4<overflow>(d00, s0, w0);
+                w0 = Load<false>(W1 + k);
+                Madd4<overflow>(d01, s0, w0);
+                w0 = Load<false>(W2 + k);
+                Madd4<overflow>(d02, s0, w0);
+                w0 = Load<false>(W3 + k);
+                Madd4<overflow>(d03, s0, w0);
+            }
+            if (KA < K)
+            {
+                size_t tail = K - KA;
+                s0 = LoadTail(S0 + KA, tail);
+                w0 = LoadTail(W0 + KA, tail);
+                Madd4<overflow>(d00, s0, w0);
+                w0 = LoadTail(W1 + KA, tail);
+                Madd4<overflow>(d01, s0, w0);
+                w0 = LoadTail(W2 + KA, tail);
+                Madd4<overflow>(d02, s0, w0);
+                w0 = LoadTail(W3 + KA, tail);
+                Madd4<overflow>(d03, s0, w0);
+            }
+            Save4Sums(d00, d01, d02, d03, D);
+        }
+
+        template<bool overflow> static void SynetInnerProduct8i2x1(size_t K, const uint8_t* S, size_t lds, const int8_t* W, size_t ldw, int32_t* D, size_t ldd)
+        {
+            size_t KA = AlignLo(K, A);
+            const uint8_t* S0 = S + 0 * lds;
+            const uint8_t* S1 = S + 1 * lds;
+            const int8_t* W0 = W + 0 * ldw;
+            int32x4_t d00 = vdupq_n_s32(0);
+            int32x4_t d10 = vdupq_n_s32(0);
+            uint8x16_t s0, s1;
+            int8x16_t w0;
+            for (size_t k = 0; k < KA; k += A)
+            {
+                s0 = Load<false>(S0 + k);
+                s1 = Load<false>(S1 + k);
+                w0 = Load<false>(W0 + k);
+                Madd4<overflow>(d00, s0, w0);
+                Madd4<overflow>(d10, s1, w0);
+            }
+            if (KA < K)
+            {
+                size_t tail = K - KA;
+                s0 = LoadTail(S0 + KA, tail);
+                s1 = LoadTail(S1 + KA, tail);
+                w0 = LoadTail(W0 + KA, tail);
+                Madd4<overflow>(d00, s0, w0);
+                Madd4<overflow>(d10, s1, w0);
+            }
+            D[0 * ldd] = ExtractInt32Sum(d00);
+            D[1 * ldd] = ExtractInt32Sum(d10);
+        }
+
+        template<bool overflow> static void SynetInnerProduct8i2x4(size_t K, const uint8_t* S, size_t lds, const int8_t* W, size_t ldw, int32_t* D, size_t ldd)
+        {
+            size_t KA = AlignLo(K, A);
+            const uint8_t* S0 = S + 0 * lds;
+            const uint8_t* S1 = S + 1 * lds;
+            const int8_t* W0 = W + 0 * ldw;
+            const int8_t* W1 = W + 1 * ldw;
+            const int8_t* W2 = W + 2 * ldw;
+            const int8_t* W3 = W + 3 * ldw;
+            int32x4_t d00 = vdupq_n_s32(0);
+            int32x4_t d01 = vdupq_n_s32(0);
+            int32x4_t d02 = vdupq_n_s32(0);
+            int32x4_t d03 = vdupq_n_s32(0);
+            int32x4_t d10 = vdupq_n_s32(0);
+            int32x4_t d11 = vdupq_n_s32(0);
+            int32x4_t d12 = vdupq_n_s32(0);
+            int32x4_t d13 = vdupq_n_s32(0);
+            uint8x16_t s0, s1;
+            int8x16_t w0;
+            for (size_t k = 0; k < KA; k += A)
+            {
+                s0 = Load<false>(S0 + k);
+                s1 = Load<false>(S1 + k);
+                w0 = Load<false>(W0 + k);
+                Madd4<overflow>(d00, s0, w0);
+                Madd4<overflow>(d10, s1, w0);
+                w0 = Load<false>(W1 + k);
+                Madd4<overflow>(d01, s0, w0);
+                Madd4<overflow>(d11, s1, w0);
+                w0 = Load<false>(W2 + k);
+                Madd4<overflow>(d02, s0, w0);
+                Madd4<overflow>(d12, s1, w0);
+                w0 = Load<false>(W3 + k);
+                Madd4<overflow>(d03, s0, w0);
+                Madd4<overflow>(d13, s1, w0);
+            }
+            if (KA < K)
+            {
+                size_t tail = K - KA;
+                s0 = LoadTail(S0 + KA, tail);
+                s1 = LoadTail(S1 + KA, tail);
+                w0 = LoadTail(W0 + KA, tail);
+                Madd4<overflow>(d00, s0, w0);
+                Madd4<overflow>(d10, s1, w0);
+                w0 = LoadTail(W1 + KA, tail);
+                Madd4<overflow>(d01, s0, w0);
+                Madd4<overflow>(d11, s1, w0);
+                w0 = LoadTail(W2 + KA, tail);
+                Madd4<overflow>(d02, s0, w0);
+                Madd4<overflow>(d12, s1, w0);
+                w0 = LoadTail(W3 + KA, tail);
+                Madd4<overflow>(d03, s0, w0);
+                Madd4<overflow>(d13, s1, w0);
+            }
+            Save4Sums(d00, d01, d02, d03, D + 0 * ldd);
+            Save4Sums(d10, d11, d12, d13, D + 1 * ldd);
+        }
+
+        template<bool overflow> void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst)
+        {
+            size_t M2 = AlignLoAny(M, 2);
+            size_t N4 = AlignLoAny(N, 4);
+            size_t i = 0;
+            for (; i < M2; i += 2)
+            {
+                size_t j = 0;
+                for (; j < N4; j += 4)
+                    SynetInnerProduct8i2x4<overflow>(K, src, K, weight + j * K, K, dst + j, N);
+                for (; j < N; j += 1)
+                    SynetInnerProduct8i2x1<overflow>(K, src, K, weight + j * K, K, dst + j, N);
+                src += K * 2;
+                dst += N * 2;
+            }
+            for (; i < M; i += 1)
+            {
+                size_t j = 0;
+                for (; j < N4; j += 4)
+                    SynetInnerProduct8i1x4<overflow>(K, src, K, weight + j * K, K, dst + j, N);
+                for (; j < N; j += 1)
+                    SynetInnerProduct8i1x1<overflow>(K, src, K, weight + j * K, K, dst + j, N);
+                src += K;
+                dst += N;
+            }
+        }
+
+        void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility)
+        {
+            if (Base::Precise(compatibility))
+                SynetInnerProduct8i<false>(M, N, K, src, weight, dst);
+            else
+                SynetInnerProduct8i<true>(M, N, K, src, weight, dst);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetInnerProduct.cpp
+++ b/src/Test/TestSynetInnerProduct.cpp
@@ -351,6 +351,7 @@ namespace Test
         result = result && SynetInnerProduct8iAutoTest(1, 256, 6912, c, f1, f2);
         result = result && SynetInnerProduct8iAutoTest(10, 256, 6912, c, f1, f2);
         result = result && SynetInnerProduct8iAutoTest(15, 65, 255, c, f1, f2);
+        result = result && SynetInnerProduct8iAutoTest(3, 5, 17, c, f1, f2);
 
         return result;
     }
@@ -385,6 +386,11 @@ namespace Test
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && SynetInnerProduct8iAutoTest(FUNC_IP8I(Simd::Avx512bw::SynetInnerProduct8i), FUNC_IP8I(SimdSynetInnerProduct8i));
+#endif
+
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetInnerProduct8iAutoTest(FUNC_IP8I(Simd::Neon::SynetInnerProduct8i), FUNC_IP8I(SimdSynetInnerProduct8i));
 #endif
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Added NEON implementation of `SynetInnerProduct8i` and wired it into the runtime dispatcher.
* Added NEON auto-test coverage and an explicit small tail/block case.
* Updated VS2022 NEON project metadata and 7.2.164 release notes.

### Testing
* Passed `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`.
* Passed `cmake --build build --parallel$(nproc)`.
* Passed `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetInnerProduct8i -tt=1 -ts=1`.
* Passed `aarch64-linux-gnu-g++ -std=c++11 -O2 -c -I./src src/Simd/SimdNeonSynetInnerProduct8i.cpp -o /tmp/SimdNeonSynetInnerProduct8i.o`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2c6c5dd-f4a7-424e-aae5-f86cab7265b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2c6c5dd-f4a7-424e-aae5-f86cab7265b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

