### PR TITLE
Add NEON SynetNormalizeLayerForward16bV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,6 +84,7 @@
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
+ <li>NEON optimizations of function SynetNormalizeLayerForward16bV2.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV3.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV4.</li>
  <li>SVE2 optimizations of function SynetPoolingAverage.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetAdd16b.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetNormalize16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32fDirectNchw.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -325,6 +325,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetAdd16b.cpp">
       <Filter>Neon\Synet\Other</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetNormalize16b.cpp">
+      <Filter>Neon\Synet\Other</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConversion.cpp">
       <Filter>Neon\Synet\Other</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7225,7 +7225,7 @@ SIMD_API void SimdSynetNormalizeLayerForward16bV2(const uint16_t* src, size_t ba
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetNormalizeLayerForward16bV2Ptr) (const uint16_t* src, size_t batch, size_t channels, size_t spatial,
         const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, uint16_t* dst);
-    const static SimdSynetNormalizeLayerForward16bV2Ptr simdSynetNormalizeLayerForward16bV2 = SIMD_FUNC3(SynetNormalizeLayerForward16bV2, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);// , SIMD_NEON_FUNC);
+    const static SimdSynetNormalizeLayerForward16bV2Ptr simdSynetNormalizeLayerForward16bV2 = SIMD_FUNC4(SynetNormalizeLayerForward16bV2, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     simdSynetNormalizeLayerForward16bV2(src, batch, channels, spatial, scale, shift, eps, format, buf, dst);
 #else

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -563,6 +563,9 @@ namespace Simd
         void SynetNormalizeLayerForwardV4(const float* src, size_t batch, size_t channels, size_t spatial,
             const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
 
+        void SynetNormalizeLayerForward16bV2(const uint16_t* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, uint16_t* dst);
+
         void SynetPoolingAverage(const float* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
             size_t strideY, size_t strideX, size_t padY, size_t padX, float* dst, size_t dstH, size_t dstW, SimdBool excludePad, SimdTensorFormatType format);
 

--- a/src/Simd/SimdNeonSynetNormalize16b.cpp
+++ b/src/Simd/SimdNeonSynetNormalize16b.cpp
@@ -1,0 +1,116 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdArray.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdExtract.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdNeon.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Neon
+    {
+        SIMD_INLINE float32x4_t LoadBFloat16(const uint16_t* src)
+        {
+            return BFloat16ToFloat32(vmovl_u16(vld1_u16(src)));
+        }
+
+        SIMD_INLINE void StoreBFloat16(float32x4_t value, uint16_t* dst)
+        {
+            vst1_u16(dst, vmovn_u32(Float32ToBFloat16(value)));
+        }
+
+        void NormalizeNhwc16bV2(const uint16_t* src, size_t batch, size_t channels, size_t spatial, const float* scale, const float* shift, float eps, float* buf, uint16_t* dst)
+        {
+            float k = 1.0f / float(channels);
+            size_t channelsF = AlignLo(channels, F), c;
+            Array32f _buf;
+            if (buf == NULL)
+            {
+                _buf.Resize(channels);
+                buf = _buf.data;
+            }
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    for (c = 0; c < channelsF; c += F)
+                        vst1q_f32(buf + c, LoadBFloat16(src + c));
+                    for (; c < channels; ++c)
+                        buf[c] = Base::BFloat16ToFloat32(src[c]);
+
+                    float32x4_t _sum = vdupq_n_f32(0.0f);
+                    for (c = 0; c < channelsF; c += F)
+                        _sum = vaddq_f32(vld1q_f32(buf + c), _sum);
+                    float sum = ExtractSum32f(_sum);
+                    for (; c < channels; ++c)
+                        sum += buf[c];
+                    float32x4_t mean = vdupq_n_f32(sum * k);
+                    for (c = 0; c < channelsF; c += F)
+                        vst1q_f32(buf + c, vsubq_f32(vld1q_f32(buf + c), mean));
+                    for (; c < channels; ++c)
+                        buf[c] -= sum * k;
+
+                    float32x4_t _sqsum = vdupq_n_f32(0.0f);
+                    for (c = 0; c < channelsF; c += F)
+                    {
+                        float32x4_t _buf = vld1q_f32(buf + c);
+                        _sqsum = vaddq_f32(vmulq_f32(_buf, _buf), _sqsum);
+                    }
+                    float sqsum = ExtractSum32f(_sqsum);
+                    for (; c < channels; ++c)
+                        sqsum += Simd::Square(buf[c]);
+                    float32x4_t norm = vdupq_n_f32(1.0f / ::sqrt(sqsum * k + eps));
+                    for (c = 0; c < channelsF; c += F)
+                    {
+                        float32x4_t _buf = vmulq_f32(vld1q_f32(buf + c), norm);
+                        vst1q_f32(buf + c, vaddq_f32(vmulq_f32(_buf, vld1q_f32(scale + c)), vld1q_f32(shift + c)));
+                    }
+                    for (; c < channels; ++c)
+                        buf[c] = buf[c] * vgetq_lane_f32(norm, 0) * scale[c] + shift[c];
+
+                    for (c = 0; c < channelsF; c += F)
+                        StoreBFloat16(vld1q_f32(buf + c), dst + c);
+                    for (; c < channels; ++c)
+                        dst[c] = Base::Float32ToBFloat16(buf[c]);
+
+                    dst += channels;
+                    src += channels;
+                }
+            }
+        }
+
+        void SynetNormalizeLayerForward16bV2(const uint16_t* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, uint16_t* dst)
+        {
+            if (format == SimdTensorFormatNhwc)
+                NormalizeNhwc16bV2(src, batch, channels, spatial, scale, shift, *eps, buf, dst);
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetNormalize16b.cpp
+++ b/src/Test/TestSynetNormalize16b.cpp
@@ -109,10 +109,9 @@ namespace Test
 
         for (int f = 0; f < 1; f++)
         {
-            //result = result && SynetNormalizeLayerForward16bV2AutoTest(1, 512, 196, formats[f], 1, f1, f2);
             result = result && SynetNormalizeLayerForward16bV2AutoTest(1, C, W, formats[f], 1, f1, f2);
-            //result = result && SynetNormalizeLayerForward16bV2AutoTest(8, C, W, formats[f], 1, f1, f2);
-            //result = result && SynetNormalizeLayerForward16bV2AutoTest(7, C - O, W + O, formats[f], 0, f1, f2);
+            result = result && SynetNormalizeLayerForward16bV2AutoTest(8, C, W, formats[f], 1, f1, f2);
+            result = result && SynetNormalizeLayerForward16bV2AutoTest(7, C - O, W + O, formats[f], 0, f1, f2);
         }
 
         return result;
@@ -139,6 +138,11 @@ namespace Test
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && SynetNormalizeLayerForward16bV2AutoTest(FUNC_SNLF16B2(Simd::Avx512bw::SynetNormalizeLayerForward16bV2), FUNC_SNLF16B2(SimdSynetNormalizeLayerForward16bV2));
 #endif 
+
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetNormalizeLayerForward16bV2AutoTest(FUNC_SNLF16B2(Simd::Neon::SynetNormalizeLayerForward16bV2), FUNC_SNLF16B2(SimdSynetNormalizeLayerForward16bV2));
+#endif
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add NEON implementation and dispatch for `SimdSynetNormalizeLayerForward16bV2`.
- Extend the 16b normalize auto-test to cover NEON, batch, tail, and internal-buffer cases.
- Update VS2022 NEON project files and 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetNormalizeLayerForward16bV2 -tt=1 -ts=1`
- `cmake ./prj/cmake -B build-aarch64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DSIMD_TOOLCHAIN="" -DSIMD_TARGET="aarch64" -DSIMD_TEST=OFF -DSIMD_PYTHON=OFF -DSIMD_SHARED=ON`
- `cmake --build build-aarch64 --target Simd --parallel$(nproc)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea2b0f8c-551f-4c92-abb1-b38c8bba6b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea2b0f8c-551f-4c92-abb1-b38c8bba6b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

