### PR TITLE
Add NEON optimization for SynetQuantizedHswish

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -150,7 +150,7 @@
  <li>SVE2 optimizations of function Yuv444pToRgbaV2.</li>
  <li>SVE2 optimizations of function YToGray.</li>
  <li>SVE2 optimizations of function SynetQuantizeLinear.</li>
- <li>Base implementation, SSE4.1, AVX2, AVX-512BW optimizations of function SynetQuantizedHswish.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON optimizations of function SynetQuantizedHswish.</li>
  <li>SVE2 optimizations of function SynetQuantizedConcatLayerForward.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7473,7 +7473,7 @@ SIMD_API void SimdSynetQuantizedHswish(const uint8_t* src, const float* srcScale
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedHswishPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
-    const static SimdSynetQuantizedHswishPtr simdSynetQuantizedHswish = SIMD_FUNC3(SynetQuantizedHswish, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);// , SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedHswishPtr simdSynetQuantizedHswish = SIMD_FUNC4(SynetQuantizedHswish, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     simdSynetQuantizedHswish(src, srcScale, srcZero, size,shift, scale, dst, dstScale, dstZero);
 #else

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -520,6 +520,8 @@ namespace Simd
 
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
+        void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
+
         void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
 
         void SynetQuantizedScaleLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* scale, const float* bias, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);

--- a/src/Simd/SimdNeonSynetQuantizedActivation.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedActivation.cpp
@@ -82,6 +82,59 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE int32x4_t QuantizedHswish(int32x4_t src, int32x4_t sBias, float32x4_t sNorm, float32x4_t shift, float32x4_t scale, float32x4_t dNorm, int32x4_t dZero)
+        {
+            float32x4_t _src = DequantizeLinear(src, sBias, sNorm);
+            float32x4_t _dst = SynetHswish32f(_src, shift, scale);
+            return QuantizeLinear(_dst, dNorm, dZero);
+        }
+
+        SIMD_INLINE void QuantizedHswish1(const uint8_t* src, int32x4_t sBias, float32x4_t sNorm, float32x4_t shift, float32x4_t scale, uint8_t* dst, float32x4_t dNorm, int32x4_t dZero)
+        {
+            int32x4_t _src = vreinterpretq_s32_u32(vdupq_n_u32((uint32_t)src[0]));
+            int32x4_t d0 = QuantizedHswish(_src, sBias, sNorm, shift, scale, dNorm, dZero);
+            uint8x8_t u8 = vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vdup_n_s16(0)));
+            dst[0] = vget_lane_u8(u8, 0);
+        }
+
+        SIMD_INLINE void QuantizedHswish4(const uint8_t* src, int32x4_t sBias, float32x4_t sNorm, float32x4_t shift, float32x4_t scale, uint8_t* dst, float32x4_t dNorm, int32x4_t dZero)
+        {
+            uint8x8_t u8src = vreinterpret_u8_u32(vdup_n_u32(*(const uint32_t*)src));
+            int32x4_t _src = vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(vmovl_u8(u8src))));
+            int32x4_t d0 = QuantizedHswish(_src, sBias, sNorm, shift, scale, dNorm, dZero);
+            uint8x8_t u8 = vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vdup_n_s16(0)));
+            vst1_lane_u32((uint32_t*)dst, vreinterpret_u32_u8(u8), 0);
+        }
+
+        SIMD_INLINE void QuantizedHswish16(const uint8_t* src, int32x4_t sBias, float32x4_t sNorm, float32x4_t shift, float32x4_t scale, uint8_t* dst, float32x4_t dNorm, int32x4_t dZero)
+        {
+            uint8x16_t s8 = vld1q_u8(src);
+            uint16x8_t s16lo = vmovl_u8(vget_low_u8(s8)), s16hi = vmovl_u8(vget_high_u8(s8));
+            int32x4_t d0 = QuantizedHswish(vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(s16lo))), sBias, sNorm, shift, scale, dNorm, dZero);
+            int32x4_t d1 = QuantizedHswish(vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(s16lo))), sBias, sNorm, shift, scale, dNorm, dZero);
+            int32x4_t d2 = QuantizedHswish(vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(s16hi))), sBias, sNorm, shift, scale, dNorm, dZero);
+            int32x4_t d3 = QuantizedHswish(vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(s16hi))), sBias, sNorm, shift, scale, dNorm, dZero);
+            vst1q_u8(dst, vcombine_u8(
+                vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vqmovn_s32(d1))),
+                vqmovun_s16(vcombine_s16(vqmovn_s32(d2), vqmovn_s32(d3)))));
+        }
+
+        void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            int32x4_t sBias = vdupq_n_s32(-srcZero), dZero = vdupq_n_s32(dstZero);
+            float32x4_t sNorm = vdupq_n_f32(srcScale[0]), dNorm = vdupq_n_f32(1.0f / dstScale[0]);
+            float32x4_t _shift = vdupq_n_f32(shift[0]), _scale = vdupq_n_f32(scale[0]);
+            size_t i = 0, size4 = AlignLo(size, 4), size16 = AlignLo(size, 16);
+            for (; i < size16; i += 16)
+                QuantizedHswish16(src + i, sBias, sNorm, _shift, _scale, dst + i, dNorm, dZero);
+            for (; i < size4; i += 4)
+                QuantizedHswish4(src + i, sBias, sNorm, _shift, _scale, dst + i, dNorm, dZero);
+            for (; i < size; i += 1)
+                QuantizedHswish1(src + i, sBias, sNorm, _shift, _scale, dst + i, dNorm, dZero);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE int32x4_t QuantizedPrelu(int32x4_t src, int32x4_t sBias, float32x4_t sNorm, float32x4_t slope, float32x4_t dNorm, int32x4_t dZero)
         {
             float32x4_t _src = DequantizeLinear(src, sBias, sNorm);

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -322,6 +322,11 @@ namespace Test
             result = result && SynetQuantizedHswishAutoTest(FUNC_SQHS(Simd::Avx512bw::SynetQuantizedHswish), FUNC_SQHS(SimdSynetQuantizedHswish));
 #endif 
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetQuantizedHswishAutoTest(FUNC_SQHS(Simd::Neon::SynetQuantizedHswish), FUNC_SQHS(SimdSynetQuantizedHswish));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add NEON implementation and declaration for `SynetQuantizedHswish`.
- Enable NEON dispatch for `SimdSynetQuantizedHswish`.
- Add NEON autotest coverage and update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && cd build && ./Test "-r=.." -fi=SynetQuantizedHswish -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -I./build -c src/Simd/SimdNeonSynetQuantizedActivation.cpp -o /tmp/simd_neon_quantized_activation.o`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c133f0cf-c106-415b-913f-89b2593922bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c133f0cf-c106-415b-913f-89b2593922bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

