### PR TITLE
Add SVE2 SynetQuantizedMul optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -141,7 +141,7 @@
  <li>SVE2 optimizations of function Yuv444pToRgbaV2.</li>
  <li>SVE2 optimizations of function YToGray.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswishLayerForward.</li>
- <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON optimizations of class SynetQuantizedMulUniversal.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -104,6 +104,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetGridSample2d32fBlZ.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -398,6 +398,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7613,7 +7613,7 @@ SIMD_API void* SimdSynetQuantizedMulInit(const size_t* aShape, size_t aCount, Si
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetQuantizedMulInitPtr) (const size_t* aShape, size_t aCount, SimdTensorDataType aType, const float* aScale, int32_t aZero,
         const size_t* bShape, size_t bCount, SimdTensorDataType bType, const float* bScale, int32_t bZero, SimdTensorDataType dstType, const float* dstScale, int32_t dstZero);
-    const static SimdSynetQuantizedMulInitPtr simdSynetQuantizedMulInit = SIMD_FUNC4(SynetQuantizedMulInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedMulInitPtr simdSynetQuantizedMulInit = SIMD_FUNC5(SynetQuantizedMulInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetQuantizedMulInit(aShape, aCount, aType, aScale, aZero, bShape, bCount, bType, bScale, bZero, dstType, dstScale, dstZero);
 #else

--- a/src/Simd/SimdSve2SynetQuantizedMul.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMul.cpp
@@ -1,0 +1,255 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedMul.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE svfloat32_t DequantizeLinear(const svint32_t& value, const svint32_t& bias, const svfloat32_t& norm, const svbool_t& mask)
+        {
+            return svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, value, bias)), norm);
+        }
+
+        SIMD_INLINE svint32_t QuantizeLinear(const svfloat32_t& value, const svfloat32_t& norm, const svint32_t& zero, const svbool_t& mask)
+        {
+            svfloat32_t scaled = svmul_f32_x(mask, value, norm);
+            svfloat32_t round = svsel_f32(svcmpgt_n_f32(mask, scaled, 0.0f), svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
+            return svadd_s32_x(mask, svcvt_s32_f32_x(mask, svadd_f32_x(mask, scaled, round)), zero);
+        }
+
+        SIMD_INLINE void Store8u(const svint32_t& value, uint8_t* dst, const svbool_t& mask)
+        {
+            svint32_t lo = svmax_n_s32_x(mask, value, 0);
+            svuint32_t u32 = svreinterpret_u32_s32(svmin_n_s32_x(mask, lo, 255));
+            svst1b_u32(mask, dst, u32);
+        }
+
+        SIMD_INLINE svint32_t QuantizedMul8u8u8u(const svint32_t& a, const svint32_t& aBias, const svfloat32_t& aNorm,
+            const svint32_t& b, const svint32_t& bBias, const svfloat32_t& bNorm, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            svfloat32_t _a = DequantizeLinear(a, aBias, aNorm, mask);
+            svfloat32_t _b = DequantizeLinear(b, bBias, bNorm, mask);
+            return QuantizeLinear(svmul_f32_x(mask, _a, _b), dNorm, dZero, mask);
+        }
+
+        SIMD_INLINE svint32_t Load8u(const uint8_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE void QuantizedMul8u8u8uNN(const uint8_t* a, const svint32_t& aBias, const svfloat32_t& aNorm, const uint8_t* b, const svint32_t& bBias, const svfloat32_t& bNorm,
+            size_t size, uint8_t* dst, const svfloat32_t& dNorm, const svint32_t& dZero)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 0 * F, full), aBias, aNorm, Load8u(b + i + 0 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 0 * F, full);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 1 * F, full), aBias, aNorm, Load8u(b + i + 1 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 1 * F, full);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 2 * F, full), aBias, aNorm, Load8u(b + i + 2 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 2 * F, full);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 3 * F, full), aBias, aNorm, Load8u(b + i + 3 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 3 * F, full);
+            }
+            for (; i < size; i += F)
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i, mask), aBias, aNorm, Load8u(b + i, mask), bBias, bNorm, dNorm, dZero, mask), dst + i, mask);
+            }
+        }
+
+        SIMD_INLINE void QuantizedMul8u8u8u1N(const uint8_t* a, const svint32_t& aBias, const svfloat32_t& aNorm, const uint8_t* b, const svint32_t& bBias, const svfloat32_t& bNorm,
+            size_t size, uint8_t* dst, const svfloat32_t& dNorm, const svint32_t& dZero)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            svint32_t _a = svdup_n_s32((int32_t)a[0]);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                Store8u(QuantizedMul8u8u8u(_a, aBias, aNorm, Load8u(b + i + 0 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 0 * F, full);
+                Store8u(QuantizedMul8u8u8u(_a, aBias, aNorm, Load8u(b + i + 1 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 1 * F, full);
+                Store8u(QuantizedMul8u8u8u(_a, aBias, aNorm, Load8u(b + i + 2 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 2 * F, full);
+                Store8u(QuantizedMul8u8u8u(_a, aBias, aNorm, Load8u(b + i + 3 * F, full), bBias, bNorm, dNorm, dZero, full), dst + i + 3 * F, full);
+            }
+            for (; i < size; i += F)
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                Store8u(QuantizedMul8u8u8u(_a, aBias, aNorm, Load8u(b + i, mask), bBias, bNorm, dNorm, dZero, mask), dst + i, mask);
+            }
+        }
+
+        SIMD_INLINE void QuantizedMul8u8u8uN1(const uint8_t* a, const svint32_t& aBias, const svfloat32_t& aNorm, const uint8_t* b, const svint32_t& bBias, const svfloat32_t& bNorm,
+            size_t size, uint8_t* dst, const svfloat32_t& dNorm, const svint32_t& dZero)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            svint32_t _b = svdup_n_s32((int32_t)b[0]);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 0 * F, full), aBias, aNorm, _b, bBias, bNorm, dNorm, dZero, full), dst + i + 0 * F, full);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 1 * F, full), aBias, aNorm, _b, bBias, bNorm, dNorm, dZero, full), dst + i + 1 * F, full);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 2 * F, full), aBias, aNorm, _b, bBias, bNorm, dNorm, dZero, full), dst + i + 2 * F, full);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i + 3 * F, full), aBias, aNorm, _b, bBias, bNorm, dNorm, dZero, full), dst + i + 3 * F, full);
+            }
+            for (; i < size; i += F)
+            {
+                svbool_t mask = svwhilelt_b32(i, size);
+                Store8u(QuantizedMul8u8u8u(Load8u(a + i, mask), aBias, aNorm, _b, bBias, bNorm, dNorm, dZero, mask), dst + i, mask);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <size_t N> void QuantizedMulUniversal8u8u8u(const uint8_t* a8, const size_t* aSteps, float aScale, int aZero,
+            const uint8_t* b8, const size_t* bSteps, float bScale, int bZero, uint8_t* dst8, const size_t* dstShape, float dScale, int dZero)
+        {
+            svint32_t _aBias = svdup_n_s32(-aZero), _bBias = svdup_n_s32(-bZero), _dZero = svdup_n_s32(dZero);
+            svfloat32_t _aScale = svdup_n_f32(aScale), _bScale = svdup_n_f32(bScale), _scale = svdup_n_f32(1.0f / dScale);
+            const uint8_t* a0 = (uint8_t*)a8;
+            const uint8_t* b0 = (uint8_t*)b8;
+            uint8_t* dst = (uint8_t*)dst8;
+            size_t n1 = dstShape[N - 1];
+            bool aN = aSteps[N - 1] == 1, bN = bSteps[N - 1] == 1;
+            if (N == 1)
+            {
+                if (aN && bN)
+                    QuantizedMul8u8u8uNN(a0, _aBias, _aScale, b0, _bBias, _bScale, n1, dst, _scale, _dZero);
+                else if (bN)
+                    QuantizedMul8u8u8u1N(a0, _aBias, _aScale, b0, _bBias, _bScale, n1, dst, _scale, _dZero);
+                else if (aN)
+                    QuantizedMul8u8u8uN1(a0, _aBias, _aScale, b0, _bBias, _bScale, n1, dst, _scale, _dZero);
+            }
+            else if (N == 2)
+            {
+                for (size_t i0 = 0; i0 < dstShape[0]; ++i0)
+                {
+                    if (aN && bN)
+                        QuantizedMul8u8u8uNN(a0, _aBias, _aScale, b0, _bBias, _bScale, n1, dst, _scale, _dZero);
+                    else if (bN)
+                        QuantizedMul8u8u8u1N(a0, _aBias, _aScale, b0, _bBias, _bScale, n1, dst, _scale, _dZero);
+                    else if (aN)
+                        QuantizedMul8u8u8uN1(a0, _aBias, _aScale, b0, _bBias, _bScale, n1, dst, _scale, _dZero);
+                    dst += n1;
+                    a0 += aSteps[0];
+                    b0 += bSteps[0];
+                }
+            }
+            else if (N == 3)
+            {
+                for (size_t i0 = 0; i0 < dstShape[0]; ++i0)
+                {
+                    const uint8_t* a1 = a0;
+                    const uint8_t* b1 = b0;
+                    for (size_t i1 = 0; i1 < dstShape[1]; ++i1)
+                    {
+                        if (aN && bN)
+                            QuantizedMul8u8u8uNN(a1, _aBias, _aScale, b1, _bBias, _bScale, n1, dst, _scale, _dZero);
+                        else if (bN)
+                            QuantizedMul8u8u8u1N(a1, _aBias, _aScale, b1, _bBias, _bScale, n1, dst, _scale, _dZero);
+                        else if (aN)
+                            QuantizedMul8u8u8uN1(a1, _aBias, _aScale, b1, _bBias, _bScale, n1, dst, _scale, _dZero);
+                        dst += n1;
+                        a1 += aSteps[1];
+                        b1 += bSteps[1];
+                    }
+                    a0 += aSteps[0];
+                    b0 += bSteps[0];
+                }
+            }
+            else if (N == 4)
+            {
+                for (size_t i0 = 0; i0 < dstShape[0]; ++i0)
+                {
+                    const uint8_t* a1 = a0;
+                    const uint8_t* b1 = b0;
+                    for (size_t i1 = 0; i1 < dstShape[1]; ++i1)
+                    {
+                        const uint8_t* a2 = a1;
+                        const uint8_t* b2 = b1;
+                        for (size_t i2 = 0; i2 < dstShape[2]; ++i2)
+                        {
+                            if (aN && bN)
+                                QuantizedMul8u8u8uNN(a2, _aBias, _aScale, b2, _bBias, _bScale, n1, dst, _scale, _dZero);
+                            else if (bN)
+                                QuantizedMul8u8u8u1N(a2, _aBias, _aScale, b2, _bBias, _bScale, n1, dst, _scale, _dZero);
+                            else if (aN)
+                                QuantizedMul8u8u8uN1(a2, _aBias, _aScale, b2, _bBias, _bScale, n1, dst, _scale, _dZero);
+                            dst += n1;
+                            a2 += aSteps[2];
+                            b2 += bSteps[2];
+                        }
+                        a1 += aSteps[1];
+                        b1 += bSteps[1];
+                    }
+                    a0 += aSteps[0];
+                    b0 += bSteps[0];
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        static SynetQuantizedMulUniversal::UniversalPtr GetQuantizedMulUniversal8u8u8u(size_t dim)
+        {
+            switch (dim)
+            {
+            case 1: return QuantizedMulUniversal8u8u8u<1>;
+            case 2: return QuantizedMulUniversal8u8u8u<2>;
+            case 3: return QuantizedMulUniversal8u8u8u<3>;
+            case 4: return QuantizedMulUniversal8u8u8u<4>;
+            default:
+                return NULL;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetQuantizedMulUniversal::SynetQuantizedMulUniversal(const QuantizedMulParam& p)
+            : Base::SynetQuantizedMulUniversal(p)
+        {
+            if (p.aType == SimdTensorData8u && p.bType == SimdTensorData8u && p.dType == SimdTensorData8u)
+                _universal = GetQuantizedMulUniversal8u8u8u(_dShape.size());
+        }
+
+        ////-------------------------------------------------------------------------------------------------
+
+        void* SynetQuantizedMulInit(const size_t* aShape, size_t aCount, SimdTensorDataType aType, const float* aScale, int32_t aZero,
+            const size_t* bShape, size_t bCount, SimdTensorDataType bType, const float* bScale, int32_t bZero, SimdTensorDataType dstType, const float* dstScale, int32_t dstZero)
+        {
+            QuantizedMulParam param(aShape, aCount, aType, aScale, aZero, bShape, bCount, bType, bScale, bZero, dstType, dstScale, dstZero);
+            if (!param.Valid())
+                return NULL;
+            if (SynetQuantizedMulUniversal::Preferable(param))
+                return new SynetQuantizedMulUniversal(param);
+            return NULL;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetQuantizedMul.h
+++ b/src/Simd/SimdSynetQuantizedMul.h
@@ -148,6 +148,22 @@ namespace Simd
     }
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class SynetQuantizedMulUniversal : public Base::SynetQuantizedMulUniversal
+        {
+        public:
+            SynetQuantizedMulUniversal(const QuantizedMulParam& p);
+        };
+
+        //------------------------------------------------------------------------------------------------
+
+        void* SynetQuantizedMulInit(const size_t* aShape, size_t aCount, SimdTensorDataType aType, const float* aScale, int32_t aZero,
+            const size_t* bShape, size_t bCount, SimdTensorDataType bType, const float* bScale, int32_t bZero, SimdTensorDataType dstType, const float* dstScale, int32_t dstZero);
+    }
+#endif
+
 #ifdef SIMD_NEON_ENABLE
     namespace Neon
     {

--- a/src/Test/TestSynetQuantizedMul.cpp
+++ b/src/Test/TestSynetQuantizedMul.cpp
@@ -165,6 +165,11 @@ namespace Test
             result = result && SynetQuantizedMulForwardAutoTest(FUNC_QM(Simd::Neon::SynetQuantizedMulInit), FUNC_QM(SimdSynetQuantizedMulInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedMulForwardAutoTest(FUNC_QM(Simd::Sve2::SynetQuantizedMulInit), FUNC_QM(SimdSynetQuantizedMulInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 optimized `SynetQuantizedMulUniversal` kernels for `8u x 8u -> 8u` broadcast/universal cases.
* Wire SVE2 dispatch and auto-test coverage for `SynetQuantizedMulInit`.
* Add Visual Studio SVE2 project entries and update 7.2.164 release notes.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetQuantizedMul -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -I/workspace/src -std=c++17 -c /workspace/src/Simd/SimdSve2SynetQuantizedMul.cpp -o /tmp/SimdSve2SynetQuantizedMul.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7c77f63-b1c9-4ff5-b1d6-dd5722455720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7c77f63-b1c9-4ff5-b1d6-dd5722455720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

