### PR TITLE
Add AVX-512BW quantized hard sigmoid

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -149,7 +149,7 @@
  <li>SVE2 optimizations of function YToGray.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswish.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
- <li>Base implementation, SSE4.1, AVX2 optimizations of function SynetQuantizedHardSigmoid.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHardSigmoid.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/src/Simd/SimdAvx512bw.h
+++ b/src/Simd/SimdAvx512bw.h
@@ -553,6 +553,8 @@ namespace Simd
 
         void SynetQuantizedConcatLayerForward(size_t count, const uint8_t** src, size_t num, const size_t* size, const int32_t* bias, const float* norm, const float* scale, int32_t zero, uint8_t* dst);
 
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
+
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);

--- a/src/Simd/SimdAvx512bwSynetQuantizedActivation.cpp
+++ b/src/Simd/SimdAvx512bwSynetQuantizedActivation.cpp
@@ -30,6 +30,45 @@ namespace Simd
 #if defined(SIMD_AVX512BW_ENABLE) && defined(SIMD_SYNET_ENABLE)   
     namespace Avx512bw
     {
+        SIMD_INLINE __m512i QuantizedHardSigmoid(const __m512i& src, const __m512i& sBias, const __m512& sNorm, const __m512& scale, const __m512& shift, const __m512& dNorm, const __m512i& dZero)
+        {
+            __m512 _src = DequantizeLinear(src, sBias, sNorm);
+            __m512 _dst = SynetHardSigmoid32f(_src, scale, shift);
+            return QuantizeLinear(_dst, dNorm, dZero);
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid16(const uint8_t* src, const __m512i& sBias, const __m512& sNorm, const __m512& scale, const __m512& shift, uint8_t* dst, const __m512& dNorm, const __m512i& dZero, __mmask16 tail = -1)
+        {
+            __m512i _src = _mm512_cvtepu8_epi32(_mm_maskz_loadu_epi8(tail, src));
+            __m512i d0 = QuantizedHardSigmoid(_src, sBias, sNorm, scale, shift, dNorm, dZero);
+            _mm_mask_storeu_epi8(dst, tail, _mm512_castsi512_si128(PackI16ToU8(PackI32ToI16(d0, K_ZERO), K_ZERO)));
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid64(const uint8_t* src, const __m512i& sBias, const __m512& sNorm, const __m512& scale, const __m512& shift, uint8_t* dst, const __m512& dNorm, const __m512i& dZero)
+        {
+            __m512i d0 = QuantizedHardSigmoid(_mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)src + 0)), sBias, sNorm, scale, shift, dNorm, dZero);
+            __m512i d1 = QuantizedHardSigmoid(_mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)src + 1)), sBias, sNorm, scale, shift, dNorm, dZero);
+            __m512i d2 = QuantizedHardSigmoid(_mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)src + 2)), sBias, sNorm, scale, shift, dNorm, dZero);
+            __m512i d3 = QuantizedHardSigmoid(_mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)src + 3)), sBias, sNorm, scale, shift, dNorm, dZero);
+            _mm512_storeu_si512((__m512i*)dst, PackI16ToU8(PackI32ToI16(d0, d1), PackI32ToI16(d2, d3)));
+        }
+
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            __m512i sBias = _mm512_set1_epi32(-srcZero), dZero = _mm512_set1_epi32(dstZero);
+            __m512 sNorm = _mm512_set1_ps(srcScale[0]), dNorm = _mm512_set1_ps(1.0f / dstScale[0]);
+            __m512 _scale = _mm512_set1_ps(scale[0]), _shift = _mm512_set1_ps(shift[0]);
+            size_t i = 0, size16 = AlignLo(size, 16), size64 = AlignLo(size, 64);
+            for (; i < size64; i += 64)
+                QuantizedHardSigmoid64(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+            for (; i < size16; i += 16)
+                QuantizedHardSigmoid16(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+            if (i < size)
+                QuantizedHardSigmoid16(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero, TailMask16(size - size16));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE __m512i QuantizedHswish(const __m512i& src, const __m512i& sBias, const __m512& sNorm, const __m512& shift, const __m512& scale, const __m512& dNorm, const __m512i& dZero)
         {
             __m512 _src = DequantizeLinear(src, sBias, sNorm);

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7460,7 +7460,7 @@ SIMD_API void SimdSynetQuantizedHardSigmoid(const uint8_t* src, const float* src
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedHardSigmoidPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
-    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC2(SynetQuantizedHardSigmoid, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);// , SIMD_AVX512BW_FUNC);// , SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC3(SynetQuantizedHardSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);// , SIMD_NEON_FUNC);
 
     simdSynetQuantizedHardSigmoid(src, srcScale, srcZero, size, scale, shift, dst, dstScale, dstZero);
 #else

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -217,10 +217,10 @@ namespace Test
             result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx2::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
 #endif 
 
-//#ifdef SIMD_AVX512BW_ENABLE
-//        if (Simd::Avx512bw::Enable && TestSse41(options))
-//            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx512bw::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
-//#endif 
+#ifdef SIMD_AVX512BW_ENABLE
+        if (Simd::Avx512bw::Enable && TestAvx512bw(options))
+            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx512bw::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
+#endif 
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add AVX-512BW implementation of `SynetQuantizedHardSigmoid`.
* Enable AVX-512BW dispatch and auto-test coverage for quantized hard sigmoid.
* Update the 7.2.164 release note.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetQuantizedHardSigmoid -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc784124-3d96-4dad-9a4d-2c8ce7e789a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc784124-3d96-4dad-9a4d-2c8ce7e789a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

