### PR TITLE
Add SVE2 SynetTiledScale2D32f optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -105,6 +105,7 @@
  <li>SVE2 optimizations of function SynetSetInput.</li>
  <li>SVE2 optimizations of function SynetSwish32f.</li>
  <li>SVE2 optimizations of function SynetTanh32f.</li>
+ <li>SVE2 optimizations of function SynetTiledScale2D32f.</li>
  <li>NEON, SVE2 optimizations of function SynetInnerProduct8i.</li>
  <li>SVE2 optimizations of function SynetInnerProductLayerForward.</li>
  <li>SVE2 optimizations of function SynetLrnLayerCrossChannels.</li>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7972,7 +7972,7 @@ SIMD_API void SimdSynetTiledScale2D32f(const float* src, size_t channels, size_t
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void(*SimdSynetTiledScale2D32fPtr) (const float* src, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* ver, const float* hor, float* dst);
-    const static SimdSynetTiledScale2D32fPtr simdSynetTiledScale2D32f = SIMD_FUNC4(SynetTiledScale2D32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetTiledScale2D32fPtr simdSynetTiledScale2D32f = SIMD_FUNC5(SynetTiledScale2D32f, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     simdSynetTiledScale2D32f(src, channels, height, width, format, ver, hor, dst);
 #else

--- a/src/Simd/SimdSve2.h
+++ b/src/Simd/SimdSve2.h
@@ -633,6 +633,8 @@ namespace Simd
 
         void SynetTanh32f(const float* src, size_t size, const float* slope, float* dst);
 
+        void SynetTiledScale2D32f(const float* src, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* ver, const float* hor, float* dst);
+
         void SynetSoftplus32f(const float* src, size_t size, const float* beta, const float* threshold, float* dst);
 
         void SynetSwish32f(const float* src, size_t size, const float* slope, float* dst);

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -612,6 +612,76 @@ namespace Simd
             else
                 SynetSoftmax32fInner(src, outer, count, inner, dst);
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void SynetTiledScale2D32fNchw(const float* src, const float* ver, const svfloat32_t& hor, float* dst, size_t offset, const svbool_t& mask)
+        {
+            svfloat32_t scale = svmul_f32_x(mask, svld1_f32(mask, ver + offset), hor);
+            svst1_f32(mask, dst + offset, svmul_f32_x(mask, svld1_f32(mask, src + offset), scale));
+        }
+
+        SIMD_INLINE void SynetTiledScale2D32fNhwc(const float* src, const float* ver, const float* hor, float* dst, size_t offset, const svbool_t& mask)
+        {
+            svfloat32_t scale = svmul_f32_x(mask, svld1_f32(mask, ver + offset), svld1_f32(mask, hor + offset));
+            svst1_f32(mask, dst + offset, svmul_f32_x(mask, svld1_f32(mask, src + offset), scale));
+        }
+
+        void SynetTiledScale2D32f(const float* src, size_t channels, size_t height, size_t width, SimdTensorFormatType format, const float* ver, const float* hor, float* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+
+            if (format == SimdTensorFormatNchw)
+            {
+                size_t width4F = AlignLo(width, QF);
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    for (size_t y = 0; y < height; ++y)
+                    {
+                        svfloat32_t _hor = svdup_n_f32(hor[y]);
+                        size_t x = 0;
+                        for (; x < width4F; x += QF)
+                        {
+                            SynetTiledScale2D32fNchw(src, ver, _hor, dst, x + 0 * F, body);
+                            SynetTiledScale2D32fNchw(src, ver, _hor, dst, x + 1 * F, body);
+                            SynetTiledScale2D32fNchw(src, ver, _hor, dst, x + 2 * F, body);
+                            SynetTiledScale2D32fNchw(src, ver, _hor, dst, x + 3 * F, body);
+                        }
+                        for (; x < width; x += F)
+                            SynetTiledScale2D32fNchw(src, ver, _hor, dst, x, svwhilelt_b32(x, width));
+                        src += width, dst += width;
+                    }
+                    hor += height;
+                    ver += width;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                size_t channels4F = AlignLo(channels, QF);
+                for (size_t y = 0; y < height; ++y)
+                {
+                    const float* pVer = ver;
+                    for (size_t x = 0; x < width; ++x)
+                    {
+                        size_t c = 0;
+                        for (; c < channels4F; c += QF)
+                        {
+                            SynetTiledScale2D32fNhwc(src, pVer, hor, dst, c + 0 * F, body);
+                            SynetTiledScale2D32fNhwc(src, pVer, hor, dst, c + 1 * F, body);
+                            SynetTiledScale2D32fNhwc(src, pVer, hor, dst, c + 2 * F, body);
+                            SynetTiledScale2D32fNhwc(src, pVer, hor, dst, c + 3 * F, body);
+                        }
+                        for (; c < channels; c += F)
+                            SynetTiledScale2D32fNhwc(src, pVer, hor, dst, c, svwhilelt_b32(c, channels));
+                        src += channels, dst += channels, pVer += channels;
+                    }
+                    hor += channels;
+                }
+            }
+            else
+                assert(0);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynet.cpp
+++ b/src/Test/TestSynet.cpp
@@ -576,6 +576,11 @@ namespace Test
             result = result && SynetTiledScale2D32fAutoTest(FUNC_TS2D32F(Simd::Neon::SynetTiledScale2D32f), FUNC_TS2D32F(SimdSynetTiledScale2D32f));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetTiledScale2D32fAutoTest(FUNC_TS2D32F(Simd::Sve2::SynetTiledScale2D32f), FUNC_TS2D32F(SimdSynetTiledScale2D32f));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add SVE2 implementation of `SynetTiledScale2D32f` for NCHW and NHWC tensors.
- Wire the SVE2 path into public dispatch and targeted auto tests.
- Update 7.2.164 release notes.

### Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetTiledScale2D32f -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2 -msve-vector-bits=scalable -std=c++17 -fsyntax-only -I src src/Simd/SimdSve2Synet.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b014e3f0-36a5-41f8-a812-14ab7266722a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b014e3f0-36a5-41f8-a812-14ab7266722a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

