### PR TITLE
Fix wrong UV order in AVX2 `BgraToYuv422pV2`

### DIFF
--- a/src/Simd/SimdAvx2BgraToYuvV2.cpp
+++ b/src/Simd/SimdAvx2BgraToYuvV2.cpp
@@ -126,8 +126,8 @@ namespace Simd
             __m256i _b16_r16[2], _g16_1[2];
             LoadPreparedBgra16<false>(bgra + 0, _b16_r16[0], _g16_1[0]);
             LoadPreparedBgra16<false>(bgra + 1, _b16_r16[1], _g16_1[1]);
-            b16_r16 = _mm256_hadd_epi32(_b16_r16[0], _b16_r16[1]);
-            g16_1 = _mm256_hadd_epi32(_g16_1[0], _g16_1[1]);
+            b16_r16 = _mm256_permute4x64_epi64(_mm256_hadd_epi32(_b16_r16[0], _b16_r16[1]), 0xD8);
+            g16_1 = _mm256_permute4x64_epi64(_mm256_hadd_epi32(_g16_1[0], _g16_1[1]), 0xD8);
             return BgrToY16<T>(_b16_r16, _g16_1);
         }
 

--- a/src/Test/TestAnyToYuv.cpp
+++ b/src/Test/TestAnyToYuv.cpp
@@ -178,8 +178,8 @@ namespace Test
         const int uvHeight = height / dy;
 
         View src(width, height, srcType, NULL, TEST_ALIGN(width));
-        //FillRandom(src);
-        FillSequence(src);
+        FillRandom(src);
+        // FillSequence(src);
 
         View y1(width, height, View::Gray8, NULL, TEST_ALIGN(width));
         View u1(uvWidth, uvHeight, View::Gray8, NULL, TEST_ALIGN(uvWidth));


### PR DESCRIPTION
## Issue

`_mm256_hadd_epi32` interleaves `_b16_r16`, causing the following PackXXToYY produces wrong order of U and V.

Also, the Test uses `FillSequence` to silent the failure.

## Fix

Use `_mm256_permute4x64_epi64` to restore the order.

Re-enable `FillRandom` in the test.

## Test

Local test passed.

```
.\build\Release\Test.exe -m=a -tt=1 -fi=BgraToYuv422pV2 -ot="log.txt"

Test progress: 100.0%

[000] Info: ALL TESTS ARE FINISHED SUCCESSFULLY!

[000] Info:

Simd Library Performance Report:

Execution time: 2026.07.16 10:05:30. Test threads: 1. Simd version: 7.2.163.rgb-2-yuv422-pack-41e273d22. CPU: 13th Gen Intel(R) Core(TM) i7-13800H.
Sockets: 1, Cores: 14, Threads: 20; Cache L1D: 48 KB, L2: 1280 KB, L3: 24.0 MB, RAM: 31.6 GB; SIMD: AVX2 FMA AVX SSE4.1 SSSE3 SSE3 SSE2 SSE.

-------------------------------------------------------------------------
| Function        |   API  Base Sse41  Avx2 | Bs/S4 Bs/A2 | Bs/S4 S4/A2 |
-------------------------------------------------------------------------
| Common, ms      | 0.843 3.847 1.267 0.834 |  3.04  4.61 |  3.04  1.52 |
-------------------------------------------------------------------------
| BgraToYuv422pV2 | 0.843 3.847 1.267 0.834 |  3.04  4.61 |  3.04  1.52 |
-------------------------------------------------------------------------
```