### PR TITLE
Improve AVX-512BW GetColSums

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -165,9 +165,11 @@
 <h5>Improving</h5>
 <ul>
  <li>AVX2 optimizations of function GetColSums.</li>
+ <li>AVX-512BW optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GrayToY.</li>
  <li>SVE2 optimizations of function YToGray.</li>
  <li>SSE4.1 optimizations of function GetColSums.</li>
+</ul>
 <h5>Bug fixing</h5>
 <ul>
  <li>Error in NEON optimization of function CosineDistance16f.</li>

--- a/src/Simd/SimdAvx512bwStatistic.cpp
+++ b/src/Simd/SimdAvx512bwStatistic.cpp
@@ -150,11 +150,48 @@ namespace Simd
 
         const __m512i K32_PERMUTE_FOR_COL_SUMS = SIMD_MM512_SETR_EPI32(0x0, 0x8, 0x4, 0xC, 0x1, 0x9, 0x5, 0xD, 0x2, 0xA, 0x6, 0xE, 0x3, 0xB, 0x7, 0xF);
 
-        template<bool align, bool masked> SIMD_INLINE void GetColSum16(const uint8_t * src, uint16_t * dst, __mmask64 tail = -1)
+        SIMD_INLINE void AddColSum16(__m512i src, __m512i& lo, __m512i& hi)
         {
-            __m512i _src = _mm512_permutexvar_epi32(K32_PERMUTE_FOR_COL_SUMS, (Load<align, masked>(src, tail)));
-            Store<true>(dst + 00, _mm512_add_epi16(Load<true>(dst + 00), _mm512_unpacklo_epi8(_src, K_ZERO)));
-            Store<true>(dst + HA, _mm512_add_epi16(Load<true>(dst + HA), _mm512_unpackhi_epi8(_src, K_ZERO)));
+            src = _mm512_permutexvar_epi32(K32_PERMUTE_FOR_COL_SUMS, src);
+            lo = _mm512_add_epi16(lo, _mm512_unpacklo_epi8(src, K_ZERO));
+            hi = _mm512_add_epi16(hi, _mm512_unpackhi_epi8(src, K_ZERO));
+        }
+
+        template<bool align, bool masked> SIMD_INLINE void GetColSum16x1(const uint8_t * src, uint16_t * dst, __mmask64 tail = -1)
+        {
+            __m512i lo = Load<true>(dst + 00);
+            __m512i hi = Load<true>(dst + HA);
+            AddColSum16(Load<align, masked>(src, tail), lo, hi);
+            Store<true>(dst + 00, lo);
+            Store<true>(dst + HA, hi);
+        }
+
+        template<bool align, bool masked> SIMD_INLINE void GetColSum16x4(const uint8_t * src, size_t stride, uint16_t * dst, __mmask64 tail = -1)
+        {
+            __m512i lo = Load<true>(dst + 00);
+            __m512i hi = Load<true>(dst + HA);
+            AddColSum16(Load<align, masked>(src + 0 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 1 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 2 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 3 * stride, tail), lo, hi);
+            Store<true>(dst + 00, lo);
+            Store<true>(dst + HA, hi);
+        }
+
+        template<bool align, bool masked> SIMD_INLINE void GetColSum16x8(const uint8_t * src, size_t stride, uint16_t * dst, __mmask64 tail = -1)
+        {
+            __m512i lo = Load<true>(dst + 00);
+            __m512i hi = Load<true>(dst + HA);
+            AddColSum16(Load<align, masked>(src + 0 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 1 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 2 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 3 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 4 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 5 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 6 * stride, tail), lo, hi);
+            AddColSum16(Load<align, masked>(src + 7 * stride, tail), lo, hi);
+            Store<true>(dst + 00, lo);
+            Store<true>(dst + HA, hi);
         }
 
         SIMD_INLINE void Sum16To32(const uint16_t * src, uint32_t * dst)
@@ -181,14 +218,36 @@ namespace Simd
             {
                 size_t rowStart = step*stepSize;
                 size_t rowEnd = Min(rowStart + stepSize, height);
+                size_t rowEnd4 = AlignLo(rowEnd, 4);
+                size_t rowEnd8 = AlignLo(rowEnd, 8);
+
                 memset(buffer.sums16, 0, sizeof(uint16_t)*alignedHiWidth);
-                for (size_t row = rowStart; row < rowEnd; ++row)
+                size_t row = rowStart;
+                for (; row < rowEnd8; row += 8)
                 {
                     size_t col = 0;
                     for (; col < alignedLoWidth; col += A)
-                        GetColSum16<align, false>(src + col, buffer.sums16 + col);
+                        GetColSum16x8<align, false>(src + col, stride, buffer.sums16 + col);
                     if (col < width)
-                        GetColSum16<align, true>(src + col, buffer.sums16 + col, tailMask);
+                        GetColSum16x8<align, true>(src + col, stride, buffer.sums16 + col, tailMask);
+                    src += 8 * stride;
+                }
+                for (; row < rowEnd4; row += 4)
+                {
+                    size_t col = 0;
+                    for (; col < alignedLoWidth; col += A)
+                        GetColSum16x4<align, false>(src + col, stride, buffer.sums16 + col);
+                    if (col < width)
+                        GetColSum16x4<align, true>(src + col, stride, buffer.sums16 + col, tailMask);
+                    src += 4 * stride;
+                }
+                for (; row < rowEnd; ++row)
+                {
+                    size_t col = 0;
+                    for (; col < alignedLoWidth; col += A)
+                        GetColSum16x1<align, false>(src + col, buffer.sums16 + col);
+                    if (col < width)
+                        GetColSum16x1<align, true>(src + col, buffer.sums16 + col, tailMask);
                     src += stride;
                 }
                 for (size_t col = 0; col < alignedHiWidth; col += A)

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -493,7 +493,12 @@ namespace Test
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
+        {
             result = result && GetSumsAutoTest(FUNC3(Simd::Avx512bw::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Avx512bw::A, 127, FUNC3(Simd::Avx512bw::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Avx512bw::A + 1, 128, FUNC3(Simd::Avx512bw::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Avx512bw::A * 2 - 1, 129, FUNC3(Simd::Avx512bw::GetColSums), FUNC3(SimdGetColSums), false);
+        }
 #endif 
 
 #ifdef SIMD_NEON_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
* Improve AVX-512BW `GetColSums` with 8-row and 4-row accumulation kernels.
* Add AVX-512BW column-sum boundary coverage for vector/tail widths and 127/128/129 heights.
* Document the AVX-512BW `GetColSums` improvement in release 7.2.164.

### Testing
* `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
* `cmake --build build --parallel$(nproc)`
* `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GetColSums -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f62a74e8-246a-4a60-92ee-bb8476278381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f62a74e8-246a-4a60-92ee-bb8476278381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

