### PR TITLE
Add SSE4.1 SynetQuantizedPoolingAverage optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -158,7 +158,7 @@
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of class SynetQuantizedMulUniversal.</li>
  <li>Base implementation, SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function SynetQuantizedHardSigmoid.</li>
  <li>SVE2 optimizations of function SynetQuantizedPreluLayerForward.</li>
- <li>Base implementation of function SynetQuantizedPoolingAverage.</li>
+ <li>Base implementation and SSE4.1 optimization of function SynetQuantizedPoolingAverage.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/vs2022/Sse41.vcxproj
+++ b/prj/vs2022/Sse41.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedMergedConvolutionInput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedMergedConvolutionOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedMul.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedPooling.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedScale.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedShuffle.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizeLinear.cpp" />

--- a/prj/vs2022/Sse41.vcxproj.filters
+++ b/prj/vs2022/Sse41.vcxproj.filters
@@ -511,6 +511,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedMul.cpp">
       <Filter>Sse41\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSse41SynetQuantizedPooling.cpp">
+      <Filter>Sse41\Synet\Quantized</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Sse41">

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7655,7 +7655,7 @@ SIMD_API void SimdSynetQuantizedPoolingAverage(const uint8_t* src, const float* 
     typedef void(*SimdSynetQuantizedPoolingAveragePtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t batch, size_t srcC, size_t srcH, size_t srcW,
         size_t kernelY, size_t kernelX, size_t strideY, size_t strideX, size_t padY, size_t padX, SimdBool excludePad,
         uint8_t* dst, const float* dstScale, int dstZero, size_t dstH, size_t dstW, SimdTensorFormatType format);
-    const static SimdSynetQuantizedPoolingAveragePtr simdSynetQuantizedPoolingAverage = SIMD_FUNC0(SynetQuantizedPoolingAverage);
+    const static SimdSynetQuantizedPoolingAveragePtr simdSynetQuantizedPoolingAverage = SIMD_FUNC1(SynetQuantizedPoolingAverage, SIMD_SSE41_FUNC);
 
     simdSynetQuantizedPoolingAverage(src, srcScale, srcZero, batch, srcC, srcH, srcW, kernelY, kernelX, 
         strideY, strideX, padY, padX, excludePad, dst, dstScale, dstZero, dstH, dstW, format);

--- a/src/Simd/SimdSse41.h
+++ b/src/Simd/SimdSse41.h
@@ -572,6 +572,10 @@ namespace Simd
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
 
+        void SynetQuantizedPoolingAverage(const uint8_t* src, const float* srcScale, int srcZero, size_t batch, size_t srcC, size_t srcH, size_t srcW,
+            size_t kernelY, size_t kernelX, size_t strideY, size_t strideX, size_t padY, size_t padX, SimdBool excludePad,
+            uint8_t* dst, const float* dstScale, int dstZero, size_t dstH, size_t dstW, SimdTensorFormatType format);
+
         void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
 
         void SynetQuantizedScaleLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* scale, const float* bias, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);

--- a/src/Simd/SimdSse41SynetQuantizedPooling.cpp
+++ b/src/Simd/SimdSse41SynetQuantizedPooling.cpp
@@ -1,0 +1,219 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSse41.h"
+
+namespace Simd
+{
+#if defined(SIMD_SSE41_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sse41
+    {
+        SIMD_INLINE __m128i QuantizeSumLinear(__m128i sum, const __m128i& bias, const __m128& norm, const __m128i& zero)
+        {
+            return _mm_add_epi32(_mm_cvtps_epi32(_mm_mul_ps(_mm_cvtepi32_ps(_mm_add_epi32(sum, bias)), norm)), zero);
+        }
+
+        SIMD_INLINE void QuantizeSumLinear16(__m128i sum, const __m128i& bias, const __m128& norm, const __m128i& zero, uint8_t* dst)
+        {
+            __m128i d0 = QuantizeSumLinear(_mm_cvtepu8_epi32(_mm_srli_si128(sum, 0 * 4)), bias, norm, zero);
+            __m128i d1 = QuantizeSumLinear(_mm_cvtepu8_epi32(_mm_srli_si128(sum, 1 * 4)), bias, norm, zero);
+            __m128i d2 = QuantizeSumLinear(_mm_cvtepu8_epi32(_mm_srli_si128(sum, 2 * 4)), bias, norm, zero);
+            __m128i d3 = QuantizeSumLinear(_mm_cvtepu8_epi32(_mm_srli_si128(sum, 3 * 4)), bias, norm, zero);
+            _mm_storeu_si128((__m128i*)dst, _mm_packus_epi16(_mm_packs_epi32(d0, d1), _mm_packs_epi32(d2, d3)));
+        }
+
+        SIMD_INLINE void QuantizeSumLinear4i(__m128i sum, const __m128i& bias, const __m128& norm, const __m128i& zero, uint8_t* dst)
+        {
+            __m128i d0 = QuantizeSumLinear(sum, bias, norm, zero);
+            ((uint32_t*)dst)[0] = _mm_cvtsi128_si32(_mm_packus_epi16(_mm_packs_epi32(d0, K_ZERO), K_ZERO));
+        }
+
+        SIMD_INLINE void QuantizeSumLinear4(__m128i sum, const __m128i& bias, const __m128& norm, const __m128i& zero, uint8_t* dst)
+        {
+            __m128i d0 = QuantizeSumLinear(_mm_cvtepu8_epi32(sum), bias, norm, zero);
+            ((uint32_t*)dst)[0] = _mm_cvtsi128_si32(_mm_packus_epi16(_mm_packs_epi32(d0, K_ZERO), K_ZERO));
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageNhwc(const uint8_t* src, size_t srcS, size_t srcC, size_t srcCF4, size_t srcCF16,
+            size_t kH, size_t kW, const __m128i& bias, const __m128& norm, const __m128i& zero, uint8_t* dst)
+        {
+            size_t c = 0;
+            for (; c < srcCF16; c += A)
+            {
+                __m128i sum = K_ZERO;
+                for (size_t h = 0; h < kH; ++h)
+                {
+                    for (size_t w = 0; w < kW; ++w)
+                        sum = _mm_add_epi8(sum, _mm_loadu_si128((__m128i*)(src + w * srcC + c)));
+                    src += srcS;
+                }
+                QuantizeSumLinear16(sum, bias, norm, zero, dst + c);
+                src -= srcS * kH;
+            }
+            for (; c < srcCF4; c += F)
+            {
+                __m128i sum = K_ZERO;
+                for (size_t h = 0; h < kH; ++h)
+                {
+                    for (size_t w = 0; w < kW; ++w)
+                        sum = _mm_add_epi8(sum, _mm_cvtsi32_si128(((int32_t*)(src + w * srcC + c))[0]));
+                    src += srcS;
+                }
+                QuantizeSumLinear4(sum, bias, norm, zero, dst + c);
+                src -= srcS * kH;
+            }
+            for (; c < srcC; ++c)
+            {
+                uint8_t sum = 0;
+                for (size_t h = 0; h < kH; ++h)
+                    for (size_t w = 0; w < kW; ++w)
+                        sum += src[h * srcS + w * srcC + c];
+                dst[c] = (uint8_t)Base::QuantizeSumLinear(sum, _mm_cvtsi128_si32(bias), _mm_cvtss_f32(norm), _mm_cvtsi128_si32(zero), 0, 255);
+            }
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageGlobalNhwc(const uint8_t* src, int srcZero, const float* srcScale,
+            size_t batch, size_t channels, size_t spatial, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            int32_t bias = -srcZero * int32_t(spatial);
+            __m128i _bias = _mm_set1_epi32(bias), _zero = _mm_set1_epi32(dstZero);
+            __m128 _norm = _mm_set1_ps(srcScale[0] / (dstScale[0] * float(spatial)));
+            size_t channels4 = AlignLo(channels, F), channels16 = AlignLo(channels, A);
+            for (size_t b = 0; b < batch; ++b)
+            {
+                size_t c = 0;
+                for (; c < channels16; c += A)
+                {
+                    __m128i sum = K_ZERO, _src = _mm_loadu_si128((__m128i*)(src + c));
+                    for (size_t s = 0; s < spatial; ++s)
+                        sum = _mm_add_epi8(sum, _src);
+                    QuantizeSumLinear16(sum, _bias, _norm, _zero, dst + c);
+                }
+                for (; c < channels4; c += F)
+                {
+                    __m128i sum = K_ZERO, _src = _mm_cvtsi32_si128(((int32_t*)(src + c))[0]);
+                    for (size_t s = 0; s < spatial; ++s)
+                        sum = _mm_add_epi8(sum, _src);
+                    QuantizeSumLinear4(sum, _bias, _norm, _zero, dst + c);
+                }
+                for (; c < channels; ++c)
+                {
+                    uint8_t sum = 0;
+                    for (size_t s = 0; s < spatial; ++s)
+                        sum += src[c];
+                    dst[c] = (uint8_t)Base::QuantizeSumLinear(sum, bias, _mm_cvtss_f32(_norm), dstZero, 0, 255);
+                }
+                src += spatial * channels;
+                dst += channels;
+            }
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageNchw2x2(const uint8_t* src, size_t srcC, size_t srcH, size_t srcW,
+            uint8_t* dst, size_t dstH, size_t dstW, const __m128i& bias, const __m128& norm, const __m128i& zero)
+        {
+            size_t dstWF = AlignLo(dstW, F);
+            const __m128i one = _mm_set1_epi16(1);
+            for (size_t b = 0; b < srcC; ++b)
+            {
+                for (size_t dy = 0; dy < dstH; ++dy)
+                {
+                    size_t dx = 0, sx = 0;
+                    const uint8_t* src0 = src + dy * 2 * srcW;
+                    const uint8_t* src1 = src0 + srcW;
+                    for (; dx < dstWF; dx += F, sx += DF)
+                    {
+                        __m128i s0 = _mm_cvtepu8_epi16(_mm_loadl_epi64((__m128i*)(src0 + sx)));
+                        __m128i s1 = _mm_cvtepu8_epi16(_mm_loadl_epi64((__m128i*)(src1 + sx)));
+                        __m128i sum = _mm_madd_epi16(_mm_add_epi16(s0, s1), one);
+                        QuantizeSumLinear4i(sum, bias, norm, zero, dst + dx);
+                    }
+                    for (; dx < dstW; ++dx, sx += 2)
+                    {
+                        int32_t sum = src0[sx] + src0[sx + 1] + src1[sx] + src1[sx + 1];
+                        dst[dx] = (uint8_t)Base::QuantizeSumLinear(sum, _mm_cvtsi128_si32(bias), _mm_cvtss_f32(norm), _mm_cvtsi128_si32(zero), 0, 255);
+                    }
+                    dst += dstW;
+                }
+                src += srcH * srcW;
+            }
+        }
+
+        void SynetQuantizedPoolingAverage(const uint8_t* src, const float* srcScale, int srcZero, size_t batch, size_t srcC, size_t srcH, size_t srcW,
+            size_t kernelY, size_t kernelX, size_t strideY, size_t strideX, size_t padY, size_t padX, SimdBool excludePad,
+            uint8_t* dst, const float* dstScale, int dstZero, size_t dstH, size_t dstW, SimdTensorFormatType format)
+        {
+            if (format == SimdTensorFormatNhwc && srcC >= F)
+            {
+                if (kernelY == srcH && kernelX == srcW && strideY == 1 && strideX == 1 && padY == 0 && padX == 0)
+                {
+                    QuantizedPoolingAverageGlobalNhwc(src, srcZero, srcScale, batch, srcC, srcH * srcW, dst, dstScale, dstZero);
+                    return;
+                }
+                size_t srcS = srcW * srcC, srcCF4 = AlignLo(srcC, F), srcCF16 = AlignLo(srcC, A);
+                __m128i zero = _mm_set1_epi32(dstZero);
+                int32_t bias = -srcZero * int32_t(kernelY * kernelX);
+                float norm = srcScale[0] / (dstScale[0] * float(kernelY * kernelX));
+                for (size_t b = 0; b < batch; ++b)
+                {
+                    for (size_t ph = 0; ph < dstH; ++ph)
+                    {
+                        size_t hStart = ph * strideY - padY;
+                        size_t hEnd = Simd::Min(hStart + kernelY, srcH);
+                        hStart = Simd::Max<ptrdiff_t>(0, hStart);
+                        for (size_t pw = 0; pw < dstW; ++pw)
+                        {
+                            size_t wStart = pw * strideX - padX;
+                            size_t wEnd = Simd::Min(wStart + kernelX, srcW);
+                            wStart = Simd::Max<ptrdiff_t>(0, wStart);
+                            const uint8_t* ps = src + hStart * srcS + wStart * srcC;
+                            if (excludePad)
+                            {
+                                int area = int(hEnd - hStart) * int(wEnd - wStart);
+                                QuantizedPoolingAverageNhwc(ps, srcS, srcC, srcCF4, srcCF16, hEnd - hStart, wEnd - wStart,
+                                    _mm_set1_epi32(-srcZero * area), _mm_set1_ps(srcScale[0] / (dstScale[0] * float(area))), zero, dst);
+                            }
+                            else
+                                QuantizedPoolingAverageNhwc(ps, srcS, srcC, srcCF4, srcCF16, hEnd - hStart, wEnd - wStart,
+                                    _mm_set1_epi32(bias), _mm_set1_ps(norm), zero, dst);
+                            dst += srcC;
+                        }
+                    }
+                    src += srcC * srcH * srcW;
+                }
+                return;
+            }
+            else if (format == SimdTensorFormatNchw && kernelY == 2 && kernelX == 2 && strideY == 2 && strideX == 2 && padY == 0 && padX == 0 &&
+                dstH * 2 <= srcH && dstW * 2 <= srcW)
+            {
+                QuantizedPoolingAverageNchw2x2(src, srcC * batch, srcH, srcW, dst, dstH, dstW, _mm_set1_epi32(-srcZero * 4),
+                    _mm_set1_ps(srcScale[0] / (dstScale[0] * 4.0f)), _mm_set1_epi32(dstZero));
+                return;
+            }
+            Base::SynetQuantizedPoolingAverage(src, srcScale, srcZero, batch, srcC, srcH, srcW, kernelY, kernelX, strideY, strideX,
+                padY, padX, excludePad, dst, dstScale, dstZero, dstH, dstW, format);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetQuantizedPooling.cpp
+++ b/src/Test/TestSynetQuantizedPooling.cpp
@@ -114,7 +114,9 @@ namespace Test
 
 #ifdef NDEBUG
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(4, 127, 55, 95, f), f1, f2);
+        result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(2, 33, 25, 45, f), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 128, 54, 96, _2, _2, _0, _0, f, c, e), f1, f2);
+        result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 33, 54, 40, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 128, 27, 48, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 128, 13, 24, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 65, 13, 24, _3, _2, _0, _1, f, c, e), f1, f2);
@@ -148,10 +150,10 @@ namespace Test
         if (TestBase(options))
             result = result && SynetQuantizedPoolingAverageAutoTest(FUNC_SQPA(Simd::Base::SynetQuantizedPoolingAverage), FUNC_SQPA(SimdSynetQuantizedPoolingAverage));
 
-//#ifdef SIMD_SSE41_ENABLE
-//        if (Simd::Sse41::Enable && TestSse41(options))
-//            result = result && SynetQuantizedPoolingAverageAutoTest(FUNC_SQPA(Simd::Sse41::SynetQuantizedPoolingAverage), FUNC_SQPA(SimdSynetQuantizedPoolingAverage));
-//#endif 
+#ifdef SIMD_SSE41_ENABLE
+        if (Simd::Sse41::Enable && TestSse41(options))
+            result = result && SynetQuantizedPoolingAverageAutoTest(FUNC_SQPA(Simd::Sse41::SynetQuantizedPoolingAverage), FUNC_SQPA(SimdSynetQuantizedPoolingAverage));
+#endif 
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SSE4.1 implementation for `SynetQuantizedPoolingAverage` and route runtime dispatch to it.
- Enable SSE4.1 autotest coverage with vector-tail cases.
- Register the new source in VS2022 project files and update the 7.2.164 release note.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=SynetQuantizedPoolingAverage -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19f0abb9-fa80-4aa1-a5b5-164f07fc95a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19f0abb9-fa80-4aa1-a5b5-164f07fc95a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

