### PR TITLE
Add SVE2 SynetPoolingAverage optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -85,6 +85,7 @@
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV3.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV4.</li>
+ <li>SVE2 optimizations of function SynetPoolingAverage.</li>
  <li>SVE2 optimizations of function SynetPermuteInit.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingAverage32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -401,6 +401,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingAverage32f.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7275,7 +7275,7 @@ void SimdSynetPoolingAverage(const float* src, size_t srcC, size_t srcH, size_t 
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetPoolingAveragePtr) (const float* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
         size_t strideY, size_t strideX, size_t padY, size_t padX, float* dst, size_t dstH, size_t dstW, SimdBool exludePad, SimdTensorFormatType format);
-    const static SimdSynetPoolingAveragePtr simdSynetPoolingAverage = SIMD_FUNC4(SynetPoolingAverage, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetPoolingAveragePtr simdSynetPoolingAverage = SIMD_FUNC5(SynetPoolingAverage, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetPoolingAverage(src, srcC, srcH, srcW, kernelY, kernelX, strideY, strideX, padY, padX, dst, dstH, dstW, excludePad, format);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -625,6 +625,9 @@ namespace Simd
         void SynetNormalizeLayerForwardV4(const float* src, size_t batch, size_t channels, size_t spatial,
             const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
 
+        void SynetPoolingAverage(const float* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
+            size_t strideY, size_t strideX, size_t padY, size_t padX, float* dst, size_t dstH, size_t dstW, SimdBool excludePad, SimdTensorFormatType format);
+
         void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);

--- a/src/Simd/SimdSve2SynetPoolingAverage32f.cpp
+++ b/src/Simd/SimdSve2SynetPoolingAverage32f.cpp
@@ -1,0 +1,220 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void PoolingAverageNhwc1(const float* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svfloat32_t& norm, float* dst, const svbool_t& mask)
+        {
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const float* ps = src + w * srcC;
+                    sum0 = svadd_f32_x(mask, sum0, svld1_f32(mask, ps));
+                }
+                src += srcS;
+            }
+            svst1_f32(mask, dst, svmul_f32_x(mask, sum0, norm));
+        }
+
+        SIMD_INLINE void PoolingAverageNhwc2(const float* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svfloat32_t& norm, float* dst, const svbool_t& mask)
+        {
+            const size_t F = svcntw();
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const float* ps = src + w * srcC;
+                    sum0 = svadd_f32_x(mask, sum0, svld1_f32(mask, ps + 0 * F));
+                    sum1 = svadd_f32_x(mask, sum1, svld1_f32(mask, ps + 1 * F));
+                }
+                src += srcS;
+            }
+            svst1_f32(mask, dst + 0 * F, svmul_f32_x(mask, sum0, norm));
+            svst1_f32(mask, dst + 1 * F, svmul_f32_x(mask, sum1, norm));
+        }
+
+        SIMD_INLINE void PoolingAverageNhwc4(const float* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svfloat32_t& norm, float* dst, const svbool_t& mask)
+        {
+            const size_t F = svcntw();
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            svfloat32_t sum2 = svdup_n_f32(0.0f);
+            svfloat32_t sum3 = svdup_n_f32(0.0f);
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const float* ps = src + w * srcC;
+                    sum0 = svadd_f32_x(mask, sum0, svld1_f32(mask, ps + 0 * F));
+                    sum1 = svadd_f32_x(mask, sum1, svld1_f32(mask, ps + 1 * F));
+                    sum2 = svadd_f32_x(mask, sum2, svld1_f32(mask, ps + 2 * F));
+                    sum3 = svadd_f32_x(mask, sum3, svld1_f32(mask, ps + 3 * F));
+                }
+                src += srcS;
+            }
+            svst1_f32(mask, dst + 0 * F, svmul_f32_x(mask, sum0, norm));
+            svst1_f32(mask, dst + 1 * F, svmul_f32_x(mask, sum1, norm));
+            svst1_f32(mask, dst + 2 * F, svmul_f32_x(mask, sum2, norm));
+            svst1_f32(mask, dst + 3 * F, svmul_f32_x(mask, sum3, norm));
+        }
+
+        SIMD_INLINE void PoolingAverageNhwc8(const float* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svfloat32_t& norm, float* dst, const svbool_t& mask)
+        {
+            const size_t F = svcntw();
+            svfloat32_t sum0 = svdup_n_f32(0.0f);
+            svfloat32_t sum1 = svdup_n_f32(0.0f);
+            svfloat32_t sum2 = svdup_n_f32(0.0f);
+            svfloat32_t sum3 = svdup_n_f32(0.0f);
+            svfloat32_t sum4 = svdup_n_f32(0.0f);
+            svfloat32_t sum5 = svdup_n_f32(0.0f);
+            svfloat32_t sum6 = svdup_n_f32(0.0f);
+            svfloat32_t sum7 = svdup_n_f32(0.0f);
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const float* ps = src + w * srcC;
+                    sum0 = svadd_f32_x(mask, sum0, svld1_f32(mask, ps + 0 * F));
+                    sum1 = svadd_f32_x(mask, sum1, svld1_f32(mask, ps + 1 * F));
+                    sum2 = svadd_f32_x(mask, sum2, svld1_f32(mask, ps + 2 * F));
+                    sum3 = svadd_f32_x(mask, sum3, svld1_f32(mask, ps + 3 * F));
+                    sum4 = svadd_f32_x(mask, sum4, svld1_f32(mask, ps + 4 * F));
+                    sum5 = svadd_f32_x(mask, sum5, svld1_f32(mask, ps + 5 * F));
+                    sum6 = svadd_f32_x(mask, sum6, svld1_f32(mask, ps + 6 * F));
+                    sum7 = svadd_f32_x(mask, sum7, svld1_f32(mask, ps + 7 * F));
+                }
+                src += srcS;
+            }
+            svst1_f32(mask, dst + 0 * F, svmul_f32_x(mask, sum0, norm));
+            svst1_f32(mask, dst + 1 * F, svmul_f32_x(mask, sum1, norm));
+            svst1_f32(mask, dst + 2 * F, svmul_f32_x(mask, sum2, norm));
+            svst1_f32(mask, dst + 3 * F, svmul_f32_x(mask, sum3, norm));
+            svst1_f32(mask, dst + 4 * F, svmul_f32_x(mask, sum4, norm));
+            svst1_f32(mask, dst + 5 * F, svmul_f32_x(mask, sum5, norm));
+            svst1_f32(mask, dst + 6 * F, svmul_f32_x(mask, sum6, norm));
+            svst1_f32(mask, dst + 7 * F, svmul_f32_x(mask, sum7, norm));
+        }
+
+        SIMD_INLINE void PoolingAverageNhwc(const float* src, size_t srcS, size_t srcC, size_t srcCF1,
+            size_t srcCF2, size_t srcCF4, size_t srcCF8, size_t kernelY, size_t kernelX, const svfloat32_t& norm, float* dst, const svbool_t& body)
+        {
+            const size_t F = svcntw();
+            size_t c = 0;
+            for (; c < srcCF8; c += 8 * F)
+                PoolingAverageNhwc8(src + c, srcS, srcC, kernelY, kernelX, norm, dst + c, body);
+            for (; c < srcCF4; c += 4 * F)
+                PoolingAverageNhwc4(src + c, srcS, srcC, kernelY, kernelX, norm, dst + c, body);
+            for (; c < srcCF2; c += 2 * F)
+                PoolingAverageNhwc2(src + c, srcS, srcC, kernelY, kernelX, norm, dst + c, body);
+            for (; c < srcCF1; c += 1 * F)
+                PoolingAverageNhwc1(src + c, srcS, srcC, kernelY, kernelX, norm, dst + c, body);
+            if (c < srcC)
+                PoolingAverageNhwc1(src + c, srcS, srcC, kernelY, kernelX, norm, dst + c, svwhilelt_b32(c, srcC));
+        }
+
+        void SynetPoolingAverage(const float* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
+            size_t strideY, size_t strideX, size_t padY, size_t padX, float* dst, size_t dstH, size_t dstW, SimdBool excludePad, SimdTensorFormatType format)
+        {
+            const size_t F = svcntw();
+            if (format == SimdTensorFormatNhwc)
+            {
+                if (srcC >= F)
+                {
+                    size_t srcS = srcW * srcC;
+                    size_t srcCF1 = AlignLo(srcC, 1 * F);
+                    size_t srcCF2 = AlignLo(srcC, 2 * F);
+                    size_t srcCF4 = AlignLo(srcC, 4 * F);
+                    size_t srcCF8 = AlignLo(srcC, 8 * F);
+                    svbool_t body = svptrue_b32();
+                    if (padX == 0 && padY == 0 && (dstW - 1) * strideX + kernelX == srcW && (dstH - 1) * strideY + kernelY == srcH)
+                    {
+                        size_t stepY = srcW * srcC * strideY, stepX = strideX * srcC;
+                        svfloat32_t norm = svdup_n_f32(1.0f / (kernelY * kernelX));
+                        for (size_t ph = 0; ph < dstH; ++ph)
+                        {
+                            const float* ps = src + ph * stepY;
+                            for (size_t pw = 0; pw < dstW; ++pw, ps += stepX, dst += srcC)
+                                PoolingAverageNhwc(ps, srcS, srcC, srcCF1, srcCF2, srcCF4, srcCF8, kernelY, kernelX, norm, dst, body);
+                        }
+                    }
+                    else if (excludePad)
+                    {
+                        for (size_t ph = 0; ph < dstH; ++ph)
+                        {
+                            size_t hStart = ph * strideY - padY;
+                            size_t hEnd = Simd::Min(hStart + kernelY, srcH);
+                            hStart = Simd::Max<ptrdiff_t>(0, hStart);
+                            size_t kH = hEnd - hStart;
+                            for (size_t pw = 0; pw < dstW; ++pw)
+                            {
+                                size_t wStart = pw * strideX - padX;
+                                size_t wEnd = Simd::Min(wStart + kernelX, srcW);
+                                wStart = Simd::Max<ptrdiff_t>(0, wStart);
+                                size_t kW = wEnd - wStart;
+                                const float* ps = src + hStart * srcS + wStart * srcC;
+                                svfloat32_t norm = svdup_n_f32(1.0f / (kH * kW));
+                                PoolingAverageNhwc(ps, srcS, srcC, srcCF1, srcCF2, srcCF4, srcCF8, kH, kW, norm, dst, body);
+                                dst += srcC;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        svfloat32_t norm = svdup_n_f32(1.0f / (kernelY * kernelX));
+                        for (size_t ph = 0; ph < dstH; ++ph)
+                        {
+                            size_t hStart = ph * strideY - padY;
+                            size_t hEnd = Simd::Min(hStart + kernelY, srcH);
+                            hStart = Simd::Max<ptrdiff_t>(0, hStart);
+                            size_t kH = hEnd - hStart;
+                            for (size_t pw = 0; pw < dstW; ++pw)
+                            {
+                                size_t wStart = pw * strideX - padX;
+                                size_t wEnd = Simd::Min(wStart + kernelX, srcW);
+                                wStart = Simd::Max<ptrdiff_t>(0, wStart);
+                                size_t kW = wEnd - wStart;
+                                const float* ps = src + hStart * srcS + wStart * srcC;
+                                PoolingAverageNhwc(ps, srcS, srcC, srcCF1, srcCF2, srcCF4, srcCF8, kH, kW, norm, dst, body);
+                                dst += srcC;
+                            }
+                        }
+                    }
+                    return;
+                }
+            }
+            Base::SynetPoolingAverage(src, srcC, srcH, srcW, kernelY, kernelX, strideY, strideX, padY, padX, dst, dstH, dstW, excludePad, format);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetPooling.cpp
+++ b/src/Test/TestSynetPooling.cpp
@@ -143,10 +143,12 @@ namespace Test
         result = result && SynetPoolingAverageAutoTest(ParamP(128, 54, 96, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetPoolingAverageAutoTest(ParamP(128, 27, 48, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetPoolingAverageAutoTest(ParamP(128, 13, 24, _2, _2, _0, _0, f, c, e), f1, f2);
+        result = result && SynetPoolingAverageAutoTest(ParamP(65, 13, 24, _3, _2, _0, _1, f, c, e), f1, f2);
         //result = result && SynetPoolingAverageAutoTest(ParamP(32, 99, 99, _3, _1, _1, _1, f, c, e), f1, f2);
         //result = result && SynetPoolingAverageAutoTest(ParamP(32, 46, 46, _3, _2, _0, _1, f, c, e), f1, f2);
 #else
         result = result && SynetPoolingAverageAutoTest(ParamP(7, 54, 40, _2, _2, _0, _0, f, c, e), f1, f2);
+        result = result && SynetPoolingAverageAutoTest(ParamP(17, 27, 24, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetPoolingAverageAutoTest(ParamP(16, 33, 33, _3, _1, _1, _1, f, c, e), f1, f2);
         result = result && SynetPoolingAverageAutoTest(ParamP(16, 22, 22, _3, _2, _0, _1, f, c, e), f1, f2);
 #endif
@@ -191,6 +193,11 @@ namespace Test
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetPoolingAverageAutoTest(FUNC_PA(Simd::Neon::SynetPoolingAverage), FUNC_PA(SimdSynetPoolingAverage));
+#endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetPoolingAverageAutoTest(FUNC_PA(Simd::Sve2::SynetPoolingAverage), FUNC_PA(SimdSynetPoolingAverage));
 #endif 
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 NHWC average pooling implementation with predicated tail handling.
- Wire SVE2 dispatch, declarations, tests, VS2022 project files, and release notes.
- Add odd-channel pooling test coverage for vector tails.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetPoolingAverage -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -fsyntax-only -march=armv8.5-a+sve2 -I./src src/Simd/SimdSve2SynetPoolingAverage32f.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c134729-c38f-4a81-8e2b-daa16dcb69af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c134729-c38f-4a81-8e2b-daa16dcb69af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

