### PR TITLE
Add SVE2 SynetScaleLayerForward optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -97,6 +97,7 @@
  <li>SVE2 optimizations of function SynetPoolingMax8u.</li>
  <li>SVE2 optimizations of function SynetPermuteInit.</li>
  <li>SVE2 optimizations of function SynetQuantizedScaleLayerForward.</li>
+ <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedScale.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedShuffle.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2UyvyToBgr.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -503,5 +503,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetActivation.cpp">
       <Filter>Sve2\Synet\Other</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale.cpp">
+      <Filter>Sve2\Synet\Other</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7762,7 +7762,7 @@ SIMD_API void SimdSynetScaleLayerForward(const float* src, const float* scale, c
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetScaleLayerForwardPtr) (const float* src, const float* scale, const float* bias, size_t channels, size_t height, size_t width, float* dst, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);
-    const static SimdSynetScaleLayerForwardPtr simdSynetScaleLayerForward = SIMD_FUNC4(SynetScaleLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetScaleLayerForwardPtr simdSynetScaleLayerForward = SIMD_FUNC5(SynetScaleLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetScaleLayerForward(src, scale, bias, channels, height, width, dst, format, compatibility);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -638,6 +638,8 @@ namespace Simd
 
         void SynetQuantizedScaleLayerForward(const uint8_t* src, const float* srcScale, int srcZero, size_t channels, size_t spatial, const float* scale, const float* bias, uint8_t* dst, const float* dstScale, int dstZero, SimdTensorFormatType format);
 
+        void SynetScaleLayerForward(const float* src, const float* scale, const float* bias, size_t channels, size_t height, size_t width, float* dst, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);
+
         void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,

--- a/src/Simd/SimdSve2SynetScale.cpp
+++ b/src/Simd/SimdSve2SynetScale.cpp
@@ -1,0 +1,190 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        template<bool nofma> SIMD_INLINE svfloat32_t SynetScaleLayerForward(const svfloat32_t& src, const svfloat32_t& scale, const svfloat32_t& bias, const svbool_t& mask)
+        {
+            if (nofma)
+                return svadd_f32_x(mask, svmul_f32_x(mask, src, scale), bias);
+            else
+                return svmla_f32_x(mask, bias, src, scale);
+        }
+
+        template<bool nofma> SIMD_INLINE void SynetScaleLayerForward(const float* src, const svfloat32_t& scale, const svfloat32_t& bias, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, SynetScaleLayerForward<nofma>(svld1_f32(mask, src), scale, bias, mask));
+        }
+
+        template<bool nofma> SIMD_INLINE void SynetScaleLayerForward(const float* src, const float* scale, const float* bias, float* dst, const svbool_t& mask)
+        {
+            SynetScaleLayerForward<nofma>(src, svld1_f32(mask, scale), svld1_f32(mask, bias), dst, mask);
+        }
+
+        SIMD_INLINE void SynetScaleLayerForward(const float* src, const svfloat32_t& scale, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, svmul_f32_x(mask, svld1_f32(mask, src), scale));
+        }
+
+        SIMD_INLINE void SynetScaleLayerForward(const float* src, const float* scale, float* dst, const svbool_t& mask)
+        {
+            SynetScaleLayerForward(src, svld1_f32(mask, scale), dst, mask);
+        }
+
+        template<bool nofma, bool notail> void SynetScaleLayerForwardNchw(const float* src, const float* scale, const float* bias, size_t channels, size_t spatial, float* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            if (bias)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _scale = svdup_n_f32(scale[c]);
+                    svfloat32_t _bias = svdup_n_f32(bias[c]);
+                    size_t s = 0;
+                    for (; s + QF <= spatial; s += QF)
+                    {
+                        SynetScaleLayerForward<nofma>(src + s + 0 * F, _scale, _bias, dst + s + 0 * F, full);
+                        SynetScaleLayerForward<nofma>(src + s + 1 * F, _scale, _bias, dst + s + 1 * F, full);
+                        SynetScaleLayerForward<nofma>(src + s + 2 * F, _scale, _bias, dst + s + 2 * F, full);
+                        SynetScaleLayerForward<nofma>(src + s + 3 * F, _scale, _bias, dst + s + 3 * F, full);
+                    }
+                    for (; s + F <= spatial; s += F)
+                        SynetScaleLayerForward<nofma>(src + s, _scale, _bias, dst + s, full);
+                    if (s < spatial)
+                    {
+                        svbool_t tail = svwhilelt_b32(s, spatial);
+                        SynetScaleLayerForward<nofma || notail>(src + s, _scale, _bias, dst + s, tail);
+                    }
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _scale = svdup_n_f32(scale[c]);
+                    size_t s = 0;
+                    for (; s + QF <= spatial; s += QF)
+                    {
+                        SynetScaleLayerForward(src + s + 0 * F, _scale, dst + s + 0 * F, full);
+                        SynetScaleLayerForward(src + s + 1 * F, _scale, dst + s + 1 * F, full);
+                        SynetScaleLayerForward(src + s + 2 * F, _scale, dst + s + 2 * F, full);
+                        SynetScaleLayerForward(src + s + 3 * F, _scale, dst + s + 3 * F, full);
+                    }
+                    for (; s < spatial; s += F)
+                        SynetScaleLayerForward(src + s, _scale, dst + s, svwhilelt_b32(s, spatial));
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+        }
+
+        void SynetScaleLayerForwardNchw(const float* src, const float* scale, const float* bias, size_t channels, size_t spatial, float* dst, SimdSynetCompatibilityType compatibility)
+        {
+            if (Base::FmaAvoid(compatibility))
+                SynetScaleLayerForwardNchw<true, true>(src, scale, bias, channels, spatial, dst);
+            else if (Base::FmaNoTail(compatibility))
+                SynetScaleLayerForwardNchw<false, true>(src, scale, bias, channels, spatial, dst);
+            else
+                SynetScaleLayerForwardNchw<false, false>(src, scale, bias, channels, spatial, dst);
+        }
+
+        template<bool nofma, bool notail> void SynetScaleLayerForwardNhwc(const float* src, const float* scale, const float* bias, size_t channels, size_t spatial, float* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            if (bias)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    size_t c = 0;
+                    for (; c + QF <= channels; c += QF)
+                    {
+                        SynetScaleLayerForward<nofma>(src + c + 0 * F, scale + c + 0 * F, bias + c + 0 * F, dst + c + 0 * F, full);
+                        SynetScaleLayerForward<nofma>(src + c + 1 * F, scale + c + 1 * F, bias + c + 1 * F, dst + c + 1 * F, full);
+                        SynetScaleLayerForward<nofma>(src + c + 2 * F, scale + c + 2 * F, bias + c + 2 * F, dst + c + 2 * F, full);
+                        SynetScaleLayerForward<nofma>(src + c + 3 * F, scale + c + 3 * F, bias + c + 3 * F, dst + c + 3 * F, full);
+                    }
+                    for (; c + F <= channels; c += F)
+                        SynetScaleLayerForward<nofma>(src + c, scale + c, bias + c, dst + c, full);
+                    if (c < channels)
+                    {
+                        svbool_t tail = svwhilelt_b32(c, channels);
+                        SynetScaleLayerForward<nofma || notail>(src + c, scale + c, bias + c, dst + c, tail);
+                    }
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    size_t c = 0;
+                    for (; c + QF <= channels; c += QF)
+                    {
+                        SynetScaleLayerForward(src + c + 0 * F, scale + c + 0 * F, dst + c + 0 * F, full);
+                        SynetScaleLayerForward(src + c + 1 * F, scale + c + 1 * F, dst + c + 1 * F, full);
+                        SynetScaleLayerForward(src + c + 2 * F, scale + c + 2 * F, dst + c + 2 * F, full);
+                        SynetScaleLayerForward(src + c + 3 * F, scale + c + 3 * F, dst + c + 3 * F, full);
+                    }
+                    for (; c < channels; c += F)
+                        SynetScaleLayerForward(src + c, scale + c, dst + c, svwhilelt_b32(c, channels));
+                    src += channels;
+                    dst += channels;
+                }
+            }
+        }
+
+        void SynetScaleLayerForwardNhwc(const float* src, const float* scale, const float* bias, size_t channels, size_t spatial, float* dst, SimdSynetCompatibilityType compatibility)
+        {
+            if (Base::FmaAvoid(compatibility))
+                SynetScaleLayerForwardNhwc<true, true>(src, scale, bias, channels, spatial, dst);
+            else if (Base::FmaNoTail(compatibility))
+                SynetScaleLayerForwardNhwc<false, true>(src, scale, bias, channels, spatial, dst);
+            else
+                SynetScaleLayerForwardNhwc<false, false>(src, scale, bias, channels, spatial, dst);
+        }
+
+        void SynetScaleLayerForward(const float* src, const float* scale, const float* bias, size_t channels, size_t height, size_t width, float* dst, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility)
+        {
+            size_t spatial = height * width;
+            if (Base::NchwCompatible(channels, spatial, format))
+                SynetScaleLayerForwardNchw(src, scale, bias, channels, spatial, dst, compatibility);
+            else if (Base::NhwcCompatible(channels, spatial, format))
+                SynetScaleLayerForwardNhwc(src, scale, bias, channels, spatial, dst, compatibility);
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Test/TestSynetScale.cpp
+++ b/src/Test/TestSynetScale.cpp
@@ -32,6 +32,7 @@
 #include "Simd/SimdSynetScale8i.h"
 #include "Simd/SimdSynetScale16b.h"
 #include "Simd/SimdSynet.h"
+#include "Simd/SimdSve2.h"
 
 namespace Test
 {
@@ -144,6 +145,11 @@ namespace Test
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetScaleLayerForwardAutoTest(FUNC_SCLF(Simd::Neon::SynetScaleLayerForward), FUNC_SCLF(SimdSynetScaleLayerForward));
 #endif 
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetScaleLayerForwardAutoTest(FUNC_SCLF(Simd::Sve2::SynetScaleLayerForward), FUNC_SCLF(SimdSynetScaleLayerForward));
+#endif
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetScaleLayerForward` for FP32 NCHW/NHWC scale with predicated tail handling.
- Wire SVE2 dispatch and auto-test coverage for `SynetScaleLayerForward`.
- Add the source to VS2022 SVE2 project metadata and document the 7.2.164 release change.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetScaleLayerForward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.5-a+sve2 -std=c++11 -O2 -I src -fsyntax-only src/Simd/SimdSve2SynetScale.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-383850e6-d5af-4185-884a-28dcee6bc9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-383850e6-d5af-4185-884a-28dcee6bc9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

