### PR TITLE
Add SVE2 Synet shuffle layer forward

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -98,6 +98,7 @@
  <li>SVE2 optimizations of function SynetPermuteInit.</li>
  <li>SVE2 optimizations of function SynetQuantizedScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
+ <li>SVE2 optimizations of function SynetShuffleLayerForward.</li>
  <li>SVE2 optimizations of function SynetSetInput.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7881,7 +7881,7 @@ SIMD_API void SimdSynetShuffleLayerForward(const float* src0, const float* src1,
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetShuffleLayerForwardPtr) (const float* src0, const float* src1, size_t channels0, size_t channels1, size_t spatial, float* dst0, float* dst1, SimdTensorFormatType format, int type);
-    const static SimdSynetShuffleLayerForwardPtr simdSynetShuffleLayerForward = SIMD_FUNC4(SynetShuffleLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetShuffleLayerForwardPtr simdSynetShuffleLayerForward = SIMD_FUNC5(SynetShuffleLayerForward, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetShuffleLayerForward(src0, src1, channels0, channels1, spatial, dst0, dst1, format, type);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -643,6 +643,8 @@ namespace Simd
 
         void SynetScaleLayerForward(const float* src, const float* scale, const float* bias, size_t channels, size_t height, size_t width, float* dst, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility);
 
+        void SynetShuffleLayerForward(const float* src0, const float* src1, size_t channels0, size_t channels1, size_t spatial, float* dst0, float* dst1, SimdTensorFormatType format, int type);
+
         void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -412,6 +412,80 @@ namespace Simd
             else
                 assert(0);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void SynetShuffleLayerForward(const float* src0, const float* src1, size_t channels0, size_t channels1, size_t spatial, float* dst0, float* dst1, SimdTensorFormatType format, int type)
+        {
+            if (format == SimdTensorFormatNchw)
+                Base::SynetShuffleLayerForward(src0, src1, channels0, channels1, spatial, dst0, dst1, format, type);
+            else if (format == SimdTensorFormatNhwc)
+            {
+                const size_t F = svcntw(), channels = (channels0 + channels1) / 2;
+                if (type == 0)
+                {
+                    for (size_t s = 0; s < spatial; ++s)
+                    {
+                        size_t cd = 0, cs0 = 0, cs1 = 0;
+                        for (; cs0 < channels0;)
+                        {
+                            size_t count = Simd::Min(F, (channels0 - cs0) / 2);
+                            svbool_t mask = svwhilelt_b32((size_t)0, count);
+                            svfloat32x2_t _src0 = svld2_f32(mask, src0 + cs0);
+                            svst1_f32(mask, dst0 + cd, svget2_f32(_src0, 0));
+                            svst1_f32(mask, dst1 + cd, svget2_f32(_src0, 1));
+                            cs0 += 2 * count;
+                            cd += count;
+                        }
+                        for (; cs1 < channels1;)
+                        {
+                            size_t count = Simd::Min(F, (channels1 - cs1) / 2);
+                            svbool_t mask = svwhilelt_b32((size_t)0, count);
+                            svfloat32x2_t _src1 = svld2_f32(mask, src1 + cs1);
+                            svst1_f32(mask, dst0 + cd, svget2_f32(_src1, 0));
+                            svst1_f32(mask, dst1 + cd, svget2_f32(_src1, 1));
+                            cs1 += 2 * count;
+                            cd += count;
+                        }
+                        src0 += channels0;
+                        src1 += channels1;
+                        dst0 += channels;
+                        dst1 += channels;
+                    }
+                }
+                else if (type == 1)
+                {
+                    for (size_t s = 0; s < spatial; ++s)
+                    {
+                        size_t cs = 0, cd0 = 0, cd1 = 0;
+                        for (; cd0 < channels0;)
+                        {
+                            size_t count = Simd::Min(F, (channels0 - cd0) / 2);
+                            svbool_t mask = svwhilelt_b32((size_t)0, count);
+                            svst2_f32(mask, dst0 + cd0, svcreate2_f32(svld1_f32(mask, src0 + cs), svld1_f32(mask, src1 + cs)));
+                            cd0 += 2 * count;
+                            cs += count;
+                        }
+                        for (; cd1 < channels1;)
+                        {
+                            size_t count = Simd::Min(F, (channels1 - cd1) / 2);
+                            svbool_t mask = svwhilelt_b32((size_t)0, count);
+                            svst2_f32(mask, dst1 + cd1, svcreate2_f32(svld1_f32(mask, src0 + cs), svld1_f32(mask, src1 + cs)));
+                            cd1 += 2 * count;
+                            cs += count;
+                        }
+                        src0 += channels;
+                        src1 += channels;
+                        dst0 += channels0;
+                        dst1 += channels1;
+                    }
+                }
+                else
+                    assert(0);
+            }
+            else
+                assert(0);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynet.cpp
+++ b/src/Test/TestSynet.cpp
@@ -465,6 +465,11 @@ namespace Test
             result = result && SynetShuffleLayerForwardAutoTest(FUNC_SHLF(Simd::Avx512bw::SynetShuffleLayerForward), FUNC_SHLF(SimdSynetShuffleLayerForward));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetShuffleLayerForwardAutoTest(FUNC_SHLF(Simd::Sve2::SynetShuffleLayerForward), FUNC_SHLF(SimdSynetShuffleLayerForward));
+#endif 
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetShuffleLayerForwardAutoTest(FUNC_SHLF(Simd::Neon::SynetShuffleLayerForward), FUNC_SHLF(SimdSynetShuffleLayerForward));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 NHWC implementation of `SynetShuffleLayerForward` with Base fallback for NCHW.
- Wire SVE2 dispatch and architecture-specific auto test coverage.
- Update 7.2.164 release notes for the new SVE2 optimization.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetShuffleLayerForward -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I src -fsyntax-only src/Simd/SimdSve2Synet.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e7474fa-9caf-48b4-a05d-34829adb0abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e7474fa-9caf-48b4-a05d-34829adb0abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

