### PR TITLE
Add SVE2 SynetPreluLayerForward optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -81,6 +81,7 @@
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
  <li>SVE2 optimizations of function SynetMish32f.</li>
+ <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV3.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7335,7 +7335,7 @@ SIMD_API void SimdSynetPreluLayerForward(const float * src, const float * slope,
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetPreluLayerForwardPtr) (const float * src, const float * slope, size_t channels, size_t spatial, float * dst, SimdTensorFormatType format);
-    const static SimdSynetPreluLayerForwardPtr simdSynetPreluLayerForward = SIMD_FUNC4(SynetPreluLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetPreluLayerForwardPtr simdSynetPreluLayerForward = SIMD_FUNC5(SynetPreluLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetPreluLayerForward(src, slope, channels, spatial, dst, format);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -613,6 +613,8 @@ namespace Simd
 
         void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst);
 
+        void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
+
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,
             const float* eps, SimdBool acrossSpatial, SimdTensorFormatType format, float* buf, float* dst);
 

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -232,6 +232,82 @@ namespace Simd
             if (i < size)
                 SynetMish32f(src + i, svwhilelt_b32(i, size), _threshold, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetPreluLayerForward(const svbool_t& mask, svfloat32_t src, svfloat32_t slope)
+        {
+            svfloat32_t pos = svmax_n_f32_x(mask, src, 0.0f);
+            svfloat32_t neg = svmin_n_f32_x(mask, src, 0.0f);
+            return svmla_f32_x(mask, pos, slope, neg);
+        }
+
+        SIMD_INLINE void SynetPreluLayerForward(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)
+        {
+            svst1_f32(mask, dst, SynetPreluLayerForward(mask, svld1_f32(mask, src), slope));
+        }
+
+        SIMD_INLINE void SynetPreluLayerForward(const float* src, const svbool_t& mask, const float* slope, float* dst)
+        {
+            svst1_f32(mask, dst, SynetPreluLayerForward(mask, svld1_f32(mask, src), svld1_f32(mask, slope)));
+        }
+
+        void SynetPreluLayerForwardNchw(const float* src, const float* slope, size_t channels, size_t spatial, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            for (size_t c = 0; c < channels; ++c)
+            {
+                size_t s = 0;
+                svfloat32_t _slope = svdup_n_f32(slope[c]);
+                for (; s + QF <= spatial; s += QF)
+                {
+                    SynetPreluLayerForward(src + s + 0 * F, body, _slope, dst + s + 0 * F);
+                    SynetPreluLayerForward(src + s + 1 * F, body, _slope, dst + s + 1 * F);
+                    SynetPreluLayerForward(src + s + 2 * F, body, _slope, dst + s + 2 * F);
+                    SynetPreluLayerForward(src + s + 3 * F, body, _slope, dst + s + 3 * F);
+                }
+                for (; s + F <= spatial; s += F)
+                    SynetPreluLayerForward(src + s, body, _slope, dst + s);
+                if (s < spatial)
+                    SynetPreluLayerForward(src + s, svwhilelt_b32(s, spatial), _slope, dst + s);
+                src += spatial;
+                dst += spatial;
+            }
+        }
+
+        void SynetPreluLayerForwardNhwc(const float* src, const float* slope, size_t channels, size_t spatial, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            for (size_t s = 0; s < spatial; ++s)
+            {
+                size_t c = 0;
+                for (; c + QF <= channels; c += QF)
+                {
+                    SynetPreluLayerForward(src + c + 0 * F, body, slope + c + 0 * F, dst + c + 0 * F);
+                    SynetPreluLayerForward(src + c + 1 * F, body, slope + c + 1 * F, dst + c + 1 * F);
+                    SynetPreluLayerForward(src + c + 2 * F, body, slope + c + 2 * F, dst + c + 2 * F);
+                    SynetPreluLayerForward(src + c + 3 * F, body, slope + c + 3 * F, dst + c + 3 * F);
+                }
+                for (; c + F <= channels; c += F)
+                    SynetPreluLayerForward(src + c, body, slope + c, dst + c);
+                if (c < channels)
+                    SynetPreluLayerForward(src + c, svwhilelt_b32(c, channels), slope + c, dst + c);
+                src += channels;
+                dst += channels;
+            }
+        }
+
+        void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format)
+        {
+            if (Base::NchwCompatible(channels, spatial, format))
+                SynetPreluLayerForwardNchw(src, slope, channels, spatial, dst);
+            else if (Base::NhwcCompatible(channels, spatial, format))
+                SynetPreluLayerForwardNhwc(src, slope, channels, spatial, dst);
+            else
+                assert(0);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -531,7 +531,8 @@ namespace Test
         Tensor32f dst1(ToShape(channels, spatial, format));
         Tensor32f dst2(ToShape(channels, spatial, format));
 
-        FillRandom(src.Data(), slope.Size(), -10.0, 10.0);
+        FillRandom(src.Data(), src.Size(), -10.0, 10.0);
+        FillRandom(slope.Data(), slope.Size(), -10.0, 10.0);
 
         TEST_ALIGN(SIMD_ALIGN);
 
@@ -577,6 +578,11 @@ namespace Test
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && SynetPreluLayerForwardAutoTest(FUNC_PLF(Simd::Avx512bw::SynetPreluLayerForward), FUNC_PLF(SimdSynetPreluLayerForward));
+#endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetPreluLayerForwardAutoTest(FUNC_PLF(Simd::Sve2::SynetPreluLayerForward), FUNC_PLF(SimdSynetPreluLayerForward));
 #endif
 
 #ifdef SIMD_NEON_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an SVE2 implementation of `SynetPreluLayerForward` for NCHW and NHWC tensors.
- Wire SVE2 into public dispatch and architecture-specific auto-tests.
- Update release 7.2.164 notes for the new optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetPreluLayerForward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdSve2SynetActivation.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -fsyntax-only -I./src src/Simd/SimdLib.cpp`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -std=c++17 -fsyntax-only -I./src src/Test/TestSynetActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e05b6f9-e3fd-4398-b134-f099d934e952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e05b6f9-e3fd-4398-b134-f099d934e952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

