### PR TITLE
Add SVE2 quantized hard sigmoid

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -149,7 +149,7 @@
  <li>SVE2 optimizations of function YToGray.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswish.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
- <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON optimizations of function SynetQuantizedHardSigmoid.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -108,6 +108,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingAverage32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax8u.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -410,6 +410,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax8u.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedActivation.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7460,7 +7460,7 @@ SIMD_API void SimdSynetQuantizedHardSigmoid(const uint8_t* src, const float* src
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedHardSigmoidPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
-    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC4(SynetQuantizedHardSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedHardSigmoidPtr simdSynetQuantizedHardSigmoid = SIMD_FUNC5(SynetQuantizedHardSigmoid, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetQuantizedHardSigmoid(src, srcScale, srcZero, size, scale, shift, dst, dstScale, dstZero);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -613,6 +613,8 @@ namespace Simd
 
         void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst);
 
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
+
         void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,

--- a/src/Simd/SimdSve2SynetQuantizedActivation.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedActivation.cpp
@@ -1,0 +1,95 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE svfloat32_t DequantizeLinear(const svint32_t& value, const svint32_t& bias, const svfloat32_t& norm, const svbool_t& mask)
+        {
+            return svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, value, bias)), norm);
+        }
+
+        SIMD_INLINE svint32_t QuantizeLinear(const svfloat32_t& value, const svfloat32_t& norm, const svint32_t& zero, const svbool_t& mask)
+        {
+            svfloat32_t scaled = svmul_f32_x(mask, value, norm);
+            svfloat32_t round = svsel_f32(svcmpgt_n_f32(mask, scaled, 0.0f), svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
+            return svadd_s32_x(mask, svcvt_s32_f32_x(mask, svadd_f32_x(mask, scaled, round)), zero);
+        }
+
+        SIMD_INLINE svint32_t Load8u(const uint8_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE void Store8u(const svint32_t& value, uint8_t* dst, const svbool_t& mask)
+        {
+            svint32_t lo = svmax_n_s32_x(mask, value, 0);
+            svuint32_t u32 = svreinterpret_u32_s32(svmin_n_s32_x(mask, lo, 255));
+            svst1b_u32(mask, dst, u32);
+        }
+
+        SIMD_INLINE svfloat32_t SynetHardSigmoid32f(const svfloat32_t& value, const svfloat32_t& scale, const svfloat32_t& shift, const svbool_t& mask)
+        {
+            return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_f32_x(mask, shift, value, scale), 1.0f), 0.0f);
+        }
+
+        SIMD_INLINE svint32_t QuantizedHardSigmoid(const svint32_t& src, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svfloat32_t& scale, const svfloat32_t& shift, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            svfloat32_t _src = DequantizeLinear(src, sBias, sNorm, mask);
+            svfloat32_t _dst = SynetHardSigmoid32f(_src, scale, shift, mask);
+            return QuantizeLinear(_dst, dNorm, dZero, mask);
+        }
+
+        SIMD_INLINE void QuantizedHardSigmoid(const uint8_t* src, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svfloat32_t& scale, const svfloat32_t& shift, uint8_t* dst, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            Store8u(QuantizedHardSigmoid(Load8u(src, mask), sBias, sNorm, scale, shift, dNorm, dZero, mask), dst, mask);
+        }
+
+        void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            const svint32_t sBias = svdup_n_s32(-srcZero), dZero = svdup_n_s32(dstZero);
+            const svfloat32_t sNorm = svdup_n_f32(srcScale[0]), dNorm = svdup_n_f32(1.0f / dstScale[0]);
+            const svfloat32_t _scale = svdup_n_f32(scale[0]), _shift = svdup_n_f32(shift[0]);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                QuantizedHardSigmoid(src + i + 0 * F, sBias, sNorm, _scale, _shift, dst + i + 0 * F, dNorm, dZero, full);
+                QuantizedHardSigmoid(src + i + 1 * F, sBias, sNorm, _scale, _shift, dst + i + 1 * F, dNorm, dZero, full);
+                QuantizedHardSigmoid(src + i + 2 * F, sBias, sNorm, _scale, _shift, dst + i + 2 * F, dNorm, dZero, full);
+                QuantizedHardSigmoid(src + i + 3 * F, sBias, sNorm, _scale, _shift, dst + i + 3 * F, dNorm, dZero, full);
+            }
+            for (; i < size; i += F)
+                QuantizedHardSigmoid(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero, svwhilelt_b32(i, size));
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -227,6 +227,11 @@ namespace Test
             result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Neon::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedHardSigmoidAutoTest(FUNC_SQHI(Simd::Sve2::SynetQuantizedHardSigmoid), FUNC_SQHI(SimdSynetQuantizedHardSigmoid));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Add SVE2 optimization for `SimdSynetQuantizedHardSigmoid`.
* Wire SVE2 dispatch and focused auto-test coverage.
* Add the new SVE2 source to VS2022 project files and update release 7.2.164 notes.

### Testing
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2SynetQuantizedActivation.cpp`
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetQuantizedHardSigmoid -tt=1 -ts=1`
* `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdLib.cpp src/Test/TestSynetQuantizedActivation.cpp`
* `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23fc8701-f429-4bbb-a601-67036b4f5839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23fc8701-f429-4bbb-a601-67036b4f5839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

