### PR TITLE
Add SVE2 SynetRelu16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,7 +84,7 @@
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetRelu32f.</li>
- <li>NEON optimizations of function SynetRelu16b.</li>
+ <li>NEON, SVE2 optimizations of function SynetRelu16b.</li>
  <li>SVE2 optimizations of function SynetRestrictRange32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7736,7 +7736,7 @@ SIMD_API void SimdSynetRelu16b(const uint16_t* src, size_t size, const float* sl
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetRelu16bPtr) (const uint16_t* src, size_t size, const float* slope, uint16_t* dst);
-    const static SimdSynetRelu16bPtr simdSynetRelu16b = SIMD_FUNC4(SynetRelu16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetRelu16bPtr simdSynetRelu16b = SIMD_FUNC5(SynetRelu16b, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetRelu16b(src, size, slope, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -620,6 +620,8 @@ namespace Simd
 
         void SynetMish32f(const float* src, size_t size, const float* threshold, float* dst);
 
+        void SynetRelu16b(const uint16_t* src, size_t size, const float* slope, uint16_t* dst);
+
         void SynetRelu32f(const float* src, size_t size, const float* slope, float* dst);
 
         void SynetRestrictRange32f(const float* src, size_t size, const float* lower, const float* upper, float* dst);

--- a/src/Simd/SimdSve2SynetQuantizedActivation.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedActivation.cpp
@@ -23,12 +23,52 @@
 */
 #include "Simd/SimdSynetQuantizedActivation.h"
 #include "Simd/SimdSve2.h"
+#include "Simd/SimdBFloat16.h"
 
 namespace Simd
 {
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Sve2
     {
+        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
+        {
+            svuint32_t bits = svreinterpret_u32_f32(value);
+            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+        }
+
+        SIMD_INLINE svfloat32_t BFloat16ToFloat32(svuint32_t value, const svbool_t& mask)
+        {
+            return svreinterpret_f32_u32(svlsl_n_u32_x(mask, value, Base::Bf16::SHIFT));
+        }
+
+        SIMD_INLINE void SynetRelu16b(const uint16_t* src, const svbool_t& mask, const svfloat32_t& slope, uint16_t* dst)
+        {
+            svfloat32_t _src = BFloat16ToFloat32(svld1uh_u32(mask, src), mask);
+            svfloat32_t pos = svmax_n_f32_x(mask, _src, 0.0f);
+            svfloat32_t neg = svmin_n_f32_x(mask, _src, 0.0f);
+            svst1h_u32(mask, dst, Float32ToBFloat16(svmla_f32_x(mask, pos, slope, neg), mask));
+        }
+
+        void SynetRelu16b(const uint16_t* src, size_t size, const float* slope, uint16_t* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
+            size_t i = 0;
+            for (; i + QF <= size; i += QF)
+            {
+                SynetRelu16b(src + i + 0 * F, body, _slope, dst + i + 0 * F);
+                SynetRelu16b(src + i + 1 * F, body, _slope, dst + i + 1 * F);
+                SynetRelu16b(src + i + 2 * F, body, _slope, dst + i + 2 * F);
+                SynetRelu16b(src + i + 3 * F, body, _slope, dst + i + 3 * F);
+            }
+            for (; i < size; i += F)
+                SynetRelu16b(src + i, svwhilelt_b32(i, size), _slope, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE svfloat32_t DequantizeLinear(const svint32_t& value, const svint32_t& bias, const svfloat32_t& norm, const svbool_t& mask)
         {
             return svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, value, bias)), norm);

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -768,6 +768,11 @@ namespace Test
             result = result && SynetRelu16bAutoTest(FUNC_RE16B(Simd::Avx512bw::SynetRelu16b), FUNC_RE16B(SimdSynetRelu16b));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetRelu16bAutoTest(FUNC_RE16B(Simd::Sve2::SynetRelu16b), FUNC_RE16B(SimdSynetRelu16b));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetRelu16bAutoTest(FUNC_RE16B(Simd::Neon::SynetRelu16b), FUNC_RE16B(SimdSynetRelu16b));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `SynetRelu16b`.
- Include SVE2 in `SimdSynetRelu16b` dispatch and `SynetRelu16bAutoTest` coverage.
- Update the 7.2.164 release notes for the SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetRelu16b -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2SynetQuantizedActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32d34219-848f-4bf2-ac91-c2079b65e773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32d34219-848f-4bf2-ac91-c2079b65e773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

