### PR TITLE
Add SVE2 SynetNormalizeLayerForward16bV2 optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,7 +84,7 @@
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
- <li>NEON optimizations of function SynetNormalizeLayerForward16bV2.</li>
+ <li>NEON, SVE2 optimizations of function SynetNormalizeLayerForward16bV2.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV3.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV4.</li>
  <li>SVE2 optimizations of function SynetPoolingAverage.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -104,6 +104,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetGridSample2d32fBlZ.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingAverage32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPoolingMax32f.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -398,6 +398,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize16b.cpp">
+      <Filter>Sve2</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetPermute.cpp">
       <Filter>Sve2</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7225,7 +7225,7 @@ SIMD_API void SimdSynetNormalizeLayerForward16bV2(const uint16_t* src, size_t ba
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetNormalizeLayerForward16bV2Ptr) (const uint16_t* src, size_t batch, size_t channels, size_t spatial,
         const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, uint16_t* dst);
-    const static SimdSynetNormalizeLayerForward16bV2Ptr simdSynetNormalizeLayerForward16bV2 = SIMD_FUNC4(SynetNormalizeLayerForward16bV2, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetNormalizeLayerForward16bV2Ptr simdSynetNormalizeLayerForward16bV2 = SIMD_FUNC5(SynetNormalizeLayerForward16bV2, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetNormalizeLayerForward16bV2(src, batch, channels, spatial, scale, shift, eps, format, buf, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -629,6 +629,9 @@ namespace Simd
         void SynetNormalizeLayerForwardV4(const float* src, size_t batch, size_t channels, size_t spatial,
             const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, float* dst);
 
+        void SynetNormalizeLayerForward16bV2(const uint16_t* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, uint16_t* dst);
+
         void SynetPoolingAverage(const float* src, size_t srcC, size_t srcH, size_t srcW, size_t kernelY, size_t kernelX,
             size_t strideY, size_t strideX, size_t padY, size_t padX, float* dst, size_t dstH, size_t dstW, SimdBool excludePad, SimdTensorFormatType format);
 

--- a/src/Simd/SimdSve2SynetNormalize16b.cpp
+++ b/src/Simd/SimdSve2SynetNormalize16b.cpp
@@ -1,0 +1,120 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdArray.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE float Sum16bV2(const float* src, size_t size)
+        {
+            const size_t F = svcntw(), sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sum = svdup_n_f32(0.0f);
+            size_t i = 0;
+            for (; i < sizeF; i += F)
+                sum = svadd_f32_x(body, sum, svld1_f32(body, src + i));
+            float result = svaddv_f32(body, sum);
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                result += svaddv_f32(tail, svld1_f32(tail, src + i));
+            }
+            return result;
+        }
+
+        SIMD_INLINE float SumSquares16bV2(const float* src, size_t size)
+        {
+            const size_t F = svcntw(), sizeF = AlignLo(size, F);
+            const svbool_t body = svptrue_b32();
+            svfloat32_t sum = svdup_n_f32(0.0f);
+            size_t i = 0;
+            for (; i < sizeF; i += F)
+            {
+                svfloat32_t value = svld1_f32(body, src + i);
+                sum = svmla_f32_x(body, sum, value, value);
+            }
+            float result = svaddv_f32(body, sum);
+            if (i < size)
+            {
+                svbool_t tail = svwhilelt_b32(i, size);
+                svfloat32_t value = svld1_f32(tail, src + i);
+                result += svaddv_f32(tail, svmul_f32_x(tail, value, value));
+            }
+            return result;
+        }
+
+        void NormalizeNhwc16bV2(const uint16_t* src, size_t batch, size_t channels, size_t spatial, const float* scale, const float* shift, float eps, float* buf, uint16_t* dst)
+        {
+            float k = 1.0f / float(channels);
+            const size_t F = svcntw();
+            Array32f _buf;
+            if (buf == NULL)
+            {
+                _buf.Resize(channels);
+                buf = _buf.data;
+            }
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    BFloat16ToFloat32(src, channels, buf);
+
+                    svfloat32_t mean = svdup_n_f32(Sum16bV2(buf, channels) * k);
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svst1_f32(mask, buf + c, svsub_f32_x(mask, svld1_f32(mask, buf + c), mean));
+                    }
+
+                    svfloat32_t norm = svdup_n_f32(1.0f / ::sqrt(SumSquares16bV2(buf, channels) * k + eps));
+                    for (size_t c = 0; c < channels; c += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(c, channels);
+                        svfloat32_t value = svmul_f32_x(mask, svld1_f32(mask, buf + c), norm);
+                        svst1_f32(mask, buf + c, svmla_f32_x(mask, svld1_f32(mask, shift + c), value, svld1_f32(mask, scale + c)));
+                    }
+
+                    Float32ToBFloat16(buf, channels, dst);
+
+                    dst += channels;
+                    src += channels;
+                }
+            }
+        }
+
+        void SynetNormalizeLayerForward16bV2(const uint16_t* src, size_t batch, size_t channels, size_t spatial,
+            const float* scale, const float* shift, const float* eps, SimdTensorFormatType format, float* buf, uint16_t* dst)
+        {
+            if (format == SimdTensorFormatNhwc)
+                NormalizeNhwc16bV2(src, batch, channels, spatial, scale, shift, *eps, buf, dst);
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetNormalize16b.cpp
+++ b/src/Test/TestSynetNormalize16b.cpp
@@ -144,6 +144,11 @@ namespace Test
             result = result && SynetNormalizeLayerForward16bV2AutoTest(FUNC_SNLF16B2(Simd::Neon::SynetNormalizeLayerForward16bV2), FUNC_SNLF16B2(SimdSynetNormalizeLayerForward16bV2));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetNormalizeLayerForward16bV2AutoTest(FUNC_SNLF16B2(Simd::Sve2::SynetNormalizeLayerForward16bV2), FUNC_SNLF16B2(SimdSynetNormalizeLayerForward16bV2));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetNormalizeLayerForward16bV2` for NHWC bfloat16 tensors.
- Wire SVE2 dispatch and auto-test coverage for the public API.
- Register the new source in the VS2022 SVE2 project and update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetNormalizeLayerForward16bV2 -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.2-a+sve2 -I/workspace/src -fsyntax-only /workspace/src/Simd/SimdSve2SynetNormalize16b.cpp`
- `cmake ./prj/cmake -B build-aarch64-sve2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DSIMD_TARGET="" -DSIMD_SVE2=ON -DSIMD_TEST=OFF -DSIMD_SHARED=OFF && cmake --build build-aarch64-sve2 --parallel$(nproc)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b01327-92d9-49eb-91e5-e399c1011c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b01327-92d9-49eb-91e5-e399c1011c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

