### PR TITLE
Add SVE2 SynetNormalizeLayerForwardV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -82,6 +82,7 @@
  <li>SVE2 optimizations of function SynetHswish32f.</li>
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
+ <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7179,7 +7179,7 @@ SIMD_API void SimdSynetNormalizeLayerForwardV2(const float* src, size_t batch, s
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetNormalizeLayerForwardV2Ptr) (const float* src, size_t batch, size_t channels, size_t spatial,
         const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
-    const static SimdSynetNormalizeLayerForwardV2Ptr simdSynetNormalizeLayerForwardV2 = SIMD_FUNC4(SynetNormalizeLayerForwardV2, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetNormalizeLayerForwardV2Ptr simdSynetNormalizeLayerForwardV2 = SIMD_FUNC5(SynetNormalizeLayerForwardV2, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetNormalizeLayerForwardV2(src, batch, channels, spatial, scale, shift, eps, format, buf, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -616,6 +616,9 @@ namespace Simd
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,
             const float* eps, SimdBool acrossSpatial, SimdTensorFormatType format, float* buf, float* dst);
 
+        void SynetNormalizeLayerForwardV2(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
+
         void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);

--- a/src/Simd/SimdSve2SynetNormalize.cpp
+++ b/src/Simd/SimdSve2SynetNormalize.cpp
@@ -51,6 +51,23 @@ namespace Simd
             return result;
         }
 
+        SIMD_INLINE float Sum(const float* src, size_t size)
+        {
+            const size_t F = svcntw(), sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sum = svdup_n_f32(0.0f);
+            size_t i = 0;
+            for (; i < sizeF; i += F)
+                sum = svadd_f32_x(body, sum, svld1_f32(body, src + i));
+            float result = svaddv_f32(body, sum);
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                result += svaddv_f32(tail, svld1_f32(tail, src + i));
+            }
+            return result;
+        }
+
         SIMD_INLINE svfloat32_t ReciprocalSqrt(const svfloat32_t& value, const svbool_t& mask)
         {
             return svdiv_f32_x(mask, svdup_n_f32(1.0f), svsqrt_f32_x(mask, value));
@@ -177,6 +194,131 @@ namespace Simd
                 else
                     NormalizeNhwc0(src, batch, channels, spatial, scale, eps[0], dst);
             }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void NormalizeNchwV2(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, float eps, float* buf, float* dst)
+        {
+            float k = 1.0f / float(channels);
+            Array32f _buf;
+            if (buf == NULL)
+            {
+                _buf.Resize(spatial);
+                buf = _buf.data;
+            }
+            const size_t F = svcntw();
+            svfloat32_t _k = svdup_n_f32(k), _eps = svdup_n_f32(eps);
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    svst1_f32(mask, buf + s, svdup_n_f32(0.0f));
+                }
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    const float* ps = src + c * spatial;
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svst1_f32(mask, buf + s, svadd_f32_x(mask, svld1_f32(mask, buf + s), svld1_f32(mask, ps + s)));
+                    }
+                }
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    svst1_f32(mask, buf + s, svmul_f32_x(mask, svld1_f32(mask, buf + s), _k));
+                }
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    const float* ps = src + c * spatial;
+                    float* pd = dst + c * spatial;
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svst1_f32(mask, pd + s, svsub_f32_x(mask, svld1_f32(mask, ps + s), svld1_f32(mask, buf + s)));
+                    }
+                }
+
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    svst1_f32(mask, buf + s, svdup_n_f32(0.0f));
+                }
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    const float* pd = dst + c * spatial;
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svfloat32_t d = svld1_f32(mask, pd + s);
+                        svst1_f32(mask, buf + s, svmla_f32_x(mask, svld1_f32(mask, buf + s), d, d));
+                    }
+                }
+                for (size_t s = 0; s < spatial; s += F)
+                {
+                    svbool_t mask = svwhilelt_b32(s, spatial);
+                    svst1_f32(mask, buf + s, ReciprocalSqrt(svadd_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, buf + s), _k), _eps), mask));
+                }
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _scale = svdup_n_f32(scale[c]);
+                    svfloat32_t _shift = svdup_n_f32(shift[c]);
+                    float* pd = dst + c * spatial;
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svfloat32_t norm = svmul_f32_x(mask, svld1_f32(mask, pd + s), svld1_f32(mask, buf + s));
+                        svst1_f32(mask, pd + s, svmla_f32_x(mask, _shift, norm, _scale));
+                    }
+                }
+
+                src += channels * spatial;
+                dst += channels * spatial;
+            }
+        }
+
+        void NormalizeNhwcV2(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, float eps, float* dst)
+        {
+            float k = 1.0f / float(channels);
+            const size_t F = svcntw();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    svfloat32_t mean = svdup_n_f32(Sum(src, channels) * k);
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svst1_f32(mask, dst + c, svsub_f32_x(mask, svld1_f32(mask, src + c), mean));
+                    }
+
+                    svfloat32_t norm = svdup_n_f32(1.0f / ::sqrt(SumSquares(dst, channels) * k + eps));
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svfloat32_t _dst = svmul_f32_x(mask, svld1_f32(mask, dst + c), norm);
+                        svst1_f32(mask, dst + c, svmla_f32_x(mask, svld1_f32(mask, shift + c), _dst, svld1_f32(mask, scale + c)));
+                    }
+
+                    dst += channels;
+                    src += channels;
+                }
+            }
+        }
+
+        void SynetNormalizeLayerForwardV2(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst)
+        {
+            if (format == SimdTensorFormatNchw)
+                NormalizeNchwV2(src, batch, channels, spatial, scale, shift, *eps, buf, dst);
+            else if (format == SimdTensorFormatNhwc)
+                NormalizeNhwcV2(src, batch, channels, spatial, scale, shift, *eps, dst);
             else
                 assert(0);
         }

--- a/src/Test/TestSynetNormalize32f.cpp
+++ b/src/Test/TestSynetNormalize32f.cpp
@@ -255,6 +255,11 @@ namespace Test
             result = result && SynetNormalizeLayerForwardV2AutoTest(FUNC_SNLF2(Simd::Neon::SynetNormalizeLayerForwardV2), FUNC_SNLF2(SimdSynetNormalizeLayerForwardV2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetNormalizeLayerForwardV2AutoTest(FUNC_SNLF2(Simd::Sve2::SynetNormalizeLayerForwardV2), FUNC_SNLF2(SimdSynetNormalizeLayerForwardV2));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetNormalizeLayerForwardV2` for NCHW and NHWC formats.
- Wire SVE2 into the public dispatcher and auto tests.
- Document the optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetNormalizeLayerForwardV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2SynetNormalize.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d4d2f30-cfe8-460b-8560-4665951b6f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d4d2f30-cfe8-460b-8560-4665951b6f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

