### PR TITLE
Add SVE2 SynetPoolingMax8u optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -87,6 +87,7 @@
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV4.</li>
  <li>SVE2 optimizations of function SynetPoolingAverage.</li>
  <li>SVE2 optimizations of function SynetPoolingMax32f.</li>
+ <li>SVE2 optimizations of function SynetPoolingMax8u.</li>
  <li>SVE2 optimizations of function SynetPermuteInit.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingAverage32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax32f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax8u.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -407,6 +407,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax32f.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax8u.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7322,7 +7322,7 @@ SIMD_API void SimdSynetPoolingMax8u(const uint8_t* src, size_t srcC, size_t srcH
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetPoolingMax8uPtr) (const uint8_t* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
         size_t strideY, size_t strideX, size_t padY, size_t padX, uint8_t* dst, size_t dstH, size_t dstW, SimdTensorFormatType format);
-    const static SimdSynetPoolingMax8uPtr simdSynetPoolingMax8u = SIMD_FUNC4(SynetPoolingMax8u, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetPoolingMax8uPtr simdSynetPoolingMax8u = SIMD_FUNC5(SynetPoolingMax8u, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetPoolingMax8u(src, srcC, srcH, srcW, kernelY, kernelX, strideY, strideX, padY, padX, dst, dstH, dstW, format);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -632,6 +632,9 @@ namespace Simd
             size_t kernelC, size_t kernelY, size_t kernelX, size_t strideC, size_t strideY, size_t strideX,
             size_t padC, size_t padY, size_t padX, float* dst, size_t dstC, size_t dstH, size_t dstW, SimdTensorFormatType format);
 
+        void SynetPoolingMax8u(const uint8_t* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
+            size_t strideY, size_t strideX, size_t padY, size_t padX, uint8_t* dst, size_t dstH, size_t dstW, SimdTensorFormatType format);
+
         void SynetInnerProduct8i(size_t M, size_t N, size_t K, const uint8_t* src, const int8_t* weight, int32_t* dst, SimdSynetCompatibilityType compatibility);
 
         void SynetInnerProductLayerForward(const float* src, const float* weight, const float* bias, size_t count, size_t size, float* dst);

--- a/src/Simd/SimdSve2SynetPoolingMax8u.cpp
+++ b/src/Simd/SimdSve2SynetPoolingMax8u.cpp
@@ -1,0 +1,198 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE void PoolingMax8uNhwc1(const uint8_t* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svuint8_t& min, uint8_t* dst, const svbool_t& mask)
+        {
+            svuint8_t max0 = min;
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const uint8_t* ps = src + w * srcC;
+                    max0 = svmax_u8_x(mask, max0, svld1_u8(mask, ps));
+                }
+                src += srcS;
+            }
+            svst1_u8(mask, dst, max0);
+        }
+
+        SIMD_INLINE void PoolingMax8uNhwc2(const uint8_t* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svuint8_t& min, uint8_t* dst, const svbool_t& mask)
+        {
+            const size_t A = svcntb();
+            svuint8_t max0 = min;
+            svuint8_t max1 = min;
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const uint8_t* ps = src + w * srcC;
+                    max0 = svmax_u8_x(mask, max0, svld1_u8(mask, ps + 0 * A));
+                    max1 = svmax_u8_x(mask, max1, svld1_u8(mask, ps + 1 * A));
+                }
+                src += srcS;
+            }
+            svst1_u8(mask, dst + 0 * A, max0);
+            svst1_u8(mask, dst + 1 * A, max1);
+        }
+
+        SIMD_INLINE void PoolingMax8uNhwc4(const uint8_t* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svuint8_t& min, uint8_t* dst, const svbool_t& mask)
+        {
+            const size_t A = svcntb();
+            svuint8_t max0 = min;
+            svuint8_t max1 = min;
+            svuint8_t max2 = min;
+            svuint8_t max3 = min;
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const uint8_t* ps = src + w * srcC;
+                    max0 = svmax_u8_x(mask, max0, svld1_u8(mask, ps + 0 * A));
+                    max1 = svmax_u8_x(mask, max1, svld1_u8(mask, ps + 1 * A));
+                    max2 = svmax_u8_x(mask, max2, svld1_u8(mask, ps + 2 * A));
+                    max3 = svmax_u8_x(mask, max3, svld1_u8(mask, ps + 3 * A));
+                }
+                src += srcS;
+            }
+            svst1_u8(mask, dst + 0 * A, max0);
+            svst1_u8(mask, dst + 1 * A, max1);
+            svst1_u8(mask, dst + 2 * A, max2);
+            svst1_u8(mask, dst + 3 * A, max3);
+        }
+
+        SIMD_INLINE void PoolingMax8uNhwc8(const uint8_t* src, size_t srcS, size_t srcC, size_t kH, size_t kW, const svuint8_t& min, uint8_t* dst, const svbool_t& mask)
+        {
+            const size_t A = svcntb();
+            svuint8_t max0 = min;
+            svuint8_t max1 = min;
+            svuint8_t max2 = min;
+            svuint8_t max3 = min;
+            svuint8_t max4 = min;
+            svuint8_t max5 = min;
+            svuint8_t max6 = min;
+            svuint8_t max7 = min;
+            for (size_t h = 0; h < kH; ++h)
+            {
+                for (size_t w = 0; w < kW; ++w)
+                {
+                    const uint8_t* ps = src + w * srcC;
+                    max0 = svmax_u8_x(mask, max0, svld1_u8(mask, ps + 0 * A));
+                    max1 = svmax_u8_x(mask, max1, svld1_u8(mask, ps + 1 * A));
+                    max2 = svmax_u8_x(mask, max2, svld1_u8(mask, ps + 2 * A));
+                    max3 = svmax_u8_x(mask, max3, svld1_u8(mask, ps + 3 * A));
+                    max4 = svmax_u8_x(mask, max4, svld1_u8(mask, ps + 4 * A));
+                    max5 = svmax_u8_x(mask, max5, svld1_u8(mask, ps + 5 * A));
+                    max6 = svmax_u8_x(mask, max6, svld1_u8(mask, ps + 6 * A));
+                    max7 = svmax_u8_x(mask, max7, svld1_u8(mask, ps + 7 * A));
+                }
+                src += srcS;
+            }
+            svst1_u8(mask, dst + 0 * A, max0);
+            svst1_u8(mask, dst + 1 * A, max1);
+            svst1_u8(mask, dst + 2 * A, max2);
+            svst1_u8(mask, dst + 3 * A, max3);
+            svst1_u8(mask, dst + 4 * A, max4);
+            svst1_u8(mask, dst + 5 * A, max5);
+            svst1_u8(mask, dst + 6 * A, max6);
+            svst1_u8(mask, dst + 7 * A, max7);
+        }
+
+        SIMD_INLINE void PoolingMax8uNhwc(const uint8_t* src, size_t srcS, size_t srcC, size_t srcCA1,
+            size_t srcCA2, size_t srcCA4, size_t srcCA8, size_t kernelY, size_t kernelX, const svuint8_t& min, uint8_t* dst, const svbool_t& body)
+        {
+            const size_t A = svcntb();
+            size_t c = 0;
+            for (; c < srcCA8; c += 8 * A)
+                PoolingMax8uNhwc8(src + c, srcS, srcC, kernelY, kernelX, min, dst + c, body);
+            for (; c < srcCA4; c += 4 * A)
+                PoolingMax8uNhwc4(src + c, srcS, srcC, kernelY, kernelX, min, dst + c, body);
+            for (; c < srcCA2; c += 2 * A)
+                PoolingMax8uNhwc2(src + c, srcS, srcC, kernelY, kernelX, min, dst + c, body);
+            for (; c < srcCA1; c += 1 * A)
+                PoolingMax8uNhwc1(src + c, srcS, srcC, kernelY, kernelX, min, dst + c, body);
+            if (c < srcC)
+                PoolingMax8uNhwc1(src + c, srcS, srcC, kernelY, kernelX, min, dst + c, svwhilelt_b8(c, srcC));
+        }
+
+        void SynetPoolingMax8u(const uint8_t* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
+            size_t strideY, size_t strideX, size_t padY, size_t padX, uint8_t* dst, size_t dstH, size_t dstW, SimdTensorFormatType format)
+        {
+            const size_t A = svcntb();
+            if (format == SimdTensorFormatNhwc)
+            {
+                if (srcC >= A)
+                {
+                    size_t srcS = srcW * srcC;
+                    size_t srcCA1 = AlignLo(srcC, 1 * A);
+                    size_t srcCA2 = AlignLo(srcC, 2 * A);
+                    size_t srcCA4 = AlignLo(srcC, 4 * A);
+                    size_t srcCA8 = AlignLo(srcC, 8 * A);
+                    svbool_t body = svptrue_b8();
+                    svuint8_t min = svdup_n_u8(0);
+                    if (padX == 0 && padY == 0 && (dstW - 1) * strideX + kernelX == srcW && (dstH - 1) * strideY + kernelY == srcH)
+                    {
+                        size_t stepY = srcW * srcC * strideY, stepX = strideX * srcC;
+                        for (size_t ph = 0; ph < dstH; ++ph)
+                        {
+                            const uint8_t* ps = src + ph * stepY;
+                            for (size_t pw = 0; pw < dstW; ++pw, ps += stepX, dst += srcC)
+                                PoolingMax8uNhwc(ps, srcS, srcC, srcCA1, srcCA2, srcCA4, srcCA8, kernelY, kernelX, min, dst, body);
+                        }
+                    }
+                    else
+                    {
+                        for (size_t ph = 0; ph < dstH; ++ph)
+                        {
+                            size_t hStart = ph * strideY - padY;
+                            size_t hEnd = Simd::Min(hStart + kernelY, srcH);
+                            hStart = Simd::Max<ptrdiff_t>(0, hStart);
+                            size_t kH = hEnd - hStart;
+                            for (size_t pw = 0; pw < dstW; ++pw)
+                            {
+                                size_t wStart = pw * strideX - padX;
+                                size_t wEnd = Simd::Min(wStart + kernelX, srcW);
+                                wStart = Simd::Max<ptrdiff_t>(0, wStart);
+                                size_t kW = wEnd - wStart;
+                                const uint8_t* ps = src + hStart * srcS + wStart * srcC;
+                                PoolingMax8uNhwc(ps, srcS, srcC, srcCA1, srcCA2, srcCA4, srcCA8, kH, kW, min, dst, body);
+                                dst += srcC;
+                            }
+                        }
+                    }
+                    return;
+                }
+            }
+            Base::SynetPoolingMax8u(src, srcC, srcH, srcW, kernelY, kernelX, strideY, strideX, padY, padX, dst, dstH, dstW, format);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetPooling.cpp
+++ b/src/Test/TestSynetPooling.cpp
@@ -524,6 +524,7 @@ namespace Test
         Size _0(0, 0), _1(1, 1), _2(2, 2), _3(3, 3);
 
         result = result && SynetPoolingMax8uAutoTest(ParamP(10, 238, 133, _2, _2, _0, _0, f, c, e), f1, f2);
+        result = result && SynetPoolingMax8uAutoTest(ParamP(65, 22, 22, _3, _2, _0, _1, f, c, e), f1, f2);
         result = result && SynetPoolingMax8uAutoTest(ParamP(28, 99, 99, _3, _1, _1, _1, f, c, e), f1, f2);
         result = result && SynetPoolingMax8uAutoTest(ParamP(32, 46, 46, _3, _2, _0, _1, f, c, e), f1, f2);
         result = result && SynetPoolingMax8uAutoTest(ParamP(64, 21, 21, _3, _2, _1, _1, f, c, e), f1, f2);
@@ -567,6 +568,11 @@ namespace Test
         if (Simd::Neon::Enable && TestNeon(options))
            result = result && SynetPoolingMax8uAutoTest(FUNC_PM8U(Simd::Neon::SynetPoolingMax8u), FUNC_PM8U(SimdSynetPoolingMax8u));
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetPoolingMax8uAutoTest(FUNC_PM8U(Simd::Sve2::SynetPoolingMax8u), FUNC_PM8U(SimdSynetPoolingMax8u));
+#endif
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 NHWC implementation for `SynetPoolingMax8u` with SVE byte-vector pooling and Base fallback for unsupported layouts/channel counts.
- Wire SVE2 dispatch and direct auto-test coverage, including a 65-channel tail case.
- Add the new SVE2 source to VS2022 project files and release 7.2.164 notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=SynetPoolingMax8u -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -I/workspace/src -fsyntax-only /workspace/src/Simd/SimdSve2SynetPoolingMax8u.cpp`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -I/workspace/src -fsyntax-only /workspace/src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c720c0c-d5ca-41c7-879e-4b62edaabc96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c720c0c-d5ca-41c7-879e-4b62edaabc96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

