### PR TITLE
Optimize SVE2 SynetConvolution8i direct

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -184,6 +184,7 @@
  <li>SVE2 optimizations of function GrayToY.</li>
  <li>SVE2 optimizations of function YToGray.</li>
  <li>SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function GetColSums.</li>
+ <li>SVE2 optimizations of class SynetConvolution8iNhwcDirect.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -155,7 +155,8 @@ namespace Simd
             const svint32_t& sum1, const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t upper, size_t size, size_t F, size_t dstC)
         {
             Save1<term, type>(dst, buf, sum0, norm, bias, params, scale, shift, upper, F);
-            Save1<term, type>(dst + F * size, buf + F, sum1, norm + F, bias + F, params + F, scale + F, shift + F, upper, dstC - F);
+            Save1<term, type>(dst + F * size, buf + F, sum1, norm + F, bias + F,
+                type == ::SimdConvolutionActivationPrelu ? params + F : params, scale + F, shift + F, upper, dstC - F);
         }
 
         SIMD_INLINE svuint8_t Set4(const uint8_t* src, size_t tail)

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -366,7 +366,7 @@ namespace Simd
             const ConvParam& p, const AlgParam& a, size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const int8_t* weight,
             const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
         {
-            const size_t F = a.F, DF = 2 * F, n = 12, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            const size_t F = a.F, DF = 2 * F, n = 1, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
             ConvolutionNhwcDirect1x1_2xM_Ptr convolutionNhwcDirect1x1_2xN = GetConvolutionNhwcDirect1x1_2xM<overflow, term, type>(n);
             ConvolutionNhwcDirect1x1_2xM_Ptr convolutionNhwcDirect1x1_2xM = GetConvolutionNhwcDirect1x1_2xM<overflow, term, type>(m);
             for (size_t dc = 0; dc < dstC; dc += DF)

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -414,7 +414,7 @@ namespace Simd
             const ConvParam& p, const AlgParam& a, size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const int8_t* weight,
             const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
         {
-            const size_t F = a.F, DF = 2 * F, n = 12, noseW = p.NoseW(), bodyW = p.BodyW(), bodyWn = AlignLoAny(bodyW - noseW, n) + noseW, m = bodyW - bodyWn;
+            const size_t F = a.F, DF = 2 * F, n = 1, noseW = p.NoseW(), bodyW = p.BodyW(), bodyWn = AlignLoAny(bodyW - noseW, n) + noseW, m = bodyW - bodyWn;
             ConvolutionNhwcDirect_2xM_Ptr convolutionNhwcDirect_2x1 = GetConvolutionNhwcDirect_2xM<overflow, term, type>(1);
             ConvolutionNhwcDirect_2xM_Ptr convolutionNhwcDirect_2xN = GetConvolutionNhwcDirect_2xM<overflow, term, type>(n);
             ConvolutionNhwcDirect_2xM_Ptr convolutionNhwcDirect_2xM = GetConvolutionNhwcDirect_2xM<overflow, term, type>(m);

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -96,11 +96,12 @@ namespace Simd
                 const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t upper, size_t tail)
             {
                 int32_t sums[SIMD_SVE2_VECTOR_SIZE_MAX / sizeof(int32_t)];
+                int32_t _upper = upper & 0xFF;
                 svst1_s32(svwhilelt_b32((size_t)0, tail), sums, sum);
                 for (size_t i = 0; i < tail; ++i)
                 {
                     float value = Activate<type>(float(sums[i]) * norm[i] + bias[i], params, i);
-                    dst[i] = (uint8_t)Simd::RestrictRange(Simd::Round(value * scale[i] + shift[i]), 0, upper);
+                    dst[i] = (uint8_t)Simd::RestrictRange(Simd::Round(value * scale[i] + shift[i]), 0, _upper);
                 }
             }
         };

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -60,14 +60,7 @@ namespace Simd
             return Set4(tmp);
         }
 
-        template<bool overflow> SIMD_INLINE void Madd4(svint32_t& sum, const svuint8_t& src, const int8_t* weight);
-
-        template<> SIMD_INLINE void Madd4<false>(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
-        {
-            sum = svusdot_s32(sum, src, svld1_s8(svptrue_b8(), weight));
-        }
-
-        template<> SIMD_INLINE void Madd4<true>(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
+        template<bool overflow> SIMD_INLINE void Madd4(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
         {
             const svbool_t body8 = svptrue_b8();
             const svbool_t body16 = svptrue_b16();
@@ -79,7 +72,7 @@ namespace Simd
             svint16_t wHi = svmovlt_s16(_weight);
             svint16_t lo = svmul_s16_x(body16, sLo, wLo);
             svint16_t hi = svmul_s16_x(body16, sHi, wHi);
-            svint16_t pairs = svqadd_s16(lo, hi);
+            svint16_t pairs = overflow ? svqadd_s16(lo, hi) : svadd_s16_x(body16, lo, hi);
             svint16_t zero = svdup_n_s16(0);
             svint32_t sum0 = svaddlb_s32(pairs, zero);
             svint32_t sum1 = svaddlt_s32(pairs, zero);
@@ -152,82 +145,79 @@ namespace Simd
             Save1<term, type>(dst + F * size, buf + F, sum1, norm + F, bias + F, params + F, scale + F, shift + F, upper, dstC - F);
         }
 
-        template<bool overflow, int M> SIMD_INLINE void Madd4(const uint8_t* src, size_t step, size_t offs, size_t tail, svint32_t* sum, const int8_t* weight)
+        SIMD_INLINE svuint8_t Set4(const uint8_t* src, size_t tail)
         {
-            if (tail == 4)
-            {
-                for (size_t i = 0; i < M; ++i)
-                    Madd4<overflow>(sum[i], Set4(src + i * step + offs), weight);
-            }
-            else
-            {
-                for (size_t i = 0; i < M; ++i)
-                    Madd4<overflow>(sum[i], Set4(src + i * step + offs, tail, 0), weight);
-            }
+            return tail == 4 ? Set4(src) : Set4(src, tail, 0);
         }
 
-        template<bool overflow, int M> SIMD_INLINE void Madd4(const svuint8_t& src, svint32_t* sum, const int8_t* weight)
-        {
-            for (size_t i = 0; i < M; ++i)
-                Madd4<overflow>(sum[i], src, weight);
-        }
+#define SIMD_SVE2_DECL_D0() svint32_t d00, d10, d20, d30, d40, d50, d60, d70, d80, d90, dA0, dB0
+#define SIMD_SVE2_DECL_D1() svint32_t d01, d11, d21, d31, d41, d51, d61, d71, d81, d91, dA1, dB1
+#define SIMD_SVE2_INIT_D0(I) if (M > 0x##I) d##I##0 = LoadSum(first, buf + 0x##I * dB, Simd::Min(F, dstC))
+#define SIMD_SVE2_INIT_D1(I) if (M > 0x##I) d##I##1 = LoadSum(first, buf + 0x##I * dB + F, dstC - F)
+#define SIMD_SVE2_MADD_SRC_1(I) if (M > 0x##I) s0 = Set4(src + 0x##I * step + offs, tail), Madd4<overflow>(d##I##0, s0, weight0)
+#define SIMD_SVE2_MADD_SRC_2(I) if (M > 0x##I) s0 = Set4(src + 0x##I * step + offs, tail), Madd4<overflow>(d##I##0, s0, weight0), Madd4<overflow>(d##I##1, s0, weight1)
+#define SIMD_SVE2_MADD_ZERO_1(I) if (M > 0x##I) Madd4<overflow>(d##I##0, zero, weight0)
+#define SIMD_SVE2_MADD_ZERO_2(I) if (M > 0x##I) Madd4<overflow>(d##I##0, zero, weight0), Madd4<overflow>(d##I##1, zero, weight1)
+#define SIMD_SVE2_SAVE_1(I) if (M > 0x##I) Save1<term, type>(dst + 0x##I * dD, buf + 0x##I * dB, d##I##0, norm, bias, params, scale, shift, a.upper, dstC)
+#define SIMD_SVE2_SAVE_2(I) if (M > 0x##I) Save2<term, type>(dst + 0x##I * dD, buf + 0x##I * dB, d##I##0, d##I##1, norm, bias, params, scale, shift, a.upper, a.size, F, dstC)
+#define SIMD_SVE2_APPLY_12(MACRO) MACRO(0); MACRO(1); MACRO(2); MACRO(3); MACRO(4); MACRO(5); MACRO(6); MACRO(7); MACRO(8); MACRO(9); MACRO(A); MACRO(B)
 
-        template<bool overflow, int M> SIMD_INLINE void ConvolutionNhwcDirect1x1_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t srcC, size_t dstC, const int8_t* weight0, int32_t* buf, uint8_t* dst, int first,
-            const float* norm, const float* bias, const float* params, const float* scale, const float* shift)
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_2xM(
+            const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, const int8_t* weight0,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
         {
-            const size_t F = a.F, A = F * 4, dS = p.srcC * p.strideX, dD = p.dstC * a.size, dB = p.dstC;
+            const size_t F = a.F, A = F * 4, step = p.srcC * p.strideX, dD = p.dstC * a.size, dB = p.dstC;
             const size_t srcCA = AlignLo(srcC, 4);
-            svint32_t d0[12], d1[12];
             const int8_t* weight1 = weight0 + DivHi(p.srcC, 4) * A;
-            for (size_t i = 0; i < M; ++i)
-                d0[i] = LoadSum(first, buf + i * dB, Simd::Min(F, dstC));
+            svuint8_t s0;
+            SIMD_SVE2_DECL_D0();
+            SIMD_SVE2_DECL_D1();
+            SIMD_SVE2_APPLY_12(SIMD_SVE2_INIT_D0);
             if (dstC > F)
             {
-                for (size_t i = 0; i < M; ++i)
-                    d1[i] = LoadSum(first, buf + i * dB + F, dstC - F);
-                size_t offs = 0;
+                SIMD_SVE2_APPLY_12(SIMD_SVE2_INIT_D1);
+                size_t offs = 0, tail = 4;
+                const uint8_t* src = src0;
                 for (; offs < srcCA; offs += 4, weight0 += A, weight1 += A)
-                {
-                    Madd4<overflow, M>(src0, dS, offs, 4, d0, weight0);
-                    Madd4<overflow, M>(src0, dS, offs, 4, d1, weight1);
-                }
+                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_2);
                 if (offs < srcC)
                 {
-                    Madd4<overflow, M>(src0, dS, offs, srcC - offs, d0, weight0);
-                    Madd4<overflow, M>(src0, dS, offs, srcC - offs, d1, weight1);
+                    tail = srcC - offs;
+                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_2);
                 }
-                for (size_t i = 0; i < M; ++i)
-                    Save2<term, type>(dst + i * dD, buf + i * dB, d0[i], d1[i], norm, bias, params, scale, shift, a.upper, a.size, F, dstC);
+                SIMD_SVE2_APPLY_12(SIMD_SVE2_SAVE_2);
             }
             else
             {
-                size_t offs = 0;
+                size_t offs = 0, tail = 4;
+                const uint8_t* src = src0;
                 for (; offs < srcCA; offs += 4, weight0 += A)
-                    Madd4<overflow, M>(src0, dS, offs, 4, d0, weight0);
+                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_1);
                 if (offs < srcC)
-                    Madd4<overflow, M>(src0, dS, offs, srcC - offs, d0, weight0);
-                for (size_t i = 0; i < M; ++i)
-                    Save1<term, type>(dst + i * dD, buf + i * dB, d0[i], norm, bias, params, scale, shift, a.upper, dstC);
+                {
+                    tail = srcC - offs;
+                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_1);
+                }
+                SIMD_SVE2_APPLY_12(SIMD_SVE2_SAVE_1);
             }
         }
 
-        template<bool overflow, int M> SIMD_INLINE void ConvolutionNhwcDirect_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t dy, size_t dx, size_t srcC, size_t dstC, const int8_t* weight0, int32_t* buf, uint8_t* dst, int first,
-            const float* norm, const float* bias, const float* params, const float* scale, const float* shift)
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect_2xM(
+            const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const int8_t* weight0,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
         {
-            const size_t F = a.F, A = F * 4, dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dD = p.dstC * a.size, dB = p.dstC;
+            const size_t F = a.F, A = F * 4, dY = p.srcW * p.srcC, dX = p.srcC, step = p.srcC * p.strideX, dD = p.dstC * a.size, dB = p.dstC;
             const size_t srcCF = DivHi(srcC, 4), srcCA = AlignLo(srcC, 4), dW = (DivHi(p.srcC, 4) - srcCF) * A;
             const size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
             const int8_t* weight1 = weight0 + p.kernelY * p.kernelX * DivHi(p.srcC, 4) * A;
             const size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
-            svint32_t d0[12], d1[12];
-            for (size_t i = 0; i < M; ++i)
-                d0[i] = LoadSum(first, buf + i * dB, Simd::Min(F, dstC));
+            svuint8_t s0, zero = Set4((uint32_t)a.zero);
+            SIMD_SVE2_DECL_D0();
+            SIMD_SVE2_DECL_D1();
+            SIMD_SVE2_APPLY_12(SIMD_SVE2_INIT_D0);
             if (dstC > F)
             {
-                for (size_t i = 0; i < M; ++i)
-                    d1[i] = LoadSum(first, buf + i * dB + F, dstC - F);
+                SIMD_SVE2_APPLY_12(SIMD_SVE2_INIT_D1);
                 for (size_t ky = 0; ky < kY; ky += p.dilationY)
                 {
                     if (sy + ky < p.srcH)
@@ -237,27 +227,20 @@ namespace Simd
                             if (sx + kx < p.srcW && sx + kx + (M - 1) * p.strideX < p.srcW)
                             {
                                 const uint8_t* src = src0 + (sy + ky) * dY + (sx + kx) * dX;
-                                size_t offs = 0;
+                                size_t offs = 0, tail = 4;
                                 for (; offs < srcCA; offs += 4, weight0 += A, weight1 += A)
-                                {
-                                    Madd4<overflow, M>(src, dS, offs, 4, d0, weight0);
-                                    Madd4<overflow, M>(src, dS, offs, 4, d1, weight1);
-                                }
+                                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_2);
                                 if (offs < srcC)
                                 {
-                                    Madd4<overflow, M>(src, dS, offs, srcC - offs, d0, weight0);
-                                    Madd4<overflow, M>(src, dS, offs, srcC - offs, d1, weight1);
+                                    tail = srcC - offs;
+                                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_2);
                                     weight0 += A, weight1 += A;
                                 }
                             }
                             else if (a.zero)
                             {
-                                svuint8_t zero = Set4((uint32_t)a.zero);
                                 for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A, weight1 += A)
-                                {
-                                    Madd4<overflow, M>(zero, d0, weight0);
-                                    Madd4<overflow, M>(zero, d1, weight1);
-                                }
+                                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_ZERO_2);
                             }
                             else
                                 weight0 += srcCF * A, weight1 += srcCF * A;
@@ -266,14 +249,10 @@ namespace Simd
                     }
                     else if (a.zero)
                     {
-                        svuint8_t zero = Set4((uint32_t)a.zero);
                         for (size_t kx = 0; kx < kX; kx += p.dilationX)
                         {
                             for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A, weight1 += A)
-                            {
-                                Madd4<overflow, M>(zero, d0, weight0);
-                                Madd4<overflow, M>(zero, d1, weight1);
-                            }
+                                SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_ZERO_2);
                             weight0 += dW, weight1 += dW;
                         }
                     }
@@ -283,8 +262,7 @@ namespace Simd
                         weight1 += (srcCF * A + dW) * p.kernelX;
                     }
                 }
-                for (size_t i = 0; i < M; ++i)
-                    Save2<term, type>(dst + i * dD, buf + i * dB, d0[i], d1[i], norm, bias, params, scale, shift, a.upper, a.size, F, dstC);
+                SIMD_SVE2_APPLY_12(SIMD_SVE2_SAVE_2);
             }
             else
             {
@@ -297,20 +275,20 @@ namespace Simd
                             if (sx + kx < p.srcW && sx + kx + (M - 1) * p.strideX < p.srcW)
                             {
                                 const uint8_t* src = src0 + (sy + ky) * dY + (sx + kx) * dX;
-                                size_t offs = 0;
+                                size_t offs = 0, tail = 4;
                                 for (; offs < srcCA; offs += 4, weight0 += A)
-                                    Madd4<overflow, M>(src, dS, offs, 4, d0, weight0);
+                                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_1);
                                 if (offs < srcC)
                                 {
-                                    Madd4<overflow, M>(src, dS, offs, srcC - offs, d0, weight0);
+                                    tail = srcC - offs;
+                                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_SRC_1);
                                     weight0 += A;
                                 }
                             }
                             else if (a.zero)
                             {
-                                svuint8_t zero = Set4((uint32_t)a.zero);
                                 for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A)
-                                    Madd4<overflow, M>(zero, d0, weight0);
+                                    SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_ZERO_1);
                             }
                             else
                                 weight0 += srcCF * A;
@@ -319,35 +297,31 @@ namespace Simd
                     }
                     else if (a.zero)
                     {
-                        svuint8_t zero = Set4((uint32_t)a.zero);
                         for (size_t kx = 0; kx < kX; kx += p.dilationX)
                         {
                             for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A)
-                                Madd4<overflow, M>(zero, d0, weight0);
+                                SIMD_SVE2_APPLY_12(SIMD_SVE2_MADD_ZERO_1);
                             weight0 += dW;
                         }
                     }
                     else
                         weight0 += (srcCF * A + dW) * p.kernelX;
                 }
-                for (size_t i = 0; i < M; ++i)
-                    Save1<term, type>(dst + i * dD, buf + i * dB, d0[i], norm, bias, params, scale, shift, a.upper, dstC);
+                SIMD_SVE2_APPLY_12(SIMD_SVE2_SAVE_1);
             }
         }
 
-        template<bool overflow, Term8iType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_2xM(
-            const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, const int8_t* weight0,
-            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
-        {
-            ConvolutionNhwcDirect1x1_2xM<overflow, M>(src0, p, a, srcC, dstC, weight0, buf, dst, first, norm, bias, params, scale, shift);
-        }
-
-        template<bool overflow, Term8iType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect_2xM(
-            const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const int8_t* weight0,
-            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
-        {
-            ConvolutionNhwcDirect_2xM<overflow, M>(src0, p, a, dy, dx, srcC, dstC, weight0, buf, dst, first, norm, bias, params, scale, shift);
-        }
+#undef SIMD_SVE2_DECL_D0
+#undef SIMD_SVE2_DECL_D1
+#undef SIMD_SVE2_INIT_D0
+#undef SIMD_SVE2_INIT_D1
+#undef SIMD_SVE2_MADD_SRC_1
+#undef SIMD_SVE2_MADD_SRC_2
+#undef SIMD_SVE2_MADD_ZERO_1
+#undef SIMD_SVE2_MADD_ZERO_2
+#undef SIMD_SVE2_SAVE_1
+#undef SIMD_SVE2_SAVE_2
+#undef SIMD_SVE2_APPLY_12
 
         typedef void(*ConvolutionNhwcDirect1x1_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC,
             const int8_t* weight0, const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first);

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -60,7 +60,14 @@ namespace Simd
             return Set4(tmp);
         }
 
-        template<bool overflow> SIMD_INLINE void Madd4(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
+        template<bool overflow> SIMD_INLINE void Madd4(svint32_t& sum, const svuint8_t& src, const int8_t* weight);
+
+        template<> SIMD_INLINE void Madd4<false>(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
+        {
+            sum = svusdot_s32(sum, src, svld1_s8(svptrue_b8(), weight));
+        }
+
+        template<> SIMD_INLINE void Madd4<true>(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
         {
             const svbool_t body8 = svptrue_b8();
             const svbool_t body16 = svptrue_b16();
@@ -72,11 +79,7 @@ namespace Simd
             svint16_t wHi = svmovlt_s16(_weight);
             svint16_t lo = svmul_s16_x(body16, sLo, wLo);
             svint16_t hi = svmul_s16_x(body16, sHi, wHi);
-            svint16_t pairs;
-            if (overflow)
-                pairs = svqadd_s16(lo, hi);
-            else
-                pairs = svadd_s16_x(body16, lo, hi);
+            svint16_t pairs = svqadd_s16(lo, hi);
             svint16_t zero = svdup_n_s16(0);
             svint32_t sum0 = svaddlb_s32(pairs, zero);
             svint32_t sum1 = svaddlt_s32(pairs, zero);
@@ -130,6 +133,324 @@ namespace Simd
                 svst1_s32(svwhilelt_b32((size_t)0, tail), buf, sum);
             }
         };
+
+        SIMD_INLINE svint32_t LoadSum(int first, const int32_t* buf, size_t tail)
+        {
+            return first ? svdup_n_s32(0) : svld1_s32(svwhilelt_b32((size_t)0, tail), buf);
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t upper, size_t tail)
+        {
+            Term8i<term>::template Save<type>(dst, buf, sum, norm, bias, params, scale, shift, upper, tail);
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, const svint32_t& sum0,
+            const svint32_t& sum1, const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t upper, size_t size, size_t F, size_t dstC)
+        {
+            Save1<term, type>(dst, buf, sum0, norm, bias, params, scale, shift, upper, F);
+            Save1<term, type>(dst + F * size, buf + F, sum1, norm + F, bias + F, params + F, scale + F, shift + F, upper, dstC - F);
+        }
+
+        template<bool overflow, int M> SIMD_INLINE void Madd4(const uint8_t* src, size_t step, size_t offs, size_t tail, svint32_t* sum, const int8_t* weight)
+        {
+            if (tail == 4)
+            {
+                for (size_t i = 0; i < M; ++i)
+                    Madd4<overflow>(sum[i], Set4(src + i * step + offs), weight);
+            }
+            else
+            {
+                for (size_t i = 0; i < M; ++i)
+                    Madd4<overflow>(sum[i], Set4(src + i * step + offs, tail, 0), weight);
+            }
+        }
+
+        template<bool overflow, int M> SIMD_INLINE void Madd4(const svuint8_t& src, svint32_t* sum, const int8_t* weight)
+        {
+            for (size_t i = 0; i < M; ++i)
+                Madd4<overflow>(sum[i], src, weight);
+        }
+
+        template<bool overflow, int M> SIMD_INLINE void ConvolutionNhwcDirect1x1_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, const int8_t* weight0, int32_t* buf, uint8_t* dst, int first,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift)
+        {
+            const size_t F = a.F, A = F * 4, dS = p.srcC * p.strideX, dD = p.dstC * a.size, dB = p.dstC;
+            const size_t srcCA = AlignLo(srcC, 4);
+            svint32_t d0[12], d1[12];
+            const int8_t* weight1 = weight0 + DivHi(p.srcC, 4) * A;
+            for (size_t i = 0; i < M; ++i)
+                d0[i] = LoadSum(first, buf + i * dB, Simd::Min(F, dstC));
+            if (dstC > F)
+            {
+                for (size_t i = 0; i < M; ++i)
+                    d1[i] = LoadSum(first, buf + i * dB + F, dstC - F);
+                size_t offs = 0;
+                for (; offs < srcCA; offs += 4, weight0 += A, weight1 += A)
+                {
+                    Madd4<overflow, M>(src0, dS, offs, 4, d0, weight0);
+                    Madd4<overflow, M>(src0, dS, offs, 4, d1, weight1);
+                }
+                if (offs < srcC)
+                {
+                    Madd4<overflow, M>(src0, dS, offs, srcC - offs, d0, weight0);
+                    Madd4<overflow, M>(src0, dS, offs, srcC - offs, d1, weight1);
+                }
+                for (size_t i = 0; i < M; ++i)
+                    Save2<term, type>(dst + i * dD, buf + i * dB, d0[i], d1[i], norm, bias, params, scale, shift, a.upper, a.size, F, dstC);
+            }
+            else
+            {
+                size_t offs = 0;
+                for (; offs < srcCA; offs += 4, weight0 += A)
+                    Madd4<overflow, M>(src0, dS, offs, 4, d0, weight0);
+                if (offs < srcC)
+                    Madd4<overflow, M>(src0, dS, offs, srcC - offs, d0, weight0);
+                for (size_t i = 0; i < M; ++i)
+                    Save1<term, type>(dst + i * dD, buf + i * dB, d0[i], norm, bias, params, scale, shift, a.upper, dstC);
+            }
+        }
+
+        template<bool overflow, int M> SIMD_INLINE void ConvolutionNhwcDirect_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t dy, size_t dx, size_t srcC, size_t dstC, const int8_t* weight0, int32_t* buf, uint8_t* dst, int first,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift)
+        {
+            const size_t F = a.F, A = F * 4, dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dD = p.dstC * a.size, dB = p.dstC;
+            const size_t srcCF = DivHi(srcC, 4), srcCA = AlignLo(srcC, 4), dW = (DivHi(p.srcC, 4) - srcCF) * A;
+            const size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const int8_t* weight1 = weight0 + p.kernelY * p.kernelX * DivHi(p.srcC, 4) * A;
+            const size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            svint32_t d0[12], d1[12];
+            for (size_t i = 0; i < M; ++i)
+                d0[i] = LoadSum(first, buf + i * dB, Simd::Min(F, dstC));
+            if (dstC > F)
+            {
+                for (size_t i = 0; i < M; ++i)
+                    d1[i] = LoadSum(first, buf + i * dB + F, dstC - F);
+                for (size_t ky = 0; ky < kY; ky += p.dilationY)
+                {
+                    if (sy + ky < p.srcH)
+                    {
+                        for (size_t kx = 0; kx < kX; kx += p.dilationX)
+                        {
+                            if (sx + kx < p.srcW && sx + kx + (M - 1) * p.strideX < p.srcW)
+                            {
+                                const uint8_t* src = src0 + (sy + ky) * dY + (sx + kx) * dX;
+                                size_t offs = 0;
+                                for (; offs < srcCA; offs += 4, weight0 += A, weight1 += A)
+                                {
+                                    Madd4<overflow, M>(src, dS, offs, 4, d0, weight0);
+                                    Madd4<overflow, M>(src, dS, offs, 4, d1, weight1);
+                                }
+                                if (offs < srcC)
+                                {
+                                    Madd4<overflow, M>(src, dS, offs, srcC - offs, d0, weight0);
+                                    Madd4<overflow, M>(src, dS, offs, srcC - offs, d1, weight1);
+                                    weight0 += A, weight1 += A;
+                                }
+                            }
+                            else if (a.zero)
+                            {
+                                svuint8_t zero = Set4((uint32_t)a.zero);
+                                for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A, weight1 += A)
+                                {
+                                    Madd4<overflow, M>(zero, d0, weight0);
+                                    Madd4<overflow, M>(zero, d1, weight1);
+                                }
+                            }
+                            else
+                                weight0 += srcCF * A, weight1 += srcCF * A;
+                            weight0 += dW, weight1 += dW;
+                        }
+                    }
+                    else if (a.zero)
+                    {
+                        svuint8_t zero = Set4((uint32_t)a.zero);
+                        for (size_t kx = 0; kx < kX; kx += p.dilationX)
+                        {
+                            for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A, weight1 += A)
+                            {
+                                Madd4<overflow, M>(zero, d0, weight0);
+                                Madd4<overflow, M>(zero, d1, weight1);
+                            }
+                            weight0 += dW, weight1 += dW;
+                        }
+                    }
+                    else
+                    {
+                        weight0 += (srcCF * A + dW) * p.kernelX;
+                        weight1 += (srcCF * A + dW) * p.kernelX;
+                    }
+                }
+                for (size_t i = 0; i < M; ++i)
+                    Save2<term, type>(dst + i * dD, buf + i * dB, d0[i], d1[i], norm, bias, params, scale, shift, a.upper, a.size, F, dstC);
+            }
+            else
+            {
+                for (size_t ky = 0; ky < kY; ky += p.dilationY)
+                {
+                    if (sy + ky < p.srcH)
+                    {
+                        for (size_t kx = 0; kx < kX; kx += p.dilationX)
+                        {
+                            if (sx + kx < p.srcW && sx + kx + (M - 1) * p.strideX < p.srcW)
+                            {
+                                const uint8_t* src = src0 + (sy + ky) * dY + (sx + kx) * dX;
+                                size_t offs = 0;
+                                for (; offs < srcCA; offs += 4, weight0 += A)
+                                    Madd4<overflow, M>(src, dS, offs, 4, d0, weight0);
+                                if (offs < srcC)
+                                {
+                                    Madd4<overflow, M>(src, dS, offs, srcC - offs, d0, weight0);
+                                    weight0 += A;
+                                }
+                            }
+                            else if (a.zero)
+                            {
+                                svuint8_t zero = Set4((uint32_t)a.zero);
+                                for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A)
+                                    Madd4<overflow, M>(zero, d0, weight0);
+                            }
+                            else
+                                weight0 += srcCF * A;
+                            weight0 += dW;
+                        }
+                    }
+                    else if (a.zero)
+                    {
+                        svuint8_t zero = Set4((uint32_t)a.zero);
+                        for (size_t kx = 0; kx < kX; kx += p.dilationX)
+                        {
+                            for (size_t offs = 0; offs < srcC; offs += 4, weight0 += A)
+                                Madd4<overflow, M>(zero, d0, weight0);
+                            weight0 += dW;
+                        }
+                    }
+                    else
+                        weight0 += (srcCF * A + dW) * p.kernelX;
+                }
+                for (size_t i = 0; i < M; ++i)
+                    Save1<term, type>(dst + i * dD, buf + i * dB, d0[i], norm, bias, params, scale, shift, a.upper, dstC);
+            }
+        }
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_2xM(
+            const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, const int8_t* weight0,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
+        {
+            ConvolutionNhwcDirect1x1_2xM<overflow, M>(src0, p, a, srcC, dstC, weight0, buf, dst, first, norm, bias, params, scale, shift);
+        }
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect_2xM(
+            const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const int8_t* weight0,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
+        {
+            ConvolutionNhwcDirect_2xM<overflow, M>(src0, p, a, dy, dx, srcC, dstC, weight0, buf, dst, first, norm, bias, params, scale, shift);
+        }
+
+        typedef void(*ConvolutionNhwcDirect1x1_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC,
+            const int8_t* weight0, const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first);
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect1x1_2xM_Ptr GetConvolutionNhwcDirect1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0x0: return NULL;
+            case 0x1: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x1>;
+            case 0x2: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x2>;
+            case 0x3: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x3>;
+            case 0x4: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x4>;
+            case 0x5: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x5>;
+            case 0x6: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x6>;
+            case 0x7: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x7>;
+            case 0x8: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x8>;
+            case 0x9: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0x9>;
+            case 0xA: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0xA>;
+            case 0xB: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0xB>;
+            case 0xC: return ConvolutionNhwcDirect1x1_2xM<overflow, term, type, 0xC>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect1x1_2(const uint8_t* src,
+            const ConvParam& p, const AlgParam& a, size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const int8_t* weight,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F, n = 12, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            ConvolutionNhwcDirect1x1_2xM_Ptr convolutionNhwcDirect1x1_2xN = GetConvolutionNhwcDirect1x1_2xM<overflow, term, type>(n);
+            ConvolutionNhwcDirect1x1_2xM_Ptr convolutionNhwcDirect1x1_2xM = GetConvolutionNhwcDirect1x1_2xM<overflow, term, type>(m);
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                const uint8_t* s = src + yBeg * p.srcW * p.srcC;
+                uint8_t* d = dst + (dc + yBeg * p.dstW * p.dstC) * a.size;
+                int32_t* b = buf + dc + yBeg * p.dstW * p.dstC;
+                size_t i = 0;
+                for (; i < nn; i += n, s += p.srcC * n, b += p.dstC * n, d += p.dstC * a.size * n)
+                    convolutionNhwcDirect1x1_2xN(s, p, a, srcC, dC, weight, norm + dc, bias + dc, _params, scale + dc, shift + dc, b, d, first);
+                for (; i < n1; i += m, s += p.srcC * m, b += p.dstC * m, d += p.dstC * a.size * m)
+                    convolutionNhwcDirect1x1_2xM(s, p, a, srcC, dC, weight, norm + dc, bias + dc, _params, scale + dc, shift + dc, b, d, first);
+                weight += DivHi(p.srcC, 4) * DF * 4;
+            }
+        }
+
+        typedef void(*ConvolutionNhwcDirect_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC,
+            const int8_t* weight0, const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first);
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect_2xM_Ptr GetConvolutionNhwcDirect_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0x0: return NULL;
+            case 0x1: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x1>;
+            case 0x2: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x2>;
+            case 0x3: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x3>;
+            case 0x4: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x4>;
+            case 0x5: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x5>;
+            case 0x6: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x6>;
+            case 0x7: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x7>;
+            case 0x8: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x8>;
+            case 0x9: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0x9>;
+            case 0xA: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0xA>;
+            case 0xB: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0xB>;
+            case 0xC: return ConvolutionNhwcDirect_2xM<overflow, term, type, 0xC>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2(const uint8_t* src,
+            const ConvParam& p, const AlgParam& a, size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const int8_t* weight,
+            const float* norm, const float* bias, const float* params, const float* scale, const float* shift, int32_t* buf, uint8_t* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F, n = 12, noseW = p.NoseW(), bodyW = p.BodyW(), bodyWn = AlignLoAny(bodyW - noseW, n) + noseW, m = bodyW - bodyWn;
+            ConvolutionNhwcDirect_2xM_Ptr convolutionNhwcDirect_2x1 = GetConvolutionNhwcDirect_2xM<overflow, term, type>(1);
+            ConvolutionNhwcDirect_2xM_Ptr convolutionNhwcDirect_2xN = GetConvolutionNhwcDirect_2xM<overflow, term, type>(n);
+            ConvolutionNhwcDirect_2xM_Ptr convolutionNhwcDirect_2xM = GetConvolutionNhwcDirect_2xM<overflow, term, type>(m);
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                uint8_t* d = dst + (dc + yBeg * p.dstW * p.dstC) * a.size;
+                int32_t* b = buf + dc + yBeg * p.dstW * p.dstC;
+                for (size_t dy = yBeg; dy < yEnd; dy++)
+                {
+                    size_t dx = 0;
+                    for (; dx < noseW; dx++, b += p.dstC, d += p.dstC * a.size)
+                        convolutionNhwcDirect_2x1(src, p, a, dy, dx, srcC, dC, weight, norm + dc, bias + dc, _params, scale + dc, shift + dc, b, d, first);
+                    for (; dx < bodyWn; dx += n, b += p.dstC * n, d += p.dstC * a.size * n)
+                        convolutionNhwcDirect_2xN(src, p, a, dy, dx, srcC, dC, weight, norm + dc, bias + dc, _params, scale + dc, shift + dc, b, d, first);
+                    for (; dx < bodyW; dx += m, b += p.dstC * m, d += p.dstC * a.size * m)
+                        convolutionNhwcDirect_2xM(src, p, a, dy, dx, srcC, dC, weight, norm + dc, bias + dc, _params, scale + dc, shift + dc, b, d, first);
+                    for (; dx < p.dstW; dx++, b += p.dstC, d += p.dstC * a.size)
+                        convolutionNhwcDirect_2x1(src, p, a, dy, dx, srcC, dC, weight, norm + dc, bias + dc, _params, scale + dc, shift + dc, b, d, first);
+                }
+                weight += p.kernelY * p.kernelX * DivHi(p.srcC, 4) * DF * 4;
+            }
+        }
 
         template<bool overflow, Term8iType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect(const uint8_t* src,
             const ConvParam& p, const AlgParam& a, size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const int8_t* weight,
@@ -189,41 +510,80 @@ namespace Simd
             }
         }
 
-        template<bool overflow, Term8iType term, SimdConvolutionActivationType activation> void Set(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType activation> void SetDirect1x1(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
         {
-            d[term] = ConvolutionNhwcDirect<overflow, term, activation>;
+            d[term] = ConvolutionNhwcDirect1x1_2<overflow, term, activation>;
         }
 
-        template<Term8iType term, SimdConvolutionActivationType activation> void Set(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        template<Term8iType term, SimdConvolutionActivationType activation> void SetDirect1x1(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
         {
             if (Base::Overflow(p.compatibility))
-                Set<true, term, activation>(p, a, d);
+                SetDirect1x1<true, term, activation>(p, a, d);
             else
-                Set<false, term, activation>(p, a, d);
+                SetDirect1x1<false, term, activation>(p, a, d);
         }
 
-        template<SimdConvolutionActivationType activation> void Set(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        template<SimdConvolutionActivationType activation> void SetDirect1x1(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
         {
-            Set<Term8iLast8u, activation>(p, a, d);
-            Set<Term8iLast32f, activation>(p, a, d);
-            Set<Term8iInterim, SimdConvolutionActivationIdentity>(p, a, d);
+            SetDirect1x1<Term8iLast8u, activation>(p, a, d);
+            SetDirect1x1<Term8iLast32f, activation>(p, a, d);
+            SetDirect1x1<Term8iInterim, SimdConvolutionActivationIdentity>(p, a, d);
         }
 
-        static void Set(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        void SetDirect1x1(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
         {
             switch (p.activation)
             {
-            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, a, d); break;
-            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, a, d); break;
-            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, a, d); break;
-            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, a, d); break;
-            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, a, d); break;
-            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, a, d); break;
-            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, a, d); break;
-            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, a, d); break;
-            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, a, d); break;
-            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, a, d); break;
-            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, a, d); break;
+            case SimdConvolutionActivationIdentity: SetDirect1x1<SimdConvolutionActivationRestrictRange>(p, a, d); break;
+            case SimdConvolutionActivationRelu: SetDirect1x1<SimdConvolutionActivationRestrictRange>(p, a, d); break;
+            case SimdConvolutionActivationLeakyRelu: SetDirect1x1<SimdConvolutionActivationPrelu>(p, a, d); break;
+            case SimdConvolutionActivationRestrictRange: SetDirect1x1<SimdConvolutionActivationRestrictRange>(p, a, d); break;
+            case SimdConvolutionActivationPrelu: SetDirect1x1<SimdConvolutionActivationPrelu>(p, a, d); break;
+            case SimdConvolutionActivationElu: SetDirect1x1<SimdConvolutionActivationElu>(p, a, d); break;
+            case SimdConvolutionActivationHswish: SetDirect1x1<SimdConvolutionActivationHswish>(p, a, d); break;
+            case SimdConvolutionActivationMish: SetDirect1x1<SimdConvolutionActivationMish>(p, a, d); break;
+            case SimdConvolutionActivationHardSigmoid: SetDirect1x1<SimdConvolutionActivationHardSigmoid>(p, a, d); break;
+            case SimdConvolutionActivationSwish: SetDirect1x1<SimdConvolutionActivationSwish>(p, a, d); break;
+            case SimdConvolutionActivationGelu: SetDirect1x1<SimdConvolutionActivationGelu>(p, a, d); break;
+            default: assert(0);
+            }
+        }
+
+        template<bool overflow, Term8iType term, SimdConvolutionActivationType activation> void SetDirectAny(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        {
+            d[term] = ConvolutionNhwcDirect_2<overflow, term, activation>;
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType activation> void SetDirectAny(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        {
+            if (Base::Overflow(p.compatibility))
+                SetDirectAny<true, term, activation>(p, a, d);
+            else
+                SetDirectAny<false, term, activation>(p, a, d);
+        }
+
+        template<SimdConvolutionActivationType activation> void SetDirectAny(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        {
+            SetDirectAny<Term8iLast8u, activation>(p, a, d);
+            SetDirectAny<Term8iLast32f, activation>(p, a, d);
+            SetDirectAny<Term8iInterim, SimdConvolutionActivationIdentity>(p, a, d);
+        }
+
+        void SetDirectAny(const ConvParam& p, const AlgParam& a, ConvolutionPtr* d)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetDirectAny<SimdConvolutionActivationRestrictRange>(p, a, d); break;
+            case SimdConvolutionActivationRelu: SetDirectAny<SimdConvolutionActivationRestrictRange>(p, a, d); break;
+            case SimdConvolutionActivationLeakyRelu: SetDirectAny<SimdConvolutionActivationPrelu>(p, a, d); break;
+            case SimdConvolutionActivationRestrictRange: SetDirectAny<SimdConvolutionActivationRestrictRange>(p, a, d); break;
+            case SimdConvolutionActivationPrelu: SetDirectAny<SimdConvolutionActivationPrelu>(p, a, d); break;
+            case SimdConvolutionActivationElu: SetDirectAny<SimdConvolutionActivationElu>(p, a, d); break;
+            case SimdConvolutionActivationHswish: SetDirectAny<SimdConvolutionActivationHswish>(p, a, d); break;
+            case SimdConvolutionActivationMish: SetDirectAny<SimdConvolutionActivationMish>(p, a, d); break;
+            case SimdConvolutionActivationHardSigmoid: SetDirectAny<SimdConvolutionActivationHardSigmoid>(p, a, d); break;
+            case SimdConvolutionActivationSwish: SetDirectAny<SimdConvolutionActivationSwish>(p, a, d); break;
+            case SimdConvolutionActivationGelu: SetDirectAny<SimdConvolutionActivationGelu>(p, a, d); break;
             default: assert(0);
             }
         }
@@ -232,8 +592,11 @@ namespace Simd
             : Base::SynetConvolution8iNhwcDirect(p)
         {
             size_t F = svcntw();
-            SetAlgParam(F, F, 1, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3());
-            Set(p, _alg, _convolutions);
+            SetAlgParam(F, 2 * F, 12, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3());
+            if (p.Is1x1())
+                SetDirect1x1(p, _alg, _convolutions);
+            else
+                SetDirectAny(p, _alg, _convolutions);
             _convertSrc = Sve2::SynetConvert32fTo8u;
         }
 

--- a/src/Simd/SimdSve2SynetConvolution8i.cpp
+++ b/src/Simd/SimdSve2SynetConvolution8i.cpp
@@ -60,7 +60,19 @@ namespace Simd
             return Set4(tmp);
         }
 
-        template<bool overflow> SIMD_INLINE void Madd4(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
+        template<bool overflow> SIMD_INLINE void Madd4(svint32_t& sum, const svuint8_t& src, const int8_t* weight);
+
+        template<> SIMD_INLINE void Madd4<false>(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
+        {
+            const svbool_t body8 = svptrue_b8();
+            const svbool_t body32 = svptrue_b32();
+            svint8_t _weight = svld1_s8(body8, weight);
+            svint8_t _src = svreinterpret_s8_u8(svsub_n_u8_x(body8, src, 128));
+            svint32_t corr = svmul_n_s32_x(body32, svdot_s32(svdup_n_s32(0), svdup_n_s8(1), _weight), 128);
+            sum = svadd_s32_x(body32, svdot_s32(sum, _src, _weight), corr);
+        }
+
+        template<> SIMD_INLINE void Madd4<true>(svint32_t& sum, const svuint8_t& src, const int8_t* weight)
         {
             const svbool_t body8 = svptrue_b8();
             const svbool_t body16 = svptrue_b16();
@@ -72,7 +84,7 @@ namespace Simd
             svint16_t wHi = svmovlt_s16(_weight);
             svint16_t lo = svmul_s16_x(body16, sLo, wLo);
             svint16_t hi = svmul_s16_x(body16, sHi, wHi);
-            svint16_t pairs = overflow ? svqadd_s16(lo, hi) : svadd_s16_x(body16, lo, hi);
+            svint16_t pairs = svqadd_s16(lo, hi);
             svint16_t zero = svdup_n_s16(0);
             svint32_t sum0 = svaddlb_s32(pairs, zero);
             svint32_t sum1 = svaddlt_s32(pairs, zero);

--- a/src/Test/TestSynetConvolution8i.cpp
+++ b/src/Test/TestSynetConvolution8i.cpp
@@ -180,8 +180,8 @@ namespace Test
         const float e = EPS;
         const SimdBool t0 = SimdFalse, t1 = SimdTrue;
         const SimdTensorDataType f32 = SimdTensorData32f, u8 = SimdTensorData8u;
-        const SimdConvolutionActivationType aId = SimdConvolutionActivationIdentity, aRe = SimdConvolutionActivationRelu, 
-            aLr = SimdConvolutionActivationLeakyRelu, aRr = SimdConvolutionActivationRestrictRange, aPr = SimdConvolutionActivationPrelu, 
+        const SimdConvolutionActivationType aId = SimdConvolutionActivationIdentity, aRe = SimdConvolutionActivationRelu,
+            aLr = SimdConvolutionActivationLeakyRelu, aRr = SimdConvolutionActivationRestrictRange, aPr = SimdConvolutionActivationPrelu,
             aEl = SimdConvolutionActivationElu, aHs = SimdConvolutionActivationHswish, aMi = SimdConvolutionActivationMish,
             aHi = SimdConvolutionActivationHardSigmoid, aSw = SimdConvolutionActivationSwish, aGe = SimdConvolutionActivationGelu;
         //SimdSynetCompatibilityType c = (SimdSynetCompatibilityType)((SimdCpuInfo(SimdCpuInfoAvx512vnni) ? SimdSynetCompatibilityFmaUse : SimdSynetCompatibility8iOverflow)  | SimdSynetCompatibilityFmaAvoid);
@@ -231,6 +231,8 @@ namespace Test
         result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 64, 70, 102, 64, _5, _1, _2, _2, _2, 64, aPr, t1, u8, f32), 0, c, f1, f2);
 #endif
 #if 1
+        result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 67, 8, 12, 129, _1, _1, _1, _0, _0, 1, aRe, t1, u8, u8), 1, c, f1, f2);
+        result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 67, 8, 12, 129, _3, _1, _1, _1, _1, 1, aPr, t1, u8, u8), 1, c, f1, f2);
         //result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 64, 16, 16, 32, _1, _1, _1, _0, _0, 1, aRe, t1, u8, f32), 0, c, f1, f2);
         //result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 64, 16, 16, 64, _1, _1, _1, _0, _0, 1, aRe, t1, u8, f32), 0, c, f1, f2);
         //result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 128, 16, 16, 64, _1, _1, _1, _0, _0, 1, aRe, t1, u8, u8), 0, c, f1, f2);
@@ -252,6 +254,7 @@ namespace Test
 #endif
 #else
         //result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 2000, 30, 30, 64, _1, _1, _1, _0, _0, 1, aRe, t1, f32, u8), 0, c, f1, f2);
+        result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 67, 8, 12, 129, _1, _1, _1, _0, _0, 1, aRe, t1, u8, u8), 1, c, f1, f2);
         result = result && SynetConvolution8iForwardAutoTest(e, Param(1, 128, 30, 40, 76, _3, _1, _1, _1, _1, 1, aPr, t1, u8, u8), 1, c, f1, f2);
 #endif
 
@@ -284,7 +287,7 @@ namespace Test
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
             result = result && SynetConvolution8iForwardAutoTest(FUNC_C(Simd::Sse41::SynetConvolution8iInit), FUNC_C(SimdSynetConvolution8iInit));
-#endif 
+#endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
@@ -309,12 +312,12 @@ namespace Test
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
             result = result && SynetConvolution8iForwardAutoTest(FUNC_C(Simd::Sve2::SynetConvolution8iInit), FUNC_C(SimdSynetConvolution8iInit));
-#endif 
+#endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetConvolution8iForwardAutoTest(FUNC_C(Simd::Neon::SynetConvolution8iInit), FUNC_C(SimdSynetConvolution8iInit));
-#endif 
+#endif
 
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE2 two-destination-block NHWC direct kernels for SynetConvolution8i 1x1 and general convolution paths.
- Exercise channel-tail 1x1 and 3x3 direct cases in SynetConvolution8i tests.
- Document the SVE2 SynetConvolution8iNhwcDirect improvement in release 7.2.164 notes.
- Fix SVE2 8u output clamping to use the low byte of the packed upper bound.
- Fix SVE2 non-overflow unsigned 8-bit by signed 8-bit accumulation with a corrected signed-dot formulation.
- Fix second destination-block activation parameter handling for shared non-PReLU activation parameters.
- Route 1x1 and general direct paths through the single-spatial SVE2 kernel; the optimization keeps two destination-channel blocks per kernel.

## Testing
- `aarch64-linux-gnu-g++ -std=c++17 -march=armv8.5-a+sve2 -I src -fsyntax-only src/Simd/SimdSve2SynetConvolution8i.cpp`
- `cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd)/build:${LD_LIBRARY_PATH}" && ./build/Test "-r=." -fi=SynetConvolution8i -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-328d777d-f1ac-47aa-b7be-ce46ed1e4d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-328d777d-f1ac-47aa-b7be-ce46ed1e4d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

