### PR TITLE
Add SVE2 SynetSoftplus32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -101,6 +101,7 @@
  <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetShuffleLayerForward.</li>
  <li>SVE2 optimizations of function SynetSoftmax32f.</li>
+ <li>SVE2 optimizations of function SynetSoftplus32f.</li>
  <li>SVE2 optimizations of function SynetSetInput.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7933,7 +7933,7 @@ SIMD_API void SimdSynetSoftplus32f(const float* src, size_t size, const float* b
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetSoftplus32fPtr) (const float* src, size_t size, const float* beta, const float* threshold, float* dst);
-    const static SimdSynetSoftplus32fPtr simdSynetSoftplus32f = SIMD_FUNC4(SynetSoftplus32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetSoftplus32fPtr simdSynetSoftplus32f = SIMD_FUNC5(SynetSoftplus32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetSoftplus32f(src, size, beta, threshold, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -631,6 +631,8 @@ namespace Simd
 
         void SynetSigmoid32f(const float* src, size_t size, const float* slope, float* dst);
 
+        void SynetSoftplus32f(const float* src, size_t size, const float* beta, const float* threshold, float* dst);
+
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -51,6 +51,27 @@ namespace Simd
             return svmul_f32_x(mask, expipart, expfpart);
         }
 
+        SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
+        {
+            svuint32_t i = svreinterpret_u32_f32(x);
+            svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
+            svfloat32_t e = svcvt_f32_s32_x(mask, e32);
+            svfloat32_t one = svdup_n_f32(1.0f);
+            svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
+            svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
+            p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
+            p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
+            p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
+            p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
+            p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
+            return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
+        }
+
+        SIMD_INLINE svfloat32_t Logarithm(const svbool_t& mask, svfloat32_t value)
+        {
+            return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
+        }
+
         SIMD_INLINE svfloat32_t Exponent(const svbool_t& mask, svfloat32_t value)
         {
             return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
@@ -398,6 +419,40 @@ namespace Simd
                 SynetSigmoid32f(src + i, body, _slope, dst + i);
             if (i < size)
                 SynetSigmoid32f(src + i, svwhilelt_b32(i, size), _slope, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetSoftplus32f(const svbool_t& mask, svfloat32_t value, svfloat32_t beta, svfloat32_t threshold)
+        {
+            svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, beta));
+            svfloat32_t log = Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f));
+            svfloat32_t softplus = svdiv_f32_x(mask, log, beta);
+            return svsel_f32(svcmpgt_f32(mask, value, threshold), value, softplus);
+        }
+
+        SIMD_INLINE void SynetSoftplus32f(const float* src, const svbool_t& mask, svfloat32_t beta, svfloat32_t threshold, float* dst)
+        {
+            svst1_f32(mask, dst, SynetSoftplus32f(mask, svld1_f32(mask, src), beta, threshold));
+        }
+
+        void SynetSoftplus32f(const float* src, size_t size, const float* beta, const float* threshold, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _beta = svdup_n_f32(beta[0]);
+            const svfloat32_t _threshold = svdup_n_f32(threshold[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetSoftplus32f(src + i + 0 * F, body, _beta, _threshold, dst + i + 0 * F);
+                SynetSoftplus32f(src + i + 1 * F, body, _beta, _threshold, dst + i + 1 * F);
+                SynetSoftplus32f(src + i + 2 * F, body, _beta, _threshold, dst + i + 2 * F);
+                SynetSoftplus32f(src + i + 3 * F, body, _beta, _threshold, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetSoftplus32f(src + i, body, _beta, _threshold, dst + i);
+            if (i < size)
+                SynetSoftplus32f(src + i, svwhilelt_b32(i, size), _beta, _threshold, dst + i);
         }
     }
 #endif

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -1121,6 +1121,11 @@ namespace Test
             result = result && SynetSoftplus32fAutoTest(FUNC_SP(Simd::Avx512bw::SynetSoftplus32f), FUNC_SP(SimdSynetSoftplus32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetSoftplus32fAutoTest(FUNC_SP(Simd::Sve2::SynetSoftplus32f), FUNC_SP(SimdSynetSoftplus32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetSoftplus32fAutoTest(FUNC_SP(Simd::Neon::SynetSoftplus32f), FUNC_SP(SimdSynetSoftplus32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 vector implementation of `SynetSoftplus32f` with masked tail handling.
- Wire SVE2 into the public dispatcher and focused auto-test.
- Update release notes for version 7.2.164.

### Validation
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetSoftplus32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.2-a+sve2 -std=c++17 -O2 -I src -c src/Simd/SimdSve2SynetActivation.cpp -o /tmp/SimdSve2SynetActivation.o`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dff0adf0-0f78-43d6-9d9d-1232b0e7a15e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dff0adf0-0f78-43d6-9d9d-1232b0e7a15e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

