### PR TITLE
Optimize GetColSums for SVE2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -56,7 +56,7 @@
  <li>SVE2 optimizations of function InterleaveBgr.</li>
  <li>SVE2 optimizations of function InterleaveBgra.</li>
  <li>SVE2 optimizations of function GetStatistic.</li>
- <li>NEON optimizations of function GetColSums.</li>
+ <li>NEON, SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
  <li>SVE2 optimizations of class ResizerByteArea2x2.</li>
  <li>SVE2 optimizations of class ResizerByteBilinearOpenCv.</li>

--- a/src/Simd/SimdSve2Statistic.cpp
+++ b/src/Simd/SimdSve2Statistic.cpp
@@ -141,59 +141,101 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE void AddColSum16(const svuint8_t& src, const svbool_t& lo16, const svbool_t& hi16, svuint16_t& lo, svuint16_t& hi)
+        {
+            lo = svadd_u16_x(lo16, lo, svunpklo_u16(src));
+            hi = svadd_u16_x(hi16, hi, svunpkhi_u16(src));
+        }
+
+        SIMD_INLINE void GetColSum16x1(const uint8_t* src, const svbool_t& mask8, const svbool_t& lo16, const svbool_t& hi16, size_t half, uint16_t* dst)
+        {
+            svuint16_t lo = svld1_u16(lo16, dst);
+            svuint16_t hi = svld1_u16(hi16, dst + half);
+            AddColSum16(svld1_u8(mask8, src), lo16, hi16, lo, hi);
+            svst1_u16(lo16, dst, lo);
+            svst1_u16(hi16, dst + half, hi);
+        }
+
+        SIMD_INLINE void GetColSum16x4(const uint8_t* src, size_t stride, const svbool_t& mask8, const svbool_t& lo16, const svbool_t& hi16, size_t half, uint16_t* dst)
+        {
+            svuint16_t lo = svld1_u16(lo16, dst);
+            svuint16_t hi = svld1_u16(hi16, dst + half);
+            AddColSum16(svld1_u8(mask8, src + 0 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 1 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 2 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 3 * stride), lo16, hi16, lo, hi);
+            svst1_u16(lo16, dst, lo);
+            svst1_u16(hi16, dst + half, hi);
+        }
+
+        SIMD_INLINE void GetColSum16x8(const uint8_t* src, size_t stride, const svbool_t& mask8, const svbool_t& lo16, const svbool_t& hi16, size_t half, uint16_t* dst)
+        {
+            svuint16_t lo = svld1_u16(lo16, dst);
+            svuint16_t hi = svld1_u16(hi16, dst + half);
+            AddColSum16(svld1_u8(mask8, src + 0 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 1 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 2 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 3 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 4 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 5 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 6 * stride), lo16, hi16, lo, hi);
+            AddColSum16(svld1_u8(mask8, src + 7 * stride), lo16, hi16, lo, hi);
+            svst1_u16(lo16, dst, lo);
+            svst1_u16(hi16, dst + half, hi);
+        }
+
         void GetColSums(const uint8_t* src, size_t stride, size_t width, size_t height, uint32_t* sums)
         {
-            const size_t HA = svlen(svuint16_t());
-            const size_t widthB = AlignHi(width, HA);
-            const size_t stepSize = SCHAR_MAX + 1;
-            const size_t stepCount = (height + SCHAR_MAX) / stepSize;
+            const size_t A = svcntb(), HA = svcnth(), F = svcntw();
+            const size_t alignedLoWidth = AlignLo(width, A);
+            const size_t alignedHiWidth = AlignHi(width, A);
+            const size_t stepSize = 256;
+            const size_t stepCount = DivHi(height, stepSize);
+            const svbool_t body8 = svptrue_b8();
+            const svbool_t body16 = svptrue_b16();
 
-            Buffer buffer(widthB);
-            memset(buffer.sums32, 0, sizeof(uint32_t) * widthB);
+            Buffer buffer(alignedHiWidth);
+            memset(buffer.sums32, 0, sizeof(uint32_t) * alignedHiWidth);
             for (size_t step = 0; step < stepCount; ++step)
             {
                 const size_t rowStart = step * stepSize;
                 const size_t rowEnd = Min(rowStart + stepSize, height);
+                const size_t rowEnd4 = rowStart + AlignLo(rowEnd - rowStart, 4);
+                const size_t rowEnd8 = rowStart + AlignLo(rowEnd - rowStart, 8);
 
-                memset(buffer.sums16, 0, sizeof(uint16_t) * widthB);
+                memset(buffer.sums16, 0, sizeof(uint16_t) * alignedHiWidth);
+                const uint8_t* rowSrc = src + rowStart * stride;
                 size_t row = rowStart;
-                for (; row + 8 <= rowEnd; row += 8)
+                for (; row < rowEnd8; row += 8)
                 {
-                    const uint8_t* src0 = src + row * stride;
-                    const uint8_t* src1 = src0 + stride;
-                    const uint8_t* src2 = src1 + stride;
-                    const uint8_t* src3 = src2 + stride;
-                    const uint8_t* src4 = src3 + stride;
-                    const uint8_t* src5 = src4 + stride;
-                    const uint8_t* src6 = src5 + stride;
-                    const uint8_t* src7 = src6 + stride;
-                    for (size_t col = 0; col < width; col += HA)
-                    {
-                        svbool_t mask = svwhilelt_b16(col, width);
-                        svuint16_t sum = svld1_u16(mask, buffer.sums16 + col);
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src0 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src1 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src2 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src3 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src4 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src5 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src6 + col));
-                        sum = svadd_u16_x(mask, sum, svld1ub_u16(mask, src7 + col));
-                        svst1_u16(mask, buffer.sums16 + col, sum);
-                    }
+                    size_t col = 0;
+                    for (; col < alignedLoWidth; col += A)
+                        GetColSum16x8(rowSrc + col, stride, body8, body16, body16, HA, buffer.sums16 + col);
+                    if (col < width)
+                        GetColSum16x8(rowSrc + col, stride, svwhilelt_b8(col, width), svwhilelt_b16(col, width), svwhilelt_b16(col + HA, width), HA, buffer.sums16 + col);
+                    rowSrc += 8 * stride;
+                }
+                for (; row < rowEnd4; row += 4)
+                {
+                    size_t col = 0;
+                    for (; col < alignedLoWidth; col += A)
+                        GetColSum16x4(rowSrc + col, stride, body8, body16, body16, HA, buffer.sums16 + col);
+                    if (col < width)
+                        GetColSum16x4(rowSrc + col, stride, svwhilelt_b8(col, width), svwhilelt_b16(col, width), svwhilelt_b16(col + HA, width), HA, buffer.sums16 + col);
+                    rowSrc += 4 * stride;
                 }
                 for (; row < rowEnd; ++row)
                 {
-                    const uint8_t* rowSrc = src + row * stride;
-                    for (size_t col = 0; col < width; col += HA)
-                    {
-                        svbool_t mask = svwhilelt_b16(col, width);
-                        svst1_u16(mask, buffer.sums16 + col, svadd_u16_x(mask, svld1_u16(mask, buffer.sums16 + col), svld1ub_u16(mask, rowSrc + col)));
-                    }
+                    size_t col = 0;
+                    for (; col < alignedLoWidth; col += A)
+                        GetColSum16x1(rowSrc + col, body8, body16, body16, HA, buffer.sums16 + col);
+                    if (col < width)
+                        GetColSum16x1(rowSrc + col, svwhilelt_b8(col, width), svwhilelt_b16(col, width), svwhilelt_b16(col + HA, width), HA, buffer.sums16 + col);
+                    rowSrc += stride;
                 }
 
-                for (size_t col = 0; col < width; col += svcntw() * 2)
-                    AddSums16To32(buffer.sums16, buffer.sums32, col, width, svcntw());
+                for (size_t col = 0; col < alignedHiWidth; col += HA)
+                    AddSums16To32(buffer.sums16, buffer.sums32, col, alignedHiWidth, F);
             }
             memcpy(sums, buffer.sums32, sizeof(uint32_t) * width);
         }

--- a/src/Test/TestStatistic.cpp
+++ b/src/Test/TestStatistic.cpp
@@ -513,7 +513,13 @@ namespace Test
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcntb();
             result = result && GetSumsAutoTest(FUNC3(Simd::Sve2::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest(A, 255, FUNC3(Simd::Sve2::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest(A + 1, 256, FUNC3(Simd::Sve2::GetColSums), FUNC3(SimdGetColSums), false);
+            result = result && GetSumsAutoTest(A * 2 - 1, 257, FUNC3(Simd::Sve2::GetColSums), FUNC3(SimdGetColSums), false);
+        }
 #endif
 
 #ifdef SIMD_HVX_ENABLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Optimizes SVE2 `GetColSums` with byte-vector accumulation and low/high 16-bit unpacking.
- Adds SVE2-specific column-sum test dimensions around the runtime vector width.
- Updates the 7.2.164 release notes for `GetColSums`.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=GetColSums -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -DNDEBUG -I./src -march=armv8.5-a+sve2 -c src/Simd/SimdSve2Statistic.cpp -o /tmp/SimdSve2Statistic.o`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -DNDEBUG -I./src -march=armv8.5-a+sve2 -c src/Test/TestStatistic.cpp -o /tmp/TestStatistic.o`
- `git -c core.whitespace=cr-at-eol diff origin/dev...HEAD --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-114ec611-a10e-4e4f-801c-4d6956b4134c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-114ec611-a10e-4e4f-801c-4d6956b4134c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

