### PR TITLE
Add SVE2 SynetTanh32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -104,6 +104,7 @@
  <li>SVE2 optimizations of function SynetSoftplus32f.</li>
  <li>SVE2 optimizations of function SynetSetInput.</li>
  <li>SVE2 optimizations of function SynetSwish32f.</li>
+ <li>SVE2 optimizations of function SynetTanh32f.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7959,7 +7959,7 @@ SIMD_API void SimdSynetTanh32f(const float* src, size_t size, const float* slope
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetTanh32fPtr) (const float* src, size_t size, const float* slope, float* dst);
-    const static SimdSynetTanh32fPtr simdSynetTanh32f = SIMD_FUNC4(SynetTanh32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetTanh32fPtr simdSynetTanh32f = SIMD_FUNC5(SynetTanh32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetTanh32f(src, size, slope, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -631,6 +631,8 @@ namespace Simd
 
         void SynetSigmoid32f(const float* src, size_t size, const float* slope, float* dst);
 
+        void SynetTanh32f(const float* src, size_t size, const float* slope, float* dst);
+
         void SynetSoftplus32f(const float* src, size_t size, const float* beta, const float* threshold, float* dst);
 
         void SynetSwish32f(const float* src, size_t size, const float* slope, float* dst);

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -423,6 +423,38 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        SIMD_INLINE svfloat32_t SynetTanh32f(const svbool_t& mask, svfloat32_t value, svfloat32_t slope)
+        {
+            const svfloat32_t _1 = svdup_n_f32(1.0f);
+            svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, slope));
+            return svdiv_f32_x(mask, svsub_f32_x(mask, exp, _1), svadd_f32_x(mask, exp, _1));
+        }
+
+        SIMD_INLINE void SynetTanh32f(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)
+        {
+            svst1_f32(mask, dst, SynetTanh32f(mask, svld1_f32(mask, src), slope));
+        }
+
+        void SynetTanh32f(const float* src, size_t size, const float* slope, float* dst)
+        {
+            size_t F = svcntw(), QF = 4 * F, i = 0;
+            const svbool_t body = svptrue_b32();
+            const svfloat32_t _slope = svdup_n_f32(2.0f * slope[0]);
+            for (; i + QF <= size; i += QF)
+            {
+                SynetTanh32f(src + i + 0 * F, body, _slope, dst + i + 0 * F);
+                SynetTanh32f(src + i + 1 * F, body, _slope, dst + i + 1 * F);
+                SynetTanh32f(src + i + 2 * F, body, _slope, dst + i + 2 * F);
+                SynetTanh32f(src + i + 3 * F, body, _slope, dst + i + 3 * F);
+            }
+            for (; i + F <= size; i += F)
+                SynetTanh32f(src + i, body, _slope, dst + i);
+            if (i < size)
+                SynetTanh32f(src + i, svwhilelt_b32(i, size), _slope, dst + i);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         SIMD_INLINE svfloat32_t SynetSoftplus32f(const svbool_t& mask, svfloat32_t value, svfloat32_t beta, svfloat32_t threshold)
         {
             svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, beta));

--- a/src/Test/TestSynetActivation.cpp
+++ b/src/Test/TestSynetActivation.cpp
@@ -1215,6 +1215,11 @@ namespace Test
             result = result && SynetTanh32fAutoTest(FUNC_TH(Simd::Avx512bw::SynetTanh32f), FUNC_TH(SimdSynetTanh32f));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetTanh32fAutoTest(FUNC_TH(Simd::Sve2::SynetTanh32f), FUNC_TH(SimdSynetTanh32f));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetTanh32fAutoTest(FUNC_TH(Simd::Neon::SynetTanh32f), FUNC_TH(SimdSynetTanh32f));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation and dispatch for `SimdSynetTanh32f`.
- Extend `SynetTanh32fAutoTest` to cover the SVE2 implementation.
- Document the SVE2 optimization in release 7.2.164 notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="/workspace/build:${LD_LIBRARY_PATH}" && ./Test "-r=.." -fi=SynetTanh32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -c src/Simd/SimdSve2SynetActivation.cpp -o /tmp/SimdSve2SynetActivation.o -std=c++17 -O2 -I src -march=armv9-a+sve2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da9cade3-86ca-414a-88b8-cd4b033cd28b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da9cade3-86ca-414a-88b8-cd4b033cd28b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

