### PR TITLE
Add NEON WarpAffine nearest optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -96,6 +96,7 @@
  <li>NEON, SVE2 optimizations of class SynetGridSample2d32fBlZ.</li>
  <li>SVE2 optimizations of function TextureBoostedSaturatedGradient.</li>
  <li>SVE2 optimizations of function TextureBoostedUv.</li>
+ <li>NEON optimizations of class WarpAffineNearest.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetFilter.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetInput.</li>
  <li>SVE2 optimizations of function WinogradKernel1x3Block1x4SetOutput.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -136,6 +136,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonTransform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonUyvyToBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonUyvyToYuv.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonWarpAffine.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonWinograd1.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonWinograd2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonWinograd3.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -214,6 +214,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonShiftBilinear.cpp">
       <Filter>Neon\Transform</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonWarpAffine.cpp">
+      <Filter>Neon\Transform</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonOperation.cpp">
       <Filter>Neon\Math</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -8182,7 +8182,7 @@ SIMD_API void* SimdWarpAffineInit(size_t srcW, size_t srcH, size_t srcS, size_t 
 {
     SIMD_EMPTY();    
     typedef void* (*SimdWarpAffineInitPtr) (size_t srcW, size_t srcH, size_t srcS, size_t dstW, size_t dstH, size_t dstS, size_t channels, const float* mat, SimdWarpAffineFlags flags, const uint8_t* border);
-    const static SimdWarpAffineInitPtr simdWarpAffineInit = SIMD_FUNC3(WarpAffineInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);//, SIMD_NEON_FUNC);
+    const static SimdWarpAffineInitPtr simdWarpAffineInit = SIMD_FUNC4(WarpAffineInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
     return simdWarpAffineInit(srcW, srcH, srcS, dstW, dstH, dstS, channels, mat, flags, border);
 }
 

--- a/src/Simd/SimdNeonWarpAffine.cpp
+++ b/src/Simd/SimdNeonWarpAffine.cpp
@@ -1,0 +1,232 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdWarpAffine.h"
+#include "Simd/SimdWarpAffineCommon.h"
+#include "Simd/SimdCopy.h"
+#include "Simd/SimdConst.h"
+#include "Simd/SimdStore.h"
+
+#include "Simd/SimdPoint.hpp"
+
+namespace Simd
+{
+#ifdef SIMD_NEON_ENABLE
+    namespace Neon
+    {
+        template<int N> SIMD_INLINE void FillBorder(uint8_t* dst, int count, const uint8x16_t& bv, const uint8_t* bs)
+        {
+            int i = 0, size = count * N, size16 = (int)AlignLo(size, A);
+            for (; i < size16; i += A)
+                vst1q_u8(dst + i, bv);
+            for (; i < size; i += N)
+                Base::CopyPixel<N>(bs, dst + i);
+        }
+
+        template<> SIMD_INLINE void FillBorder<3>(uint8_t* dst, int count, const uint8x16_t& bv, const uint8_t* bs)
+        {
+            int i = 0, size = count * 3, size3 = size - 3;
+            for (; i < size3; i += 3)
+                Base::CopyPixel<4>(bs, dst + i);
+            for (; i < size; i += 3)
+                Base::CopyPixel<3>(bs, dst + i);
+        }
+
+        template<int N> SIMD_INLINE uint8x16_t InitBorder(const uint8_t* border)
+        {
+            switch (N)
+            {
+            case 1: return vdupq_n_u8(*border);
+            case 2: return (uint8x16_t)vdupq_n_u16(*(uint16_t*)border);
+            case 3: return K8_00;
+            case 4: return (uint8x16_t)vdupq_n_u32(*(uint32_t*)border);
+            }
+            return K8_00;
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE uint32x4_t NearestOffset(float32x4_t x, float32x4_t y, const float32x4_t* m, int32x4_t w, const int32x4_t& h, const int32x4_t& n, const int32x4_t& s)
+        {
+            float32x4_t dx = vaddq_f32(vaddq_f32(vmulq_f32(x, m[0]), vmulq_f32(y, m[1])), m[2]);
+            float32x4_t dy = vaddq_f32(vaddq_f32(vmulq_f32(x, m[3]), vmulq_f32(y, m[4])), m[5]);
+            int32x4_t zero = vdupq_n_s32(0);
+            int32x4_t ix = vminq_s32(vmaxq_s32(Round(dx), zero), w);
+            int32x4_t iy = vminq_s32(vmaxq_s32(Round(dy), zero), h);
+            return vreinterpretq_u32_s32(vaddq_s32(vmulq_s32(ix, n), vmulq_s32(iy, s)));
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<int N> void NearestRun(const WarpAffParam& p, int yBeg, int yEnd, const int32_t* beg, const int32_t* end, const uint8_t* src, uint8_t* dst, uint32_t* buf)
+        {
+            bool fill = p.NeedFill();
+            int width = (int)p.dstW, s = (int)p.srcS, w = (int)p.srcW - 1, h = (int)p.srcH - 1;
+            const float32x4_t _4 = vdupq_n_f32(4.0f);
+            const int32x4_t _0123 = SIMD_VEC_SETR_EPI32(0, 1, 2, 3);
+            float32x4_t _m[6];
+            for (int i = 0; i < 6; ++i)
+                _m[i] = vdupq_n_f32(p.inv[i]);
+            int32x4_t _w = vdupq_n_s32(w);
+            int32x4_t _h = vdupq_n_s32(h);
+            int32x4_t _n = vdupq_n_s32(N);
+            int32x4_t _s = vdupq_n_s32(s);
+            uint8x16_t _border = InitBorder<N>(p.border);
+            dst += yBeg * p.dstS;
+            for (int y = yBeg; y < yEnd; ++y)
+            {
+                int nose = beg[y], tail = end[y];
+                {
+                    int x = nose;
+                    float32x4_t _y = vcvtq_f32_s32(vdupq_n_s32(y));
+                    float32x4_t _x = vcvtq_f32_s32(vaddq_s32(vdupq_n_s32(x), _0123));
+                    for (; x < tail; x += 4)
+                    {
+                        vst1q_u32(buf + x, NearestOffset(_x, _y, _m, _w, _h, _n, _s));
+                        _x = vaddq_f32(_x, _4);
+                    }
+                }
+                if (fill)
+                    FillBorder<N>(dst, nose, _border, p.border);
+                Base::NearestGather<N>(src, buf + nose, tail - nose, dst + N * nose);
+                if (fill)
+                    FillBorder<N>(dst + tail * N, width - tail, _border, p.border);
+                dst += p.dstS;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        WarpAffineNearest::WarpAffineNearest(const WarpAffParam& param)
+            : Base::WarpAffineNearest(param)
+        {
+            switch (_param.channels)
+            {
+            case 1: _run = NearestRun<1>; break;
+            case 2: _run = NearestRun<2>; break;
+            case 3: _run = NearestRun<3>; break;
+            case 4: _run = NearestRun<4>; break;
+            }
+        }
+
+        void WarpAffineNearest::SetRange(const Base::Point* points)
+        {
+            const WarpAffParam& p = _param;
+            int w = (int)p.dstW, h = (int)p.dstH, h4 = (int)AlignLo(h, 4);
+            const int32x4_t _0123 = SIMD_VEC_SETR_EPI32(0, 1, 2, 3);
+            int32x4_t _w = vdupq_n_s32(w), _1 = vdupq_n_s32(1), _0 = vdupq_n_s32(0);
+            int y = 0;
+            for (; y < h4; y += 4)
+            {
+                vst1q_s32(_beg.data + y, _w);
+                vst1q_s32(_end.data + y, _0);
+            }
+            for (; y < h; ++y)
+            {
+                _beg[y] = w;
+                _end[y] = 0;
+            }
+            for (int v = 0; v < 4; ++v)
+            {
+                const Base::Point& curr = points[v];
+                const Base::Point& next = points[(v + 1) & 3];
+                float yMin = Simd::Max(Simd::Min(curr.y, next.y), 0.0f);
+                float yMax = Simd::Min(Simd::Max(curr.y, next.y), (float)p.dstH);
+                int yBeg = Round(yMin);
+                int yEnd = Round(yMax);
+                int yEnd4 = (int)AlignLo(yEnd - yBeg, 4) + yBeg;
+                if (next.y == curr.y)
+                    continue;
+                float a = (next.x - curr.x) / (next.y - curr.y);
+                float b = curr.x - curr.y * a;
+                float32x4_t _a = vdupq_n_f32(a);
+                float32x4_t _b = vdupq_n_f32(b);
+                if (abs(a) <= 1.0f)
+                {
+                    int y = yBeg;
+                    for (; y < yEnd4; y += 4)
+                    {
+                        float32x4_t _y = vcvtq_f32_s32(vaddq_s32(vdupq_n_s32(y), _0123));
+                        int32x4_t _x = Round(vaddq_f32(vmulq_f32(_y, _a), _b));
+                        int32x4_t xBeg = vld1q_s32(_beg.data + y);
+                        int32x4_t xEnd = vld1q_s32(_end.data + y);
+                        xBeg = vminq_s32(xBeg, vmaxq_s32(_x, _0));
+                        xEnd = vmaxq_s32(xEnd, vminq_s32(vaddq_s32(_x, _1), _w));
+                        vst1q_s32(_beg.data + y, xBeg);
+                        vst1q_s32(_end.data + y, xEnd);
+                    }
+                    for (; y < yEnd; ++y)
+                    {
+                        int x = Round(y * a + b);
+                        _beg[y] = Simd::Min(_beg[y], Simd::Max(x, 0));
+                        _end[y] = Simd::Max(_end[y], Simd::Min(x + 1, w));
+                    }
+                }
+                else
+                {
+                    int y = yBeg;
+                    float32x4_t _05 = vdupq_n_f32(0.5f);
+                    float32x4_t _yMin = vdupq_n_f32(yMin);
+                    float32x4_t _yMax = vdupq_n_f32(yMax);
+                    for (; y < yEnd4; y += 4)
+                    {
+                        float32x4_t _y = vcvtq_f32_s32(vaddq_s32(vdupq_n_s32(y), _0123));
+                        float32x4_t yM = vminq_f32(vmaxq_f32(vsubq_f32(_y, _05), _yMin), _yMax);
+                        float32x4_t yP = vminq_f32(vmaxq_f32(vaddq_f32(_y, _05), _yMin), _yMax);
+                        float32x4_t xM = vaddq_f32(vmulq_f32(yM, _a), _b);
+                        float32x4_t xP = vaddq_f32(vmulq_f32(yP, _a), _b);
+                        int32x4_t xBeg = vld1q_s32(_beg.data + y);
+                        int32x4_t xEnd = vld1q_s32(_end.data + y);
+                        xBeg = vminq_s32(xBeg, vmaxq_s32(Round(vminq_f32(xM, xP)), _0));
+                        xEnd = vmaxq_s32(xEnd, vminq_s32(vaddq_s32(Round(vmaxq_f32(xM, xP)), _1), _w));
+                        vst1q_s32(_beg.data + y, xBeg);
+                        vst1q_s32(_end.data + y, xEnd);
+                    }
+                    for (; y < yEnd; ++y)
+                    {
+                        float xM = b + Simd::RestrictRange(float(y) - 0.5f, yMin, yMax) * a;
+                        float xP = b + Simd::RestrictRange(float(y) + 0.5f, yMin, yMax) * a;
+                        int xBeg = Round(Simd::Min(xM, xP));
+                        int xEnd = Round(Simd::Max(xM, xP));
+                        _beg[y] = Simd::Min(_beg[y], Simd::Max(xBeg, 0));
+                        _end[y] = Simd::Max(_end[y], Simd::Min(xEnd + 1, w));
+                    }
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* WarpAffineInit(size_t srcW, size_t srcH, size_t srcS, size_t dstW, size_t dstH, size_t dstS, size_t channels, const float* mat, SimdWarpAffineFlags flags, const uint8_t* border)
+        {
+            WarpAffParam param(srcW, srcH, srcS, dstW, dstH, dstS, channels, mat, flags, border, A);
+            if (!param.Valid())
+                return NULL;
+            if (param.IsNearest())
+                return new WarpAffineNearest(param);
+            else
+                return Base::WarpAffineInit(srcW, srcH, srcS, dstW, dstH, dstS, channels, mat, flags, border);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdNeonWarpAffine.cpp
+++ b/src/Simd/SimdNeonWarpAffine.cpp
@@ -152,8 +152,8 @@ namespace Simd
                 const Base::Point& next = points[(v + 1) & 3];
                 float yMin = Simd::Max(Simd::Min(curr.y, next.y), 0.0f);
                 float yMax = Simd::Min(Simd::Max(curr.y, next.y), (float)p.dstH);
-                int yBeg = Round(yMin);
-                int yEnd = Round(yMax);
+                int yBeg = Simd::Round(yMin);
+                int yEnd = Simd::Round(yMax);
                 int yEnd4 = (int)AlignLo(yEnd - yBeg, 4) + yBeg;
                 if (next.y == curr.y)
                     continue;
@@ -177,7 +177,7 @@ namespace Simd
                     }
                     for (; y < yEnd; ++y)
                     {
-                        int x = Round(y * a + b);
+                        int x = Simd::Round(y * a + b);
                         _beg[y] = Simd::Min(_beg[y], Simd::Max(x, 0));
                         _end[y] = Simd::Max(_end[y], Simd::Min(x + 1, w));
                     }
@@ -206,8 +206,8 @@ namespace Simd
                     {
                         float xM = b + Simd::RestrictRange(float(y) - 0.5f, yMin, yMax) * a;
                         float xP = b + Simd::RestrictRange(float(y) + 0.5f, yMin, yMax) * a;
-                        int xBeg = Round(Simd::Min(xM, xP));
-                        int xEnd = Round(Simd::Max(xM, xP));
+                        int xBeg = Simd::Round(Simd::Min(xM, xP));
+                        int xEnd = Simd::Round(Simd::Max(xM, xP));
                         _beg[y] = Simd::Min(_beg[y], Simd::Max(xBeg, 0));
                         _end[y] = Simd::Max(_end[y], Simd::Min(xEnd + 1, w));
                     }

--- a/src/Simd/SimdWarpAffine.h
+++ b/src/Simd/SimdWarpAffine.h
@@ -233,5 +233,23 @@ namespace Simd
         void* WarpAffineInit(size_t srcW, size_t srcH, size_t srcS, size_t dstW, size_t dstH, size_t dstS, size_t channels, const float* mat, SimdWarpAffineFlags flags, const uint8_t* border);
     }
 #endif
+
+#ifdef SIMD_NEON_ENABLE
+    namespace Neon
+    {
+        class WarpAffineNearest : public Base::WarpAffineNearest
+        {
+        public:
+            WarpAffineNearest(const WarpAffParam& param);
+
+        protected:
+            virtual void SetRange(const Base::Point* points);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* WarpAffineInit(size_t srcW, size_t srcH, size_t srcS, size_t dstW, size_t dstH, size_t dstS, size_t channels, const float* mat, SimdWarpAffineFlags flags, const uint8_t* border);
+    }
+#endif
 }
 #endif//__SimdWarpAffine_h__

--- a/src/Test/TestWarpAffine.cpp
+++ b/src/Test/TestWarpAffine.cpp
@@ -262,10 +262,10 @@ namespace Test
             result = result && WarpAffineAutoTest(FUNC_WA(Simd::Avx512bw::WarpAffineInit), FUNC_WA(SimdWarpAffineInit));
 #endif
 
-//#ifdef SIMD_NEON_ENABLE
-//        if (Simd::Neon::Enable && TestNeon(options))
-//            result = result && ResizerAutoTest(FUNC_RS(Simd::Neon::ResizerInit), FUNC_RS(SimdResizerInit));
-//#endif 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && WarpAffineAutoTest(FUNC_WA(Simd::Neon::WarpAffineInit), FUNC_WA(SimdWarpAffineInit));
+#endif 
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add NEON implementation of `WarpAffineNearest` with vectorized offset and range setup.
- Route `SimdWarpAffineInit` and WarpAffine auto-tests through the NEON initializer.
- Register `SimdNeonWarpAffine.cpp` in VS2022 NEON project files and document the 7.2.164 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=WarpAffine -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -fsyntax-only -std=c++11 -I./src -O2 src/Simd/SimdNeonWarpAffine.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a40f9d3-3956-4953-906f-f29442eafdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a40f9d3-3956-4953-906f-f29442eafdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

