### PR TITLE
Add SVE2 quantized PReLU optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -154,6 +154,7 @@
  <li>SVE2 optimizations of function SynetQuantizedConcatLayerForward.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>
+ <li>SVE2 optimizations of function SynetQuantizedPreluLayerForward.</li>
  <li>Base implementation of function SynetQuantizedPoolingAverage.</li>
 </ul>
 <h5>Improving</h5>
@@ -210,6 +211,7 @@
  <li>Tests for verifying functionality of function SynetQuantizedHswish.</li>
  <li>Tests for verifying functionality of function SynetQuantizedMulInit.</li>
  <li>Tests for verifying functionality of function SynetQuantizedPoolingAverage.</li>
+ <li>Tests for verifying functionality of SVE2 version of function SynetQuantizedPreluLayerForward.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7669,7 +7669,7 @@ SIMD_API void SimdSynetQuantizedPreluLayerForward(const uint8_t* src, const floa
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedPreluLayerForwardPtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
-    const static SimdSynetQuantizedPreluLayerForwardPtr simdSynetQuantizedPreluLayerForward = SIMD_FUNC4(SynetQuantizedPreluLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedPreluLayerForwardPtr simdSynetQuantizedPreluLayerForward = SIMD_FUNC5(SynetQuantizedPreluLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetQuantizedPreluLayerForward(src, srcScale, srcZero, channels, spatial, slope, dst, dstScale, dstZero, format);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -621,6 +621,8 @@ namespace Simd
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
 
+        void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
+
         void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,

--- a/src/Simd/SimdSve2SynetQuantizedActivation.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedActivation.cpp
@@ -132,6 +132,72 @@ namespace Simd
             for (; i < size; i += F)
                 QuantizedHswish(src + i, sBias, sNorm, _shift, _scale, dst + i, dNorm, dZero, svwhilelt_b32(i, size));
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svint32_t QuantizedPrelu(const svint32_t& src, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svfloat32_t& slope, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            svfloat32_t _src = DequantizeLinear(src, sBias, sNorm, mask);
+            svfloat32_t pos = svmax_n_f32_x(mask, _src, 0.0f);
+            svfloat32_t neg = svmin_n_f32_x(mask, _src, 0.0f);
+            svfloat32_t _dst = svmla_f32_x(mask, pos, slope, neg);
+            return QuantizeLinear(_dst, dNorm, dZero, mask);
+        }
+
+        SIMD_INLINE void QuantizedPrelu(const uint8_t* src, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svfloat32_t& slope, uint8_t* dst, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            Store8u(QuantizedPrelu(Load8u(src, mask), sBias, sNorm, slope, dNorm, dZero, mask), dst, mask);
+        }
+
+        void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            const svint32_t sBias = svdup_n_s32(-srcZero), dZero = svdup_n_s32(dstZero);
+            const svfloat32_t sNorm = svdup_n_f32(srcScale[0]), dNorm = svdup_n_f32(1.0f / dstScale[0]);
+            if (format == SimdTensorFormatNhwc)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    size_t c = 0;
+                    for (; c + QF <= channels; c += QF)
+                    {
+                        QuantizedPrelu(src + c + 0 * F, sBias, sNorm, svld1_f32(full, slope + c + 0 * F), dst + c + 0 * F, dNorm, dZero, full);
+                        QuantizedPrelu(src + c + 1 * F, sBias, sNorm, svld1_f32(full, slope + c + 1 * F), dst + c + 1 * F, dNorm, dZero, full);
+                        QuantizedPrelu(src + c + 2 * F, sBias, sNorm, svld1_f32(full, slope + c + 2 * F), dst + c + 2 * F, dNorm, dZero, full);
+                        QuantizedPrelu(src + c + 3 * F, sBias, sNorm, svld1_f32(full, slope + c + 3 * F), dst + c + 3 * F, dNorm, dZero, full);
+                    }
+                    for (; c < channels; c += F)
+                    {
+                        svbool_t tail = svwhilelt_b32(c, channels);
+                        QuantizedPrelu(src + c, sBias, sNorm, svld1_f32(tail, slope + c), dst + c, dNorm, dZero, tail);
+                    }
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _slope = svdup_n_f32(slope[c]);
+                    size_t s = 0;
+                    for (; s + QF <= spatial; s += QF)
+                    {
+                        QuantizedPrelu(src + s + 0 * F, sBias, sNorm, _slope, dst + s + 0 * F, dNorm, dZero, full);
+                        QuantizedPrelu(src + s + 1 * F, sBias, sNorm, _slope, dst + s + 1 * F, dNorm, dZero, full);
+                        QuantizedPrelu(src + s + 2 * F, sBias, sNorm, _slope, dst + s + 2 * F, dNorm, dZero, full);
+                        QuantizedPrelu(src + s + 3 * F, sBias, sNorm, _slope, dst + s + 3 * F, dNorm, dZero, full);
+                    }
+                    for (; s < spatial; s += F)
+                        QuantizedPrelu(src + s, sBias, sNorm, _slope, dst + s, dNorm, dZero, svwhilelt_b32(s, spatial));
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetQuantizedActivation.cpp
+++ b/src/Test/TestSynetQuantizedActivation.cpp
@@ -133,6 +133,11 @@ namespace Test
             result = result && SynetQuantizedPreluLayerForwardAutoTest(FUNC_SQPLF(Simd::Neon::SynetQuantizedPreluLayerForward), FUNC_SQPLF(SimdSynetQuantizedPreluLayerForward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedPreluLayerForwardAutoTest(FUNC_SQPLF(Simd::Sve2::SynetQuantizedPreluLayerForward), FUNC_SQPLF(SimdSynetQuantizedPreluLayerForward));
+#endif
+
         return result;
     }
     //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SynetQuantizedPreluLayerForward`.
- Add SVE2 coverage to the quantized PReLU auto test.
- Update 7.2.164 release notes for the algorithm and test changes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetQuantizedPreluLayerForward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv9-a+sve2 -msve-vector-bits=scalable -I src -fsyntax-only src/Simd/SimdSve2SynetQuantizedActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf247b2d-dc46-41f0-a637-5926e9ef58eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf247b2d-dc46-41f0-a637-5926e9ef58eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

