### PR TITLE
Add SVE2 SynetNormalizeLayerForward

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -81,6 +81,7 @@
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
  <li>SVE2 optimizations of function SynetMish32f.</li>
+ <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetGridSample2d32fBlZ.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -395,6 +395,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7164,7 +7164,7 @@ SIMD_API void SimdSynetNormalizeLayerForward(const float* src, size_t batch, siz
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetNormalizeLayerForwardPtr) (const float* src, size_t batch, size_t channels, size_t spatial,
         const float* scale, const float* eps, SimdBool acrossSpatial, SimdTensorFormatType format, float* buf, float* dst);
-    const static SimdSynetNormalizeLayerForwardPtr simdSynetNormalizeLayerForward = SIMD_FUNC4(SynetNormalizeLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetNormalizeLayerForwardPtr simdSynetNormalizeLayerForward = SIMD_FUNC5(SynetNormalizeLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetNormalizeLayerForward(src, batch, channels, spatial, scale, eps, acrossSpatial, format, buf, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -613,6 +613,9 @@ namespace Simd
 
         void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst);
 
+        void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,
+            const float* eps, SimdBool acrossSpatial, SimdTensorFormatType format, float* buf, float* dst);
+
         void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);

--- a/src/Simd/SimdSve2SynetNormalize.cpp
+++ b/src/Simd/SimdSve2SynetNormalize.cpp
@@ -1,0 +1,185 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdArray.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE float SumSquares(const float* src, size_t size)
+        {
+            const size_t F = svcntw(), sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sum = svdup_n_f32(0.0f);
+            size_t i = 0;
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t _src = svld1_f32(body, src + i);
+                sum = svmla_f32_x(body, sum, _src, _src);
+            }
+            float result = svaddv_f32(body, sum);
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t _src = svld1_f32(tail, src + i);
+                result += svaddv_f32(tail, svmul_f32_x(tail, _src, _src));
+            }
+            return result;
+        }
+
+        SIMD_INLINE svfloat32_t ReciprocalSqrt(const svfloat32_t& value, const svbool_t& mask)
+        {
+            return svdiv_f32_x(mask, svdup_n_f32(1.0f), svsqrt_f32_x(mask, value));
+        }
+
+        void NormalizeNchw1(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale, float eps, float* dst)
+        {
+            const size_t F = svcntw(), size = channels * spatial;
+            for (size_t b = 0; b < batch; ++b)
+            {
+                float k0 = 1.0f / ::sqrt(SumSquares(src, size) + eps);
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _k = svdup_n_f32(scale[c] * k0);
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svst1_f32(mask, dst + s, svmul_f32_x(mask, svld1_f32(mask, src + s), _k));
+                    }
+                    dst += spatial;
+                    src += spatial;
+                }
+            }
+        }
+
+        void NormalizeNchw0(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale, float eps, float* buf, float* dst)
+        {
+            Array32f _buf;
+            if (buf == NULL)
+            {
+                _buf.Resize(spatial);
+                buf = _buf.data;
+            }
+            const size_t F = svcntw();
+            svfloat32_t _eps = svdup_n_f32(eps);
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    svst1_f32(mask, buf + s, _eps);
+                }
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    const float* ps = src + c * spatial;
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svfloat32_t _src = svld1_f32(mask, ps + s);
+                        svst1_f32(mask, buf + s, svmla_f32_x(mask, svld1_f32(mask, buf + s), _src, _src));
+                    }
+                }
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    svst1_f32(mask, buf + s, ReciprocalSqrt(svld1_f32(mask, buf + s), mask));
+                }
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _scale = svdup_n_f32(scale[c]);
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svst1_f32(mask, dst + s, svmul_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src + s), svld1_f32(mask, buf + s)), _scale));
+                    }
+                    dst += spatial;
+                    src += spatial;
+                }
+            }
+        }
+
+        void NormalizeNhwc1(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale, float eps, float* dst)
+        {
+            const size_t F = svcntw(), size = channels * spatial;
+            for (size_t b = 0; b < batch; ++b)
+            {
+                svfloat32_t _k = svdup_n_f32(1.0f / ::sqrt(SumSquares(src, size) + eps));
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svst1_f32(mask, dst + c, svmul_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src + c), svld1_f32(mask, scale + c)), _k));
+                    }
+                    dst += channels;
+                    src += channels;
+                }
+            }
+        }
+
+        void NormalizeNhwc0(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale, float eps, float* dst)
+        {
+            const size_t F = svcntw();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    svfloat32_t _k = svdup_n_f32(1.0f / ::sqrt(SumSquares(src, channels) + eps));
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svst1_f32(mask, dst + c, svmul_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src + c), svld1_f32(mask, scale + c)), _k));
+                    }
+                    dst += channels;
+                    src += channels;
+                }
+            }
+        }
+
+        void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,
+            const float* eps, SimdBool acrossSpatial, SimdTensorFormatType format, float* buf, float* dst)
+        {
+            if (format == SimdTensorFormatNchw)
+            {
+                if (acrossSpatial)
+                    NormalizeNchw1(src, batch, channels, spatial, scale, eps[0], dst);
+                else
+                    NormalizeNchw0(src, batch, channels, spatial, scale, eps[0], buf, dst);
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                if (acrossSpatial)
+                    NormalizeNhwc1(src, batch, channels, spatial, scale, eps[0], dst);
+                else
+                    NormalizeNhwc0(src, batch, channels, spatial, scale, eps[0], dst);
+            }
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetNormalize32f.cpp
+++ b/src/Test/TestSynetNormalize32f.cpp
@@ -108,8 +108,8 @@ namespace Test
             for (int acrossSpatial = 0; acrossSpatial <= 1; ++acrossSpatial)
             {
                 result = result && SynetNormalizeLayerForwardAutoTest(1, C, W, acrossSpatial, formats[f], 1, f1, f2);
-                //result = result && SynetNormalizeLayerForwardAutoTest(8, C, W, acrossSpatial, formats[f], 1, f1, f2);
-                //result = result && SynetNormalizeLayerForwardAutoTest(7, C - O, W + O, acrossSpatial, formats[f], 0, f1, f2);
+                result = result && SynetNormalizeLayerForwardAutoTest(8, C, W, acrossSpatial, formats[f], 1, f1, f2);
+                result = result && SynetNormalizeLayerForwardAutoTest(7, C - O, W + O, acrossSpatial, formats[f], 0, f1, f2);
             }
         }
 
@@ -141,6 +141,11 @@ namespace Test
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetNormalizeLayerForwardAutoTest(FUNC_SNLF(Simd::Neon::SynetNormalizeLayerForward), FUNC_SNLF(SimdSynetNormalizeLayerForward));
+#endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetNormalizeLayerForwardAutoTest(FUNC_SNLF(Simd::Sve2::SynetNormalizeLayerForward), FUNC_SNLF(SimdSynetNormalizeLayerForward));
 #endif
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and runtime dispatch for `SimdSynetNormalizeLayerForward`.
- Add SVE2 auto-test coverage and broaden normalize forward cases for batch/tail/internal-buffer paths.
- Update VS2022 SVE2 project metadata and 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetNormalizeLayerForward -tt=1 -ts=1 "-ot=/opt/cursor/artifacts/synet_normalize_test.log"`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -O2 -I src -c src/Simd/SimdSve2SynetNormalize.cpp -o /tmp/SimdSve2SynetNormalize.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b663fe1-f985-43b1-a8dc-e2920b63e150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b663fe1-f985-43b1-a8dc-e2920b63e150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

