### PR TITLE
Add SVE2 quantized shuffle optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -152,6 +152,7 @@
  <li>SVE2 optimizations of function SynetQuantizeLinear.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHswish.</li>
  <li>SVE2 optimizations of function SynetQuantizedConcatLayerForward.</li>
+ <li>SVE2 optimizations of function SynetQuantizedShuffleLayerForward.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>
  <li>SVE2 optimizations of function SynetQuantizedPreluLayerForward.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -113,6 +113,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConcat.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedShuffle.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -449,6 +449,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedShuffle.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7697,7 +7697,7 @@ SIMD_API void SimdSynetQuantizedShuffleLayerForward(const uint8_t* src0, int bia
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetQuantizedShuffleLayerForwardPtr) (const uint8_t* src0, int bias0, const float* norm0, size_t srcC0, const uint8_t* src1, int bias1, const float* norm1, size_t srcC1,
         size_t spatial, uint8_t* dst0, uint8_t* dst1, const float* scale, int zero, SimdTensorFormatType format, int type);
-    const static SimdSynetQuantizedShuffleLayerForwardPtr simdSynetQuantizedShuffleLayerForward = SIMD_FUNC4(SynetQuantizedShuffleLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedShuffleLayerForwardPtr simdSynetQuantizedShuffleLayerForward = SIMD_FUNC5(SynetQuantizedShuffleLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetQuantizedShuffleLayerForward(src0, bias0, norm0, srcC0, src1, bias1, norm1, srcC1, spatial, dst0, dst1, scale, zero, format, type);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -603,6 +603,9 @@ namespace Simd
 
         void SynetQuantizedConcatLayerForward(size_t count, const uint8_t** src, size_t num, const size_t* size, const int32_t* bias, const float* norm, const float* scale, int32_t zero, uint8_t* dst);
 
+        void SynetQuantizedShuffleLayerForward(const uint8_t* src0, int bias0, const float* norm0, size_t srcC0, const uint8_t* src1, int bias1, const float* norm1, size_t srcC1,
+            size_t spatial, uint8_t* dst0, uint8_t* dst1, const float* scale, int zero, SimdTensorFormatType format, int type);
+
         void SynetQuantizeLinear(const float* src, size_t size, const float* norm, int32_t zero, uint8_t* dst);
 
         void SynetEltwiseLayerForward(float const* const* src, const float* weight, size_t count, size_t size, SimdSynetEltwiseOperationType type, float* dst);

--- a/src/Simd/SimdSve2SynetQuantizedShuffle.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedShuffle.cpp
@@ -108,11 +108,11 @@ namespace Simd
             svfloat32_t _norm0 = svdup_n_f32(norm0), _norm1 = svdup_n_f32(norm1), _scale = svdup_n_f32(scale);
             for (size_t s = 0; s < spatial; ++s)
             {
-                size_t cd = 0, srcC0H = srcC0 / 2, srcC1H = srcC1 / 2;
-                for (; cd < srcC0H; cd += F)
-                    DequantizeQuantizeLinearNhwc0(src0 + 2 * cd, _bias0, _norm0, _scale, _zero, even, odd, dst0 + cd, dst1 + cd, svwhilelt_b32(cd, srcC0H));
-                for (size_t c1 = 0; c1 < srcC1H; c1 += F, cd += F)
-                    DequantizeQuantizeLinearNhwc0(src1 + 2 * c1, _bias1, _norm1, _scale, _zero, even, odd, dst0 + cd, dst1 + cd, svwhilelt_b32(c1, srcC1H));
+                size_t srcC0H = srcC0 / 2, srcC1H = srcC1 / 2;
+                for (size_t c0 = 0; c0 < srcC0H; c0 += F)
+                    DequantizeQuantizeLinearNhwc0(src0 + 2 * c0, _bias0, _norm0, _scale, _zero, even, odd, dst0 + c0, dst1 + c0, svwhilelt_b32(c0, srcC0H));
+                for (size_t c1 = 0; c1 < srcC1H; c1 += F)
+                    DequantizeQuantizeLinearNhwc0(src1 + 2 * c1, _bias1, _norm1, _scale, _zero, even, odd, dst0 + srcC0H + c1, dst1 + srcC0H + c1, svwhilelt_b32(c1, srcC1H));
                 src0 += srcC0;
                 src1 += srcC1;
                 dst0 += dstC;

--- a/src/Simd/SimdSve2SynetQuantizedShuffle.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedShuffle.cpp
@@ -1,0 +1,203 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE svint32_t QuantizeLinear(const svfloat32_t& value, const svfloat32_t& norm, const svint32_t& zero, const svbool_t& mask)
+        {
+            svfloat32_t scaled = svmul_f32_x(mask, value, norm);
+            svfloat32_t round = svsel_f32(svcmpgt_n_f32(mask, scaled, 0.0f), svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
+            return svadd_s32_x(mask, svcvt_s32_f32_x(mask, svadd_f32_x(mask, scaled, round)), zero);
+        }
+
+        SIMD_INLINE svuint32_t DequantizeQuantizeLinear(const svuint32_t& src, const svint32_t& bias, const svfloat32_t& norm, const svfloat32_t& scale, const svint32_t& zero, const svbool_t& mask)
+        {
+            svint32_t value = svadd_s32_x(mask, svreinterpret_s32_u32(src), bias);
+            svint32_t i32 = QuantizeLinear(svmul_f32_x(mask, svcvt_f32_s32_x(mask, value), norm), scale, zero, mask);
+            i32 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, i32, 0), 255);
+            return svreinterpret_u32_s32(i32);
+        }
+
+        SIMD_INLINE void DequantizeQuantizeLinear(const uint8_t* src, const svint32_t& bias, const svfloat32_t& norm, const svfloat32_t& scale, const svint32_t& zero, uint8_t* dst, const svbool_t& mask)
+        {
+            svst1b_u32(mask, dst, DequantizeQuantizeLinear(svld1ub_u32(mask, src), bias, norm, scale, zero, mask));
+        }
+
+        SIMD_INLINE void DequantizeQuantizeLinear(const uint8_t* src, size_t size, const svint32_t& bias, const svfloat32_t& norm, const svfloat32_t& scale, const svint32_t& zero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                DequantizeQuantizeLinear(src + i + 0 * F, bias, norm, scale, zero, dst + i + 0 * F, body);
+                DequantizeQuantizeLinear(src + i + 1 * F, bias, norm, scale, zero, dst + i + 1 * F, body);
+                DequantizeQuantizeLinear(src + i + 2 * F, bias, norm, scale, zero, dst + i + 2 * F, body);
+                DequantizeQuantizeLinear(src + i + 3 * F, bias, norm, scale, zero, dst + i + 3 * F, body);
+            }
+            for (; i < size; i += F)
+                DequantizeQuantizeLinear(src + i, bias, norm, scale, zero, dst + i, svwhilelt_b32(i, size));
+        }
+
+        void SynetQuantizedShuffleLayerForwardNchw0(const uint8_t* src0, int bias0, float norm0, size_t srcC0,
+            const uint8_t* src1, int bias1, float norm1, size_t srcC1, size_t spatial, uint8_t* dst0, uint8_t* dst1, float scale, int zero)
+        {
+            svint32_t _bias0 = svdup_n_s32(bias0), _bias1 = svdup_n_s32(bias1), _zero = svdup_n_s32(zero);
+            svfloat32_t _norm0 = svdup_n_f32(norm0), _norm1 = svdup_n_f32(norm1), _scale = svdup_n_f32(scale);
+            for (size_t cs = 0; cs < srcC0; cs += 2)
+            {
+                DequantizeQuantizeLinear(src0, spatial, _bias0, _norm0, _scale, _zero, dst0);
+                src0 += spatial;
+                dst0 += spatial;
+                DequantizeQuantizeLinear(src0, spatial, _bias0, _norm0, _scale, _zero, dst1);
+                src0 += spatial;
+                dst1 += spatial;
+            }
+            for (size_t cs = 0; cs < srcC1; cs += 2)
+            {
+                DequantizeQuantizeLinear(src1, spatial, _bias1, _norm1, _scale, _zero, dst0);
+                src1 += spatial;
+                dst0 += spatial;
+                DequantizeQuantizeLinear(src1, spatial, _bias1, _norm1, _scale, _zero, dst1);
+                src1 += spatial;
+                dst1 += spatial;
+            }
+        }
+
+        //--------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void DequantizeQuantizeLinearNhwc0(const uint8_t* src, const svint32_t& bias, const svfloat32_t& norm, const svfloat32_t& scale,
+            const svint32_t& zero, const svuint32_t& even, const svuint32_t& odd, uint8_t* dst0, uint8_t* dst1, const svbool_t& mask)
+        {
+            svst1b_u32(mask, dst0, DequantizeQuantizeLinear(svld1ub_gather_u32offset_u32(mask, src, even), bias, norm, scale, zero, mask));
+            svst1b_u32(mask, dst1, DequantizeQuantizeLinear(svld1ub_gather_u32offset_u32(mask, src, odd), bias, norm, scale, zero, mask));
+        }
+
+        void SynetQuantizedShuffleLayerForwardNhwc0(const uint8_t* src0, int bias0, float norm0, size_t srcC0,
+            const uint8_t* src1, int bias1, float norm1, size_t srcC1, size_t spatial, uint8_t* dst0, uint8_t* dst1, float scale, int zero)
+        {
+            const size_t F = svcntw(), dstC = (srcC0 + srcC1) / 2;
+            const svuint32_t even = svindex_u32(0, 2), odd = svindex_u32(1, 2);
+            svint32_t _bias0 = svdup_n_s32(bias0), _bias1 = svdup_n_s32(bias1), _zero = svdup_n_s32(zero);
+            svfloat32_t _norm0 = svdup_n_f32(norm0), _norm1 = svdup_n_f32(norm1), _scale = svdup_n_f32(scale);
+            for (size_t s = 0; s < spatial; ++s)
+            {
+                size_t cd = 0, srcC0H = srcC0 / 2, srcC1H = srcC1 / 2;
+                for (; cd < srcC0H; cd += F)
+                    DequantizeQuantizeLinearNhwc0(src0 + 2 * cd, _bias0, _norm0, _scale, _zero, even, odd, dst0 + cd, dst1 + cd, svwhilelt_b32(cd, srcC0H));
+                for (size_t c1 = 0; c1 < srcC1H; c1 += F, cd += F)
+                    DequantizeQuantizeLinearNhwc0(src1 + 2 * c1, _bias1, _norm1, _scale, _zero, even, odd, dst0 + cd, dst1 + cd, svwhilelt_b32(c1, srcC1H));
+                src0 += srcC0;
+                src1 += srcC1;
+                dst0 += dstC;
+                dst1 += dstC;
+            }
+        }
+
+        //--------------------------------------------------------------------------------------------------
+
+        void SynetQuantizedShuffleLayerForwardNchw1(const uint8_t* src0, int bias0, float norm0, size_t srcC0,
+            const uint8_t* src1, int bias1, float norm1, size_t srcC1, size_t spatial, uint8_t* dst0, uint8_t* dst1, float scale, int zero)
+        {
+            svint32_t _bias0 = svdup_n_s32(bias0), _bias1 = svdup_n_s32(bias1), _zero = svdup_n_s32(zero);
+            svfloat32_t _norm0 = svdup_n_f32(norm0), _norm1 = svdup_n_f32(norm1), _scale = svdup_n_f32(scale);
+            for (size_t cd = 0; cd < srcC0; cd += 2)
+            {
+                DequantizeQuantizeLinear(src0, spatial, _bias0, _norm0, _scale, _zero, dst0);
+                src0 += spatial;
+                dst0 += spatial;
+                DequantizeQuantizeLinear(src1, spatial, _bias1, _norm1, _scale, _zero, dst0);
+                src1 += spatial;
+                dst0 += spatial;
+            }
+            for (size_t cd = 0; cd < srcC1; cd += 2)
+            {
+                DequantizeQuantizeLinear(src0, spatial, _bias0, _norm0, _scale, _zero, dst1);
+                src0 += spatial;
+                dst1 += spatial;
+                DequantizeQuantizeLinear(src1, spatial, _bias1, _norm1, _scale, _zero, dst1);
+                src1 += spatial;
+                dst1 += spatial;
+            }
+        }
+
+        //--------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void DequantizeQuantizeLinearNhwc1(const uint8_t* src0, const uint8_t* src1, const svint32_t& bias0, const svint32_t& bias1,
+            const svfloat32_t& norm0, const svfloat32_t& norm1, const svfloat32_t& scale, const svint32_t& zero, const svuint32_t& even, const svuint32_t& odd, uint8_t* dst, const svbool_t& mask)
+        {
+            svst1b_scatter_u32offset_u32(mask, dst, even, DequantizeQuantizeLinear(svld1ub_u32(mask, src0), bias0, norm0, scale, zero, mask));
+            svst1b_scatter_u32offset_u32(mask, dst, odd, DequantizeQuantizeLinear(svld1ub_u32(mask, src1), bias1, norm1, scale, zero, mask));
+        }
+
+        void SynetQuantizedShuffleLayerForwardNhwc1(const uint8_t* src0, int bias0, float norm0, size_t srcC0,
+            const uint8_t* src1, int bias1, float norm1, size_t srcC1, size_t spatial, uint8_t* dst0, uint8_t* dst1, float scale, int zero)
+        {
+            const size_t F = svcntw(), dstC = (srcC0 + srcC1) / 2;
+            const svuint32_t even = svindex_u32(0, 2), odd = svindex_u32(1, 2);
+            svint32_t _bias0 = svdup_n_s32(bias0), _bias1 = svdup_n_s32(bias1), _zero = svdup_n_s32(zero);
+            svfloat32_t _norm0 = svdup_n_f32(norm0), _norm1 = svdup_n_f32(norm1), _scale = svdup_n_f32(scale);
+            for (size_t s = 0; s < spatial; ++s)
+            {
+                size_t dstC0H = srcC0 / 2, dstC1H = srcC1 / 2;
+                for (size_t cd = 0; cd < dstC0H; cd += F)
+                    DequantizeQuantizeLinearNhwc1(src0 + cd, src1 + cd, _bias0, _bias1, _norm0, _norm1, _scale, _zero, even, odd, dst0 + 2 * cd, svwhilelt_b32(cd, dstC0H));
+                for (size_t cd = 0; cd < dstC1H; cd += F)
+                    DequantizeQuantizeLinearNhwc1(src0 + dstC0H + cd, src1 + dstC0H + cd, _bias0, _bias1, _norm0, _norm1, _scale, _zero, even, odd, dst1 + 2 * cd, svwhilelt_b32(cd, dstC1H));
+                src0 += dstC;
+                src1 += dstC;
+                dst0 += srcC0;
+                dst1 += srcC1;
+            }
+        }
+
+        //--------------------------------------------------------------------------------------------------
+
+        void SynetQuantizedShuffleLayerForward(const uint8_t* src0, int bias0, const float* norm0, size_t srcC0, const uint8_t* src1, int bias1, const float* norm1, size_t srcC1,
+            size_t spatial, uint8_t* dst0, uint8_t* dst1, const float* scale, int zero, SimdTensorFormatType format, int shuffleType)
+        {
+            switch (shuffleType)
+            {
+            case 0:
+                if (format == SimdTensorFormatNhwc)
+                    SynetQuantizedShuffleLayerForwardNhwc0(src0, bias0, *norm0, srcC0, src1, bias1, *norm1, srcC1, spatial, dst0, dst1, *scale, zero);
+                else
+                    SynetQuantizedShuffleLayerForwardNchw0(src0, bias0, *norm0, srcC0, src1, bias1, *norm1, srcC1, spatial, dst0, dst1, *scale, zero);
+                break;
+            case 1:
+                if (format == SimdTensorFormatNhwc)
+                    SynetQuantizedShuffleLayerForwardNhwc1(src0, bias0, *norm0, srcC0, src1, bias1, *norm1, srcC1, spatial, dst0, dst1, *scale, zero);
+                else
+                    SynetQuantizedShuffleLayerForwardNchw1(src0, bias0, *norm0, srcC0, src1, bias1, *norm1, srcC1, spatial, dst0, dst1, *scale, zero);
+                break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetQuantizedShuffle.cpp
+++ b/src/Test/TestSynetQuantizedShuffle.cpp
@@ -143,6 +143,11 @@ namespace Test
             result = result && SynetQuantizedShuffleLayerForwardAutoTest(FUNC_SQSLF(Simd::Neon::SynetQuantizedShuffleLayerForward), FUNC_SQSLF(SimdSynetQuantizedShuffleLayerForward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedShuffleLayerForwardAutoTest(FUNC_SQSLF(Simd::Sve2::SynetQuantizedShuffleLayerForward), FUNC_SQSLF(SimdSynetQuantizedShuffleLayerForward));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetQuantizedShuffleLayerForward` with predicated contiguous, gather, and scatter paths.
- Register SVE2 dispatch and SVE2 auto-test coverage for quantized shuffle.
- Add the new SVE2 source to VS2022 project files and document the 7.2.164 release note.
- Fix NHWC type 0 masked-tail destination offset so the `src1` half starts at `srcC0 / 2` instead of the next full vector position.

### Validation
- `aarch64-linux-gnu-g++ -I/workspace/src -c /workspace/src/Simd/SimdSve2SynetQuantizedShuffle.cpp -o /tmp/SimdSve2SynetQuantizedShuffle.o -march=armv8.6-a+sve2 -std=c++11`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetQuantizedShuffleLayerForward -tt=1 -ts=1`
- Boundary check for the reported `srcC0 / 2 == 105` case confirms the first `src1` destination offset is now 105 instead of 112.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47b8340d-0432-46b3-b0d8-28cb8f655690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47b8340d-0432-46b3-b0d8-28cb8f655690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

