### PR TITLE
Add SVE2 SynetPermute optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -85,6 +85,7 @@
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV3.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV4.</li>
+ <li>SVE2 optimizations of function SynetPermuteInit.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -104,6 +104,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetGridSample2d32fBlZ.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -398,6 +398,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7238,7 +7238,7 @@ SIMD_API void* SimdSynetPermuteInit(const size_t* shape, const size_t* order, si
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetPermuteInitPtr) (const size_t* shape, const size_t* order, size_t count, SimdTensorDataType type);
-    const static SimdSynetPermuteInitPtr simdSynetPermuteInit = SIMD_FUNC4(SynetPermuteInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetPermuteInitPtr simdSynetPermuteInit = SIMD_FUNC5(SynetPermuteInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetPermuteInit(shape, order, count, type);
 #else

--- a/src/Simd/SimdSve2SynetPermute.cpp
+++ b/src/Simd/SimdSve2SynetPermute.cpp
@@ -1,0 +1,134 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdSynetPermute.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        template<class T> SIMD_INLINE svuint32_t Load(const T* src, const svuint32_t& offset, const svbool_t& mask);
+
+        template<> SIMD_INLINE svuint32_t Load<uint8_t>(const uint8_t* src, const svuint32_t& offset, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src, offset);
+        }
+
+        template<> SIMD_INLINE svuint32_t Load<uint16_t>(const uint16_t* src, const svuint32_t& offset, const svbool_t& mask)
+        {
+            return svld1uh_gather_u32offset_u32(mask, src, offset);
+        }
+
+        template<> SIMD_INLINE svuint32_t Load<uint32_t>(const uint32_t* src, const svuint32_t& offset, const svbool_t& mask)
+        {
+            return svld1_gather_u32offset_u32(mask, src, offset);
+        }
+
+        template<class T> SIMD_INLINE void Store(T* dst, const svuint32_t& value, const svbool_t& mask);
+
+        template<> SIMD_INLINE void Store<uint8_t>(uint8_t* dst, const svuint32_t& value, const svbool_t& mask)
+        {
+            svst1b_u32(mask, dst, value);
+        }
+
+        template<> SIMD_INLINE void Store<uint16_t>(uint16_t* dst, const svuint32_t& value, const svbool_t& mask)
+        {
+            svst1h_u32(mask, dst, value);
+        }
+
+        template<> SIMD_INLINE void Store<uint32_t>(uint32_t* dst, const svuint32_t& value, const svbool_t& mask)
+        {
+            svst1_u32(mask, dst, value);
+        }
+
+        template<class T> void Permute2(const uint8_t* src_, const Base::Shape& shape, const Base::Shape& stride, uint8_t* dst_)
+        {
+            const T* src = (const T*)src_;
+            T* dst = (T*)dst_;
+            const size_t width = shape[0], height = shape[1], F = svcntw(), scale = stride[1] * sizeof(T);
+            const svuint32_t offset = svmul_n_u32_x(svptrue_b32(), svindex_u32(0, 1), (uint32_t)scale);
+            for (size_t i = 0; i < width; ++i)
+            {
+                const T* ps = src + i * stride[0];
+                T* pd = dst + i * height;
+                size_t j = 0;
+                for (; j < height; j += F)
+                {
+                    svbool_t mask = svwhilelt_b32(j, height);
+                    svuint32_t offs = svadd_n_u32_x(mask, offset, (uint32_t)(j * scale));
+                    Store<T>(pd + j, Load<T>(ps, offs, mask), mask);
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetPermute::SynetPermute(const Base::PermuteParam& param)
+#ifdef SIMD_NEON_ENABLE
+            : Neon::SynetPermute(param)
+#else
+            : Base::SynetPermute(param)
+#endif
+        {
+            if (_count == 2)
+            {
+                switch (_param.type)
+                {
+                case SimdTensorData32f:
+                case SimdTensorData32i:
+                    _permute = Permute2<uint32_t>;
+                    break;
+                case SimdTensorData8i:
+                case SimdTensorData8u:
+                    _permute = Permute2<uint8_t>;
+                    break;
+                case SimdTensorData16b:
+                case SimdTensorData16f:
+                    _permute = Permute2<uint16_t>;
+                    break;
+                default:
+                    assert(0);
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetPermuteInit(const size_t* shape, const size_t* order, size_t count, SimdTensorDataType type)
+        {
+            Base::PermuteParam param(shape, order, count, type,
+#ifdef SIMD_NEON_ENABLE
+                Neon::A
+#else
+                1
+#endif
+            );
+            if (!param.Valid())
+                return NULL;
+            return new SynetPermute(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetPermute.h
+++ b/src/Simd/SimdSynetPermute.h
@@ -173,6 +173,26 @@ namespace Simd
         void* SynetPermuteInit(const size_t* shape, const size_t* order, size_t count, SimdTensorDataType type);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class SynetPermute :
+#ifdef SIMD_NEON_ENABLE
+            public Neon::SynetPermute
+#else
+            public Base::SynetPermute
+#endif
+        {
+        public:
+            SynetPermute(const Base::PermuteParam& param);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetPermuteInit(const size_t* shape, const size_t* order, size_t count, SimdTensorDataType type);
+    }
+#endif
 }
 
 #endif

--- a/src/Test/TestSynetPermute.cpp
+++ b/src/Test/TestSynetPermute.cpp
@@ -158,6 +158,11 @@ namespace Test
             result = result && SynetPermuteAutoTest(FUNC_SP(Simd::Neon::SynetPermuteInit), FUNC_SP(SimdSynetPermuteInit));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetPermuteAutoTest(FUNC_SP(Simd::Sve2::SynetPermuteInit), FUNC_SP(SimdSynetPermuteInit));
+#endif 
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `Simd::Sve2::SynetPermute` with an SVE2 vectorized 2D permute path for 8/16/32-bit tensors.
- Route `SimdSynetPermuteInit` through SVE2 before NEON and add SVE2 auto-test coverage.
- Register `SimdSve2SynetPermute.cpp` in the VS2022 SVE2 project and document the release change for 7.2.164.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=SynetPermute -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -O2 -I./src -c ./src/Simd/SimdSve2SynetPermute.cpp -o /tmp/simd_sve2_synet_permute.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1d34415-b5f8-4bc5-bf00-d29650c836bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1d34415-b5f8-4bc5-bf00-d29650c836bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

