### PR TITLE
Add SVE2 SynetSigmoid32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -86,6 +86,7 @@
  <li>SVE2 optimizations of function SynetRelu32f.</li>
  <li>NEON, SVE2 optimizations of function SynetRelu16b.</li>
  <li>SVE2 optimizations of function SynetRestrictRange32f.</li>
+ <li>SVE2 optimizations of function SynetSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForward.</li>
  <li>SVE2 optimizations of function SynetNormalizeLayerForwardV2.</li>
  <li>NEON, SVE2 optimizations of function SynetNormalizeLayerForward16bV2.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7894,7 +7894,7 @@ SIMD_API void SimdSynetSigmoid32f(const float* src, size_t size, const float* sl
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetSigmoid32fPtr) (const float* src, size_t size, const float* slope, float* dst);
-    const static SimdSynetSigmoid32fPtr simdSynetSigmoid32f = SIMD_FUNC4(SynetSigmoid32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetSigmoid32fPtr simdSynetSigmoid32f = SIMD_FUNC5(SynetSigmoid32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetSigmoid32f(src, size, slope, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -629,6 +629,8 @@ namespace Simd
 
         void SynetRestrictRange32f(const float* src, size_t size, const float* lower, const float* upper, float* dst);
 
+        void SynetSigmoid32f(const float* src, size_t size, const float* slope, float* dst);
+
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -368,6 +368,37 @@ namespace Simd
             if (i < size)
                 SynetRestrictRange32f(src + i, svwhilelt_b32(i, size), _lower, _upper, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetSigmoid32f(const svbool_t& mask, svfloat32_t value, svfloat32_t slope)
+        {
+            svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, slope));
+            return svdiv_f32_x(mask, svdup_n_f32(1.0f), svadd_n_f32_x(mask, exp, 1.0f));
+        }
+
+        SIMD_INLINE void SynetSigmoid32f(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)
+        {
+            svst1_f32(mask, dst, SynetSigmoid32f(mask, svld1_f32(mask, src), slope));
+        }
+
+        void SynetSigmoid32f(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _slope = svdup_n_f32(-slope[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetSigmoid32f(src + i + 0 * F, body, _slope, dst + i + 0 * F);
+                SynetSigmoid32f(src + i + 1 * F, body, _slope, dst + i + 1 * F);
+                SynetSigmoid32f(src + i + 2 * F, body, _slope, dst + i + 2 * F);
+                SynetSigmoid32f(src + i + 3 * F, body, _slope, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetSigmoid32f(src + i, body, _slope, dst + i);
+            if (i < size)
+                SynetSigmoid32f(src + i, svwhilelt_b32(i, size), _slope, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -947,6 +947,11 @@ namespace Test
             result = result && SynetSigmoid32fAutoTest(FUNC_SG(Simd::Avx512bw::SynetSigmoid32f), FUNC_SG(SimdSynetSigmoid32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetSigmoid32fAutoTest(FUNC_SG(Simd::Sve2::SynetSigmoid32f), FUNC_SG(SimdSynetSigmoid32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetSigmoid32fAutoTest(FUNC_SG(Simd::Neon::SynetSigmoid32f), FUNC_SG(SimdSynetSigmoid32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and declaration for `SynetSigmoid32f`.
- Register SVE2 in `SimdSynetSigmoid32f` dispatch and auto-tests.
- Document the SVE2 optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetSigmoid32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -I./src -std=c++11 -fPIC -fsyntax-only src/Simd/SimdSve2SynetActivation.cpp`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD~1..HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72850998-4b70-4304-9acb-c7251ed47e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72850998-4b70-4304-9acb-c7251ed47e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

