### PR TITLE
Add SVE2 optimization for SynetNormalizeLayerForwardV3

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -83,6 +83,7 @@
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
+ <li>SVE2 optimizations of function SynetNormalizeLayerForwardV3.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7194,7 +7194,7 @@ SIMD_API void SimdSynetNormalizeLayerForwardV3(const float* src, size_t batch, s
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetNormalizeLayerForwardV3Ptr) (const float* src, size_t batch, size_t channels, size_t spatial,
         const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
-    const static SimdSynetNormalizeLayerForwardV3Ptr simdSynetNormalizeLayerForwardV3 = SIMD_FUNC4(SynetNormalizeLayerForwardV3, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetNormalizeLayerForwardV3Ptr simdSynetNormalizeLayerForwardV3 = SIMD_FUNC5(SynetNormalizeLayerForwardV3, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetNormalizeLayerForwardV3(src, batch, channels, spatial, scale, shift, eps, format, buf, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -619,6 +619,9 @@ namespace Simd
         void SynetNormalizeLayerForwardV2(const float* src, size_t batch, size_t channels, size_t spatial,
             const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
 
+        void SynetNormalizeLayerForwardV3(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
+
         void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);

--- a/src/Simd/SimdSve2SynetNormalize.cpp
+++ b/src/Simd/SimdSve2SynetNormalize.cpp
@@ -322,6 +322,132 @@ namespace Simd
             else
                 assert(0);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void NormalizeNchwV3(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, float eps, float* dst)
+        {
+            float k = 1.0f / float(spatial);
+            const size_t F = svcntw();
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    float mean = Sum(src, spatial) * k;
+                    svfloat32_t _mean = svdup_n_f32(mean);
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svst1_f32(mask, dst + s, svsub_f32_x(mask, svld1_f32(mask, src + s), _mean));
+                    }
+
+                    svfloat32_t _norm = svdup_n_f32(1.0f / ::sqrt(SumSquares(dst, spatial) * k + eps));
+                    svfloat32_t _scale = svdup_n_f32(scale[c]);
+                    svfloat32_t _shift = svdup_n_f32(shift[c]);
+                    for (size_t s = 0; s < spatial; s += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(s, spatial);
+                        svfloat32_t norm = svmul_f32_x(mask, svld1_f32(mask, dst + s), _norm);
+                        svst1_f32(mask, dst + s, svmla_f32_x(mask, _shift, norm, _scale));
+                    }
+
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+        }
+
+        void NormalizeNhwcV3(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, float eps, float* buf, float* dst)
+        {
+            float k = 1.0f / float(spatial);
+            Array32f _buf;
+            if (buf == NULL)
+            {
+                _buf.Resize(channels);
+                buf = _buf.data;
+            }
+            const size_t F = svcntw();
+            svfloat32_t _k = svdup_n_f32(k), _eps = svdup_n_f32(eps);
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t c = 0; c < channels; c += F)
+                {
+                    svbool_t mask = svwhilelt_b32(c, channels);
+                    svst1_f32(mask, buf + c, svdup_n_f32(0.0f));
+                }
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    const float* ps = src + s * channels;
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svst1_f32(mask, buf + c, svadd_f32_x(mask, svld1_f32(mask, buf + c), svld1_f32(mask, ps + c)));
+                    }
+                }
+                for (size_t c = 0; c < channels; c += F)
+                {
+                    svbool_t mask = svwhilelt_b32(c, channels);
+                    svst1_f32(mask, buf + c, svmul_f32_x(mask, svld1_f32(mask, buf + c), _k));
+                }
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    const float* ps = src + s * channels;
+                    float* pd = dst + s * channels;
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svst1_f32(mask, pd + c, svsub_f32_x(mask, svld1_f32(mask, ps + c), svld1_f32(mask, buf + c)));
+                    }
+                }
+
+                for (size_t c = 0; c < channels; c += F)
+                {
+                    svbool_t mask = svwhilelt_b32(c, channels);
+                    svst1_f32(mask, buf + c, svdup_n_f32(0.0f));
+                }
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    const float* pd = dst + s * channels;
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svfloat32_t d = svld1_f32(mask, pd + c);
+                        svst1_f32(mask, buf + c, svmla_f32_x(mask, svld1_f32(mask, buf + c), d, d));
+                    }
+                }
+                for (size_t c = 0; c < channels; c += F)
+                {
+                    svbool_t mask = svwhilelt_b32(c, channels);
+                    svst1_f32(mask, buf + c, ReciprocalSqrt(svadd_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, buf + c), _k), _eps), mask));
+                }
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    float* pd = dst + s * channels;
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svfloat32_t norm = svmul_f32_x(mask, svld1_f32(mask, pd + c), svld1_f32(mask, buf + c));
+                        svst1_f32(mask, pd + c, svmla_f32_x(mask, svld1_f32(mask, shift + c), norm, svld1_f32(mask, scale + c)));
+                    }
+                }
+
+                src += channels * spatial;
+                dst += channels * spatial;
+            }
+        }
+
+        void SynetNormalizeLayerForwardV3(const float* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst)
+        {
+            if (format == SimdTensorFormatNchw)
+                NormalizeNchwV3(src, batch, channels, spatial, scale, shift, *eps, dst);
+            else if (format == SimdTensorFormatNhwc)
+                NormalizeNhwcV3(src, batch, channels, spatial, scale, shift, *eps, buf, dst);
+            else
+                assert(0);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetNormalize32f.cpp
+++ b/src/Test/TestSynetNormalize32f.cpp
@@ -290,6 +290,11 @@ namespace Test
             result = result && SynetNormalizeLayerForwardV2AutoTest(FUNC_SNLF2(Simd::Neon::SynetNormalizeLayerForwardV3), FUNC_SNLF2(SimdSynetNormalizeLayerForwardV3));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetNormalizeLayerForwardV2AutoTest(FUNC_SNLF2(Simd::Sve2::SynetNormalizeLayerForwardV3), FUNC_SNLF2(SimdSynetNormalizeLayerForwardV3));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetNormalizeLayerForwardV3` for NCHW and NHWC tensors.
- Wire SVE2 dispatch and auto-test coverage for V3.
- Update the 7.2.164 release notes.

### Validation
- Native release CMake configure/build with `gcc/g++` completed successfully.
- Targeted `SynetNormalizeLayerForwardV3` auto-test completed successfully on x86_64.
- AArch64/SVE2 syntax compile of `src/Simd/SimdSve2SynetNormalize.cpp` completed successfully with `aarch64-linux-gnu-g++`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a709fcb-10c0-418d-940f-fc9e1942e70b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a709fcb-10c0-418d-940f-fc9e1942e70b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

