### PR TITLE
Add SVE2 optimization for SynetMish32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,7 @@
  <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
+ <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7149,7 +7149,7 @@ SIMD_API void SimdSynetMish32f(const float* src, size_t size, const float* thres
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetMish32fPtr) (const float* src, size_t size, const float* threshold, float* dst);
-    const static SimdSynetMish32fPtr simdSynetMish32f = SIMD_FUNC4(SynetMish32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetMish32fPtr simdSynetMish32f = SIMD_FUNC5(SynetMish32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetMish32f(src, size, threshold, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -611,6 +611,8 @@ namespace Simd
 
         void SynetHswish32f(const float* src, size_t size, const float* shift, const float* scale, float* dst);
 
+        void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst);
+
         void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -198,6 +198,40 @@ namespace Simd
             if (i < size)
                 SynetHswish32f(src + i, svwhilelt_b32(i, size), _shift, _scale, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetMish32f(const svbool_t& mask, svfloat32_t value, svfloat32_t threshold)
+        {
+            svfloat32_t exp = svadd_n_f32_x(mask, Exponent(mask, value), 1.0f);
+            svfloat32_t den = svadd_n_f32_x(mask, svmul_f32_x(mask, exp, exp), 1.0f);
+            svfloat32_t tanh = svsub_f32_x(mask, svdup_n_f32(1.0f), svdiv_f32_x(mask, svdup_n_f32(2.0f), den));
+            svfloat32_t mish = svmul_f32_x(mask, value, tanh);
+            return svsel_f32(svcmpgt_f32(mask, value, threshold), value, mish);
+        }
+
+        SIMD_INLINE void SynetMish32f(const float* src, const svbool_t& mask, svfloat32_t threshold, float* dst)
+        {
+            svst1_f32(mask, dst, SynetMish32f(mask, svld1_f32(mask, src), threshold));
+        }
+
+        void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _threshold = svdup_n_f32(threshold[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetMish32f(src + i + 0 * F, body, _threshold, dst + i + 0 * F);
+                SynetMish32f(src + i + 1 * F, body, _threshold, dst + i + 1 * F);
+                SynetMish32f(src + i + 2 * F, body, _threshold, dst + i + 2 * F);
+                SynetMish32f(src + i + 3 * F, body, _threshold, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetMish32f(src + i, body, _threshold, dst + i);
+            if (i < size)
+                SynetMish32f(src + i, svwhilelt_b32(i, size), _threshold, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -476,6 +476,11 @@ namespace Test
             result = result && SynetMish32fAutoTest(FUNC_MISH32F(Simd::Avx512bw::SynetMish32f), FUNC_MISH32F(SimdSynetMish32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetMish32fAutoTest(FUNC_MISH32F(Simd::Sve2::SynetMish32f), FUNC_MISH32F(SimdSynetMish32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetMish32fAutoTest(FUNC_MISH32F(Simd::Neon::SynetMish32f), FUNC_MISH32F(SimdSynetMish32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdSynetMish32f`.
- Extend `SynetMish32fAutoTest` with the SVE2 optimized path.
- Document the SVE2 Mish optimization in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=SynetMish32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -fsyntax-only -I./src src/Simd/SimdSve2SynetActivation.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -fsyntax-only -I./src src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b75fe4-5e17-41d9-b7d6-a5e667756665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b75fe4-5e17-41d9-b7d6-a5e667756665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

