### PR TITLE
check interlace buffer allocation in png__create_png_image

### DIFF
--- a/src/Simd/SimdSse41ImageLoadPng.cpp
+++ b/src/Simd/SimdSse41ImageLoadPng.cpp
@@ -1175,6 +1175,7 @@ namespace Simd
 
             // de-interlacing
             final = (png_uc*)png__malloc_mad3(a->s->img_x, a->s->img_y, out_bytes, 0);
+            if (!final) return png__err("outofmem", "Out of memory");
             for (p = 0; p < 7; ++p) {
                 int xorig[] = { 0,4,0,2,0,1,0 };
                 int yorig[] = { 0,0,4,0,2,0,1 };


### PR DESCRIPTION
**Unchecked interlace allocation in png__create_png_image**

The de-interlace branch allocates `final` with `png__malloc_mad3` but never tests the result before the Adam7 `memcpy` loop writes through it. `png__malloc_mad3` returns NULL when `img_x * img_y * out_bytes` overflows `INT_MAX`, and that is reachable from a header the decoder accepts: the IHDR check only bounds `img_x * img_y * img_n`, while `out_bytes` is `out_n * (depth == 16 ? 2 : 1)`, up to four times `img_n` for a 16-bit colour image with a tRNS chunk (`out_n = img_n + 1`). A crafted interlaced PNG of that shape leaves `final` NULL and the de-interlace copy then writes out of bounds; a genuine allocation failure lands on the same path.

Added the NULL check that the non-interlaced `png__create_png_image_raw` and upstream stb_image already carry. Valid images are unaffected since it only guards the failure path.