### PR TITLE
Add SVE2 optimization for SynetSetInput

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -98,6 +98,7 @@
  <li>SVE2 optimizations of function SynetPermuteInit.</li>
  <li>SVE2 optimizations of function SynetQuantizedScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
+ <li>SVE2 optimizations of function SynetSetInput.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7860,6 +7860,11 @@ SIMD_API void SimdSynetSetInput(const uint8_t * src, size_t width, size_t height
         Sse41::SynetSetInput(src, width, height, stride, srcFormat, lower, upper, dst, channels, dstFormat);
     else
 #endif
+#ifdef SIMD_SVE2_ENABLE
+    if (Sve2::Enable && width >= svcntw())
+        Sve2::SynetSetInput(src, width, height, stride, srcFormat, lower, upper, dst, channels, dstFormat);
+    else
+#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::SynetSetInput(src, width, height, stride, srcFormat, lower, upper, dst, channels, dstFormat);

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -599,6 +599,9 @@ namespace Simd
         void SynetConvert8uTo32f(const uint8_t* src, size_t batch, size_t channels, size_t height, size_t width,
             SimdTensorFormatType format, const float* scale, const float* shift, float* dst, SimdSynetCompatibilityType compatibility);
 
+        void SynetSetInput(const uint8_t* src, size_t width, size_t height, size_t stride, SimdPixelFormatType srcFormat,
+            const float* lower, const float* upper, float* dst, size_t channels, SimdTensorFormatType dstFormat);
+
         void SynetDequantizeLinear(const uint8_t* src, size_t size, int32_t bias, const float* norm, float* dst);
 
         void SynetQuantizedConcatLayerForward(size_t count, const uint8_t** src, size_t num, const size_t* size, const int32_t* bias, const float* norm, const float* scale, int32_t zero, uint8_t* dst);

--- a/src/Simd/SimdSve2SynetConversion.cpp
+++ b/src/Simd/SimdSve2SynetConversion.cpp
@@ -370,9 +370,8 @@ namespace Simd
         {
             const size_t F = svcntw(), channel = width * height;
             const svbool_t body = svptrue_b32();
-            svfloat32_t _scale[3], _shift[3];
-            for (size_t i = 0; i < 3; ++i)
-                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            svfloat32_t scale0 = svdup_n_f32(scale[0]), scale1 = svdup_n_f32(scale[1]), scale2 = svdup_n_f32(scale[2]);
+            svfloat32_t shift0 = svdup_n_f32(shift[0]), shift1 = svdup_n_f32(shift[1]), shift2 = svdup_n_f32(shift[2]);
             const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), step);
             for (size_t y = 0; y < height; ++y)
             {
@@ -381,9 +380,9 @@ namespace Simd
                     svbool_t mask = svwhilelt_b32(x, width);
                     const uint8_t* ps = src + step * x;
                     float* pd = dst + x;
-                    StoreScaled(LoadBgr<format>(ps, offsets, 0, mask), _scale[0], _shift[0], pd + 0 * channel, mask);
-                    StoreScaled(LoadBgr<format>(ps, offsets, 1, mask), _scale[1], _shift[1], pd + 1 * channel, mask);
-                    StoreScaled(LoadBgr<format>(ps, offsets, 2, mask), _scale[2], _shift[2], pd + 2 * channel, mask);
+                    StoreScaled(LoadBgr<format>(ps, offsets, 0, mask), scale0, shift0, pd + 0 * channel, mask);
+                    StoreScaled(LoadBgr<format>(ps, offsets, 1, mask), scale1, shift1, pd + 1 * channel, mask);
+                    StoreScaled(LoadBgr<format>(ps, offsets, 2, mask), scale2, shift2, pd + 2 * channel, mask);
                 }
                 src += stride;
                 dst += width;
@@ -393,10 +392,8 @@ namespace Simd
         template<> void SynetSetInputNchw3<SimdPixelFormatGray8, 1>(const uint8_t* src, size_t width, size_t height, size_t stride, const float* scale, const float* shift, float* dst)
         {
             const size_t F = svcntw(), channel = width * height;
-            const svbool_t body = svptrue_b32();
-            svfloat32_t _scale[3], _shift[3];
-            for (size_t i = 0; i < 3; ++i)
-                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            svfloat32_t scale0 = svdup_n_f32(scale[0]), scale1 = svdup_n_f32(scale[1]), scale2 = svdup_n_f32(scale[2]);
+            svfloat32_t shift0 = svdup_n_f32(shift[0]), shift1 = svdup_n_f32(shift[1]), shift2 = svdup_n_f32(shift[2]);
             for (size_t y = 0; y < height; ++y)
             {
                 for (size_t x = 0; x < width; x += F)
@@ -404,9 +401,9 @@ namespace Simd
                     svbool_t mask = svwhilelt_b32(x, width);
                     svuint32_t gray = svld1ub_u32(mask, src + x);
                     float* pd = dst + x;
-                    StoreScaled(gray, _scale[0], _shift[0], pd + 0 * channel, mask);
-                    StoreScaled(gray, _scale[1], _shift[1], pd + 1 * channel, mask);
-                    StoreScaled(gray, _scale[2], _shift[2], pd + 2 * channel, mask);
+                    StoreScaled(gray, scale0, shift0, pd + 0 * channel, mask);
+                    StoreScaled(gray, scale1, shift1, pd + 1 * channel, mask);
+                    StoreScaled(gray, scale2, shift2, pd + 2 * channel, mask);
                 }
                 src += stride;
                 dst += width;
@@ -417,9 +414,8 @@ namespace Simd
         {
             const size_t F = svcntw();
             const svbool_t body = svptrue_b32();
-            svfloat32_t _scale[3], _shift[3];
-            for (size_t i = 0; i < 3; ++i)
-                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            svfloat32_t scale0 = svdup_n_f32(scale[0]), scale1 = svdup_n_f32(scale[1]), scale2 = svdup_n_f32(scale[2]);
+            svfloat32_t shift0 = svdup_n_f32(shift[0]), shift1 = svdup_n_f32(shift[1]), shift2 = svdup_n_f32(shift[2]);
             const svuint32_t srcOffsets = svmul_n_u32_x(body, svindex_u32(0, 1), step);
             const svuint32_t dstOffsets = svmul_n_u32_x(body, svindex_u32(0, 1), 3 * sizeof(float));
             for (size_t y = 0; y < height; ++y)
@@ -429,9 +425,9 @@ namespace Simd
                     svbool_t mask = svwhilelt_b32(x, width);
                     const uint8_t* ps = src + step * x;
                     float* pd = dst + 3 * x;
-                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 0, mask), _scale[0], _shift[0], pd + 0, dstOffsets, mask);
-                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 1, mask), _scale[1], _shift[1], pd + 1, dstOffsets, mask);
-                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 2, mask), _scale[2], _shift[2], pd + 2, dstOffsets, mask);
+                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 0, mask), scale0, shift0, pd + 0, dstOffsets, mask);
+                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 1, mask), scale1, shift1, pd + 1, dstOffsets, mask);
+                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 2, mask), scale2, shift2, pd + 2, dstOffsets, mask);
                 }
                 src += stride;
                 dst += 3 * width;
@@ -442,9 +438,8 @@ namespace Simd
         {
             const size_t F = svcntw();
             const svbool_t body = svptrue_b32();
-            svfloat32_t _scale[3], _shift[3];
-            for (size_t i = 0; i < 3; ++i)
-                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            svfloat32_t scale0 = svdup_n_f32(scale[0]), scale1 = svdup_n_f32(scale[1]), scale2 = svdup_n_f32(scale[2]);
+            svfloat32_t shift0 = svdup_n_f32(shift[0]), shift1 = svdup_n_f32(shift[1]), shift2 = svdup_n_f32(shift[2]);
             const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), 3 * sizeof(float));
             for (size_t y = 0; y < height; ++y)
             {
@@ -453,9 +448,9 @@ namespace Simd
                     svbool_t mask = svwhilelt_b32(x, width);
                     svuint32_t gray = svld1ub_u32(mask, src + x);
                     float* pd = dst + 3 * x;
-                    StoreScaled(gray, _scale[0], _shift[0], pd + 0, offsets, mask);
-                    StoreScaled(gray, _scale[1], _shift[1], pd + 1, offsets, mask);
-                    StoreScaled(gray, _scale[2], _shift[2], pd + 2, offsets, mask);
+                    StoreScaled(gray, scale0, shift0, pd + 0, offsets, mask);
+                    StoreScaled(gray, scale1, shift1, pd + 1, offsets, mask);
+                    StoreScaled(gray, scale2, shift2, pd + 2, offsets, mask);
                 }
                 src += stride;
                 dst += 3 * width;

--- a/src/Simd/SimdSve2SynetConversion.cpp
+++ b/src/Simd/SimdSve2SynetConversion.cpp
@@ -25,6 +25,7 @@
 #include "Simd/SimdSve2.h"
 #include "Simd/SimdSynet.h"
 #include "Simd/SimdBase.h"
+#include "Simd/SimdConversion.h"
 
 namespace Simd
 {
@@ -284,6 +285,232 @@ namespace Simd
                 SynetConvert8uTo32f<true>(src, batch, channels, height, width, format, scale, shift, dst);
             else
                 SynetConvert8uTo32f<false>(src, batch, channels, height, width, format, scale, shift, dst);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void StoreScaled(const svuint32_t& value, const svfloat32_t& scale, const svfloat32_t& shift, float* dst, const svbool_t& mask)
+        {
+            svfloat32_t f32 = svcvt_f32_u32_x(mask, value);
+            svst1_f32(mask, dst, Fmadd<false>(f32, scale, shift, mask));
+        }
+
+        SIMD_INLINE void StoreScaled(const svuint32_t& value, const svfloat32_t& scale, const svfloat32_t& shift, float* dst, const svuint32_t& offsets, const svbool_t& mask)
+        {
+            svfloat32_t f32 = svcvt_f32_u32_x(mask, value);
+            svst1_scatter_u32offset_f32(mask, dst, offsets, Fmadd<false>(f32, scale, shift, mask));
+        }
+
+        template<SimdPixelFormatType format> SIMD_INLINE svuint32_t LoadBgr(const uint8_t* src, const svuint32_t& offsets, size_t channel, const svbool_t& mask);
+
+        template<> SIMD_INLINE svuint32_t LoadBgr<SimdPixelFormatGray8>(const uint8_t* src, const svuint32_t& offsets, size_t channel, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src, offsets);
+        }
+
+        template<> SIMD_INLINE svuint32_t LoadBgr<SimdPixelFormatBgr24>(const uint8_t* src, const svuint32_t& offsets, size_t channel, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src + channel, offsets);
+        }
+
+        template<> SIMD_INLINE svuint32_t LoadBgr<SimdPixelFormatBgra32>(const uint8_t* src, const svuint32_t& offsets, size_t channel, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src + channel, offsets);
+        }
+
+        template<> SIMD_INLINE svuint32_t LoadBgr<SimdPixelFormatRgb24>(const uint8_t* src, const svuint32_t& offsets, size_t channel, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src + 2 - channel, offsets);
+        }
+
+        template<> SIMD_INLINE svuint32_t LoadBgr<SimdPixelFormatRgba32>(const uint8_t* src, const svuint32_t& offsets, size_t channel, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src + 2 - channel, offsets);
+        }
+
+        SIMD_INLINE svuint32_t BgrToGray(const svuint32_t& blue, const svuint32_t& green, const svuint32_t& red, const svbool_t& mask)
+        {
+            svuint32_t gray = svdup_n_u32(Base::BGR_TO_GRAY_ROUND_TERM);
+            gray = svmla_n_u32_x(mask, gray, blue, Base::BLUE_TO_GRAY_WEIGHT);
+            gray = svmla_n_u32_x(mask, gray, green, Base::GREEN_TO_GRAY_WEIGHT);
+            gray = svmla_n_u32_x(mask, gray, red, Base::RED_TO_GRAY_WEIGHT);
+            return svlsr_n_u32_x(mask, gray, Base::BGR_TO_GRAY_AVERAGING_SHIFT);
+        }
+
+        template<SimdPixelFormatType format> SIMD_INLINE svuint32_t LoadGray(const uint8_t* src, const svuint32_t& offsets, const svbool_t& mask)
+        {
+            return BgrToGray(LoadBgr<format>(src, offsets, 0, mask), LoadBgr<format>(src, offsets, 1, mask), LoadBgr<format>(src, offsets, 2, mask), mask);
+        }
+
+        template<> SIMD_INLINE svuint32_t LoadGray<SimdPixelFormatGray8>(const uint8_t* src, const svuint32_t& offsets, const svbool_t& mask)
+        {
+            return svld1ub_gather_u32offset_u32(mask, src, offsets);
+        }
+
+        template<SimdPixelFormatType format, size_t step> void SynetSetInput1(const uint8_t* src, size_t width, size_t height, size_t stride, const float* scale, const float* shift, float* dst)
+        {
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _scale = svdup_n_f32(scale[0]);
+            const svfloat32_t _shift = svdup_n_f32(shift[0]);
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), step);
+            for (size_t y = 0; y < height; ++y)
+            {
+                for (size_t x = 0; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    StoreScaled(LoadGray<format>(src + step * x, offsets, mask), _scale, _shift, dst + x, mask);
+                }
+                src += stride;
+                dst += width;
+            }
+        }
+
+        template<SimdPixelFormatType format, size_t step> void SynetSetInputNchw3(const uint8_t* src, size_t width, size_t height, size_t stride, const float* scale, const float* shift, float* dst)
+        {
+            const size_t F = svcntw(), channel = width * height;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _scale[3], _shift[3];
+            for (size_t i = 0; i < 3; ++i)
+                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), step);
+            for (size_t y = 0; y < height; ++y)
+            {
+                for (size_t x = 0; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    const uint8_t* ps = src + step * x;
+                    float* pd = dst + x;
+                    StoreScaled(LoadBgr<format>(ps, offsets, 0, mask), _scale[0], _shift[0], pd + 0 * channel, mask);
+                    StoreScaled(LoadBgr<format>(ps, offsets, 1, mask), _scale[1], _shift[1], pd + 1 * channel, mask);
+                    StoreScaled(LoadBgr<format>(ps, offsets, 2, mask), _scale[2], _shift[2], pd + 2 * channel, mask);
+                }
+                src += stride;
+                dst += width;
+            }
+        }
+
+        template<> void SynetSetInputNchw3<SimdPixelFormatGray8, 1>(const uint8_t* src, size_t width, size_t height, size_t stride, const float* scale, const float* shift, float* dst)
+        {
+            const size_t F = svcntw(), channel = width * height;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _scale[3], _shift[3];
+            for (size_t i = 0; i < 3; ++i)
+                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            for (size_t y = 0; y < height; ++y)
+            {
+                for (size_t x = 0; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    svuint32_t gray = svld1ub_u32(mask, src + x);
+                    float* pd = dst + x;
+                    StoreScaled(gray, _scale[0], _shift[0], pd + 0 * channel, mask);
+                    StoreScaled(gray, _scale[1], _shift[1], pd + 1 * channel, mask);
+                    StoreScaled(gray, _scale[2], _shift[2], pd + 2 * channel, mask);
+                }
+                src += stride;
+                dst += width;
+            }
+        }
+
+        template<SimdPixelFormatType format, size_t step> void SynetSetInputNhwc3(const uint8_t* src, size_t width, size_t height, size_t stride, const float* scale, const float* shift, float* dst)
+        {
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _scale[3], _shift[3];
+            for (size_t i = 0; i < 3; ++i)
+                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            const svuint32_t srcOffsets = svmul_n_u32_x(body, svindex_u32(0, 1), step);
+            const svuint32_t dstOffsets = svmul_n_u32_x(body, svindex_u32(0, 1), 3 * sizeof(float));
+            for (size_t y = 0; y < height; ++y)
+            {
+                for (size_t x = 0; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    const uint8_t* ps = src + step * x;
+                    float* pd = dst + 3 * x;
+                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 0, mask), _scale[0], _shift[0], pd + 0, dstOffsets, mask);
+                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 1, mask), _scale[1], _shift[1], pd + 1, dstOffsets, mask);
+                    StoreScaled(LoadBgr<format>(ps, srcOffsets, 2, mask), _scale[2], _shift[2], pd + 2, dstOffsets, mask);
+                }
+                src += stride;
+                dst += 3 * width;
+            }
+        }
+
+        template<> void SynetSetInputNhwc3<SimdPixelFormatGray8, 1>(const uint8_t* src, size_t width, size_t height, size_t stride, const float* scale, const float* shift, float* dst)
+        {
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _scale[3], _shift[3];
+            for (size_t i = 0; i < 3; ++i)
+                _scale[i] = svdup_n_f32(scale[i]), _shift[i] = svdup_n_f32(shift[i]);
+            const svuint32_t offsets = svmul_n_u32_x(body, svindex_u32(0, 1), 3 * sizeof(float));
+            for (size_t y = 0; y < height; ++y)
+            {
+                for (size_t x = 0; x < width; x += F)
+                {
+                    svbool_t mask = svwhilelt_b32(x, width);
+                    svuint32_t gray = svld1ub_u32(mask, src + x);
+                    float* pd = dst + 3 * x;
+                    StoreScaled(gray, _scale[0], _shift[0], pd + 0, offsets, mask);
+                    StoreScaled(gray, _scale[1], _shift[1], pd + 1, offsets, mask);
+                    StoreScaled(gray, _scale[2], _shift[2], pd + 2, offsets, mask);
+                }
+                src += stride;
+                dst += 3 * width;
+            }
+        }
+
+        void SynetSetInput(const uint8_t* src, size_t width, size_t height, size_t stride, SimdPixelFormatType srcFormat,
+            const float* lower, const float* upper, float* dst, size_t channels, SimdTensorFormatType dstFormat)
+        {
+            float scale[3];
+            for (size_t i = 0; i < channels; ++i)
+                scale[i] = (upper[i] - lower[i]) / 255.0f;
+            switch (channels)
+            {
+            case 1:
+                switch (srcFormat)
+                {
+                case SimdPixelFormatGray8: SynetSetInput1<SimdPixelFormatGray8, 1>(src, width, height, stride, scale, lower, dst); return;
+                case SimdPixelFormatBgr24: SynetSetInput1<SimdPixelFormatBgr24, 3>(src, width, height, stride, scale, lower, dst); return;
+                case SimdPixelFormatBgra32: SynetSetInput1<SimdPixelFormatBgra32, 4>(src, width, height, stride, scale, lower, dst); return;
+                case SimdPixelFormatRgb24: SynetSetInput1<SimdPixelFormatRgb24, 3>(src, width, height, stride, scale, lower, dst); return;
+                case SimdPixelFormatRgba32: SynetSetInput1<SimdPixelFormatRgba32, 4>(src, width, height, stride, scale, lower, dst); return;
+                default: assert(0);
+                }
+                break;
+            case 3:
+                switch (dstFormat)
+                {
+                case SimdTensorFormatNchw:
+                    switch (srcFormat)
+                    {
+                    case SimdPixelFormatGray8: SynetSetInputNchw3<SimdPixelFormatGray8, 1>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatBgr24: SynetSetInputNchw3<SimdPixelFormatBgr24, 3>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatBgra32: SynetSetInputNchw3<SimdPixelFormatBgra32, 4>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatRgb24: SynetSetInputNchw3<SimdPixelFormatRgb24, 3>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatRgba32: SynetSetInputNchw3<SimdPixelFormatRgba32, 4>(src, width, height, stride, scale, lower, dst); return;
+                    default: assert(0);
+                    }
+                    break;
+                case SimdTensorFormatNhwc:
+                    switch (srcFormat)
+                    {
+                    case SimdPixelFormatGray8: SynetSetInputNhwc3<SimdPixelFormatGray8, 1>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatBgr24: SynetSetInputNhwc3<SimdPixelFormatBgr24, 3>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatBgra32: SynetSetInputNhwc3<SimdPixelFormatBgra32, 4>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatRgb24: SynetSetInputNhwc3<SimdPixelFormatRgb24, 3>(src, width, height, stride, scale, lower, dst); return;
+                    case SimdPixelFormatRgba32: SynetSetInputNhwc3<SimdPixelFormatRgba32, 4>(src, width, height, stride, scale, lower, dst); return;
+                    default: assert(0);
+                    }
+                    break;
+                default: assert(0);
+                }
+                break;
+            default: assert(0);
+            }
         }
     }
 #endif

--- a/src/Test/TestSynetConversion.cpp
+++ b/src/Test/TestSynetConversion.cpp
@@ -343,6 +343,11 @@ namespace Test
             result = result && SynetSetInputAutoTest(FUNC_SI(Simd::Avx512bw::SynetSetInput), FUNC_SI(SimdSynetSetInput));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetSetInputAutoTest(FUNC_SI(Simd::Sve2::SynetSetInput), FUNC_SI(SimdSynetSetInput));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetSetInputAutoTest(FUNC_SI(Simd::Neon::SynetSetInput), FUNC_SI(SimdSynetSetInput));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 `SynetSetInput` implementation for 1-channel and 3-channel NCHW/NHWC input conversion paths.
- Wire SVE2 dispatch and auto-test coverage for `SynetSetInput`.
- Document the new SVE2 optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `./build/Test "-r=." -fi=SynetSetInput -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.6-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2SynetConversion.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dd09efd-efc9-4903-8dd9-6e54c8fc3ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dd09efd-efc9-4903-8dd9-6e54c8fc3ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

