### PR TITLE
Add AVX2 optimization for quantized hard sigmoid

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -149,7 +149,7 @@
  <li>SVE2 optimizations of function YToGray.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswish.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
- <li>Base implementation, SSE4.1 optimizations of function SynetQuantizedHardSigmoid.</li>
+ <li>Base implementation, SSE4.1, AVX2 optimizations of function SynetQuantizedHardSigmoid.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/src/Simd/SimdAvx2.h
+++ b/src/Simd/SimdAvx2.h
@@ -559,6 +559,8 @@ namespace Simd
 
         void SynetQuantizedConcatLayerForward(size_t count, const uint8_t** src, size_t num, const size_t* size, const int32_t* bias, const float* norm, const float* scale, int32_t zero, uint8_t* dst);
 
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
+
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);

--- a/src/Simd/SimdAvx2SynetQuantizedActivation.cpp
+++ b/src/Simd/SimdAvx2SynetQuantizedActivation.cpp
@@ -30,6 +30,54 @@ namespace Simd
 #if defined(SIMD_AVX2_ENABLE) && defined(SIMD_SYNET_ENABLE)   
     namespace Avx2
     {
+        SIMD_INLINE __m256i QuantizedHardSigmoid(const __m256i& src, const __m256i& sBias, const __m256& sNorm, const __m256& scale, const __m256& shift, const __m256& dNorm, const __m256i& dZero)
+        {
+            __m256 _src = DequantizeLinear(src, sBias, sNorm);
+            __m256 _dst = SynetHardSigmoid32f(_src, scale, shift);
+            return QuantizeLinear(_dst, dNorm, dZero);
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid1(const uint8_t* src, const __m256i& sBias, const __m256& sNorm, const __m256& scale, const __m256& shift, uint8_t* dst, const __m256& dNorm, const __m256i& dZero)
+        {
+            __m256i _src = _mm256_set1_epi32(src[0]);
+            __m256i d0 = QuantizedHardSigmoid(_src, sBias, sNorm, scale, shift, dNorm, dZero);
+            dst[0] = _mm_cvtsi128_si32(_mm256_castsi256_si128(_mm256_packus_epi16(_mm256_packs_epi32(d0, K_ZERO), K_ZERO)));
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid8(const uint8_t* src, const __m256i& sBias, const __m256& sNorm, const __m256& scale, const __m256& shift, uint8_t* dst, const __m256& dNorm, const __m256i& dZero)
+        {
+            __m256i _src = _mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i*)src));
+            __m256i d0 = QuantizedHardSigmoid(_src, sBias, sNorm, scale, shift, dNorm, dZero);
+            _mm_storel_epi64((__m128i*)dst, _mm256_castsi256_si128(PackI16ToU8(PackI32ToI16(d0, K_ZERO), K_ZERO)));
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid32(const uint8_t* src, const __m256i& sBias, const __m256& sNorm, const __m256& scale, const __m256& shift, uint8_t* dst, const __m256& dNorm, const __m256i& dZero)
+        {
+            __m128i src0 = _mm_loadu_si128((__m128i*)src + 0);
+            __m256i d0 = QuantizedHardSigmoid(_mm256_cvtepu8_epi32(_mm_srli_si128(src0, 0)), sBias, sNorm, scale, shift, dNorm, dZero);
+            __m256i d1 = QuantizedHardSigmoid(_mm256_cvtepu8_epi32(_mm_srli_si128(src0, 8)), sBias, sNorm, scale, shift, dNorm, dZero);
+            __m128i src1 = _mm_loadu_si128((__m128i*)src + 1);
+            __m256i d2 = QuantizedHardSigmoid(_mm256_cvtepu8_epi32(_mm_srli_si128(src1, 0)), sBias, sNorm, scale, shift, dNorm, dZero);
+            __m256i d3 = QuantizedHardSigmoid(_mm256_cvtepu8_epi32(_mm_srli_si128(src1, 8)), sBias, sNorm, scale, shift, dNorm, dZero);
+            _mm256_storeu_si256((__m256i*)dst, PackI16ToU8(PackI32ToI16(d0, d1), PackI32ToI16(d2, d3)));
+        }
+
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            __m256i sBias = _mm256_set1_epi32(-srcZero), dZero = _mm256_set1_epi32(dstZero);
+            __m256 sNorm = _mm256_set1_ps(srcScale[0]), dNorm = _mm256_set1_ps(1.0f / dstScale[0]);
+            __m256 _scale = _mm256_set1_ps(scale[0]), _shift = _mm256_set1_ps(shift[0]);
+            size_t i = 0, size8 = AlignLo(size, 8), size32 = AlignLo(size, 32);
+            for (; i < size32; i += 32)
+                QuantizedHardSigmoid32(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+            for (; i < size8; i += 8)
+                QuantizedHardSigmoid8(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+            for (; i < size; i += 1)
+                QuantizedHardSigmoid1(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE __m256i QuantizedHswish(const __m256i& src, const __m256i& sBias, const __m256& sNorm, const __m256& shift, const __m256& scale, const __m256& dNorm, const __m256i& dZero)
         {
             __m256 _src = DequantizeLinear(src, sBias, sNorm);

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7460,7 +7460,7 @@ SIMD_API void SimdSynetQuantizedHardSigmoid(const uint8_t* src, const float* src
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedHardSigmoidPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
-    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC1(SynetQuantizedHardSigmoid, SIMD_SSE41_FUNC);// , SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC);// , SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC2(SynetQuantizedHardSigmoid, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);// , SIMD_AVX512BW_FUNC);// , SIMD_NEON_FUNC);
 
     simdSynetQuantizedHardSigmoid(src, srcScale, srcZero, size, scale, shift, dst, dstScale, dstZero);
 #else

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -212,11 +212,11 @@ namespace Test
             result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Sse41::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
 #endif 
 
-//#ifdef SIMD_AVX2_ENABLE
-//        if (Simd::Avx2::Enable && TestSse41(options))
-//            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx2::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
-//#endif 
-//
+#ifdef SIMD_AVX2_ENABLE
+        if (Simd::Avx2::Enable && TestAvx2(options))
+            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx2::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
+#endif 
+
 //#ifdef SIMD_AVX512BW_ENABLE
 //        if (Simd::Avx512bw::Enable && TestSse41(options))
 //            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx512bw::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add AVX2 implementation and declaration for `SynetQuantizedHardSigmoid`.
- Enable AVX2 dispatch and focused autotest coverage for quantized hard sigmoid.
- Update the 7.2.164 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetQuantizedHardSigmoid -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-002af8e1-8d05-4766-9cee-fce4acdabdda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-002af8e1-8d05-4766-9cee-fce4acdabdda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

