### PR TITLE
Improve AVX2 GetColSums

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -163,6 +163,7 @@
 </ul>
 <h5>Improving</h5>
 <ul>
+ <li>AVX2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GrayToY.</li>
  <li>SVE2 optimizations of function YToGray.</li>
  <li>SSE4.1 optimizations of function GetColSums.</li>

--- a/src/Simd/SimdAvx2Statistic.cpp
+++ b/src/Simd/SimdAvx2Statistic.cpp
@@ -203,6 +203,12 @@ namespace Simd
             Store<true>((__m256i*)dst + 1, sum1);
         }
 
+        SIMD_INLINE void Sum16(__m256i src8, uint16_t * sums16)
+        {
+            Store<true>((__m256i*)sums16 + 0, _mm256_add_epi16(Load<true>((__m256i*)sums16 + 0), _mm256_unpacklo_epi8(src8, K_ZERO)));
+            Store<true>((__m256i*)sums16 + 1, _mm256_add_epi16(Load<true>((__m256i*)sums16 + 1), _mm256_unpackhi_epi8(src8, K_ZERO)));
+        }
+
         SIMD_INLINE void Sum16To32(const uint16_t * src, uint32_t * dst)
         {
             __m256i lo = LoadPermuted<true>((__m256i*)src + 0);

--- a/src/Simd/SimdAvx2Statistic.cpp
+++ b/src/Simd/SimdAvx2Statistic.cpp
@@ -140,10 +140,67 @@ namespace Simd
             };
         }
 
-        SIMD_INLINE void Sum16(__m256i src8, uint16_t * sums16)
+        template <bool align> SIMD_INLINE void Sum16x1(const uint8_t * src, size_t, uint16_t * dst)
         {
-            Store<true>((__m256i*)sums16 + 0, _mm256_add_epi16(Load<true>((__m256i*)sums16 + 0), _mm256_unpacklo_epi8(src8, K_ZERO)));
-            Store<true>((__m256i*)sums16 + 1, _mm256_add_epi16(Load<true>((__m256i*)sums16 + 1), _mm256_unpackhi_epi8(src8, K_ZERO)));
+            __m256i sum0 = Load<true>((__m256i*)dst + 0);
+            __m256i sum1 = Load<true>((__m256i*)dst + 1);
+            __m256i src0 = Load<align>((__m256i*)src);
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            Store<true>((__m256i*)dst + 0, sum0);
+            Store<true>((__m256i*)dst + 1, sum1);
+        }
+
+        template <bool align> SIMD_INLINE void Sum16x4(const uint8_t * src, size_t stride, uint16_t * dst)
+        {
+            __m256i sum0 = Load<true>((__m256i*)dst + 0);
+            __m256i sum1 = Load<true>((__m256i*)dst + 1);
+            __m256i src0 = Load<align>((__m256i*)src);
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 1 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 2 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 3 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            Store<true>((__m256i*)dst + 0, sum0);
+            Store<true>((__m256i*)dst + 1, sum1);
+        }
+
+        template <bool align> SIMD_INLINE void Sum16x8(const uint8_t * src, size_t stride, uint16_t * dst)
+        {
+            __m256i sum0 = Load<true>((__m256i*)dst + 0);
+            __m256i sum1 = Load<true>((__m256i*)dst + 1);
+            __m256i src0 = Load<align>((__m256i*)src);
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 1 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 2 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 3 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 4 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 5 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 6 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            src0 = Load<align>((__m256i*)(src + 7 * stride));
+            sum0 = _mm256_add_epi16(sum0, _mm256_unpacklo_epi8(src0, K_ZERO));
+            sum1 = _mm256_add_epi16(sum1, _mm256_unpackhi_epi8(src0, K_ZERO));
+            Store<true>((__m256i*)dst + 0, sum0);
+            Store<true>((__m256i*)dst + 1, sum1);
         }
 
         SIMD_INLINE void Sum16To32(const uint16_t * src, uint32_t * dst)
@@ -170,19 +227,33 @@ namespace Simd
                 size_t rowStart = step*stepSize;
                 size_t rowEnd = Min(rowStart + stepSize, height);
 
+                size_t rowEnd4 = AlignLo(rowEnd, 4);
+                size_t rowEnd8 = AlignLo(rowEnd, 8);
+
                 memset(buffer.sums16, 0, sizeof(uint16_t)*alignedHiWidth);
-                for (size_t row = rowStart; row < rowEnd; ++row)
+                size_t row = rowStart;
+                for (; row < rowEnd8; row += 8)
                 {
                     for (size_t col = 0; col < alignedLoWidth; col += A)
-                    {
-                        __m256i src8 = Load<align>((__m256i*)(src + col));
-                        Sum16(src8, buffer.sums16 + col);
-                    }
+                        Sum16x8<align>(src + col, stride, buffer.sums16 + col);
                     if (alignedLoWidth != width)
-                    {
-                        __m256i src8 = Load<false>((__m256i*)(src + width - A));
-                        Sum16(src8, buffer.sums16 + alignedLoWidth);
-                    }
+                        Sum16x8<false>(src + width - A, stride, buffer.sums16 + alignedLoWidth);
+                    src += 8 * stride;
+                }
+                for (; row < rowEnd4; row += 4)
+                {
+                    for (size_t col = 0; col < alignedLoWidth; col += A)
+                        Sum16x4<align>(src + col, stride, buffer.sums16 + col);
+                    if (alignedLoWidth != width)
+                        Sum16x4<false>(src + width - A, stride, buffer.sums16 + alignedLoWidth);
+                    src += 4 * stride;
+                }
+                for (; row < rowEnd; ++row)
+                {
+                    for (size_t col = 0; col < alignedLoWidth; col += A)
+                        Sum16x1<align>(src + col, stride, buffer.sums16 + col);
+                    if (alignedLoWidth != width)
+                        Sum16x1<false>(src + width - A, stride, buffer.sums16 + alignedLoWidth);
                     src += stride;
                 }
 

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -483,7 +483,12 @@ namespace Test
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
+        {
             result = result && GetSumsAutoTest(FUNC3(Simd::Avx2::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Avx2::A, 127, FUNC3(Simd::Avx2::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Avx2::A + 1, 128, FUNC3(Simd::Avx2::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Avx2::A * 2 - 1, 129, FUNC3(Simd::Avx2::GetColSums), FUNC3(SimdGetColSums), false);
+        }
 #endif 
 
 #ifdef SIMD_AVX512BW_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Improve AVX2 `GetColSums` by accumulating 1, 4, and 8 rows per helper call before writing back to the 16-bit buffer.
- Add AVX2-focused `GetColSums` auto-test cases for exact-width, tail-width, and 128-row step-boundary coverage.
- Document the AVX2 `GetColSums` optimization in the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GetColSums -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cf860d-9683-4bf0-b539-b43390d542fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cf860d-9683-4bf0-b539-b43390d542fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

