### PR TITLE
Add SVE2 SynetScale16b optimization

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -101,7 +101,7 @@
  <li>SVE2 optimizations of function SynetQuantizedScaleLayerForward.</li>
  <li>SVE2 optimizations of function SynetScaleLayerForward.</li>
  <li>SVE2 optimizations of class SynetScale8i.</li>
- <li>NEON optimizations of class SynetScale16b.</li>
+ <li>NEON, SVE2 optimizations of class SynetScale16b.</li>
  <li>SVE2 optimizations of function SynetShuffleLayerForward.</li>
  <li>SVE2 optimizations of function SynetSoftmax32f.</li>
  <li>NEON, SVE2 optimizations of function SynetSoftmax16b.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedShuffle.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizeLinear.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetUnaryOperation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Texture.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Transform.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -512,6 +512,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale.cpp">
       <Filter>Sve2\Synet\Other</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale16b.cpp">
+      <Filter>Sve2\Synet\Other</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetUnaryOperation.cpp">
       <Filter>Sve2\Synet\Other</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7820,7 +7820,7 @@ SIMD_API void* SimdSynetScale16bInit(size_t channels, size_t spatial, SimdTensor
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetScale16bInitPtr) (size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias);
-    const static SimdSynetScale16bInitPtr simdSynetScale16bInit = SIMD_FUNC4(SynetScale16bInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetScale16bInitPtr simdSynetScale16bInit = SIMD_FUNC5(SynetScale16bInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetScale16bInit(channels, spatial, srcType, dstType, format, norm, bias);
 #else

--- a/src/Simd/SimdSve2SynetScale16b.cpp
+++ b/src/Simd/SimdSve2SynetScale16b.cpp
@@ -1,0 +1,248 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetScale16b.h"
+#include "Simd/SimdBFloat16.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
+        {
+            svuint32_t bits = svreinterpret_u32_f32(value);
+            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+        }
+
+        SIMD_INLINE svfloat32_t BFloat16ToFloat32(svuint32_t value, const svbool_t& mask)
+        {
+            return svreinterpret_f32_u32(svlsl_n_u32_x(mask, value, Base::Bf16::SHIFT));
+        }
+
+        template<class S> SIMD_INLINE svfloat32_t LoadScale16b(const S* src, const svbool_t& mask);
+
+        template<> SIMD_INLINE svfloat32_t LoadScale16b(const float* src, const svbool_t& mask)
+        {
+            return svld1_f32(mask, src);
+        }
+
+        template<> SIMD_INLINE svfloat32_t LoadScale16b(const uint16_t* src, const svbool_t& mask)
+        {
+            return BFloat16ToFloat32(svld1uh_u32(mask, src), mask);
+        }
+
+        template<class D> SIMD_INLINE void StoreScale16b(svfloat32_t value, D* dst, const svbool_t& mask);
+
+        template<> SIMD_INLINE void StoreScale16b(svfloat32_t value, float* dst, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, value);
+        }
+
+        template<> SIMD_INLINE void StoreScale16b(svfloat32_t value, uint16_t* dst, const svbool_t& mask)
+        {
+            svst1h_u32(mask, dst, Float32ToBFloat16(value, mask));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> SIMD_INLINE void NormBias16bF(const S* src, const float* norm, const float* bias, D* dst, const svbool_t& mask)
+        {
+            StoreScale16b(svmla_f32_x(mask, svld1_f32(mask, bias), LoadScale16b(src, mask), svld1_f32(mask, norm)), dst, mask);
+        }
+
+        template<class S, class D> SIMD_INLINE void NormBias16bF(const S* src, svfloat32_t norm, svfloat32_t bias, D* dst, const svbool_t& mask)
+        {
+            StoreScale16b(svmla_f32_x(mask, bias, LoadScale16b(src, mask), norm), dst, mask);
+        }
+
+        template<class S, class D> void SynetNormBias16b(const uint8_t* src8, size_t channels, size_t spatial, SimdTensorFormatType format, const float* norm, const float* bias, uint8_t* dst8)
+        {
+            const S* src = (const S*)src8;
+            D* dst = (D*)dst8;
+            const size_t F = svcntw();
+            if (format == SimdTensorFormatNchw)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _norm = svdup_n_f32(norm[c]);
+                    svfloat32_t _bias = svdup_n_f32(bias[c]);
+                    for (size_t s = 0; s < spatial; s += F)
+                        NormBias16bF<S, D>(src + s, _norm, _bias, dst + s, svwhilelt_b32(s, spatial));
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    for (size_t c = 0; c < channels; c += F)
+                        NormBias16bF<S, D>(src + c, norm + c, bias + c, dst + c, svwhilelt_b32(c, channels));
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> SIMD_INLINE void Norm16bF(const S* src, const float* norm, D* dst, const svbool_t& mask)
+        {
+            StoreScale16b(svmul_f32_x(mask, LoadScale16b(src, mask), svld1_f32(mask, norm)), dst, mask);
+        }
+
+        template<class S, class D> SIMD_INLINE void Norm16bF(const S* src, svfloat32_t norm, D* dst, const svbool_t& mask)
+        {
+            StoreScale16b(svmul_f32_x(mask, LoadScale16b(src, mask), norm), dst, mask);
+        }
+
+        template<class S, class D> void SynetNorm16b(const uint8_t* src8, size_t channels, size_t spatial, SimdTensorFormatType format, const float* norm, const float* bias, uint8_t* dst8)
+        {
+            const S* src = (const S*)src8;
+            D* dst = (D*)dst8;
+            const size_t F = svcntw();
+            if (format == SimdTensorFormatNchw)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _norm = svdup_n_f32(norm[c]);
+                    for (size_t s = 0; s < spatial; s += F)
+                        Norm16bF<S, D>(src + s, _norm, dst + s, svwhilelt_b32(s, spatial));
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    for (size_t c = 0; c < channels; c += F)
+                        Norm16bF<S, D>(src + c, norm + c, dst + c, svwhilelt_b32(c, channels));
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> SIMD_INLINE void Bias16bF(const S* src, const float* bias, D* dst, const svbool_t& mask)
+        {
+            StoreScale16b(svadd_f32_x(mask, LoadScale16b(src, mask), svld1_f32(mask, bias)), dst, mask);
+        }
+
+        template<class S, class D> SIMD_INLINE void Bias16bF(const S* src, svfloat32_t bias, D* dst, const svbool_t& mask)
+        {
+            StoreScale16b(svadd_f32_x(mask, LoadScale16b(src, mask), bias), dst, mask);
+        }
+
+        template<class S, class D> void SynetBias16b(const uint8_t* src8, size_t channels, size_t spatial, SimdTensorFormatType format, const float* norm, const float* bias, uint8_t* dst8)
+        {
+            const S* src = (const S*)src8;
+            D* dst = (D*)dst8;
+            const size_t F = svcntw();
+            if (format == SimdTensorFormatNchw)
+            {
+                for (size_t c = 0; c < channels; ++c)
+                {
+                    svfloat32_t _bias = svdup_n_f32(bias[c]);
+                    for (size_t s = 0; s < spatial; s += F)
+                        Bias16bF<S, D>(src + s, _bias, dst + s, svwhilelt_b32(s, spatial));
+                    src += spatial;
+                    dst += spatial;
+                }
+            }
+            else if (format == SimdTensorFormatNhwc)
+            {
+                for (size_t s = 0; s < spatial; ++s)
+                {
+                    for (size_t c = 0; c < channels; c += F)
+                        Bias16bF<S, D>(src + c, bias + c, dst + c, svwhilelt_b32(c, channels));
+                    src += channels;
+                    dst += channels;
+                }
+            }
+            else
+                assert(0);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<class S, class D> static SynetScale16b::WorkerPtr GetScale16bWorker(SimdBool norm, SimdBool bias)
+        {
+            if (norm)
+                return bias ? SynetNormBias16b<S, D> : SynetNorm16b<S, D>;
+            else
+                return bias ? SynetBias16b<S, D> : NULL;
+        }
+
+        template<class S> static SynetScale16b::WorkerPtr GetScale16bWorker(SimdTensorDataType dType, SimdBool norm, SimdBool bias)
+        {
+            switch (dType)
+            {
+            case SimdTensorData32f: return GetScale16bWorker<S, float>(norm, bias);
+            case SimdTensorData16b: return GetScale16bWorker<S, uint16_t>(norm, bias);
+            default:
+                return NULL;
+            }
+        }
+
+        static SynetScale16b::WorkerPtr GetScale16bWorker(SimdTensorDataType sType, SimdTensorDataType dType, SimdBool norm, SimdBool bias)
+        {
+            switch (sType)
+            {
+            case SimdTensorData32f: return GetScale16bWorker<float>(dType, norm, bias);
+            case SimdTensorData16b: return GetScale16bWorker<uint16_t>(dType, norm, bias);
+            default:
+                return NULL;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetScale16b::SynetScale16b(const Scale16bParam& p)
+            : Base::SynetScale16b(p)
+        {
+            _worker = GetScale16bWorker(p.sType, p.dType, p.norm, p.bias);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetScale16bInit(size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias)
+        {
+            Scale16bParam param(channels, spatial, srcType, dstType, format, norm, bias);
+            if (!param.Valid())
+                return NULL;
+            if (SynetScale16b::Preferable(param))
+                return new SynetScale16b(param);
+            return NULL;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetScale16b.h
+++ b/src/Simd/SimdSynetScale16b.h
@@ -153,6 +153,21 @@ namespace Simd
         void* SynetScale16bInit(size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class SynetScale16b : public Base::SynetScale16b
+        {
+        public:
+            SynetScale16b(const Scale16bParam& p);
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetScale16bInit(size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdBool norm, SimdBool bias);
+    }
+#endif
 }
 
 #endif

--- a/src/Test/TestSynetScale.cpp
+++ b/src/Test/TestSynetScale.cpp
@@ -521,6 +521,11 @@ namespace Test
             result = result && SynetScale16bAutoTest(FUNC_S16B(Simd::Neon::SynetScale16bInit), FUNC_S16B(SimdSynetScale16bInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetScale16bAutoTest(FUNC_S16B(Simd::Sve2::SynetScale16bInit), FUNC_S16B(SimdSynetScale16bInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE2 `SynetScale16b` implementation for float32/bfloat16 source and destination combinations.
- Wire SVE2 class declaration and runtime dispatch before NEON on SVE2-capable ARM.
- Add SVE2 auto-test coverage, VS2022 project/filter entries, and 7.2.164 release note text.

## Testing
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)`
- `cd build && export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=SynetScale16b -tt=1 -ts=1`
- `aarch64-linux-gnu-g++ -std=c++11 -march=armv8.5-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2SynetScale16b.cpp`
- `aarch64-linux-gnu-g++ -std=c++11 -march=armv8.5-a+sve2 -I src -fsyntax-only src/Simd/SimdLib.cpp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86f05c75-13fb-46af-8ca3-ff3c47fa7244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86f05c75-13fb-46af-8ca3-ff3c47fa7244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

