### PR TITLE
Add NEON quantized hard sigmoid

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -149,7 +149,7 @@
  <li>SVE2 optimizations of function YToGray.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswish.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
- <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHardSigmoid.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON optimizations of function SynetQuantizedHardSigmoid.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7460,7 +7460,7 @@ SIMD_API void SimdSynetQuantizedHardSigmoid(const uint8_t* src, const float* src
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedHardSigmoidPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
-    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC3(SynetQuantizedHardSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);// , SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC4(SynetQuantizedHardSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     simdSynetQuantizedHardSigmoid(src, srcScale, srcZero, size, scale, shift, dst, dstScale, dstZero);
 #else

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -518,6 +518,8 @@ namespace Simd
 
         void SynetQuantizedConcatLayerForward(size_t count, const uint8_t** src, size_t num, const size_t* size, const int32_t* bias, const float* norm, const float* scale, int32_t zero, uint8_t* dst);
 
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
+
         void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
 
         void SynetQuantizedScaleLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* scale, const float* bias, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);

--- a/src/Simd/SimdNeonSynetQuantizedActivation.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedActivation.cpp
@@ -29,6 +29,59 @@ namespace Simd
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Neon
     {
+        SIMD_INLINE int32x4_t QuantizedHardSigmoid(int32x4_t src, int32x4_t sBias, float32x4_t sNorm, float32x4_t scale, float32x4_t shift, float32x4_t dNorm, int32x4_t dZero)
+        {
+            float32x4_t _src = DequantizeLinear(src, sBias, sNorm);
+            float32x4_t _dst = SynetHardSigmoid32f(_src, scale, shift);
+            return QuantizeLinear(_dst, dNorm, dZero);
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid1(const uint8_t* src, int32x4_t sBias, float32x4_t sNorm, float32x4_t scale, float32x4_t shift, uint8_t* dst, float32x4_t dNorm, int32x4_t dZero)
+        {
+            int32x4_t _src = vreinterpretq_s32_u32(vdupq_n_u32((uint32_t)src[0]));
+            int32x4_t d0 = QuantizedHardSigmoid(_src, sBias, sNorm, scale, shift, dNorm, dZero);
+            uint8x8_t u8 = vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vdup_n_s16(0)));
+            dst[0] = vget_lane_u8(u8, 0);
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid4(const uint8_t* src, int32x4_t sBias, float32x4_t sNorm, float32x4_t scale, float32x4_t shift, uint8_t* dst, float32x4_t dNorm, int32x4_t dZero)
+        {
+            uint8x8_t u8src = vreinterpret_u8_u32(vdup_n_u32(*(const uint32_t*)src));
+            int32x4_t _src = vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(vmovl_u8(u8src))));
+            int32x4_t d0 = QuantizedHardSigmoid(_src, sBias, sNorm, scale, shift, dNorm, dZero);
+            uint8x8_t u8 = vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vdup_n_s16(0)));
+            vst1_lane_u32((uint32_t*)dst, vreinterpret_u32_u8(u8), 0);
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid16(const uint8_t* src, int32x4_t sBias, float32x4_t sNorm, float32x4_t scale, float32x4_t shift, uint8_t* dst, float32x4_t dNorm, int32x4_t dZero)
+        {
+            uint8x16_t s8 = vld1q_u8(src);
+            uint16x8_t s16lo = vmovl_u8(vget_low_u8(s8)), s16hi = vmovl_u8(vget_high_u8(s8));
+            int32x4_t d0 = QuantizedHardSigmoid(vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(s16lo))), sBias, sNorm, scale, shift, dNorm, dZero);
+            int32x4_t d1 = QuantizedHardSigmoid(vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(s16lo))), sBias, sNorm, scale, shift, dNorm, dZero);
+            int32x4_t d2 = QuantizedHardSigmoid(vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(s16hi))), sBias, sNorm, scale, shift, dNorm, dZero);
+            int32x4_t d3 = QuantizedHardSigmoid(vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(s16hi))), sBias, sNorm, scale, shift, dNorm, dZero);
+            vst1q_u8(dst, vcombine_u8(
+                vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vqmovn_s32(d1))),
+                vqmovun_s16(vcombine_s16(vqmovn_s32(d2), vqmovn_s32(d3)))));
+        }
+
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            int32x4_t sBias = vdupq_n_s32(-srcZero), dZero = vdupq_n_s32(dstZero);
+            float32x4_t sNorm = vdupq_n_f32(srcScale[0]), dNorm = vdupq_n_f32(1.0f / dstScale[0]);
+            float32x4_t _scale = vdupq_n_f32(scale[0]), _shift = vdupq_n_f32(shift[0]);
+            size_t i = 0, size4 = AlignLo(size, 4), size16 = AlignLo(size, 16);
+            for (; i < size16; i += 16)
+                QuantizedHardSigmoid16(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+            for (; i < size4; i += 4)
+                QuantizedHardSigmoid4(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+            for (; i < size; i += 1)
+                QuantizedHardSigmoid1(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE int32x4_t QuantizedPrelu(int32x4_t src, int32x4_t sBias, float32x4_t sNorm, float32x4_t slope, float32x4_t dNorm, int32x4_t dZero)
         {
             float32x4_t _src = DequantizeLinear(src, sBias, sNorm);

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -222,6 +222,11 @@ namespace Test
             result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Avx512bw::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
 #endif 
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Neon::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add NEON implementation and dispatch for `SimdSynetQuantizedHardSigmoid`.
- Extend the quantized HardSigmoid auto-test to cover NEON when available.
- Update 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetQuantizedHardSigmoid -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -I src -fsyntax-only src/Simd/SimdNeonSynetQuantizedActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b49a283-1064-41f2-8ded-d88fee766b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b49a283-1064-41f2-8ded-d88fee766b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

