### PR TITLE
Add NEON SynetScale16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -101,6 +101,7 @@
  <li>SVE2 optimizations of function SynetQuantizedScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
  <li>SVE2 optimizations of class SynetScale8i.</li>
+ <li>NEON optimizations of class SynetScale16b.</li>
  <li>SVE2 optimizations of function SynetShuffleLayerForward.</li>
  <li>SVE2 optimizations of function SynetSoftmax32f.</li>
  <li>NEON, SVE2 optimizations of function SynetSoftmax16b.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -104,6 +104,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetAdd16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetNormalize16b.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetScale16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetSoftmax16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32f.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -328,6 +328,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetNormalize16b.cpp">
       <Filter>Neon\Synet\Other</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetScale16b.cpp">
+      <Filter>Neon\Synet\Other</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetSoftmax16b.cpp">
       <Filter>Neon\Synet\Other</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7820,7 +7820,7 @@ SIMD_API void* SimdSynetScale16bInit(size_t channels, size_t spatial, SimdTensor
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetScale16bInitPtr) (size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias);
-    const static SimdSynetScale16bInitPtr simdSynetScale16bInit = SIMD_FUNC3(SynetScale16bInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetScale16bInitPtr simdSynetScale16bInit = SIMD_FUNC4(SynetScale16bInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetScale16bInit(channels, spatial, srcType, dstType, format, norm, bias);
 #else

--- a/src/Simd/SimdNeonSynetScale16b.cpp
+++ b/src/Simd/SimdNeonSynetScale16b.cpp
@@ -1,0 +1,302 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetScale16b.h"
+#include "Simd/SimdSynetAdd16bCommon.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Neon
+    {
+        SIMD_INLINE uint16x8_t Float32ToBFloat16(float32x4_t lo, float32x4_t hi)
+        {
+            return vcombine_u16(vmovn_u32(Float32ToBFloat16(lo)), vmovn_u32(Float32ToBFloat16(hi)));
+        }
+
+        SIMD_INLINE float32x4_t BFloat16ToFloat32(uint16x4_t value)
+        {
+            return BFloat16ToFloat32(vmovl_u16(value));
+        }
+
+        SIMD_INLINE float32x4_t SetF32(float a, float b, float c, float d)
+        {
+            float value[4] = { a, b, c, d };
+            return vld1q_f32(value);
+        }
+
+        template<class S> SIMD_INLINE float32x4_t Load16b(const S* src);
+
+        template<> SIMD_INLINE float32x4_t Load16b(const float* src)
+        {
+            return vld1q_f32(src);
+        }
+
+        template<> SIMD_INLINE float32x4_t Load16b(const uint16_t* src)
+        {
+            return BFloat16ToFloat32(vld1_u16(src));
+        }
+
+        template<class D> SIMD_INLINE void Store16b(float32x4_t value, D* dst);
+
+        template<> SIMD_INLINE void Store16b(float32x4_t value, float* dst)
+        {
+            vst1q_f32(dst, value);
+        }
+
+        template<> SIMD_INLINE void Store16b(float32x4_t value, uint16_t* dst)
+        {
+            vst1_u16(dst, vmovn_u32(Float32ToBFloat16(value)));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> SIMD_INLINE void NormBias16bF(const S* src, const float* norm, const float* bias, D* dst)
+        {
+            Store16b(vaddq_f32(vmulq_f32(Load16b(src), vld1q_f32(norm)), vld1q_f32(bias)), dst);
+        }
+
+        template<class S, class D> SIMD_INLINE void NormBias16bF(const S* src, float32x4_t norm, float32x4_t bias, D* dst)
+        {
+            Store16b(vaddq_f32(vmulq_f32(Load16b(src), norm), bias), dst);
+        }
+
+        template<class S, class D> void SynetNormBias16b(const uint8_t* src8, size_t channels, size_t spatial, SimdTensorFormatType format, const float* norm, const float* bias, uint8_t* dst8)
+        {
+            const S* src = (const S*)src8;
+            D* dst = (D*)dst8;
+            if (format == SimdTensorFormatNchw)
+            {
+                size_t spatialF = AlignLo(spatial, F);
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    float32x4_t _norm = vdupq_n_f32(norm[c]);
+                    float32x4_t _bias = vdupq_n_f32(bias[c]);
+                    size_t s = 0;
+                    for (; s < spatialF; s += F)
+                        NormBias16bF<S, D>(src + s, _norm, _bias, dst + s);
+                    for (; s < spatial; ++s)
+                        Base::NormBias16b<S, D>(src[s], norm[c], bias[c], dst[s]);
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                if (channels == 3)
+                {
+                    size_t spatialF = AlignLo(spatial, F) * 3;
+                    spatial *= 3;
+                    float32x4_t _norm[3];
+                    _norm[0] = SetF32(norm[0], norm[1], norm[2], norm[0]);
+                    _norm[1] = SetF32(norm[1], norm[2], norm[0], norm[1]);
+                    _norm[2] = SetF32(norm[2], norm[0], norm[1], norm[2]);
+                    float32x4_t _bias[3];
+                    _bias[0] = SetF32(bias[0], bias[1], bias[2], bias[0]);
+                    _bias[1] = SetF32(bias[1], bias[2], bias[0], bias[1]);
+                    _bias[2] = SetF32(bias[2], bias[0], bias[1], bias[2]);
+                    size_t s = 0;
+                    for (; s < spatialF; s += 3 * F)
+                    {
+                        NormBias16bF<S, D>(src + s + 0 * F, _norm[0], _bias[0], dst + s + 0 * F);
+                        NormBias16bF<S, D>(src + s + 1 * F, _norm[1], _bias[1], dst + s + 1 * F);
+                        NormBias16bF<S, D>(src + s + 2 * F, _norm[2], _bias[2], dst + s + 2 * F);
+                    }
+                    for (; s < spatial; s += 3)
+                    {
+                        Base::NormBias16b<S, D>(src[s + 0], norm[0], bias[0], dst[s + 0]);
+                        Base::NormBias16b<S, D>(src[s + 1], norm[1], bias[1], dst[s + 1]);
+                        Base::NormBias16b<S, D>(src[s + 2], norm[2], bias[2], dst[s + 2]);
+                    }
+                }
+                else
+                {
+                    size_t channelsF = AlignLo(channels, F);
+                    for (size_t s = 0; s < spatial; ++s)
+                    {
+                        size_t c = 0;
+                        for (; c < channelsF; c += F)
+                            NormBias16bF<S, D>(src + c, norm + c, bias + c, dst + c);
+                        for (; c < channels; ++c)
+                            Base::NormBias16b<S, D>(src[c], norm[c], bias[c], dst[c]);
+                        src += channels;
+                        dst += channels;
+                    }
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> SIMD_INLINE void Norm16bF(const S* src, const float* norm, D* dst)
+        {
+            Store16b(vmulq_f32(Load16b(src), vld1q_f32(norm)), dst);
+        }
+
+        template<class S, class D> SIMD_INLINE void Norm16bF(const S* src, float32x4_t norm, D* dst)
+        {
+            Store16b(vmulq_f32(Load16b(src), norm), dst);
+        }
+
+        template<class S, class D> void SynetNorm16b(const uint8_t* src8, size_t channels, size_t spatial, SimdTensorFormatType format, const float* norm, const float* bias, uint8_t* dst8)
+        {
+            const S* src = (const S*)src8;
+            D* dst = (D*)dst8;
+            if (format == SimdTensorFormatNchw)
+            {
+                size_t spatialF = AlignLo(spatial, F);
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    float32x4_t _norm = vdupq_n_f32(norm[c]);
+                    size_t s = 0;
+                    for (; s < spatialF; s += F)
+                        Norm16bF<S, D>(src + s, _norm, dst + s);
+                    for (; s < spatial; ++s)
+                        Base::Norm16b<S, D>(src[s], norm[c], dst[s]);
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                size_t channelsF = AlignLo(channels, F);
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    size_t c = 0;
+                    for (; c < channelsF; c += F)
+                        Norm16bF<S, D>(src + c, norm + c, dst + c);
+                    for (; c < channels; ++c)
+                        Base::Norm16b<S, D>(src[c], norm[c], dst[c]);
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> SIMD_INLINE void Bias16bF(const S* src, const float* bias, D* dst)
+        {
+            Store16b(vaddq_f32(Load16b(src), vld1q_f32(bias)), dst);
+        }
+
+        template<class S, class D> SIMD_INLINE void Bias16bF(const S* src, float32x4_t bias, D* dst)
+        {
+            Store16b(vaddq_f32(Load16b(src), bias), dst);
+        }
+
+        template<class S, class D> void SynetBias16b(const uint8_t* src8, size_t channels, size_t spatial, SimdTensorFormatType format, const float* norm, const float* bias, uint8_t* dst8)
+        {
+            const S* src = (const S*)src8;
+            D* dst = (D*)dst8;
+            if (format == SimdTensorFormatNchw)
+            {
+                size_t spatialF = AlignLo(spatial, F);
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    float32x4_t _bias = vdupq_n_f32(bias[c]);
+                    size_t s = 0;
+                    for (; s < spatialF; s += F)
+                        Bias16bF<S, D>(src + s, _bias, dst + s);
+                    for (; s < spatial; ++s)
+                        Base::Bias16b<S, D>(src[s], bias[c], dst[s]);
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                size_t channelsF = AlignLo(channels, F);
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    size_t c = 0;
+                    for (; c < channelsF; c += F)
+                        Bias16bF<S, D>(src + c, bias + c, dst + c);
+                    for (; c < channels; ++c)
+                        Base::Bias16b<S, D>(src[c], bias[c], dst[c]);
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> static SynetScale16b::WorkerPtr GetScale16bWorker(SimdBool norm, SimdBool bias)
+        {
+            if (norm)
+                return bias ? SynetNormBias16b<S, D> : SynetNorm16b<S, D>;
+            else
+                return bias ? SynetBias16b<S, D> : NULL;
+        }
+
+        template<class S> static SynetScale16b::WorkerPtr GetScale16bWorker(SimdTensorDataType dType, SimdBool norm, SimdBool bias)
+        {
+            switch (dType)
+            {
+            case SimdTensorData32f: return GetScale16bWorker<S, float>(norm, bias);
+            case SimdTensorData16b: return GetScale16bWorker<S, uint16_t>(norm, bias);
+            default:
+                return NULL;
+            }
+        }
+
+        static SynetScale16b::WorkerPtr GetScale16bWorker(SimdTensorDataType sType, SimdTensorDataType dType, SimdBool norm, SimdBool bias)
+        {
+            switch (sType)
+            {
+            case SimdTensorData32f: return GetScale16bWorker<float>(dType, norm, bias);
+            case SimdTensorData16b: return GetScale16bWorker<uint16_t>(dType, norm, bias);
+            default:
+                return NULL;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetScale16b::SynetScale16b(const Scale16bParam& p)
+            : Base::SynetScale16b(p)
+        {
+            _worker = GetScale16bWorker(p.sType, p.dType, p.norm, p.bias);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetScale16bInit(size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias)
+        {
+            Scale16bParam param(channels, spatial, srcType, dstType, format, norm, bias);
+            if (!param.Valid())
+                return NULL;
+            if (SynetScale16b::Preferable(param))
+                return new SynetScale16b(param);
+            return NULL;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetScale16b.h
+++ b/src/Simd/SimdSynetScale16b.h
@@ -138,6 +138,21 @@ namespace Simd
 
     }
 #endif
+
+#ifdef SIMD_NEON_ENABLE
+    namespace Neon
+    {
+        class SynetScale16b : public Base::SynetScale16b
+        {
+        public:
+            SynetScale16b(const Scale16bParam& p);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetScale16bInit(size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias);
+    }
+#endif
 }
 
 #endif

--- a/src/Test/TestSynetScale.cpp
+++ b/src/Test/TestSynetScale.cpp
@@ -465,6 +465,11 @@ namespace Test
         result = result && SynetScale16bAutoTest(8, 112 * 96, b16, b16, nchw, t, t, f1, f2);
         result = result && SynetScale16bAutoTest(8, 56 * 48, b16, b16, nchw, t, t, f1, f2);
 
+        result = result && SynetScale16bAutoTest(17, 29 * 23, b16, f32, nhwc, t, f, f1, f2);
+        result = result && SynetScale16bAutoTest(17, 29 * 23, f32, b16, nhwc, f, t, f1, f2);
+        result = result && SynetScale16bAutoTest(17, 29 * 23, b16, f32, nchw, t, f, f1, f2);
+        result = result && SynetScale16bAutoTest(17, 29 * 23, f32, b16, nchw, f, t, f1, f2);
+
 #endif
 
 #if 0
@@ -509,6 +514,11 @@ namespace Test
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
             result = result && SynetScale16bAutoTest(FUNC_S16B(Simd::Avx512bw::SynetScale16bInit), FUNC_S16B(SimdSynetScale16bInit));
+#endif
+
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetScale16bAutoTest(FUNC_S16B(Simd::Neon::SynetScale16bInit), FUNC_S16B(SimdSynetScale16bInit));
 #endif
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add NEON `SynetScale16b` worker kernels for 32f/bfloat16 source and destination combinations.
- Register NEON dispatch and tests for `SynetScale16b`.
- Add VS2022 Neon project entries and release note for 7.2.164.

## Testing
- `aarch64-linux-gnu-g++ -std=c++11 -I src -fsyntax-only src/Simd/SimdNeonSynetScale16b.cpp`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" ./Test "-r=.." -fi=SynetScale16b -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a05cc6-a15d-42ca-a000-7e887a22bd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a05cc6-a15d-42ca-a000-7e887a22bd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

