### PR TITLE
Add SVE2 quantized HSwish

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -150,7 +150,7 @@
  <li>SVE2 optimizations of function Yuv444pToRgbaV2.</li>
  <li>SVE2 optimizations of function YToGray.</li>
  <li>SVE2 optimizations of function SynetQuantizeLinear.</li>
- <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON optimizations of function SynetQuantizedHswish.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHswish.</li>
  <li>SVE2 optimizations of function SynetQuantizedConcatLayerForward.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7473,9 +7473,9 @@ SIMD_API void SimdSynetQuantizedHswish(const uint8_t* src, const float* srcScale
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedHswishPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
-    const static SimdSynetQuantizedHswishPtr simdSynetQuantizedHswish = SIMD_FUNC4(SynetQuantizedHswish, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedHswishPtr simdSynetQuantizedHswish = SIMD_FUNC5(SynetQuantizedHswish, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
-    simdSynetQuantizedHswish(src, srcScale, srcZero, size,shift, scale, dst, dstScale, dstZero);
+    simdSynetQuantizedHswish(src, srcScale, srcZero, size, shift, scale, dst, dstScale, dstZero);
 #else
     assert(0);
 #endif

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -619,6 +619,8 @@ namespace Simd
 
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
+        void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
+
         void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,

--- a/src/Simd/SimdSve2SynetQuantizedActivation.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedActivation.cpp
@@ -90,6 +90,48 @@ namespace Simd
             for (; i < size; i += F)
                 QuantizedHardSigmoid(src + i, sBias, sNorm, _scale, _shift, dst + i, dNorm, dZero, svwhilelt_b32(i, size));
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetHswish32f(const svfloat32_t& value, const svfloat32_t& shift, const svfloat32_t& scale, const svbool_t& mask)
+        {
+            svfloat32_t upper = svmin_f32_x(mask, value, shift);
+            svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, shift), 0.0f);
+            return svmul_f32_x(mask, svmul_f32_x(mask, positive, scale), value);
+        }
+
+        SIMD_INLINE svint32_t QuantizedHswish(const svint32_t& src, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svfloat32_t& shift, const svfloat32_t& scale, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            svfloat32_t _src = DequantizeLinear(src, sBias, sNorm, mask);
+            svfloat32_t _dst = SynetHswish32f(_src, shift, scale, mask);
+            return QuantizeLinear(_dst, dNorm, dZero, mask);
+        }
+
+        SIMD_INLINE void QuantizedHswish(const uint8_t* src, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svfloat32_t& shift, const svfloat32_t& scale, uint8_t* dst, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            Store8u(QuantizedHswish(Load8u(src, mask), sBias, sNorm, shift, scale, dNorm, dZero, mask), dst, mask);
+        }
+
+        void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            const svint32_t sBias = svdup_n_s32(-srcZero), dZero = svdup_n_s32(dstZero);
+            const svfloat32_t sNorm = svdup_n_f32(srcScale[0]), dNorm = svdup_n_f32(1.0f / dstScale[0]);
+            const svfloat32_t _shift = svdup_n_f32(shift[0]), _scale = svdup_n_f32(scale[0]);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                QuantizedHswish(src + i + 0 * F, sBias, sNorm, _shift, _scale, dst + i + 0 * F, dNorm, dZero, full);
+                QuantizedHswish(src + i + 1 * F, sBias, sNorm, _shift, _scale, dst + i + 1 * F, dNorm, dZero, full);
+                QuantizedHswish(src + i + 2 * F, sBias, sNorm, _shift, _scale, dst + i + 2 * F, dNorm, dZero, full);
+                QuantizedHswish(src + i + 3 * F, sBias, sNorm, _shift, _scale, dst + i + 3 * F, dNorm, dZero, full);
+            }
+            for (; i < size; i += F)
+                QuantizedHswish(src + i, sBias, sNorm, _shift, _scale, dst + i, dNorm, dZero, svwhilelt_b32(i, size));
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -327,6 +327,11 @@ namespace Test
             result = result && SynetQuantizedHswishAutoTest(FUNC_SQHS(Simd::Neon::SynetQuantizedHswish), FUNC_SQHS(SimdSynetQuantizedHswish));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedHswishAutoTest(FUNC_SQHS(Simd::Sve2::SynetQuantizedHswish), FUNC_SQHS(SimdSynetQuantizedHswish));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdSynetQuantizedHswish`.
- Extend `SynetQuantizedHswishAutoTest` to cover SVE2.
- Update release 7.2.164 notes for the new SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetQuantizedHswish -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++14 -march=armv8.2-a+sve2 -I./src -fsyntax-only src/Simd/SimdSve2SynetQuantizedActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5808652-9120-44b1-bfc2-be9a0f0b1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5808652-9120-44b1-bfc2-be9a0f0b1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

