### PR TITLE
Add SVE2 optimization for SynetRestrictRange32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -83,6 +83,7 @@
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetRelu32f.</li>
+ <li>SVE2 optimizations of function SynetRestrictRange32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>NEON, SVE2 optimizations of function SynetNormalizeLayerForward16bV2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7749,7 +7749,7 @@ SIMD_API void SimdSynetRestrictRange32f(const float * src, size_t size, const fl
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetRestrictRange32fPtr) (const float * src, size_t size, const float * lower, const float * upper, float * dst);
-    const static SimdSynetRestrictRange32fPtr simdSynetRestrictRange32f = SIMD_FUNC4(SynetRestrictRange32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetRestrictRange32fPtr simdSynetRestrictRange32f = SIMD_FUNC5(SynetRestrictRange32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetRestrictRange32f(src, size, lower, upper, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -622,6 +622,8 @@ namespace Simd
 
         void SynetRelu32f(const float* src, size_t size, const float* slope, float* dst);
 
+        void SynetRestrictRange32f(const float* src, size_t size, const float* lower, const float* upper, float* dst);
+
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -340,6 +340,34 @@ namespace Simd
             if (i < size)
                 SynetRelu32f(src + i, svwhilelt_b32(i, size), _slope, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void SynetRestrictRange32f(const float* src, const svbool_t& mask, svfloat32_t lower, svfloat32_t upper, float* dst)
+        {
+            svst1_f32(mask, dst, svmin_f32_x(mask, svmax_f32_x(mask, svld1_f32(mask, src), lower), upper));
+        }
+
+        void SynetRestrictRange32f(const float* src, size_t size, const float* lower, const float* upper, float* dst)
+        {
+            assert(lower[0] <= upper[0]);
+
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _lower = svdup_n_f32(lower[0]);
+            const svfloat32_t _upper = svdup_n_f32(upper[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetRestrictRange32f(src + i + 0 * F, body, _lower, _upper, dst + i + 0 * F);
+                SynetRestrictRange32f(src + i + 1 * F, body, _lower, _upper, dst + i + 1 * F);
+                SynetRestrictRange32f(src + i + 2 * F, body, _lower, _upper, dst + i + 2 * F);
+                SynetRestrictRange32f(src + i + 3 * F, body, _lower, _upper, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetRestrictRange32f(src + i, body, _lower, _upper, dst + i);
+            if (i < size)
+                SynetRestrictRange32f(src + i, svwhilelt_b32(i, size), _lower, _upper, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -848,6 +848,11 @@ namespace Test
             result = result && SynetRestrictRange32fAutoTest(FUNC_RR(Simd::Avx512bw::SynetRestrictRange32f), FUNC_RR(SimdSynetRestrictRange32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetRestrictRange32fAutoTest(FUNC_RR(Simd::Sve2::SynetRestrictRange32f), FUNC_RR(SimdSynetRestrictRange32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetRestrictRange32fAutoTest(FUNC_RR(Simd::Neon::SynetRestrictRange32f), FUNC_RR(SimdSynetRestrictRange32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch registration for `SimdSynetRestrictRange32f`.
- Extend `SynetRestrictRange32fAutoTest` to cover the SVE2 backend.
- Document the SVE2 optimization in release 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=SynetRestrictRange32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -fsyntax-only -I./src src/Simd/SimdSve2SynetActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03342141-550f-4a08-8f0d-c7c66e9dc180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03342141-550f-4a08-8f0d-c7c66e9dc180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

