### PR TITLE
Add AVX-512BW quantized average pooling

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -73,6 +73,7 @@
  <li>SVE2 optimizations of function SynetAddBias.</li>
  <li>NEON, SVE2 optimizations of function SynetChannelSum16b.</li>
  <li>AVX2 optimizations of function SynetQuantizedPoolingAverage.</li>
+ <li>AVX-512BW optimizations of function SynetQuantizedPoolingAverage.</li>
  <li>SVE2 optimizations of function SynetConvert32fTo8u.</li>
  <li>SVE2 optimizations of function SynetConvert8uTo32f.</li>
  <li>SVE2 optimizations of function SynetDequantizeLinear.</li>

--- a/prj/vs2022/Avx512bw.vcxproj
+++ b/prj/vs2022/Avx512bw.vcxproj
@@ -155,6 +155,7 @@
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedMergedConvolutionDepthwise.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedMergedConvolutionInput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedMergedConvolutionOutput.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedPoolingAverage.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedScale.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedShuffle.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizeLinear.cpp" />

--- a/prj/vs2022/Avx512bw.vcxproj.filters
+++ b/prj/vs2022/Avx512bw.vcxproj.filters
@@ -40,6 +40,9 @@
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedMergedConvolutionOutput.cpp">
       <Filter>Avx512bw\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedPoolingAverage.cpp">
+      <Filter>Avx512bw\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdAvx512bwSynetQuantizedScale.cpp">
       <Filter>Avx512bw\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdAvx512bw.h
+++ b/src/Simd/SimdAvx512bw.h
@@ -557,6 +557,10 @@ namespace Simd
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);
 
+        void SynetQuantizedPoolingAverage(const uint8_t* src, const float* srcScale, int srcZero, size_t batch, size_t srcC, size_t srcH, size_t srcW,
+            size_t kernelY, size_t kernelX, size_t strideY, size_t strideX, size_t padY, size_t padX, SimdBool excludePad,
+            uint8_t* dst, const float* dstScale, int dstZero, size_t dstH, size_t dstW, SimdTensorFormatType format);
+
         void SynetQuantizedPreluLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* slope, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
 
         void SynetQuantizedScaleLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* scale, const float* bias, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);

--- a/src/Simd/SimdAvx512bwSynetQuantizedPoolingAverage.cpp
+++ b/src/Simd/SimdAvx512bwSynetQuantizedPoolingAverage.cpp
@@ -1,0 +1,254 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdExtract.h"
+#include "Simd/SimdAvx512bw.h"
+
+namespace Simd
+{
+#if defined(SIMD_AVX512BW_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Avx512bw
+    {
+        SIMD_INLINE __m512i QuantizeSumLinear(__m512i sum, const __m512i& bias, const __m512& norm, const __m512i& zero)
+        {
+            return _mm512_add_epi32(_mm512_cvtps_epi32(_mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_add_epi32(sum, bias)), norm)), zero);
+        }
+
+        SIMD_INLINE void QuantizeSumLinear16(__m512i sum, const __m512i& bias, const __m512& norm, const __m512i& zero, uint8_t* dst, __mmask16 tail = -1)
+        {
+            __m512i d0 = QuantizeSumLinear(sum, bias, norm, zero);
+            _mm_mask_storeu_epi8(dst, tail, _mm512_castsi512_si128(PackI16ToU8(PackI32ToI16(d0, K_ZERO), K_ZERO)));
+        }
+
+        SIMD_INLINE void QuantizeSumLinear64(__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3,
+            const __m512i& bias, const __m512& norm, const __m512i& zero, uint8_t* dst)
+        {
+            __m512i d0 = QuantizeSumLinear(sum0, bias, norm, zero);
+            __m512i d1 = QuantizeSumLinear(sum1, bias, norm, zero);
+            __m512i d2 = QuantizeSumLinear(sum2, bias, norm, zero);
+            __m512i d3 = QuantizeSumLinear(sum3, bias, norm, zero);
+            _mm512_storeu_si512((__m512i*)dst, PackI16ToU8(PackI32ToI16(d0, d1), PackI32ToI16(d2, d3)));
+        }
+
+        SIMD_INLINE int32_t Sum8u(const uint8_t* src, size_t size)
+        {
+            size_t i = 0, sizeQA = AlignLo(size, QA), sizeA = AlignLo(size, A);
+            __m512i sums[4] = { K_ZERO, K_ZERO, K_ZERO, K_ZERO };
+            for (; i < sizeQA; i += QA)
+            {
+                sums[0] = _mm512_add_epi64(sums[0], _mm512_sad_epu8(_mm512_loadu_si512((__m512i*)(src + i + 0 * A)), K_ZERO));
+                sums[1] = _mm512_add_epi64(sums[1], _mm512_sad_epu8(_mm512_loadu_si512((__m512i*)(src + i + 1 * A)), K_ZERO));
+                sums[2] = _mm512_add_epi64(sums[2], _mm512_sad_epu8(_mm512_loadu_si512((__m512i*)(src + i + 2 * A)), K_ZERO));
+                sums[3] = _mm512_add_epi64(sums[3], _mm512_sad_epu8(_mm512_loadu_si512((__m512i*)(src + i + 3 * A)), K_ZERO));
+            }
+            sums[0] = _mm512_add_epi64(_mm512_add_epi64(sums[0], sums[1]), _mm512_add_epi64(sums[2], sums[3]));
+            for (; i < sizeA; i += A)
+                sums[0] = _mm512_add_epi64(sums[0], _mm512_sad_epu8(_mm512_loadu_si512((__m512i*)(src + i)), K_ZERO));
+            int32_t total = (int32_t)ExtractSum<uint64_t>(sums[0]);
+            for (; i < size; ++i)
+                total += src[i];
+            return total;
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageNhwc(const uint8_t* src, size_t srcS, size_t srcC, size_t srcCF16, size_t srcCF64,
+            size_t kH, size_t kW, const __m512i& bias, const __m512& norm, const __m512i& zero, uint8_t* dst)
+        {
+            size_t c = 0;
+            for (; c < srcCF64; c += A)
+            {
+                __m512i sum0 = K_ZERO, sum1 = K_ZERO, sum2 = K_ZERO, sum3 = K_ZERO;
+                for (size_t h = 0; h < kH; ++h)
+                {
+                    for (size_t w = 0; w < kW; ++w)
+                    {
+                        const uint8_t* ps = src + h * srcS + w * srcC + c;
+                        sum0 = _mm512_add_epi32(sum0, _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)ps + 0)));
+                        sum1 = _mm512_add_epi32(sum1, _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)ps + 1)));
+                        sum2 = _mm512_add_epi32(sum2, _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)ps + 2)));
+                        sum3 = _mm512_add_epi32(sum3, _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)ps + 3)));
+                    }
+                }
+                QuantizeSumLinear64(sum0, sum1, sum2, sum3, bias, norm, zero, dst + c);
+            }
+            for (; c < srcCF16; c += F)
+            {
+                __m512i sum = K_ZERO;
+                for (size_t h = 0; h < kH; ++h)
+                    for (size_t w = 0; w < kW; ++w)
+                        sum = _mm512_add_epi32(sum, _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(src + h * srcS + w * srcC + c))));
+                QuantizeSumLinear16(sum, bias, norm, zero, dst + c);
+            }
+            for (; c < srcC; ++c)
+            {
+                int32_t sum = 0;
+                for (size_t h = 0; h < kH; ++h)
+                    for (size_t w = 0; w < kW; ++w)
+                        sum += src[h * srcS + w * srcC + c];
+                dst[c] = (uint8_t)Base::QuantizeSumLinear(sum, _mm512_cvtsi512_si32(bias), _mm_cvtss_f32(_mm512_castps512_ps128(norm)), _mm512_cvtsi512_si32(zero), 0, 255);
+            }
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageGlobalNhwc(const uint8_t* src, int srcZero, const float* srcScale,
+            size_t batch, size_t channels, size_t spatial, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            int32_t bias = -srcZero * int32_t(spatial);
+            __m512i _bias = _mm512_set1_epi32(bias), _zero = _mm512_set1_epi32(dstZero);
+            __m512 _norm = _mm512_set1_ps(srcScale[0] / (dstScale[0] * float(spatial)));
+            size_t channels16 = AlignLo(channels, F), channels64 = AlignLo(channels, A);
+            Array32u sum(channels);
+            for (size_t b = 0; b < batch; ++b)
+            {
+                GetColSums(src, channels, channels, spatial, sum.data);
+                size_t c = 0;
+                uint32_t* sums = sum.data;
+                for (; c < channels64; c += A, sums += A)
+                    QuantizeSumLinear64(_mm512_loadu_si512(sums + 0 * F), _mm512_loadu_si512(sums + 1 * F),
+                        _mm512_loadu_si512(sums + 2 * F), _mm512_loadu_si512(sums + 3 * F), _bias, _norm, _zero, dst + c);
+                for (; c < channels16; c += F, sums += F)
+                    QuantizeSumLinear16(_mm512_loadu_si512(sums), _bias, _norm, _zero, dst + c);
+                for (; c < channels; ++c)
+                {
+                    int32_t sum = 0;
+                    for (size_t s = 0; s < spatial; ++s)
+                        sum += src[s * channels + c];
+                    dst[c] = (uint8_t)Base::QuantizeSumLinear(sum, bias, _mm_cvtss_f32(_mm512_castps512_ps128(_norm)), dstZero, 0, 255);
+                }
+                src += spatial * channels;
+                dst += channels;
+            }
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageGlobalNchw(const uint8_t* src, int srcZero, const float* srcScale,
+            size_t batch, size_t channels, size_t spatial, uint8_t* dst, const float* dstScale, int dstZero)
+        {
+            int32_t bias = -srcZero * int32_t(spatial);
+            const __m512i _bias = _mm512_set1_epi32(bias), _zero = _mm512_set1_epi32(dstZero);
+            const __m512 _norm = _mm512_set1_ps(srcScale[0] / (dstScale[0] * float(spatial)));
+            for (size_t b = 0; b < batch; ++b)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    __m512i sum = _mm512_set1_epi32(Sum8u(src, spatial));
+                    dst[c] = (uint8_t)_mm_cvtsi128_si32(_mm512_castsi512_si128(PackI16ToU8(PackI32ToI16(QuantizeSumLinear(sum, _bias, _norm, _zero), K_ZERO), K_ZERO)));
+                    src += spatial;
+                }
+                dst += channels;
+            }
+        }
+
+        SIMD_INLINE void QuantizedPoolingAverageNchw2x2(const uint8_t* src, size_t srcC, size_t srcH, size_t srcW,
+            uint8_t* dst, size_t dstH, size_t dstW, const __m512i& bias, const __m512& norm, const __m512i& zero)
+        {
+            size_t dstWF = AlignLo(dstW, F);
+            const __m512i one = _mm512_set1_epi16(1);
+            for (size_t b = 0; b < srcC; ++b)
+            {
+                for (size_t dy = 0; dy < dstH; ++dy)
+                {
+                    size_t dx = 0, sx = 0;
+                    const uint8_t* src0 = src + dy * 2 * srcW;
+                    const uint8_t* src1 = src0 + srcW;
+                    for (; dx < dstWF; dx += F, sx += DF)
+                    {
+                        __m512i s0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256((__m256i*)(src0 + sx)));
+                        __m512i s1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256((__m256i*)(src1 + sx)));
+                        __m512i sum = _mm512_madd_epi16(_mm512_add_epi16(s0, s1), one);
+                        QuantizeSumLinear16(sum, bias, norm, zero, dst + dx);
+                    }
+                    for (; dx < dstW; ++dx, sx += 2)
+                    {
+                        int32_t sum = src0[sx] + src0[sx + 1] + src1[sx] + src1[sx + 1];
+                        dst[dx] = (uint8_t)Base::QuantizeSumLinear(sum, _mm512_cvtsi512_si32(bias), _mm_cvtss_f32(_mm512_castps512_ps128(norm)), _mm512_cvtsi512_si32(zero), 0, 255);
+                    }
+                    dst += dstW;
+                }
+                src += srcH * srcW;
+            }
+        }
+
+        void SynetQuantizedPoolingAverage(const uint8_t* src, const float* srcScale, int srcZero, size_t batch, size_t srcC, size_t srcH, size_t srcW,
+            size_t kernelY, size_t kernelX, size_t strideY, size_t strideX, size_t padY, size_t padX, SimdBool excludePad,
+            uint8_t* dst, const float* dstScale, int dstZero, size_t dstH, size_t dstW, SimdTensorFormatType format)
+        {
+            if (format == SimdTensorFormatNhwc && srcC >= F)
+            {
+                if (kernelY == srcH && kernelX == srcW && strideY == 1 && strideX == 1 && padY == 0 && padX == 0)
+                {
+                    QuantizedPoolingAverageGlobalNhwc(src, srcZero, srcScale, batch, srcC, srcH * srcW, dst, dstScale, dstZero);
+                    return;
+                }
+                size_t srcS = srcW * srcC, srcCF16 = AlignLo(srcC, F), srcCF64 = AlignLo(srcC, A);
+                __m512i zero = _mm512_set1_epi32(dstZero);
+                int32_t bias = -srcZero * int32_t(kernelY * kernelX);
+                float norm = srcScale[0] / (dstScale[0] * float(kernelY * kernelX));
+                for (size_t b = 0; b < batch; ++b)
+                {
+                    for (size_t ph = 0; ph < dstH; ++ph)
+                    {
+                        size_t hStart = ph * strideY - padY;
+                        size_t hEnd = Simd::Min(hStart + kernelY, srcH);
+                        hStart = Simd::Max<ptrdiff_t>(0, hStart);
+                        for (size_t pw = 0; pw < dstW; ++pw)
+                        {
+                            size_t wStart = pw * strideX - padX;
+                            size_t wEnd = Simd::Min(wStart + kernelX, srcW);
+                            wStart = Simd::Max<ptrdiff_t>(0, wStart);
+                            const uint8_t* ps = src + hStart * srcS + wStart * srcC;
+                            if (excludePad)
+                            {
+                                int area = int(hEnd - hStart) * int(wEnd - wStart);
+                                QuantizedPoolingAverageNhwc(ps, srcS, srcC, srcCF16, srcCF64, hEnd - hStart, wEnd - wStart,
+                                    _mm512_set1_epi32(-srcZero * area), _mm512_set1_ps(srcScale[0] / (dstScale[0] * float(area))), zero, dst);
+                            }
+                            else
+                                QuantizedPoolingAverageNhwc(ps, srcS, srcC, srcCF16, srcCF64, hEnd - hStart, wEnd - wStart,
+                                    _mm512_set1_epi32(bias), _mm512_set1_ps(norm), zero, dst);
+                            dst += srcC;
+                        }
+                    }
+                    src += srcC * srcH * srcW;
+                }
+                return;
+            }
+            else if (format == SimdTensorFormatNchw)
+            {
+                if (kernelY == srcH && kernelX == srcW && strideY == 1 && strideX == 1 && padY == 0 && padX == 0)
+                {
+                    QuantizedPoolingAverageGlobalNchw(src, srcZero, srcScale, batch, srcC, srcH * srcW, dst, dstScale, dstZero);
+                    return;
+                }
+                if (kernelY == 2 && kernelX == 2 && strideY == 2 && strideX == 2 && padY == 0 && padX == 0 && dstH * 2 <= srcH && dstW * 2 <= srcW)
+                {
+                    QuantizedPoolingAverageNchw2x2(src, srcC * batch, srcH, srcW, dst, dstH, dstW, _mm512_set1_epi32(-srcZero * 4),
+                        _mm512_set1_ps(srcScale[0] / (dstScale[0] * 4.0f)), _mm512_set1_epi32(dstZero));
+                    return;
+                }
+            }
+            Base::SynetQuantizedPoolingAverage(src, srcScale, srcZero, batch, srcC, srcH, srcW, kernelY, kernelX, strideY, strideX,
+                padY, padX, excludePad, dst, dstScale, dstZero, dstH, dstW, format);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7655,7 +7655,7 @@ SIMD_API void SimdSynetQuantizedPoolingAverage(const uint8_t* src, const float* 
     typedef void(*SimdSynetQuantizedPoolingAveragePtr) (const uint8_t* src, const float* srcScale, int srcZero, size_t batch, size_t srcC, size_t srcH, size_t srcW,
         size_t kernelY, size_t kernelX, size_t strideY, size_t strideX, size_t padY, size_t padX, SimdBool excludePad,
         uint8_t* dst, const float* dstScale, int dstZero, size_t dstH, size_t dstW, SimdTensorFormatType format);
-    const static SimdSynetQuantizedPoolingAveragePtr simdSynetQuantizedPoolingAverage = SIMD_FUNC2(SynetQuantizedPoolingAverage, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetQuantizedPoolingAveragePtr simdSynetQuantizedPoolingAverage = SIMD_FUNC3(SynetQuantizedPoolingAverage, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
 
     simdSynetQuantizedPoolingAverage(src, srcScale, srcZero, batch, srcC, srcH, srcW, kernelY, kernelX, 
         strideY, strideX, padY, padX, excludePad, dst, dstScale, dstZero, dstH, dstW, format);

--- a/src/Test/TestSynetQuantizedPooling.cpp
+++ b/src/Test/TestSynetQuantizedPooling.cpp
@@ -124,6 +124,7 @@ namespace Test
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(2, 31, 25, 45, f), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 7, 54, 40, _2, _2, _0, _0, f, c, e), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 17, 27, 24, _2, _2, _0, _0, f, c, e), f1, f2);
+        result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 65, 13, 24, _3, _2, _0, _1, f, c, e), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 16, 33, 33, _3, _1, _1, _1, f, c, e), f1, f2);
         result = result && SynetQuantizedPoolingAverageAutoTest(ParamP(1, 16, 22, 22, _3, _2, _0, _1, f, c, e), f1, f2);
 #endif
@@ -158,6 +159,11 @@ namespace Test
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
             result = result && SynetQuantizedPoolingAverageAutoTest(FUNC_SQPA(Simd::Avx2::SynetQuantizedPoolingAverage), FUNC_SQPA(SimdSynetQuantizedPoolingAverage));
+#endif
+
+#ifdef SIMD_AVX512BW_ENABLE
+        if (Simd::Avx512bw::Enable && TestAvx512bw(options))
+            result = result && SynetQuantizedPoolingAverageAutoTest(FUNC_SQPA(Simd::Avx512bw::SynetQuantizedPoolingAverage), FUNC_SQPA(SimdSynetQuantizedPoolingAverage));
 #endif
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add AVX-512BW implementation for `SimdSynetQuantizedPoolingAverage`.
- Route public dispatch through AVX-512BW before AVX2/SSE4.1.
- Extend auto-tests, VS2022 project files, and 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetQuantizedPoolingAverage -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca3fd9ff-e80c-4607-a44d-42c387d8312a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca3fd9ff-e80c-4607-a44d-42c387d8312a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

