### PR TITLE
Fix SSE4.1 NHWC quantized pooling average

### DIFF
--- a/src/Simd/SimdSse41SynetQuantizedPooling.cpp
+++ b/src/Simd/SimdSse41SynetQuantizedPooling.cpp
@@ -107,13 +107,14 @@ namespace Simd
                 size_t c = 0;
                 for (; c < channels16; c += A)
                 {
-                    __m128i sum0 = K_ZERO, sum1 = K_ZERO, sum2 = K_ZERO, sum3 = K_ZERO, _src = _mm_loadu_si128((__m128i*)(src + c));
-                    __m128i src0 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 0 * 4));
-                    __m128i src1 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 1 * 4));
-                    __m128i src2 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 2 * 4));
-                    __m128i src3 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 3 * 4));
+                    __m128i sum0 = K_ZERO, sum1 = K_ZERO, sum2 = K_ZERO, sum3 = K_ZERO;
                     for (size_t s = 0; s < spatial; ++s)
                     {
+                        __m128i _src = _mm_loadu_si128((__m128i*)(src + s * channels + c));
+                        __m128i src0 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 0 * 4));
+                        __m128i src1 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 1 * 4));
+                        __m128i src2 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 2 * 4));
+                        __m128i src3 = _mm_cvtepu8_epi32(_mm_srli_si128(_src, 3 * 4));
                         sum0 = _mm_add_epi32(sum0, src0);
                         sum1 = _mm_add_epi32(sum1, src1);
                         sum2 = _mm_add_epi32(sum2, src2);
@@ -123,16 +124,19 @@ namespace Simd
                 }
                 for (; c < channels4; c += F)
                 {
-                    __m128i sum = K_ZERO, _src = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(((int32_t*)(src + c))[0]));
+                    __m128i sum = K_ZERO;
                     for (size_t s = 0; s < spatial; ++s)
+                    {
+                        __m128i _src = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(((int32_t*)(src + s * channels + c))[0]));
                         sum = _mm_add_epi32(sum, _src);
+                    }
                     QuantizeSumLinear4(sum, _bias, _norm, _zero, dst + c);
                 }
                 for (; c < channels; ++c)
                 {
                     int32_t sum = 0;
                     for (size_t s = 0; s < spatial; ++s)
-                        sum += src[c];
+                        sum += src[s * channels + c];
                     dst[c] = (uint8_t)Base::QuantizeSumLinear(sum, bias, _mm_cvtss_f32(_norm), dstZero, 0, 255);
                 }
                 src += spatial * channels;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fix SSE4.1 NHWC global quantized average pooling to accumulate every spatial position per channel.
- Align vector, 4-channel, and tail-channel paths with the Base reference traversal.

### Testing
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=SynetQuantizedPoolingAverage -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e399ec5f-d07c-4de0-afd5-f5aac2018c9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e399ec5f-d07c-4de0-afd5-f5aac2018c9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

