### PR TITLE
Add SVE2 SynetRelu32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -82,6 +82,7 @@
  <li>SVE2 optimizations of function SynetHswish32f.</li>
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
+ <li>SVE2 optimizations of function SynetRelu32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>NEON, SVE2 optimizations of function SynetNormalizeLayerForward16bV2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7723,7 +7723,7 @@ SIMD_API void SimdSynetRelu32f(const float* src, size_t size, const float* slope
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetRelu32fPtr) (const float* src, size_t size, const float* slope, float* dst);
-    const static SimdSynetRelu32fPtr simdSynetRelu32f = SIMD_FUNC4(SynetRelu32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetRelu32fPtr simdSynetRelu32f = SIMD_FUNC5(SynetRelu32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetRelu32f(src, size, slope, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -620,6 +620,8 @@ namespace Simd
 
         void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst);
 
+        void SynetRelu32f(const float* src, size_t size, const float* slope, float* dst);
+
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -308,6 +308,38 @@ namespace Simd
             else
                 assert(0);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetRelu32f(const svbool_t& mask, svfloat32_t src, svfloat32_t slope)
+        {
+            svfloat32_t pos = svmax_n_f32_x(mask, src, 0.0f);
+            svfloat32_t neg = svmin_n_f32_x(mask, src, 0.0f);
+            return svmla_f32_x(mask, pos, slope, neg);
+        }
+
+        SIMD_INLINE void SynetRelu32f(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)
+        {
+            svst1_f32(mask, dst, SynetRelu32f(mask, svld1_f32(mask, src), slope));
+        }
+
+        void SynetRelu32f(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetRelu32f(src + i + 0 * F, body, _slope, dst + i + 0 * F);
+                SynetRelu32f(src + i + 1 * F, body, _slope, dst + i + 1 * F);
+                SynetRelu32f(src + i + 2 * F, body, _slope, dst + i + 2 * F);
+                SynetRelu32f(src + i + 3 * F, body, _slope, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetRelu32f(src + i, body, _slope, dst + i);
+            if (i < size)
+                SynetRelu32f(src + i, svwhilelt_b32(i, size), _slope, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -669,6 +669,11 @@ namespace Test
             result = result && SynetRelu32fAutoTest(FUNC_RE32F(Simd::Avx512bw::SynetRelu32f), FUNC_RE32F(SimdSynetRelu32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetRelu32fAutoTest(FUNC_RE32F(Simd::Sve2::SynetRelu32f), FUNC_RE32F(SimdSynetRelu32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetRelu32fAutoTest(FUNC_RE32F(Simd::Neon::SynetRelu32f), FUNC_RE32F(SimdSynetRelu32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `SynetRelu32f`.
- Route `SimdSynetRelu32f` through the SVE2 dispatcher path.
- Add SVE2 coverage to `SynetRelu32fAutoTest` and update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetRelu32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2SynetActivation.cpp`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-113b38f9-27d2-4398-835e-d18ecc675303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-113b38f9-27d2-4398-835e-d18ecc675303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

