### PR TITLE
Add NEON SynetRelu16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,6 +84,7 @@
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetRelu32f.</li>
+ <li>NEON optimizations of function SynetRelu16b.</li>
  <li>SVE2 optimizations of function SynetRestrictRange32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7736,7 +7736,7 @@ SIMD_API void SimdSynetRelu16b(const uint16_t* src, size_t size, const float* sl
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetRelu16bPtr) (const uint16_t* src, size_t size, const float* slope, uint16_t* dst);
-    const static SimdSynetRelu16bPtr simdSynetRelu16b = SIMD_FUNC3(SynetRelu16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetRelu16bPtr simdSynetRelu16b = SIMD_FUNC4(SynetRelu16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     simdSynetRelu16b(src, size, slope, dst);
 #else

--- a/src/Simd/SimdNeon.h
+++ b/src/Simd/SimdNeon.h
@@ -589,6 +589,8 @@ namespace Simd
 
         void SynetRelu32f(const float* src, size_t size, const float* slope, float* dst);
 
+        void SynetRelu16b(const uint16_t* src, size_t size, const float* slope, uint16_t* dst);
+
         void SynetRestrictRange32f(const float * src, size_t size, const float * lower, const float * upper, float * dst);
 
         void SynetScaleLayerForward(const float* src, const float* scale, const float* bias, size_t channels, size_t height, size_t width, float* dst, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);

--- a/src/Simd/SimdNeonSynetQuantizedActivation.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedActivation.cpp
@@ -23,12 +23,36 @@
 */
 #include "Simd/SimdSynetQuantizeLinear.h"
 #include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynet.h"
 
 namespace Simd
 {
 #if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Neon
     {
+        SIMD_INLINE void SynetRelu16b(const uint16_t* src, float32x4_t slope, float32x4_t zero, uint16_t* dst)
+        {
+            uint16x8_t _src = vld1q_u16(src);
+            float32x4_t lo = SynetRelu32f(BFloat16ToFloat32(vmovl_u16(vget_low_u16(_src))), slope, zero);
+            float32x4_t hi = SynetRelu32f(BFloat16ToFloat32(vmovl_u16(vget_high_u16(_src))), slope, zero);
+            vst1q_u16(dst, vcombine_u16(vmovn_u32(Float32ToBFloat16(lo)), vmovn_u32(Float32ToBFloat16(hi))));
+        }
+
+        void SynetRelu16b(const uint16_t* src, size_t size, const float* slope, uint16_t* dst)
+        {
+            float32x4_t _slope = vdupq_n_f32(slope[0]);
+            float32x4_t _zero = vdupq_n_f32(0.0f);
+            size_t sizeDF = AlignLo(size, DF);
+
+            size_t i = 0;
+            for (; i < sizeDF; i += DF)
+                SynetRelu16b(src + i, _slope, _zero, dst + i);
+            for (; i < size; ++i)
+                dst[i] = Base::SynetRelu16b(src[i], slope[0]);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE int32x4_t QuantizedHardSigmoid(int32x4_t src, int32x4_t sBias, float32x4_t sNorm, float32x4_t scale, float32x4_t shift, float32x4_t dNorm, int32x4_t dZero)
         {
             float32x4_t _src = DequantizeLinear(src, sBias, sNorm);

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -768,6 +768,11 @@ namespace Test
             result = result && SynetRelu16bAutoTest(FUNC_RE16B(Simd::Avx512bw::SynetRelu16b), FUNC_RE16B(SimdSynetRelu16b));
 #endif 
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetRelu16bAutoTest(FUNC_RE16B(Simd::Neon::SynetRelu16b), FUNC_RE16B(SimdSynetRelu16b));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add NEON implementation and dispatch for `SynetRelu16b`.
- Add NEON coverage to `SynetRelu16bAutoTest`.
- Document the release note for version 7.2.164.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetRelu16b -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -O2 -I./src -c src/Simd/SimdNeonSynetQuantizedActivation.cpp -o /tmp/simd_neon_synet_quantized_activation.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7165723-23e1-4b82-aeac-40b4ffa1e089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7165723-23e1-4b82-aeac-40b4ffa1e089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

