### PR TITLE
Add SVE2 SynetSoftmax32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -100,6 +100,7 @@
  <li>SVE2 optimizations of function SynetQuantizedScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetShuffleLayerForward.</li>
+ <li>SVE2 optimizations of function SynetSoftmax32f.</li>
  <li>SVE2 optimizations of function SynetSetInput.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7907,7 +7907,7 @@ SIMD_API void SimdSynetSoftmax32f(const float * src, size_t outer, size_t count,
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetSoftmax32fPtr) (const float * src, size_t outer, size_t count, size_t inner, float * dst);
-    const static SimdSynetSoftmax32fPtr simdSynetSoftmax32f = SIMD_FUNC4(SynetSoftmax32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetSoftmax32fPtr simdSynetSoftmax32f = SIMD_FUNC5(SynetSoftmax32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetSoftmax32f(src, outer, count, inner, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -647,6 +647,8 @@ namespace Simd
 
         void SynetShuffleLayerForward(const float* src0, const float* src1, size_t channels0, size_t channels1, size_t spatial, float* dst0, float* dst1, SimdTensorFormatType format, int type);
 
+        void SynetSoftmax32f(const float* src, size_t outer, size_t count, size_t inner, float* dst);
+
         void SynetPreluLayerForward(const float* src, const float* slope, size_t channels, size_t spatial, float* dst, SimdTensorFormatType format);
 
         void SynetNormalizeLayerForward(const float* src, size_t batch, size_t channels, size_t spatial, const float* scale,

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -486,6 +486,132 @@ namespace Simd
             else
                 assert(0);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SoftmaxPoly5(const svbool_t& mask, svfloat32_t x)
+        {
+            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
+            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), x, p);
+            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), x, p);
+            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), x, p);
+            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), x, p);
+            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), x, p);
+            return p;
+        }
+
+        SIMD_INLINE svfloat32_t SoftmaxExp2(const svbool_t& mask, svfloat32_t x)
+        {
+            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
+            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
+            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
+            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+            return svmul_f32_x(mask, expipart, SoftmaxPoly5(mask, fpart));
+        }
+
+        SIMD_INLINE svfloat32_t SoftmaxExponent(const svbool_t& mask, svfloat32_t value)
+        {
+            return SoftmaxExp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
+        }
+
+        void SynetSoftmax32f21(const float* src, size_t outer, float* dst)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            const svbool_t body = svptrue_b32();
+            size_t o = 0;
+            for (; o + F <= outer; o += F)
+            {
+                svfloat32_t s0 = svld1_f32(body, src + 0);
+                svfloat32_t s1 = svld1_f32(body, src + F);
+                svfloat32_t a = svuzp1_f32(s0, s1);
+                svfloat32_t b = svuzp2_f32(s0, s1);
+                svfloat32_t max = svmax_f32_x(body, a, b);
+                svfloat32_t exp0 = SoftmaxExponent(body, svsub_f32_x(body, a, max));
+                svfloat32_t exp1 = SoftmaxExponent(body, svsub_f32_x(body, b, max));
+                svfloat32_t sum = svadd_f32_x(body, exp0, exp1);
+                svfloat32_t d0 = svdiv_f32_x(body, exp0, sum);
+                svfloat32_t d1 = svdiv_f32_x(body, exp1, sum);
+                svst1_f32(body, dst + 0, svzip1_f32(d0, d1));
+                svst1_f32(body, dst + F, svzip2_f32(d0, d1));
+                src += DF;
+                dst += DF;
+            }
+            for (; o < outer; ++o)
+            {
+                float max = Simd::Max(src[0], src[1]);
+                float exp0 = ::exp(src[0] - max);
+                float exp1 = ::exp(src[1] - max);
+                float sum = exp0 + exp1;
+                dst[0] = exp0 / sum;
+                dst[1] = exp1 / sum;
+                src += 2;
+                dst += 2;
+            }
+        }
+
+        void SynetSoftmax32fInner(const float* src, size_t outer, size_t count, size_t inner, float* dst)
+        {
+            const size_t F = svcntw();
+            Array32f tmp(inner * 2);
+            const float* s;
+            float* max = tmp.data, * sum = tmp.data + inner, * d;
+            for (size_t o = 0; o < outer; ++o)
+            {
+                memcpy(max, src, inner * sizeof(float));
+                s = src + inner;
+                for (size_t c = 1; c < count; ++c)
+                {
+                    for (size_t i = 0; i < inner; i += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(i, inner);
+                        svst1_f32(mask, max + i, svmax_f32_x(mask, svld1_f32(mask, s + i), svld1_f32(mask, max + i)));
+                    }
+                    s += inner;
+                }
+
+                s = src;
+                d = dst;
+                memset(sum, 0, inner * sizeof(float));
+                for (size_t c = 0; c < count; ++c)
+                {
+                    for (size_t i = 0; i < inner; i += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(i, inner);
+                        svfloat32_t _d = SoftmaxExponent(mask, svsub_f32_x(mask, svld1_f32(mask, s + i), svld1_f32(mask, max + i)));
+                        svst1_f32(mask, d + i, _d);
+                        svst1_f32(mask, sum + i, svadd_f32_x(mask, _d, svld1_f32(mask, sum + i)));
+                    }
+                    s += inner;
+                    d += inner;
+                }
+
+                d = dst;
+                for (size_t c = 0; c < count; ++c)
+                {
+                    for (size_t i = 0; i < inner; i += F)
+                    {
+                        svbool_t mask = svwhilelt_b32(i, inner);
+                        svst1_f32(mask, d + i, svdiv_f32_x(mask, svld1_f32(mask, d + i), svld1_f32(mask, sum + i)));
+                    }
+                    d += inner;
+                }
+                src += count * inner;
+                dst += count * inner;
+            }
+        }
+
+        void SynetSoftmax32f(const float* src, size_t outer, size_t count, size_t inner, float* dst)
+        {
+            if (inner == 1)
+            {
+                if (count == 2)
+                    SynetSoftmax32f21(src, outer, dst);
+                else
+                    Base::SynetSoftmax32f(src, outer, count, inner, dst);
+            }
+            else
+                SynetSoftmax32fInner(src, outer, count, inner, dst);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetSoftmax.cpp
+++ b/src/Test/TestSynetSoftmax.cpp
@@ -122,6 +122,11 @@ namespace Test
             result = result && SynetSoftmax32fAutoTest(FUNC_SM32F(Simd::Avx512bw::SynetSoftmax32f), FUNC_SM32F(SimdSynetSoftmax32f));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetSoftmax32fAutoTest(FUNC_SM32F(Simd::Sve2::SynetSoftmax32f), FUNC_SM32F(SimdSynetSoftmax32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetSoftmax32fAutoTest(FUNC_SM32F(Simd::Neon::SynetSoftmax32f), FUNC_SM32F(SimdSynetSoftmax32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 dispatch, declaration, implementation, and auto-test coverage for `SynetSoftmax32f`.
- Update the 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetSoftmax32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2Synet.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93cc71e6-33c7-4cc2-81bc-b619bcac8603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93cc71e6-33c7-4cc2-81bc-b619bcac8603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

