### PR TITLE
Remove SVE AbsDifferenceSum

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -189,6 +189,7 @@
 <h5>Removing</h5>
 <ul>
  <li>SVE optimization of function AbsDifference.</li>
+ <li>SVE optimization of function AbsDifferenceSum.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -353,11 +353,6 @@ SIMD_API void SimdAbsDifferenceSum(const uint8_t *a, size_t aStride, const uint8
         Sve2::AbsDifferenceSum(a, aStride, b, bStride, width, height, sum);
     else
 #endif
-#ifdef SIMD_SVE_ENABLE
-    if (Sve::Enable)
-        Sve::AbsDifferenceSum(a, aStride, b, bStride, width, height, sum);
-    else
-#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::AbsDifferenceSum(a, aStride, b, bStride, width, height, sum);

--- a/src/Simd/SimdSve1.h
+++ b/src/Simd/SimdSve1.h
@@ -31,8 +31,6 @@ namespace Simd
 #ifdef SIMD_SVE_ENABLE
     namespace Sve
     {
-        void AbsDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum);
-
         void AbsDifferenceSumMasked(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride,
             const uint8_t* mask, size_t maskStride, uint8_t index, size_t width, size_t height, uint64_t* sum);
 

--- a/src/Simd/SimdSve1AbsDifferenceSum.cpp
+++ b/src/Simd/SimdSve1AbsDifferenceSum.cpp
@@ -31,38 +31,6 @@ namespace Simd
 #ifdef SIMD_SVE_ENABLE
     namespace Sve
     {
-        SIMD_INLINE void AbsDifferenceSum(const uint8_t* a, const uint8_t* b, const svuint8_t& _1, const svbool_t & mask, svuint32_t & sum)
-        {
-            svuint8_t _a = svld1_u8(mask, a);
-            svuint8_t _b = svld1_u8(mask, b);
-            svuint8_t abd = svabd_x(mask, _a, _b);
-            sum = svdot_u32(sum, abd, _1);
-        }
-
-        void AbsDifferenceSum(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint64_t* sum)
-        {
-            size_t A = svlen(svuint8_t());
-            size_t widthA = AlignLo(width, A);
-            const svbool_t body = svwhilelt_b8(size_t(0), A);
-            const svbool_t tail = svwhilelt_b8(widthA, width);
-            svuint8_t _1 = svdup_n_u8(1);
-            *sum = 0;
-            for (size_t row = 0; row < height; ++row)
-            {
-                size_t col = 0;
-                svuint32_t _sum = svdup_n_u32(0);
-                for (; col < widthA; col += A)
-                    AbsDifferenceSum(a + col, b + col, _1, body, _sum);
-                if (widthA < width)
-                    AbsDifferenceSum(a + col, b + col, _1, tail, _sum);
-                *sum += svaddv_u32(svptrue_b32(), _sum);
-                a += aStride;
-                b += bStride;
-            }
-        }
-
-        //--------------------------------------------------------------------------------------------------
-
         SIMD_INLINE void AbsDifferenceSumMasked(const uint8_t* a, const uint8_t* b, const uint8_t* m, const svuint8_t& _1, const svuint8_t& index, const svbool_t& mask, svuint32_t& sum)
         {
             svuint8_t _a = svld1_u8(mask, a);

--- a/src/Test/TestDifferenceSum.cpp
+++ b/src/Test/TestDifferenceSum.cpp
@@ -290,11 +290,6 @@ namespace Test
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Neon::AbsDifferenceSum), FUNC_S(SimdAbsDifferenceSum), 1);
 #endif
 
-#ifdef SIMD_SVE_ENABLE
-        if (Simd::Sve::Enable && TestSve(options))
-            result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Sve::AbsDifferenceSum), FUNC_S(SimdAbsDifferenceSum), 1);
-#endif
-
 #ifdef SIMD_HVX_ENABLE
         if (Simd::Hvx::Enable && TestHvx(options) && W >= Simd::Hvx::A)
             result = result && DifferenceSumsAutoTest(FUNC_S(Simd::Hvx::AbsDifferenceSum), FUNC_S(SimdAbsDifferenceSum), 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the SVE (`Sve`) `AbsDifferenceSum` implementation, declaration, and dispatch path from `SimdLib.cpp`.
- Keep `SimdSve1AbsDifferenceSum.cpp` because it still contains Masked/3x3 variants; VS2022 project entries remain unchanged.
- Drop the SVE leg from `Test::AbsDifferenceSumAutoTest`.
- Document the removal under release 7.2.164 in `docs/2026.html`.

SVE2 optimization of `AbsDifferenceSum` is retained.

### Testing
- Configured Release shared build with g++ / `-march=native`.
- `cmake --build build --parallel$(nproc)` succeeded.
- `./build/Test "-r=.." -fi=AbsDifferenceSum -fe=Masked -tt=1 -ts=1` — all tests finished successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce0b38aa-ce13-4049-87b9-1120a9c787d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce0b38aa-ce13-4049-87b9-1120a9c787d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

