### PR TITLE
Add SVE2 SynetSwish32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -103,6 +103,7 @@
  <li>SVE2 optimizations of function SynetSoftmax32f.</li>
  <li>SVE2 optimizations of function SynetSoftplus32f.</li>
  <li>SVE2 optimizations of function SynetSetInput.</li>
+ <li>SVE2 optimizations of function SynetSwish32f.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7946,7 +7946,7 @@ SIMD_API void SimdSynetSwish32f(const float* src, size_t size, const float* slop
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetSwish32fPtr) (const float* src, size_t size, const float* slope, float* dst);
-    const static SimdSynetSwish32fPtr simdSynetSwish32f = SIMD_FUNC4(SynetSwish32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetSwish32fPtr simdSynetSwish32f = SIMD_FUNC5(SynetSwish32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetSwish32f(src, size, slope, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -633,6 +633,8 @@ namespace Simd
 
         void SynetSoftplus32f(const float* src, size_t size, const float* beta, const float* threshold, float* dst);
 
+        void SynetSwish32f(const float* src, size_t size, const float* slope, float* dst);
+
         void SynetQuantizedHardSigmoid(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* scale, const float* shift, uint8_t* dst, const float* dstScale, int dstZero);
 
         void SynetQuantizedHswish(const uint8_t* src, const float* srcScale, int srcZero, size_t size, const float* shift, const float* scale, uint8_t* dst, const float* dstScale, int dstZero);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -454,6 +454,37 @@ namespace Simd
             if (i < size)
                 SynetSoftplus32f(src + i, svwhilelt_b32(i, size), _beta, _threshold, dst + i);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svfloat32_t SynetSwish32f(const svbool_t& mask, svfloat32_t value, svfloat32_t slope)
+        {
+            svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, slope)));
+            return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
+        }
+
+        SIMD_INLINE void SynetSwish32f(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)
+        {
+            svst1_f32(mask, dst, SynetSwish32f(mask, svld1_f32(mask, src), slope));
+        }
+
+        void SynetSwish32f(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetSwish32f(src + i + 0 * F, body, _slope, dst + i + 0 * F);
+                SynetSwish32f(src + i + 1 * F, body, _slope, dst + i + 1 * F);
+                SynetSwish32f(src + i + 2 * F, body, _slope, dst + i + 2 * F);
+                SynetSwish32f(src + i + 3 * F, body, _slope, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetSwish32f(src + i, body, _slope, dst + i);
+            if (i < size)
+                SynetSwish32f(src + i, svwhilelt_b32(i, size), _slope, dst + i);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -1036,6 +1036,11 @@ namespace Test
             result = result && SynetSwish32fAutoTest(FUNC_SW(Simd::Avx512bw::SynetSwish32f), FUNC_SW(SimdSynetSwish32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetSwish32fAutoTest(FUNC_SW(Simd::Sve2::SynetSwish32f), FUNC_SW(SimdSynetSwish32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetSwish32fAutoTest(FUNC_SW(Simd::Neon::SynetSwish32f), FUNC_SW(SimdSynetSwish32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Summary:
- Add SVE2 implementation and declaration for `SynetSwish32f`.
- Route `SimdSynetSwish32f` dispatch through SVE2 when available.
- Add SVE2 coverage to `SynetSwish32fAutoTest` and update 7.2.164 release notes.

Validation:
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./build/Test "-r=." -fi=SynetSwish32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv8.6-a+sve2 -std=c++17 -I./src -fsyntax-only src/Simd/SimdSve2SynetActivation.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0095129-f26d-4b7e-90e0-bb274301fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0095129-f26d-4b7e-90e0-bb274301fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

