### PR TITLE
Optimize NEON GetColSums

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -56,6 +56,7 @@
  <li>SVE2 optimizations of function InterleaveBgr.</li>
  <li>SVE2 optimizations of function InterleaveBgra.</li>
  <li>SVE2 optimizations of function GetStatistic.</li>
+ <li>NEON optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
  <li>SVE2 optimizations of class ResizerByteArea2x2.</li>
  <li>SVE2 optimizations of class ResizerByteBilinearOpenCv.</li>

--- a/src/Simd/SimdNeonStatistic.cpp
+++ b/src/Simd/SimdNeonStatistic.cpp
@@ -160,7 +160,7 @@ namespace Simd
             };
         }
 
-        SIMD_INLINE void Sum16(const uint8x16_t & src, uint16x8_t & sum0, uint16x8_t & sum1)
+        SIMD_INLINE void AddSum16(const uint8x16_t & src, uint16x8_t & sum0, uint16x8_t & sum1)
         {
             sum0 = vaddw_u8(sum0, vget_low_u8(src));
             sum1 = vaddw_u8(sum1, vget_high_u8(src));
@@ -170,7 +170,7 @@ namespace Simd
         {
             uint16x8_t sum0 = Load<true>(dst + 0);
             uint16x8_t sum1 = Load<true>(dst + HA);
-            Sum16(Load<align>(src), sum0, sum1);
+            AddSum16(Load<align>(src), sum0, sum1);
             Store<true>(dst + 0, sum0);
             Store<true>(dst + HA, sum1);
         }
@@ -179,10 +179,10 @@ namespace Simd
         {
             uint16x8_t sum0 = Load<true>(dst + 0);
             uint16x8_t sum1 = Load<true>(dst + HA);
-            Sum16(Load<align>(src + 0 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 1 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 2 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 3 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 0 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 1 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 2 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 3 * stride), sum0, sum1);
             Store<true>(dst + 0, sum0);
             Store<true>(dst + HA, sum1);
         }
@@ -191,16 +191,28 @@ namespace Simd
         {
             uint16x8_t sum0 = Load<true>(dst + 0);
             uint16x8_t sum1 = Load<true>(dst + HA);
-            Sum16(Load<align>(src + 0 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 1 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 2 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 3 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 4 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 5 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 6 * stride), sum0, sum1);
-            Sum16(Load<align>(src + 7 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 0 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 1 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 2 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 3 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 4 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 5 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 6 * stride), sum0, sum1);
+            AddSum16(Load<align>(src + 7 * stride), sum0, sum1);
             Store<true>(dst + 0, sum0);
             Store<true>(dst + HA, sum1);
+        }
+
+        template <bool align> SIMD_INLINE void Sum16(const uint8x16_t & src, uint16_t * dst)
+        {
+            Store<align>(dst + 0, vaddq_u16(Load<align>(dst + 0), UnpackU8<0>(src)));
+            Store<align>(dst + 8, vaddq_u16(Load<align>(dst + 8), UnpackU8<1>(src)));
+        }
+
+        template <bool align> SIMD_INLINE void Sum32(const uint16x8_t & src, uint32_t * dst)
+        {
+            Store<align>(dst + 0, vaddq_u32(Load<align>(dst + 0), UnpackU16<0>(src)));
+            Store<align>(dst + 4, vaddq_u32(Load<align>(dst + 4), UnpackU16<1>(src)));
         }
 
         SIMD_INLINE void Sum16To32(const uint16_t * src, uint32_t * dst)

--- a/src/Simd/SimdNeonStatistic.cpp
+++ b/src/Simd/SimdNeonStatistic.cpp
@@ -160,25 +160,64 @@ namespace Simd
             };
         }
 
-        template <bool align> SIMD_INLINE void Sum16(const uint8x16_t & src, uint16_t * dst)
+        SIMD_INLINE void Sum16(const uint8x16_t & src, uint16x8_t & sum0, uint16x8_t & sum1)
         {
-            Store<align>(dst + 0, vaddq_u16(Load<align>(dst + 0), UnpackU8<0>(src)));
-            Store<align>(dst + 8, vaddq_u16(Load<align>(dst + 8), UnpackU8<1>(src)));
+            sum0 = vaddw_u8(sum0, vget_low_u8(src));
+            sum1 = vaddw_u8(sum1, vget_high_u8(src));
         }
 
-        template <bool align> SIMD_INLINE void Sum32(const uint16x8_t & src, uint32_t * dst)
+        template <bool align> SIMD_INLINE void Sum16x1(const uint8_t * src, size_t, uint16_t * dst)
         {
-            Store<align>(dst + 0, vaddq_u32(Load<align>(dst + 0), UnpackU16<0>(src)));
-            Store<align>(dst + 4, vaddq_u32(Load<align>(dst + 4), UnpackU16<1>(src)));
+            uint16x8_t sum0 = Load<true>(dst + 0);
+            uint16x8_t sum1 = Load<true>(dst + HA);
+            Sum16(Load<align>(src), sum0, sum1);
+            Store<true>(dst + 0, sum0);
+            Store<true>(dst + HA, sum1);
+        }
+
+        template <bool align> SIMD_INLINE void Sum16x4(const uint8_t * src, size_t stride, uint16_t * dst)
+        {
+            uint16x8_t sum0 = Load<true>(dst + 0);
+            uint16x8_t sum1 = Load<true>(dst + HA);
+            Sum16(Load<align>(src + 0 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 1 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 2 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 3 * stride), sum0, sum1);
+            Store<true>(dst + 0, sum0);
+            Store<true>(dst + HA, sum1);
+        }
+
+        template <bool align> SIMD_INLINE void Sum16x8(const uint8_t * src, size_t stride, uint16_t * dst)
+        {
+            uint16x8_t sum0 = Load<true>(dst + 0);
+            uint16x8_t sum1 = Load<true>(dst + HA);
+            Sum16(Load<align>(src + 0 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 1 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 2 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 3 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 4 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 5 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 6 * stride), sum0, sum1);
+            Sum16(Load<align>(src + 7 * stride), sum0, sum1);
+            Store<true>(dst + 0, sum0);
+            Store<true>(dst + HA, sum1);
+        }
+
+        SIMD_INLINE void Sum16To32(const uint16_t * src, uint32_t * dst)
+        {
+            uint32x4_t sum0 = Load<true>(dst + 0);
+            uint32x4_t sum1 = Load<true>(dst + 4);
+            uint16x8_t src0 = Load<true>(src);
+            Store<true>(dst + 0, vaddw_u16(sum0, vget_low_u16(src0)));
+            Store<true>(dst + 4, vaddw_u16(sum1, vget_high_u16(src0)));
         }
 
         template <bool align> void GetColSums(const uint8_t * src, size_t stride, size_t width, size_t height, uint32_t * sums)
         {
             size_t alignedLoWidth = AlignLo(width, A);
             size_t alignedHiWidth = AlignHi(width, A);
-            const uint8x16_t tailMask = ShiftLeft(K8_FF, A - width + alignedLoWidth);
-            size_t stepSize = SCHAR_MAX + 1;
-            size_t stepCount = (height + SCHAR_MAX) / stepSize;
+            size_t stepSize = 256;
+            size_t stepCount = DivHi(height, stepSize);
 
             Buffer buffer(alignedHiWidth);
             memset(buffer.sums32, 0, sizeof(uint32_t)*alignedHiWidth);
@@ -186,27 +225,42 @@ namespace Simd
             {
                 size_t rowStart = step*stepSize;
                 size_t rowEnd = Min(rowStart + stepSize, height);
+                size_t rowEnd4 = AlignLo(rowEnd, 4);
+                size_t rowEnd8 = AlignLo(rowEnd, 8);
 
-                memset(buffer.sums16, 0, sizeof(uint16_t)*width);
-                for (size_t row = rowStart; row < rowEnd; ++row)
+                memset(buffer.sums16, 0, sizeof(uint16_t)*alignedHiWidth);
+                size_t row = rowStart;
+                for (; row < rowEnd8; row += 8)
                 {
                     for (size_t col = 0; col < alignedLoWidth; col += A)
-                    {
-                        const uint8x16_t _src = Load<align>(src + col);
-                        Sum16<true>(_src, buffer.sums16 + col);
-                    }
+                        Sum16x8<align>(src + col, stride, buffer.sums16 + col);
                     if (alignedLoWidth != width)
-                    {
-                        const uint8x16_t _src = vandq_u8(Load<false>(src + width - A), tailMask);
-                        Sum16<false>(_src, buffer.sums16 + width - A);
-                    }
+                        Sum16x8<false>(src + width - A, stride, buffer.sums16 + alignedLoWidth);
+                    src += 8 * stride;
+                }
+                for (; row < rowEnd4; row += 4)
+                {
+                    for (size_t col = 0; col < alignedLoWidth; col += A)
+                        Sum16x4<align>(src + col, stride, buffer.sums16 + col);
+                    if (alignedLoWidth != width)
+                        Sum16x4<false>(src + width - A, stride, buffer.sums16 + alignedLoWidth);
+                    src += 4 * stride;
+                }
+                for (; row < rowEnd; ++row)
+                {
+                    for (size_t col = 0; col < alignedLoWidth; col += A)
+                        Sum16x1<align>(src + col, stride, buffer.sums16 + col);
+                    if (alignedLoWidth != width)
+                        Sum16x1<false>(src + width - A, stride, buffer.sums16 + alignedLoWidth);
                     src += stride;
                 }
 
                 for (size_t col = 0; col < alignedHiWidth; col += HA)
-                    Sum32<true>(Load<true>(buffer.sums16 + col), buffer.sums32 + col);
+                    Sum16To32(buffer.sums16 + col, buffer.sums32 + col);
             }
-            memcpy(sums, buffer.sums32, sizeof(uint32_t)*width);
+            memcpy(sums, buffer.sums32, sizeof(uint32_t)*alignedLoWidth);
+            if (alignedLoWidth != width)
+                memcpy(sums + alignedLoWidth, buffer.sums32 + alignedLoWidth + alignedHiWidth - width, sizeof(uint32_t)*(width - alignedLoWidth));
         }
 
         void GetColSums(const uint8_t * src, size_t stride, size_t width, size_t height, uint32_t * sums)

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -503,7 +503,12 @@ namespace Test
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
+        {
             result = result && GetSumsAutoTest(FUNC3(Simd::Neon::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Neon::A, 127, FUNC3(Simd::Neon::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Neon::A + 1, 128, FUNC3(Simd::Neon::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest((int)Simd::Neon::A * 2 - 1, 129, FUNC3(Simd::Neon::GetColSums), FUNC3(SimdGetColSums), false);
+        }
 #endif
 
 #ifdef SIMD_SVE2_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Port NEON `GetColSums` to the row-unrolled accumulation strategy used by SSE4.1/AVX2.
- Add NEON edge-case auto tests for vector-tail and 256-row chunk boundaries.
- Update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=GetColSums -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -O2 -I./src -c ./src/Simd/SimdNeonStatistic.cpp -o /tmp/SimdNeonStatistic.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8841549-994c-4edb-b2b6-b28e3fc750b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8841549-994c-4edb-b2b6-b28e3fc750b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

