### PR TITLE
Add SVE2 SynetQuantizeLinear optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -152,6 +152,7 @@
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswish.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>
+ <li>SVE2 optimizations of function SynetQuantizeLinear.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7692,7 +7692,7 @@ SIMD_API void SimdSynetQuantizeLinear(const float* src, size_t size, const float
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizeLinearPtr) (const float* src, size_t size, const float* norm, int32_t zero, uint8_t* dst);
-    const static SimdSynetQuantizeLinearPtr simdSynetQuantizeLinear = SIMD_FUNC4(SynetQuantizeLinear, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizeLinearPtr simdSynetQuantizeLinear = SIMD_FUNC5(SynetQuantizeLinear, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetQuantizeLinear(src, size, norm, zero, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -601,6 +601,8 @@ namespace Simd
 
         void SynetDequantizeLinear(const uint8_t* src, size_t size, int32_t bias, const float* norm, float* dst);
 
+        void SynetQuantizeLinear(const float* src, size_t size, const float* norm, int32_t zero, uint8_t* dst);
+
         void SynetEltwiseLayerForward(float const* const* src, const float* weight, size_t count, size_t size, SimdSynetEltwiseOperationType type, float* dst);
 
         void SynetElu32f(const float* src, size_t size, const float* alpha, float* dst);

--- a/src/Simd/SimdSve2SynetQuantizeLinear.cpp
+++ b/src/Simd/SimdSve2SynetQuantizeLinear.cpp
@@ -52,6 +52,40 @@ namespace Simd
             for (; i < size; i += F)
                 SynetDequantizeLinear(src + i, _bias, _norm, dst + i, svwhilelt_b32(i, size));
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svint32_t QuantizeLinear(const svfloat32_t& value, const svfloat32_t& norm, const svint32_t& zero, const svbool_t& mask)
+        {
+            svfloat32_t scaled = svmul_f32_x(mask, value, norm);
+            svfloat32_t round = svsel_f32(svcmpgt_n_f32(mask, scaled, 0.0f), svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
+            return svadd_s32_x(mask, svcvt_s32_f32_x(mask, svadd_f32_x(mask, scaled, round)), zero);
+        }
+
+        SIMD_INLINE void SynetQuantizeLinear(const float* src, const svfloat32_t& norm, const svint32_t& zero, uint8_t* dst, const svbool_t& mask)
+        {
+            svint32_t value = QuantizeLinear(svld1_f32(mask, src), norm, zero, mask);
+            value = svmin_n_s32_x(mask, svmax_n_s32_x(mask, value, 0), 255);
+            svst1b_u32(mask, dst, svreinterpret_u32_s32(value));
+        }
+
+        void SynetQuantizeLinear(const float* src, size_t size, const float* norm, int32_t zero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _norm = svdup_n_f32(norm[0]);
+            svint32_t _zero = svdup_n_s32(zero);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                SynetQuantizeLinear(src + i + 0 * F, _norm, _zero, dst + i + 0 * F, body);
+                SynetQuantizeLinear(src + i + 1 * F, _norm, _zero, dst + i + 1 * F, body);
+                SynetQuantizeLinear(src + i + 2 * F, _norm, _zero, dst + i + 2 * F, body);
+                SynetQuantizeLinear(src + i + 3 * F, _norm, _zero, dst + i + 3 * F, body);
+            }
+            for (; i < size; i += F)
+                SynetQuantizeLinear(src + i, _norm, _zero, dst + i, svwhilelt_b32(i, size));
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetQuantizeLinear.cpp
+++ b/src/Test/TestSynetQuantizeLinear.cpp
@@ -213,6 +213,11 @@ namespace Test
             result = result && SynetQuantizeLinearAutoTest(FUNC_QL(Simd::Neon::SynetQuantizeLinear), FUNC_QL(SimdSynetQuantizeLinear));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizeLinearAutoTest(FUNC_QL(Simd::Sve2::SynetQuantizeLinear), FUNC_QL(SimdSynetQuantizeLinear));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetQuantizeLinear` and expose it through `SimdSve2.h`.
- Include SVE2 in the public `SimdSynetQuantizeLinear` runtime dispatch.
- Add SVE2 coverage to `Test::SynetQuantizeLinearAutoTest`.
- Document the SVE2 optimization in release 7.2.164 notes.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetQuantizeLinear -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2SynetQuantizeLinear.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b094edbd-4807-4594-b4d9-8fc8fd745625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b094edbd-4807-4594-b4d9-8fc8fd745625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

