### PR TITLE
Add SVE2 optimizations for SynetMergedConvolution32f

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -83,6 +83,7 @@
  <li>SVE2 optimizations of function SynetGelu32f.</li>
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
+ <li>SVE2 optimizations of classes SynetMergedConvolution32fCdc, SynetMergedConvolution32fCd and SynetMergedConvolution32fDc.</li>
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>
  <li>SVE2 optimizations of function SynetRelu32f.</li>

--- a/prj/sh/GetVersion.sh
+++ b/prj/sh/GetVersion.sh
@@ -46,6 +46,6 @@ then
 else
 	if [ "$PRINT_INFO" != "0" ]; then echo "Create or update '$SIMD_VERSION_H' file."; fi
 	cp $SIMD_VERSION_H_TXT $SIMD_VERSION_H
-	sed "-i" "s/@VERSION@/$FULL_VERSION/g" $SIMD_VERSION_H
+	sed "-i" "s|@VERSION@|$FULL_VERSION|g" $SIMD_VERSION_H
 fi
 

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -104,6 +104,10 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fDepthwise.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fInput.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetGridSample2d32fBlZ.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -64,6 +64,9 @@
     <Filter Include="Sve2\Synet\Convolution">
       <UniqueIdentifier>{8f192517-8a60-4c7f-93c3-270103d70a43}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sve2\Synet\MergedConvolution">
+      <UniqueIdentifier>{fc234148-39a4-435c-91f2-955cb4ae41ec}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Simd\SimdSve2.h">
@@ -502,6 +505,18 @@
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp">
       <Filter>Sve2\Synet\Other</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32f.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fDepthwise.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fInput.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fOutput.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp">
       <Filter>Sve2\Synet\InnerProduct</Filter>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6913,7 +6913,7 @@ SIMD_API void * SimdSynetMergedConvolution32fInit(size_t batch, const SimdConvol
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetMergedConvolution32fInitPtr) (size_t batch, const SimdConvolutionParameters * convs, size_t count, SimdBool add);
-    const static SimdSynetMergedConvolution32fInitPtr simdSynetMergedConvolution32fInit = SIMD_FUNC4(SynetMergedConvolution32fInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetMergedConvolution32fInitPtr simdSynetMergedConvolution32fInit = SIMD_FUNC5(SynetMergedConvolution32fInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetMergedConvolution32fInit(batch, convs, count, add);
 #else

--- a/src/Simd/SimdSve2SynetMergedConvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32f.cpp
@@ -1,0 +1,82 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdUpdate.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+	namespace Sve2
+	{
+		SynetMergedConvolution32fCdc::SynetMergedConvolution32fCdc(const MergConvParam& p)
+			: Base::SynetMergedConvolution32fCdc(p)
+		{
+			SetSize(Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3(), svcntw());
+			SetInput(p.conv[0], _convolution + 0);
+			SetDepthwise(p.conv[1], false, _convolution + 1);
+			SetOutput(p.conv[2], _convolution + 2);
+		}
+
+		//-------------------------------------------------------------------------------------------------
+
+		SynetMergedConvolution32fCd::SynetMergedConvolution32fCd(const MergConvParam& p)
+			: Base::SynetMergedConvolution32fCd(p)
+		{
+			SetSize(Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3(), svcntw());
+			SetInput(_param.conv[0], _convolution + 0);
+			SetDepthwise(_param.conv[1], true, _convolution + 1);
+		}
+
+		//-------------------------------------------------------------------------------------------------
+
+		SynetMergedConvolution32fDc::SynetMergedConvolution32fDc(const MergConvParam& p)
+			: Base::SynetMergedConvolution32fDc(p)
+		{
+			SetSize(Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3(), svcntw());
+			SetDepthwise(p.conv[0], false, _convolution + 0);
+			SetOutput(p.conv[1], _convolution + 1);
+		}
+
+		//-------------------------------------------------------------------------------------------------
+
+		void* SynetMergedConvolution32fInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add)
+		{
+			MergConvParam param(batch, convs, count, add, SimdSynetCompatibilityDefault);
+			if (!param.Valid(SimdTensorData32f))
+				return NULL;
+			if (SynetMergedConvolution32fCdc::Preferable(param))
+				return new Sve2::SynetMergedConvolution32fCdc(param);
+			else if (SynetMergedConvolution32fCd::Preferable(param))
+				return new Sve2::SynetMergedConvolution32fCd(param);
+			else if (SynetMergedConvolution32fDc::Preferable(param))
+				return new Sve2::SynetMergedConvolution32fDc(param);
+			else
+				return new Base::SynetMergedConvolution32f(param);
+		}
+	}
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution32fDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32fDepthwise.cpp
@@ -1,0 +1,552 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdUpdate.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+	namespace Sve2
+	{
+		namespace
+		{
+
+		SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
+		{
+			x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
+			svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
+			svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
+			svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+			svfloat32_t p = svdup_n_f32(1.8775767e-3f);
+			p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
+			return svmul_f32_x(mask, expipart, p);
+		}
+
+		SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
+		{
+			return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
+		}
+
+		SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
+		{
+			svuint32_t i = svreinterpret_u32_f32(x);
+			svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
+			svfloat32_t e = svcvt_f32_s32_x(mask, e32);
+			svfloat32_t one = svdup_n_f32(1.0f);
+			svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
+			svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
+			p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
+			return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
+		}
+
+		SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
+		{
+			return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
+		}
+
+		SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
+		{
+			const svfloat32_t _1 = svdup_n_f32(1.0f);
+			svfloat32_t a = svmin_f32_x(mask, svabs_f32_x(mask, x), svdup_n_f32(9.0f));
+			svfloat32_t p = svdup_n_f32(0.0000430638f);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0002765672f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0001520143f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0092705272f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0422820123f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0705230784f), a, p);
+			p = svmla_f32_x(mask, _1, a, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
+			return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
+		}
+
+		SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
+		{
+			svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
+			return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, const float* params, const svbool_t& mask);
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationIdentity>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			return value;
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationRelu>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			return svmax_n_f32_x(mask, value, 0.0f);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationLeakyRelu>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			return svmla_n_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), svmin_n_f32_x(mask, value, 0.0f), params[0]);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationRestrictRange>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			return svmin_n_f32_x(mask, svmax_n_f32_x(mask, value, params[0]), params[1]);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationPrelu>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), svld1_f32(mask, params), svmin_n_f32_x(mask, value, 0.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exp(mask, value), 1.0f), params[0]);
+			return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHswish>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			svfloat32_t shift = svdup_n_f32(params[0]);
+			svfloat32_t scale = svdup_n_f32(params[1]);
+			svfloat32_t upper = svmin_f32_x(mask, value, shift);
+			svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, shift), 0.0f);
+			return svmul_f32_x(mask, svmul_f32_x(mask, positive, scale), value);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), svdup_n_f32(params[0]));
+			return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_n_f32_x(mask, svdup_n_f32(params[1]), value, params[0]), 1.0f), 0.0f);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
+			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationGelu>(svfloat32_t value, const float* params, const svbool_t& mask)
+		{
+			svfloat32_t t = svmul_n_f32_x(mask, value, 0.70710678118654752440f);
+			return svmul_f32_x(mask, svmul_n_f32_x(mask, t, 0.70710678118654752440f), svadd_n_f32_x(mask, Erf(mask, t), 1.0f));
+		}
+
+		//-------------------------------------------------------------------------------------------------------
+
+		template<SimdConvolutionActivationType type> void DepthwiseConvolution(const float* src, const SimdConvolutionParameters& p,
+			size_t srcC, size_t yBeg, size_t yEnd, const size_t bufH[2], const float* weight, const float* bias, const float* params, float* dst, int first)
+		{
+			const size_t F = svcntw();
+			size_t strideY = p.strideY, strideX = p.strideX, padY = p.padY, padX = p.padX, padH = p.padH, padW = p.padW, dstC = srcC;
+			size_t sM = (bufH[0] - 1), sD = bufH[0] ? bufH[0] * p.srcW * F : F, sX = bufH[0] ? F : p.srcC, sY = sX * p.srcW;
+			size_t dM = (bufH[1] - 1), dX = (bufH[1] ? F : p.dstC), dY = p.dstW * dX, dy0 = bufH[1] ? yBeg : 0, dD = bufH[1] ? bufH[1] * dY : F;
+			size_t wD = p.kernelY * p.kernelX * F, ssX = strideX * sX;
+			size_t noseY = NoseH(p), bodyY = BodyH(p), noseX = NoseW(p), bodyX = BodyW(p);
+			size_t bodyS = bodyX > noseX ? bodyX - noseX : 0;
+			size_t bodyX2 = AlignLo(bodyS, 2) + noseX;
+			size_t bodyX4 = AlignLo(bodyS, 4) + noseX;
+			size_t bodyX8 = AlignLo(bodyS, 8) + noseX;
+			size_t dstCF = AlignLo(dstC, F);
+
+			for (size_t c = 0; c < dstC; c += F)
+			{
+				svbool_t mask = svwhilelt_b32((uint64_t)0, (uint64_t)Simd::Min(F, dstC - c));
+				svfloat32_t _bias = bias ? svld1_f32(mask, bias + c) : svdup_n_f32(0.0f);
+				const float* pParams = (type == ::SimdConvolutionActivationPrelu) ? params + c : params;
+				if (c == dstCF)
+				{
+					for (size_t dy = yBeg; dy < yEnd; ++dy)
+					{
+						float* pd = dst + (dy & dM) * dY;
+						for (size_t dx = 0; dx < p.dstW; ++dx, pd += dX)
+						{
+							svfloat32_t sum0 = _bias;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								if (sy < p.srcH)
+								{
+									for (size_t kx = 0; kx < p.kernelX; ++kx)
+									{
+										size_t sx = dx * strideX + kx - padX;
+										if (sx < p.srcW)
+										{
+											const float* pw = weight + (ky * p.kernelX + kx) * F;
+											const float* ps = src + (sy & sM) * sY + sx * sX;
+											sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, ps), svld1_f32(mask, pw));
+										}
+									}
+								}
+							}
+							svst1_f32(mask, pd, Activate<type>(sum0, pParams, mask));
+						}
+					}
+					return;
+				}
+				const svbool_t body = svptrue_b32();
+				for (size_t dy = yBeg; dy < yEnd; ++dy)
+				{
+					float* pd = dst + (dy & dM) * dY;
+					if (dy >= noseY && dy < bodyY)
+					{
+						size_t dx = 0;
+						for (; dx < noseX; dx += 1, pd += dX)
+						{
+							svfloat32_t sum0 = _bias;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * p.strideY + ky - padY;
+								for (size_t kx = 0; kx < p.kernelX; ++kx)
+								{
+									size_t sx = dx * p.strideX + kx - padX;
+									if (sx < p.srcW)
+									{
+										const float* pw = weight + (ky * p.kernelX + kx) * F;
+										const float* ps = src + (sy & sM) * sY + sx * sX;
+										sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps), svld1_f32(body, pw));
+									}
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+						}
+						for (; dx < bodyX8; dx += 8, pd += 8 * dX)
+						{
+							svfloat32_t sum0 = _bias;
+							svfloat32_t sum1 = _bias;
+							svfloat32_t sum2 = _bias;
+							svfloat32_t sum3 = _bias;
+							svfloat32_t sum4 = _bias;
+							svfloat32_t sum5 = _bias;
+							svfloat32_t sum6 = _bias;
+							svfloat32_t sum7 = _bias;
+							const float* pw = weight;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								const float* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+								for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+								{
+									svfloat32_t w0 = svld1_f32(body, pw);
+									sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps + 0 * ssX), w0);
+									sum1 = svmla_f32_x(body, sum1, svld1_f32(body, ps + 1 * ssX), w0);
+									sum2 = svmla_f32_x(body, sum2, svld1_f32(body, ps + 2 * ssX), w0);
+									sum3 = svmla_f32_x(body, sum3, svld1_f32(body, ps + 3 * ssX), w0);
+									sum4 = svmla_f32_x(body, sum4, svld1_f32(body, ps + 4 * ssX), w0);
+									sum5 = svmla_f32_x(body, sum5, svld1_f32(body, ps + 5 * ssX), w0);
+									sum6 = svmla_f32_x(body, sum6, svld1_f32(body, ps + 6 * ssX), w0);
+									sum7 = svmla_f32_x(body, sum7, svld1_f32(body, ps + 7 * ssX), w0);
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+							svst1_f32(body, pd + 1 * dX, Activate<type>(sum1, pParams, body));
+							svst1_f32(body, pd + 2 * dX, Activate<type>(sum2, pParams, body));
+							svst1_f32(body, pd + 3 * dX, Activate<type>(sum3, pParams, body));
+							svst1_f32(body, pd + 4 * dX, Activate<type>(sum4, pParams, body));
+							svst1_f32(body, pd + 5 * dX, Activate<type>(sum5, pParams, body));
+							svst1_f32(body, pd + 6 * dX, Activate<type>(sum6, pParams, body));
+							svst1_f32(body, pd + 7 * dX, Activate<type>(sum7, pParams, body));
+						}
+						for (; dx < bodyX4; dx += 4, pd += 4 * dX)
+						{
+							svfloat32_t sum0 = _bias;
+							svfloat32_t sum1 = _bias;
+							svfloat32_t sum2 = _bias;
+							svfloat32_t sum3 = _bias;
+							const float* pw = weight;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								const float* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+								for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+								{
+									svfloat32_t w0 = svld1_f32(body, pw);
+									sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps + 0 * ssX), w0);
+									sum1 = svmla_f32_x(body, sum1, svld1_f32(body, ps + 1 * ssX), w0);
+									sum2 = svmla_f32_x(body, sum2, svld1_f32(body, ps + 2 * ssX), w0);
+									sum3 = svmla_f32_x(body, sum3, svld1_f32(body, ps + 3 * ssX), w0);
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+							svst1_f32(body, pd + 1 * dX, Activate<type>(sum1, pParams, body));
+							svst1_f32(body, pd + 2 * dX, Activate<type>(sum2, pParams, body));
+							svst1_f32(body, pd + 3 * dX, Activate<type>(sum3, pParams, body));
+						}
+						for (; dx < bodyX2; dx += 2, pd += 2 * dX)
+						{
+							svfloat32_t sum0 = _bias;
+							svfloat32_t sum1 = _bias;
+							const float* pw = weight;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								const float* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+								for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+								{
+									svfloat32_t w0 = svld1_f32(body, pw);
+									sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps + 0 * ssX), w0);
+									sum1 = svmla_f32_x(body, sum1, svld1_f32(body, ps + 1 * ssX), w0);
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+							svst1_f32(body, pd + 1 * dX, Activate<type>(sum1, pParams, body));
+						}
+						for (; dx < bodyX; dx += 1, pd += dX)
+						{
+							svfloat32_t sum0 = _bias;
+							const float* pw = weight;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								const float* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+								for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+								{
+									svfloat32_t w0 = svld1_f32(body, pw);
+									sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps), w0);
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+						}
+						for (; dx < p.dstW; dx += 1, pd += dX)
+						{
+							svfloat32_t sum0 = _bias;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								for (size_t kx = 0; kx < p.kernelX; ++kx)
+								{
+									size_t sx = dx * strideX + kx - padX;
+									if (sx < p.srcW)
+									{
+										const float* pw = weight + (ky * p.kernelX + kx) * F;
+										const float* ps = src + (sy & sM) * sY + sx * sX;
+										sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps), svld1_f32(body, pw));
+									}
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+						}
+					}
+					else
+					{
+						for (size_t dx = 0; dx < p.dstW; ++dx, pd += dX)
+						{
+							svfloat32_t sum0 = _bias;
+							for (size_t ky = 0; ky < p.kernelY; ++ky)
+							{
+								size_t sy = dy * strideY + ky - padY;
+								if (sy < p.srcH)
+								{
+									for (size_t kx = 0; kx < p.kernelX; ++kx)
+									{
+										size_t sx = dx * strideX + kx - padX;
+										if (sx < p.srcW)
+										{
+											const float* pw = weight + (ky * p.kernelX + kx) * F;
+											const float* ps = src + (sy & sM) * sY + sx * sX;
+											sum0 = svmla_f32_x(body, sum0, svld1_f32(body, ps), svld1_f32(body, pw));
+										}
+									}
+								}
+							}
+							svst1_f32(body, pd + 0 * dX, Activate<type>(sum0, pParams, body));
+						}
+					}
+				}
+				src += sD;
+				dst += dD;
+				weight += wD;
+			}
+		}
+
+		//-------------------------------------------------------------------------------------------------------
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void ConvolutionDepthwise3x3Edge2x2(
+			const float* src0, const float* src1, size_t sX, const float* weight, size_t F, svfloat32_t bias, const float* params, const svbool_t& mask, float* dst)
+		{
+			svfloat32_t sum0 = bias, sum1 = svdup_n_f32(0.0f);
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src0 + 0 * sX), svld1_f32(mask, weight + 0 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src0 + 1 * sX), svld1_f32(mask, weight + 1 * F));
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src1 + 0 * sX), svld1_f32(mask, weight + 3 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src1 + 1 * sX), svld1_f32(mask, weight + 4 * F));
+			svst1_f32(mask, dst, Activate<type>(svadd_f32_x(mask, sum0, sum1), params, mask));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void ConvolutionDepthwise3x3Edge2x3(
+			const float* src0, const float* src1, size_t sX, const float* weight, size_t F, svfloat32_t bias, const float* params, const svbool_t& mask, float* dst)
+		{
+			svfloat32_t sum0 = bias, sum1 = svdup_n_f32(0.0f), sum2 = svdup_n_f32(0.0f);
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src0 + 0 * sX), svld1_f32(mask, weight + 0 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src0 + 1 * sX), svld1_f32(mask, weight + 1 * F));
+			sum2 = svmla_f32_x(mask, sum2, svld1_f32(mask, src0 + 2 * sX), svld1_f32(mask, weight + 2 * F));
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src1 + 0 * sX), svld1_f32(mask, weight + 3 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src1 + 1 * sX), svld1_f32(mask, weight + 4 * F));
+			sum2 = svmla_f32_x(mask, sum2, svld1_f32(mask, src1 + 2 * sX), svld1_f32(mask, weight + 5 * F));
+			svst1_f32(mask, dst, Activate<type>(svadd_f32_x(mask, svadd_f32_x(mask, sum0, sum1), sum2), params, mask));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void ConvolutionDepthwise3x3Edge3x2(
+			const float* src0, const float* src1, const float* src2, size_t sX, const float* weight, size_t F, svfloat32_t bias, const float* params, const svbool_t& mask, float* dst)
+		{
+			svfloat32_t sum0 = bias, sum1 = svdup_n_f32(0.0f);
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src0 + 0 * sX), svld1_f32(mask, weight + 0 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src0 + 1 * sX), svld1_f32(mask, weight + 1 * F));
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src1 + 0 * sX), svld1_f32(mask, weight + 3 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src1 + 1 * sX), svld1_f32(mask, weight + 4 * F));
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src2 + 0 * sX), svld1_f32(mask, weight + 6 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src2 + 1 * sX), svld1_f32(mask, weight + 7 * F));
+			svst1_f32(mask, dst, Activate<type>(svadd_f32_x(mask, sum0, sum1), params, mask));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void ConvolutionDepthwise3x3Main1x1(
+			const float* src0, const float* src1, const float* src2, size_t sX, const float* weight, size_t F, svfloat32_t bias, const float* params, const svbool_t& mask, float* dst)
+		{
+			svfloat32_t sum0 = bias, sum1 = svdup_n_f32(0.0f), sum2 = svdup_n_f32(0.0f);
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src0 + 0 * sX), svld1_f32(mask, weight + 0 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src0 + 1 * sX), svld1_f32(mask, weight + 1 * F));
+			sum2 = svmla_f32_x(mask, sum2, svld1_f32(mask, src0 + 2 * sX), svld1_f32(mask, weight + 2 * F));
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src1 + 0 * sX), svld1_f32(mask, weight + 3 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src1 + 1 * sX), svld1_f32(mask, weight + 4 * F));
+			sum2 = svmla_f32_x(mask, sum2, svld1_f32(mask, src1 + 2 * sX), svld1_f32(mask, weight + 5 * F));
+			sum0 = svmla_f32_x(mask, sum0, svld1_f32(mask, src2 + 0 * sX), svld1_f32(mask, weight + 6 * F));
+			sum1 = svmla_f32_x(mask, sum1, svld1_f32(mask, src2 + 1 * sX), svld1_f32(mask, weight + 7 * F));
+			sum2 = svmla_f32_x(mask, sum2, svld1_f32(mask, src2 + 2 * sX), svld1_f32(mask, weight + 8 * F));
+			svst1_f32(mask, dst, Activate<type>(svadd_f32_x(mask, svadd_f32_x(mask, sum0, sum1), sum2), params, mask));
+		}
+
+		template<SimdConvolutionActivationType type> void DepthwiseConvolution3x3(const float* src, const SimdConvolutionParameters& p,
+			size_t srcC, size_t yBeg, size_t yEnd, const size_t bufH[2], const float* weight, const float* bias, const float* params, float* dst, int first)
+		{
+			const size_t F = svcntw();
+			const svbool_t mask = svptrue_b32();
+			size_t strideY = p.strideY, strideX = p.strideX, padY = p.padY, padX = p.padX, padH = p.padH, padW = p.padW, dstC = srcC;
+			size_t sM = (bufH[0] - 1), sD = bufH[0] ? bufH[0] * p.srcW * F : F, sX = bufH[0] ? F : p.srcC, sY = sX * p.srcW;
+			size_t dM = (bufH[1] - 1), dX = (bufH[1] ? F : p.dstC), dY = p.dstW * dX, dy0 = bufH[1] ? yBeg : 0, dD = bufH[1] ? bufH[1] * dY : F;
+			size_t wD = p.kernelY * p.kernelX * F, ssX = p.strideX * sX, ssX0 = (p.strideX - p.padX) * sX;
+			size_t xMainEnd = p.dstW - p.padW, yMainEnd = yEnd == p.dstH && p.padH ? yEnd - 1 : yEnd;
+
+			for (size_t c = 0; c < srcC; c += F)
+			{
+				const float* _weight = weight;
+				svfloat32_t _bias = bias ? svld1_f32(mask, bias + c) : svdup_n_f32(0.0f);
+				const float* pParams = (type == ::SimdConvolutionActivationPrelu) ? params + c : params;
+
+				size_t dy = yBeg;
+				if (yBeg == 0 && padY)
+				{
+					size_t sy = 0, dx = 0;
+					const float* src0 = src + ((sy + 0) & sM) * sY;
+					const float* src1 = src + ((sy + 1) & sM) * sY;
+					float* pDst = dst + (dy & dM) * dY;
+					if (padX)
+						ConvolutionDepthwise3x3Edge2x2<type>(src0, src1, sX, _weight + 4 * F, F, _bias, pParams, mask, pDst),
+						pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
+					for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
+						ConvolutionDepthwise3x3Edge2x3<type>(src0, src1, sX, _weight + 3 * F, F, _bias, pParams, mask, pDst);
+					if (padW)
+						ConvolutionDepthwise3x3Edge2x2<type>(src0, src1, sX, _weight + 3 * F, F, _bias, pParams, mask, pDst);
+					dy++;
+				}
+				for (; dy < yMainEnd; ++dy)
+				{
+					size_t sy = dy * strideY - padY, dx = 0;
+					const float* src0 = src + ((sy + 0) & sM) * sY;
+					const float* src1 = src + ((sy + 1) & sM) * sY;
+					const float* src2 = src + ((sy + 2) & sM) * sY;
+					float* pDst = dst + (dy & dM) * dY;
+					if (padX)
+						ConvolutionDepthwise3x3Edge3x2<type>(src0, src1, src2, sX, _weight + 1 * F, F, _bias, pParams, mask, pDst),
+						pDst += dX, dx++, src0 += ssX0, src1 += ssX0, src2 += ssX0;
+					for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX, src2 += ssX)
+						ConvolutionDepthwise3x3Main1x1<type>(src0, src1, src2, sX, _weight + 0 * F, F, _bias, pParams, mask, pDst);
+					if (padW)
+						ConvolutionDepthwise3x3Edge3x2<type>(src0, src1, src2, sX, _weight + 0 * F, F, _bias, pParams, mask, pDst);
+				}
+				if (dy < yEnd)
+				{
+					size_t sy = dy * strideY - padY, dx = 0;
+					const float* src0 = src + ((sy + 0) & sM) * sY;
+					const float* src1 = src + ((sy + 1) & sM) * sY;
+					float* pDst = dst + (dy & dM) * dY;
+					if (padX)
+						ConvolutionDepthwise3x3Edge2x2<type>(src0, src1, sX, _weight + 1 * F, F, _bias, pParams, mask, pDst),
+						pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
+					for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
+						ConvolutionDepthwise3x3Edge2x3<type>(src0, src1, sX, _weight + 0 * F, F, _bias, pParams, mask, pDst);
+					if (padW)
+						ConvolutionDepthwise3x3Edge2x2<type>(src0, src1, sX, _weight + 0 * F, F, _bias, pParams, mask, pDst);
+				}
+				src += sD;
+				dst += dD;
+				weight += wD;
+			}
+		}
+
+		//-------------------------------------------------------------------------------------------------------
+
+		template <SimdConvolutionActivationType type> void SetDepthwise(const ConvParam& p, bool last, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution)
+		{
+			const size_t F = svcntw();
+			if (p.kernelY == 3 && (!last || Aligned(p.dstC, F)))
+				convolution[0] = DepthwiseConvolution3x3<type>;
+			else
+				convolution[0] = DepthwiseConvolution<type>;
+		}
+
+		}
+
+		void SetDepthwise(const ConvParam& p, bool last, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution)
+		{
+			switch (p.activation)
+			{
+			case SimdConvolutionActivationIdentity: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, last, convolution); break;
+			case SimdConvolutionActivationRelu: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, last, convolution); break;
+			case SimdConvolutionActivationLeakyRelu: SetDepthwise<SimdConvolutionActivationPrelu>(p, last, convolution); break;
+			case SimdConvolutionActivationRestrictRange: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, last, convolution); break;
+			case SimdConvolutionActivationPrelu: SetDepthwise<SimdConvolutionActivationPrelu>(p, last, convolution); break;
+			case SimdConvolutionActivationElu: SetDepthwise<SimdConvolutionActivationElu>(p, last, convolution); break;
+			case SimdConvolutionActivationHswish: SetDepthwise<SimdConvolutionActivationHswish>(p, last, convolution); break;
+			case SimdConvolutionActivationMish: SetDepthwise<SimdConvolutionActivationMish>(p, last, convolution); break;
+			case SimdConvolutionActivationHardSigmoid: SetDepthwise<SimdConvolutionActivationHardSigmoid>(p, last, convolution); break;
+			case SimdConvolutionActivationSwish: SetDepthwise<SimdConvolutionActivationSwish>(p, last, convolution); break;
+			case SimdConvolutionActivationGelu: SetDepthwise<SimdConvolutionActivationGelu>(p, last, convolution); break;
+			default: assert(0);
+			}
+		}
+	}
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution32fInput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32fInput.cpp
@@ -1,0 +1,778 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdUpdate.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+	namespace Sve2
+	{
+		namespace
+		{
+
+		SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
+		{
+			x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
+			svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
+			svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
+			svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+			svfloat32_t p = svdup_n_f32(1.8775767e-3f);
+			p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
+			return svmul_f32_x(mask, expipart, p);
+		}
+
+		SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
+		{
+			return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
+		}
+
+		SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
+		{
+			svuint32_t i = svreinterpret_u32_f32(x);
+			svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
+			svfloat32_t e = svcvt_f32_s32_x(mask, e32);
+			svfloat32_t one = svdup_n_f32(1.0f);
+			svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
+			svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
+			p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
+			return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
+		}
+
+		SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
+		{
+			return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
+		}
+
+		SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
+		{
+			const svfloat32_t _1 = svdup_n_f32(1.0f);
+			svfloat32_t a = svmin_f32_x(mask, svabs_f32_x(mask, x), svdup_n_f32(9.0f));
+			svfloat32_t p = svdup_n_f32(0.0000430638f);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0002765672f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0001520143f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0092705272f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0422820123f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0705230784f), a, p);
+			p = svmla_f32_x(mask, _1, a, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
+			return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
+		}
+
+		SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
+		{
+			svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
+			return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationIdentity>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return value;
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationRelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmax_n_f32_x(mask, value, 0.0f);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationLeakyRelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), param0, svmin_n_f32_x(mask, value, 0.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationRestrictRange>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmin_f32_x(mask, svmax_f32_x(mask, param0, value), param1);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationPrelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), param0, svmin_n_f32_x(mask, value, 0.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+			return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHswish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t upper = svmin_f32_x(mask, value, param0);
+			svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, param0), 0.0f);
+			return svmul_f32_x(mask, svmul_f32_x(mask, positive, param1), value);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), param0);
+			return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_f32_x(mask, param1, value, param0), 1.0f), 0.0f);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exp(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationGelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t t = svmul_n_f32_x(mask, value, 0.70710678118654752440f);
+			return svmul_f32_x(mask, svmul_n_f32_x(mask, t, 0.70710678118654752440f), svadd_n_f32_x(mask, Erf(mask, t), 1.0f));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate0(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return Activate<type>(value, param0, param1, mask);
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate1(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return Activate<type>(value, param0, param1, mask);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate1<SimdConvolutionActivationPrelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return Activate<SimdConvolutionActivationPrelu>(value, param1, param1, mask);
+		}
+
+		//-------------------------------------------------------------------------------------------------
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void InputConvolution1x1_2x6(const float* src0, size_t srcC,
+			const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, s0, w0, w1;
+			d00 = bias0, d01 = bias1;
+			d10 = bias0, d11 = bias1;
+			d20 = bias0, d21 = bias1;
+			d30 = bias0, d31 = bias1;
+			d40 = bias0, d41 = bias1;
+			d50 = bias0, d51 = bias1;
+			const float* src1 = src0 + 1 * srcC;
+			const float* src2 = src0 + 2 * srcC;
+			const float* src3 = src0 + 3 * srcC;
+			const float* src4 = src0 + 4 * srcC;
+			const float* src5 = src0 + 5 * srcC;
+			for (size_t sc = 0; sc < srcC; ++sc)
+			{
+				w0 = svld1_f32(mask, weight + 0);
+				w1 = svld1_f32(mask, weight + F);
+				s0 = svdup_n_f32(src0[sc]);
+				d00 = svmla_f32_x(mask, d00, s0, w0);
+				d01 = svmla_f32_x(mask, d01, s0, w1);
+				s0 = svdup_n_f32(src1[sc]);
+				d10 = svmla_f32_x(mask, d10, s0, w0);
+				d11 = svmla_f32_x(mask, d11, s0, w1);
+				s0 = svdup_n_f32(src2[sc]);
+				d20 = svmla_f32_x(mask, d20, s0, w0);
+				d21 = svmla_f32_x(mask, d21, s0, w1);
+				s0 = svdup_n_f32(src3[sc]);
+				d30 = svmla_f32_x(mask, d30, s0, w0);
+				d31 = svmla_f32_x(mask, d31, s0, w1);
+				s0 = svdup_n_f32(src4[sc]);
+				d40 = svmla_f32_x(mask, d40, s0, w0);
+				d41 = svmla_f32_x(mask, d41, s0, w1);
+				s0 = svdup_n_f32(src5[sc]);
+				d50 = svmla_f32_x(mask, d50, s0, w0);
+				d51 = svmla_f32_x(mask, d51, s0, w1);
+				weight += DF;
+			}
+			svst1_f32(mask, dst0 + 0 * F, Activate0<type>(d00, param0, param1, mask));
+			svst1_f32(mask, dst1 + 0 * F, Activate1<type>(d01, param0, param1, mask));
+			svst1_f32(mask, dst0 + 1 * F, Activate0<type>(d10, param0, param1, mask));
+			svst1_f32(mask, dst1 + 1 * F, Activate1<type>(d11, param0, param1, mask));
+			svst1_f32(mask, dst0 + 2 * F, Activate0<type>(d20, param0, param1, mask));
+			svst1_f32(mask, dst1 + 2 * F, Activate1<type>(d21, param0, param1, mask));
+			svst1_f32(mask, dst0 + 3 * F, Activate0<type>(d30, param0, param1, mask));
+			svst1_f32(mask, dst1 + 3 * F, Activate1<type>(d31, param0, param1, mask));
+			svst1_f32(mask, dst0 + 4 * F, Activate0<type>(d40, param0, param1, mask));
+			svst1_f32(mask, dst1 + 4 * F, Activate1<type>(d41, param0, param1, mask));
+			svst1_f32(mask, dst0 + 5 * F, Activate0<type>(d50, param0, param1, mask));
+			svst1_f32(mask, dst1 + 5 * F, Activate1<type>(d51, param0, param1, mask));
+		}
+
+		template<SimdConvolutionActivationType type, int M> SIMD_INLINE void InputConvolution1x1_2xM(const float* src0, size_t srcC,
+			const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, s0, w0, w1;
+			if (M > 0) d00 = bias0, d01 = bias1;
+			if (M > 1) d10 = bias0, d11 = bias1;
+			if (M > 2) d20 = bias0, d21 = bias1;
+			if (M > 3) d30 = bias0, d31 = bias1;
+			if (M > 4) d40 = bias0, d41 = bias1;
+			if (M > 5) d50 = bias0, d51 = bias1;
+			const float* src1 = src0 + 1 * srcC;
+			const float* src2 = src0 + 2 * srcC;
+			const float* src3 = src0 + 3 * srcC;
+			const float* src4 = src0 + 4 * srcC;
+			const float* src5 = src0 + 5 * srcC;
+			for (size_t sc = 0; sc < srcC; ++sc)
+			{
+				w0 = svld1_f32(mask, weight + 0);
+				w1 = svld1_f32(mask, weight + F);
+				if (M > 0) s0 = svdup_n_f32(src0[sc]), d00 = svmla_f32_x(mask, d00, s0, w0), d01 = svmla_f32_x(mask, d01, s0, w1);
+				if (M > 1) s0 = svdup_n_f32(src1[sc]), d10 = svmla_f32_x(mask, d10, s0, w0), d11 = svmla_f32_x(mask, d11, s0, w1);
+				if (M > 2) s0 = svdup_n_f32(src2[sc]), d20 = svmla_f32_x(mask, d20, s0, w0), d21 = svmla_f32_x(mask, d21, s0, w1);
+				if (M > 3) s0 = svdup_n_f32(src3[sc]), d30 = svmla_f32_x(mask, d30, s0, w0), d31 = svmla_f32_x(mask, d31, s0, w1);
+				if (M > 4) s0 = svdup_n_f32(src4[sc]), d40 = svmla_f32_x(mask, d40, s0, w0), d41 = svmla_f32_x(mask, d41, s0, w1);
+				if (M > 5) s0 = svdup_n_f32(src5[sc]), d50 = svmla_f32_x(mask, d50, s0, w0), d51 = svmla_f32_x(mask, d51, s0, w1);
+				weight += DF;
+			}
+			if (M > 0) svst1_f32(mask, dst0 + 0 * F, Activate0<type>(d00, param0, param1, mask)), svst1_f32(mask, dst1 + 0 * F, Activate1<type>(d01, param0, param1, mask));
+			if (M > 1) svst1_f32(mask, dst0 + 1 * F, Activate0<type>(d10, param0, param1, mask)), svst1_f32(mask, dst1 + 1 * F, Activate1<type>(d11, param0, param1, mask));
+			if (M > 2) svst1_f32(mask, dst0 + 2 * F, Activate0<type>(d20, param0, param1, mask)), svst1_f32(mask, dst1 + 2 * F, Activate1<type>(d21, param0, param1, mask));
+			if (M > 3) svst1_f32(mask, dst0 + 3 * F, Activate0<type>(d30, param0, param1, mask)), svst1_f32(mask, dst1 + 3 * F, Activate1<type>(d31, param0, param1, mask));
+			if (M > 4) svst1_f32(mask, dst0 + 4 * F, Activate0<type>(d40, param0, param1, mask)), svst1_f32(mask, dst1 + 4 * F, Activate1<type>(d41, param0, param1, mask));
+			if (M > 5) svst1_f32(mask, dst0 + 5 * F, Activate0<type>(d50, param0, param1, mask)), svst1_f32(mask, dst1 + 5 * F, Activate1<type>(d51, param0, param1, mask));
+		}
+
+		typedef void(*InputConvolution1x1_2xM_Ptr)(const float* src0, size_t srcC, const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1);
+
+		template<SimdConvolutionActivationType type> InputConvolution1x1_2xM_Ptr GetInputConvolution1x1_2xM(size_t M)
+		{
+			switch (M)
+			{
+			case 0: return InputConvolution1x1_2xM<type, 0>;
+			case 1: return InputConvolution1x1_2xM<type, 1>;
+			case 2: return InputConvolution1x1_2xM<type, 2>;
+			case 3: return InputConvolution1x1_2xM<type, 3>;
+			case 4: return InputConvolution1x1_2xM<type, 4>;
+			case 5: return InputConvolution1x1_2xM<type, 5>;
+			}
+			assert(0);
+			return NULL;
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void InputConvolution1x1_1x6(const float* src0, size_t srcC,
+			const float* weight, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, float* dst0)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d10, d20, d30, d40, d50, s0, w0;
+			d00 = bias0;
+			d10 = bias0;
+			d20 = bias0;
+			d30 = bias0;
+			d40 = bias0;
+			d50 = bias0;
+			const float* src1 = src0 + 1 * srcC;
+			const float* src2 = src0 + 2 * srcC;
+			const float* src3 = src0 + 3 * srcC;
+			const float* src4 = src0 + 4 * srcC;
+			const float* src5 = src0 + 5 * srcC;
+			for (size_t sc = 0; sc < srcC; ++sc)
+			{
+				w0 = svld1_f32(mask, weight + 0);
+				s0 = svdup_n_f32(src0[sc]);
+				d00 = svmla_f32_x(mask, d00, s0, w0);
+				s0 = svdup_n_f32(src1[sc]);
+				d10 = svmla_f32_x(mask, d10, s0, w0);
+				s0 = svdup_n_f32(src2[sc]);
+				d20 = svmla_f32_x(mask, d20, s0, w0);
+				s0 = svdup_n_f32(src3[sc]);
+				d30 = svmla_f32_x(mask, d30, s0, w0);
+				s0 = svdup_n_f32(src4[sc]);
+				d40 = svmla_f32_x(mask, d40, s0, w0);
+				s0 = svdup_n_f32(src5[sc]);
+				d50 = svmla_f32_x(mask, d50, s0, w0);
+				weight += DF;
+			}
+			svst1_f32(mask, dst0 + 0 * F, Activate0<type>(d00, param0, param1, mask));
+			svst1_f32(mask, dst0 + 1 * F, Activate0<type>(d10, param0, param1, mask));
+			svst1_f32(mask, dst0 + 2 * F, Activate0<type>(d20, param0, param1, mask));
+			svst1_f32(mask, dst0 + 3 * F, Activate0<type>(d30, param0, param1, mask));
+			svst1_f32(mask, dst0 + 4 * F, Activate0<type>(d40, param0, param1, mask));
+			svst1_f32(mask, dst0 + 5 * F, Activate0<type>(d50, param0, param1, mask));
+		}
+
+		template<SimdConvolutionActivationType type, int M> SIMD_INLINE void InputConvolution1x1_1xM(const float* src0, size_t srcC,
+			const float* weight, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, float* dst0)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d10, d20, d30, d40, d50, s0, w0;
+			if (M > 0) d00 = bias0;
+			if (M > 1) d10 = bias0;
+			if (M > 2) d20 = bias0;
+			if (M > 3) d30 = bias0;
+			if (M > 4) d40 = bias0;
+			if (M > 5) d50 = bias0;
+			const float* src1 = src0 + 1 * srcC;
+			const float* src2 = src0 + 2 * srcC;
+			const float* src3 = src0 + 3 * srcC;
+			const float* src4 = src0 + 4 * srcC;
+			const float* src5 = src0 + 5 * srcC;
+			for (size_t sc = 0; sc < srcC; ++sc)
+			{
+				w0 = svld1_f32(mask, weight + 0);
+				if (M > 0) s0 = svdup_n_f32(src0[sc]), d00 = svmla_f32_x(mask, d00, s0, w0);
+				if (M > 1) s0 = svdup_n_f32(src1[sc]), d10 = svmla_f32_x(mask, d10, s0, w0);
+				if (M > 2) s0 = svdup_n_f32(src2[sc]), d20 = svmla_f32_x(mask, d20, s0, w0);
+				if (M > 3) s0 = svdup_n_f32(src3[sc]), d30 = svmla_f32_x(mask, d30, s0, w0);
+				if (M > 4) s0 = svdup_n_f32(src4[sc]), d40 = svmla_f32_x(mask, d40, s0, w0);
+				if (M > 5) s0 = svdup_n_f32(src5[sc]), d50 = svmla_f32_x(mask, d50, s0, w0);
+				weight += DF;
+			}
+			if (M > 0) svst1_f32(mask, dst0 + 0 * F, Activate0<type>(d00, param0, param1, mask));
+			if (M > 1) svst1_f32(mask, dst0 + 1 * F, Activate0<type>(d10, param0, param1, mask));
+			if (M > 2) svst1_f32(mask, dst0 + 2 * F, Activate0<type>(d20, param0, param1, mask));
+			if (M > 3) svst1_f32(mask, dst0 + 3 * F, Activate0<type>(d30, param0, param1, mask));
+			if (M > 4) svst1_f32(mask, dst0 + 4 * F, Activate0<type>(d40, param0, param1, mask));
+			if (M > 5) svst1_f32(mask, dst0 + 5 * F, Activate0<type>(d50, param0, param1, mask));
+		}
+
+		typedef void(*InputConvolution1x1_1xM_Ptr)(const float* src0, size_t srcC, const float* weight, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, float* dst0);
+
+		template<SimdConvolutionActivationType type> InputConvolution1x1_1xM_Ptr GetInputConvolution1x1_1xM(size_t M)
+		{
+			switch (M)
+			{
+			case 0: return InputConvolution1x1_1xM<type, 0>;
+			case 1: return InputConvolution1x1_1xM<type, 1>;
+			case 2: return InputConvolution1x1_1xM<type, 2>;
+			case 3: return InputConvolution1x1_1xM<type, 3>;
+			case 4: return InputConvolution1x1_1xM<type, 4>;
+			case 5: return InputConvolution1x1_1xM<type, 5>;
+			}
+			assert(0);
+			return NULL;
+		}
+
+		template<SimdConvolutionActivationType type> void InputConvolution1x1(const float* src, const SimdConvolutionParameters& p,
+			size_t dstC, size_t yBeg, size_t yEnd, const size_t bufH[2], const float* weight, const float* bias, const float* params, float* dst, int first)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			size_t srcH = p.srcH, srcW = p.srcW, srcC = p.srcC, dstW = p.dstW;
+			size_t dstM = (bufH[0] - 1), dstS = bufH[0] * dstW * F;
+			size_t dstCDF = AlignLo(dstC, DF);
+			svfloat32_t param0 = svdup_n_f32(params[0]), param1 = svdup_n_f32(0.0f);
+			if (type == SimdConvolutionActivationRestrictRange ||
+				type == SimdConvolutionActivationHswish ||
+				type == SimdConvolutionActivationHardSigmoid)
+				param1 = svdup_n_f32(params[1]);
+			size_t yInt = Simd::Max(yBeg, yEnd & (~dstM)), nBeg = yBeg * dstW, nInt = yInt * dstW, nEnd = yEnd * dstW;
+			size_t nInt6 = AlignLoAny(nInt - nBeg, 6) + nBeg, nEnd6 = AlignLoAny(nEnd - nInt, 6) + nInt, nIntTail = nInt - nInt6, nEndTail = nEnd - nEnd6;
+			InputConvolution1x1_2xM_Ptr tailInt_2 = GetInputConvolution1x1_2xM<type>(nIntTail);
+			InputConvolution1x1_2xM_Ptr tailEnd_2 = GetInputConvolution1x1_2xM<type>(nEndTail);
+
+			size_t dc = 0;
+			for (; dc < dstC; dc += DF)
+			{
+				svfloat32_t bias0 = bias ? svld1_f32(mask, bias + dc + 0) : svdup_n_f32(0.0f);
+				svfloat32_t bias1 = bias ? svld1_f32(mask, bias + dc + F) : svdup_n_f32(0.0f);
+				if (type == ::SimdConvolutionActivationPrelu)
+				{
+					param0 = svld1_f32(mask, params + dc + 0);
+					param1 = svld1_f32(mask, params + dc + F);
+				}
+				const float* pS = src + yBeg * srcW * srcC;
+				const float* pW = weight + dc * srcC;
+				float* pD = dst + (dc / F) * dstS;
+				float* dst0 = pD + (yBeg & dstM) * dstW * F;
+				float* dst1 = pD + (yInt & dstM) * dstW * F;
+				size_t dn = nBeg;
+				if (dstC - dc > F)
+				{
+					for (; dn < nInt6; dn += 6, pS += 6 * srcC, dst0 += 6 * F)
+						InputConvolution1x1_2x6<type>(pS, srcC, pW, bias0, bias1, param0, param1, dst0, dst0 + dstS);
+					if (nIntTail)
+						tailInt_2(pS, srcC, pW, bias0, bias1, param0, param1, dst0, dst0 + dstS), pS += nIntTail * srcC, dn += nIntTail;
+					for (; dn < nEnd6; dn += 6, pS += 6 * srcC, dst1 += 6 * F)
+						InputConvolution1x1_2x6<type>(pS, srcC, pW, bias0, bias1, param0, param1, dst1, dst1 + dstS);
+					if (nEndTail)
+						tailEnd_2(pS, srcC, pW, bias0, bias1, param0, param1, dst1, dst1 + dstS), pS += nEndTail * srcC, dn += nEndTail;
+				}
+				else
+				{
+					InputConvolution1x1_1xM_Ptr tailInt_1 = GetInputConvolution1x1_1xM<type>(nIntTail);
+					InputConvolution1x1_1xM_Ptr tailEnd_1 = GetInputConvolution1x1_1xM<type>(nEndTail);
+					for (; dn < nInt6; dn += 6, pS += 6 * srcC, dst0 += 6 * F)
+						InputConvolution1x1_1x6<type>(pS, srcC, pW, bias0, param0, param1, dst0);
+					if (nIntTail)
+						tailInt_1(pS, srcC, pW, bias0, param0, param1, dst0), pS += nIntTail * srcC, dn += nIntTail;
+					for (; dn < nEnd6; dn += 6, pS += 6 * srcC, dst1 += 6 * F)
+						InputConvolution1x1_1x6<type>(pS, srcC, pW, bias0, param0, param1, dst1);
+					if (nEndTail)
+						tailEnd_1(pS, srcC, pW, bias0, param0, param1, dst1), pS += nEndTail * srcC, dn += nEndTail;
+				}
+			}
+		}
+
+		//---------------------------------------------------------------------
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void InputConvolution_2x1(const float* src0, const SimdConvolutionParameters& p,
+			size_t kH, size_t kW, const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d01, s0, w0, w1;
+			d00 = bias0;
+			d01 = bias1;
+			size_t size = kW * p.srcC, tail = DF * (p.kernelX - kW) * p.srcC, stride = p.srcW * p.srcC;
+			for (size_t ky = 0; ky < kH; ++ky)
+			{
+				for (size_t i = 0; i < size; ++i)
+				{
+					w0 = svld1_f32(mask, weight + 0);
+					w1 = svld1_f32(mask, weight + F);
+					s0 = svdup_n_f32(src0[i]);
+					d00 = svmla_f32_x(mask, d00, s0, w0);
+					d01 = svmla_f32_x(mask, d01, s0, w1);
+					weight += DF;
+				}
+				weight += tail;
+				src0 += stride;
+			}
+			svst1_f32(mask, dst0, Activate0<type>(d00, param0, param1, mask));
+			svst1_f32(mask, dst1, Activate1<type>(d01, param0, param1, mask));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void InputConvolution_1x1(const float* src0, const SimdConvolutionParameters& p,
+			size_t kH, size_t kW, const float* weight, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, float* dst0)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, s0, w0;
+			d00 = bias0;
+			size_t size = kW * p.srcC, tail = DF * (p.kernelX - kW) * p.srcC, stride = p.srcW * p.srcC;
+			for (size_t ky = 0; ky < kH; ++ky)
+			{
+				for (size_t i = 0; i < size; ++i)
+				{
+					w0 = svld1_f32(mask, weight + 0);
+					s0 = svdup_n_f32(src0[i]);
+					d00 = svmla_f32_x(mask, d00, s0, w0);
+					weight += DF;
+				}
+				weight += tail;
+				src0 += stride;
+			}
+			svst1_f32(mask, dst0, Activate0<type>(d00, param0, param1, mask));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void InputConvolution_2x6(const float* src0, const SimdConvolutionParameters& p,
+			size_t kH, size_t kW, const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, s0, w0, w1;
+			d00 = bias0, d01 = bias1;
+			d10 = bias0, d11 = bias1;
+			d20 = bias0, d21 = bias1;
+			d30 = bias0, d31 = bias1;
+			d40 = bias0, d41 = bias1;
+			d50 = bias0, d51 = bias1;
+			size_t size = kW * p.srcC, tail = DF * (p.kernelX - kW) * p.srcC, stride = p.srcW * p.srcC, step = p.srcC * p.strideX;
+			const float* src1 = src0 + 1 * step;
+			const float* src2 = src0 + 2 * step;
+			const float* src3 = src0 + 3 * step;
+			const float* src4 = src0 + 4 * step;
+			const float* src5 = src0 + 5 * step;
+			for (size_t ky = 0; ky < kH; ++ky)
+			{
+				size_t offset = ky * stride;
+				for (size_t end = offset + size; offset < end; ++offset)
+				{
+					w0 = svld1_f32(mask, weight + 0);
+					w1 = svld1_f32(mask, weight + F);
+					s0 = svdup_n_f32(src0[offset]);
+					d00 = svmla_f32_x(mask, d00, s0, w0);
+					d01 = svmla_f32_x(mask, d01, s0, w1);
+					s0 = svdup_n_f32(src1[offset]);
+					d10 = svmla_f32_x(mask, d10, s0, w0);
+					d11 = svmla_f32_x(mask, d11, s0, w1);
+					s0 = svdup_n_f32(src2[offset]);
+					d20 = svmla_f32_x(mask, d20, s0, w0);
+					d21 = svmla_f32_x(mask, d21, s0, w1);
+					s0 = svdup_n_f32(src3[offset]);
+					d30 = svmla_f32_x(mask, d30, s0, w0);
+					d31 = svmla_f32_x(mask, d31, s0, w1);
+					s0 = svdup_n_f32(src4[offset]);
+					d40 = svmla_f32_x(mask, d40, s0, w0);
+					d41 = svmla_f32_x(mask, d41, s0, w1);
+					s0 = svdup_n_f32(src5[offset]);
+					d50 = svmla_f32_x(mask, d50, s0, w0);
+					d51 = svmla_f32_x(mask, d51, s0, w1);
+					weight += DF;
+				}
+				weight += tail;
+			}
+			svst1_f32(mask, dst0 + 0 * F, Activate0<type>(d00, param0, param1, mask));
+			svst1_f32(mask, dst1 + 0 * F, Activate1<type>(d01, param0, param1, mask));
+			svst1_f32(mask, dst0 + 1 * F, Activate0<type>(d10, param0, param1, mask));
+			svst1_f32(mask, dst1 + 1 * F, Activate1<type>(d11, param0, param1, mask));
+			svst1_f32(mask, dst0 + 2 * F, Activate0<type>(d20, param0, param1, mask));
+			svst1_f32(mask, dst1 + 2 * F, Activate1<type>(d21, param0, param1, mask));
+			svst1_f32(mask, dst0 + 3 * F, Activate0<type>(d30, param0, param1, mask));
+			svst1_f32(mask, dst1 + 3 * F, Activate1<type>(d31, param0, param1, mask));
+			svst1_f32(mask, dst0 + 4 * F, Activate0<type>(d40, param0, param1, mask));
+			svst1_f32(mask, dst1 + 4 * F, Activate1<type>(d41, param0, param1, mask));
+			svst1_f32(mask, dst0 + 5 * F, Activate0<type>(d50, param0, param1, mask));
+			svst1_f32(mask, dst1 + 5 * F, Activate1<type>(d51, param0, param1, mask));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE void InputConvolution_1x6(const float* src0, const SimdConvolutionParameters& p,
+			size_t kH, size_t kW, const float* weight, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, float* dst0)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			svfloat32_t d00, d10, d20, d30, d40, d50, s0, w0;
+			d00 = bias0;
+			d10 = bias0;
+			d20 = bias0;
+			d30 = bias0;
+			d40 = bias0;
+			d50 = bias0;
+			size_t size = kW * p.srcC, tail = DF * (p.kernelX - kW) * p.srcC, stride = p.srcW * p.srcC, step = p.srcC * p.strideX;
+			const float* src1 = src0 + 1 * step;
+			const float* src2 = src0 + 2 * step;
+			const float* src3 = src0 + 3 * step;
+			const float* src4 = src0 + 4 * step;
+			const float* src5 = src0 + 5 * step;
+			for (size_t ky = 0; ky < kH; ++ky)
+			{
+				size_t offset = ky * stride;
+				for (size_t end = offset + size; offset < end; ++offset)
+				{
+					w0 = svld1_f32(mask, weight + 0);
+					s0 = svdup_n_f32(src0[offset]);
+					d00 = svmla_f32_x(mask, d00, s0, w0);
+					s0 = svdup_n_f32(src1[offset]);
+					d10 = svmla_f32_x(mask, d10, s0, w0);
+					s0 = svdup_n_f32(src2[offset]);
+					d20 = svmla_f32_x(mask, d20, s0, w0);
+					s0 = svdup_n_f32(src3[offset]);
+					d30 = svmla_f32_x(mask, d30, s0, w0);
+					s0 = svdup_n_f32(src4[offset]);
+					d40 = svmla_f32_x(mask, d40, s0, w0);
+					s0 = svdup_n_f32(src5[offset]);
+					d50 = svmla_f32_x(mask, d50, s0, w0);
+					weight += DF;
+				}
+				weight += tail;
+			}
+			svst1_f32(mask, dst0 + 0 * F, Activate0<type>(d00, param0, param1, mask));
+			svst1_f32(mask, dst0 + 1 * F, Activate0<type>(d10, param0, param1, mask));
+			svst1_f32(mask, dst0 + 2 * F, Activate0<type>(d20, param0, param1, mask));
+			svst1_f32(mask, dst0 + 3 * F, Activate0<type>(d30, param0, param1, mask));
+			svst1_f32(mask, dst0 + 4 * F, Activate0<type>(d40, param0, param1, mask));
+			svst1_f32(mask, dst0 + 5 * F, Activate0<type>(d50, param0, param1, mask));
+		}
+
+		template<SimdConvolutionActivationType type> void InputConvolution(const float* src, const SimdConvolutionParameters& p,
+			size_t dstC, size_t yBeg, size_t yEnd, const size_t bufH[2], const float* weight, const float* bias, const float* params, float* dst, int first)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			size_t srcH = p.srcH, srcW = p.srcW, srcC = p.srcC, dstW = p.dstW;
+			size_t kernelY = p.kernelY, kernelX = p.kernelX, strideY = p.strideY, strideX = p.strideX;
+			size_t dstM = (bufH[0] - 1), dstS = bufH[0] * dstW * F;
+			size_t dstCDF = AlignLo(dstC, DF);
+			if (dstC - F > dstCDF)
+				dstCDF += DF;
+
+			size_t noseH = p.padY, noseW = p.padX;
+			size_t bodyH = p.srcH - p.kernelY + 1 + noseH, bodyW = p.srcW - p.kernelX + 1 + noseW;
+			size_t bodyW6 = AlignLoAny(bodyW - noseW, 6 * p.strideX) + noseW;
+			size_t tailH = bodyH + p.padH, tailW = bodyW + p.padW;
+			size_t wS = p.srcC * p.dstC;
+			size_t kY = p.kernelY - noseH, kX = p.kernelX - noseW, kH = bodyH + p.kernelY - 1, kW = bodyW + p.kernelX - 1;
+
+			svfloat32_t param0 = svdup_n_f32(params[0]), param1 = svdup_n_f32(0.0f);
+			if (type == SimdConvolutionActivationRestrictRange ||
+				type == SimdConvolutionActivationHswish ||
+				type == SimdConvolutionActivationHardSigmoid)
+				param1 = svdup_n_f32(params[1]);
+
+			size_t dc = 0;
+			for (; dc < dstCDF; dc += DF)
+			{
+				svfloat32_t bias0 = bias ? svld1_f32(mask, bias + dc + 0) : svdup_n_f32(0.0f);
+				svfloat32_t bias1 = bias ? svld1_f32(mask, bias + dc + F) : svdup_n_f32(0.0f);
+				if (type == ::SimdConvolutionActivationPrelu)
+				{
+					param0 = svld1_f32(mask, params + dc + 0);
+					param1 = svld1_f32(mask, params + dc + F);
+				}
+				size_t dy = yBeg, sy = dy * strideY;
+				for (; sy < noseH && dy < yEnd; sy += strideY, dy++)
+				{
+					float* dst0 = dst + (dy & dstM) * dstW * F + (dc / F) * dstS, * dst1 = dst0 + dstS;
+					size_t sx = 0;
+					const float* s = src;
+					const float* w = weight + (noseH - sy) * kernelX * DF * srcC;
+					for (; sx < noseW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s, p, kY + sy, kX + sx, w + (noseW - sx) * srcC * DF, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < bodyW6; sx += 6 * strideX, dst0 += 6 * F, dst1 += 6 * F)
+						InputConvolution_2x6<type>(s + (sx - noseW) * srcC, p, kY + sy, kernelX, w, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < bodyW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s + (sx - noseW) * srcC, p, kY + sy, kernelX, w, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < tailW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s + (sx - noseW) * srcC, p, kY + sy, kW - sx, w, bias0, bias1, param0, param1, dst0, dst1);
+				}
+				for (; sy < bodyH && dy < yEnd; sy += strideY, dy++)
+				{
+					float* dst0 = dst + (dy & dstM) * dstW * F + (dc / F) * dstS, * dst1 = dst0 + dstS;
+					size_t sx = 0;
+					const float* s = src + (sy - noseH) * srcW * srcC;
+					const float* w = weight;
+					for (; sx < noseW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s, p, kernelY, kX + sx, w + (noseW - sx) * srcC * DF, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < bodyW6; sx += 6 * strideX, dst0 += 6 * F, dst1 += 6 * F)
+						InputConvolution_2x6<type>(s + (sx - noseW) * srcC, p, kernelY, kernelX, w, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < bodyW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s + (sx - noseW) * srcC, p, kernelY, kernelX, w, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < tailW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s + (sx - noseW) * srcC, p, kernelY, kW - sx, w, bias0, bias1, param0, param1, dst0, dst1);
+				}
+				for (; sy < tailH && dy < yEnd; sy += strideY, dy++)
+				{
+					float* dst0 = dst + (dy & dstM) * dstW * F + (dc / F) * dstS, * dst1 = dst0 + dstS;
+					size_t sx = 0;
+					const float* s = src + (sy - noseH) * srcW * srcC;
+					const float* w = weight;
+					for (; sx < noseW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s, p, kH - sy, kX + sx, w + (noseW - sx) * srcC * DF, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < bodyW6; sx += 6 * strideX, dst0 += 6 * F, dst1 += 6 * F)
+						InputConvolution_2x6<type>(s + (sx - noseW) * srcC, p, kH - sy, kernelX, w, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < bodyW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s + (sx - noseW) * srcC, p, kH - sy, kernelX, w, bias0, bias1, param0, param1, dst0, dst1);
+					for (; sx < tailW; sx += strideX, dst0 += F, dst1 += F)
+						InputConvolution_2x1<type>(s + (sx - noseW) * srcC, p, kH - sy, kW - sx, w, bias0, bias1, param0, param1, dst0, dst1);
+				}
+				weight += kernelY * kernelX * srcC * DF;
+			}
+			if (dc < dstC)
+			{
+				svfloat32_t bias0 = bias ? svld1_f32(mask, bias + dc) : svdup_n_f32(0.0f);
+				if (type == ::SimdConvolutionActivationPrelu)
+					param0 = svld1_f32(mask, params + dc);
+				size_t dy = yBeg, sy = dy * strideY;
+				for (; sy < noseH && dy < yEnd; sy += strideY, dy++)
+				{
+					float* dst0 = dst + (dy & dstM) * dstW * F + (dc / F) * dstS;
+					size_t sx = 0;
+					const float* s = src;
+					const float* w = weight + (noseH - sy) * kernelX * DF * srcC;
+					for (; sx < noseW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s, p, kY + sy, kX + sx, w + (noseW - sx) * srcC * DF, bias0, param0, param1, dst0);
+					for (; sx < bodyW6; sx += 6 * strideX, dst0 += 6 * F)
+						InputConvolution_1x6<type>(s + (sx - noseW) * srcC, p, kY + sy, kernelX, w, bias0, param0, param1, dst0);
+					for (; sx < bodyW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s + (sx - noseW) * srcC, p, kY + sy, kernelX, w, bias0, param0, param1, dst0);
+					for (; sx < tailW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s + (sx - noseW) * srcC, p, kY + sy, kW - sx, w, bias0, param0, param1, dst0);
+				}
+				for (; sy < bodyH && dy < yEnd; sy += strideY, dy++)
+				{
+					float* dst0 = dst + (dy & dstM) * dstW * F + (dc / F) * dstS;
+					size_t sx = 0;
+					const float* s = src + (sy - noseH) * srcW * srcC;
+					const float* w = weight;
+					for (; sx < noseW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s, p, kernelY, kX + sx, w + (noseW - sx) * srcC * DF, bias0, param0, param1, dst0);
+					for (; sx < bodyW6; sx += 6 * strideX, dst0 += 6 * F)
+						InputConvolution_1x6<type>(s + (sx - noseW) * srcC, p, kernelY, kernelX, w, bias0, param0, param1, dst0);
+					for (; sx < bodyW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s + (sx - noseW) * srcC, p, kernelY, kernelX, w, bias0, param0, param1, dst0);
+					for (; sx < tailW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s + (sx - noseW) * srcC, p, kernelY, kW - sx, w, bias0, param0, param1, dst0);
+				}
+				for (; sy < tailH && dy < yEnd; sy += strideY, dy++)
+				{
+					float* dst0 = dst + (dy & dstM) * dstW * F + (dc / F) * dstS;
+					size_t sx = 0;
+					const float* s = src + (sy - noseH) * srcW * srcC;
+					const float* w = weight;
+					for (; sx < noseW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s, p, kH - sy, kX + sx, w + (noseW - sx) * srcC * DF, bias0, param0, param1, dst0);
+					for (; sx < bodyW6; sx += 6 * strideX, dst0 += 6 * F)
+						InputConvolution_1x6<type>(s + (sx - noseW) * srcC, p, kH - sy, kernelX, w, bias0, param0, param1, dst0);
+					for (; sx < bodyW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s + (sx - noseW) * srcC, p, kH - sy, kernelX, w, bias0, param0, param1, dst0);
+					for (; sx < tailW; sx += strideX, dst0 += F)
+						InputConvolution_1x1<type>(s + (sx - noseW) * srcC, p, kH - sy, kW - sx, w, bias0, param0, param1, dst0);
+				}
+			}
+		}
+
+		//-------------------------------------------------------------------------------------------------------
+
+		template <SimdConvolutionActivationType type> void SetInput(const ConvParam& p, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution)
+		{
+			if (p.kernelY == 1 && p.strideY == 1)
+				convolution[0] = InputConvolution1x1<type>;
+			else
+				convolution[0] = InputConvolution<type>;
+		}
+
+		}
+
+		void SetInput(const ConvParam& p, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution)
+		{
+			switch (p.activation)
+			{
+			case SimdConvolutionActivationIdentity: SetInput<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+			case SimdConvolutionActivationRelu: SetInput<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+			case SimdConvolutionActivationLeakyRelu: SetInput<SimdConvolutionActivationPrelu>(p, convolution); break;
+			case SimdConvolutionActivationRestrictRange: SetInput<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+			case SimdConvolutionActivationPrelu: SetInput<SimdConvolutionActivationPrelu>(p, convolution); break;
+			case SimdConvolutionActivationElu: SetInput<SimdConvolutionActivationElu>(p, convolution); break;
+			case SimdConvolutionActivationHswish: SetInput<SimdConvolutionActivationHswish>(p, convolution); break;
+			case SimdConvolutionActivationMish: SetInput<SimdConvolutionActivationMish>(p, convolution); break;
+			case SimdConvolutionActivationHardSigmoid: SetInput<SimdConvolutionActivationHardSigmoid>(p, convolution); break;
+			case SimdConvolutionActivationSwish: SetInput<SimdConvolutionActivationSwish>(p, convolution); break;
+			case SimdConvolutionActivationGelu: SetInput<SimdConvolutionActivationGelu>(p, convolution); break;
+			default: assert(0);
+			}
+		}
+	}
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution32fOutput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32fOutput.cpp
@@ -1,0 +1,739 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdUpdate.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+	namespace Sve2
+	{
+		namespace
+		{
+		SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
+		{
+			x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
+			svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
+			svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
+			svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+			svfloat32_t p = svdup_n_f32(1.8775767e-3f);
+			p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
+			p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
+			return svmul_f32_x(mask, expipart, p);
+		}
+
+		SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
+		{
+			return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
+		}
+
+		SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
+		{
+			svuint32_t i = svreinterpret_u32_f32(x);
+			svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
+			svfloat32_t e = svcvt_f32_s32_x(mask, e32);
+			svfloat32_t one = svdup_n_f32(1.0f);
+			svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
+			svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
+			p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
+			p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
+			return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
+		}
+
+		SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
+		{
+			return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
+		}
+
+		SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
+		{
+			const svfloat32_t _1 = svdup_n_f32(1.0f);
+			svfloat32_t a = svmin_f32_x(mask, svabs_f32_x(mask, x), svdup_n_f32(9.0f));
+			svfloat32_t p = svdup_n_f32(0.0000430638f);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0002765672f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0001520143f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0092705272f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0422820123f), a, p);
+			p = svmla_f32_x(mask, svdup_n_f32(0.0705230784f), a, p);
+			p = svmla_f32_x(mask, _1, a, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			p = svmul_f32_x(mask, p, p);
+			svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
+			return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
+		}
+
+		SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
+		{
+			svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
+			return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationIdentity>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return value;
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationRelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmax_n_f32_x(mask, value, 0.0f);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationLeakyRelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), param0, svmin_n_f32_x(mask, value, 0.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationRestrictRange>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmin_f32_x(mask, svmax_f32_x(mask, param0, value), param1);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationPrelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), param0, svmin_n_f32_x(mask, value, 0.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+			return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHswish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t upper = svmin_f32_x(mask, value, param0);
+			svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, param0), 0.0f);
+			return svmul_f32_x(mask, svmul_f32_x(mask, positive, param1), value);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), param0);
+			return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_f32_x(mask, param1, value, param0), 1.0f), 0.0f);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exp(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationGelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			svfloat32_t t = svmul_n_f32_x(mask, value, 0.70710678118654752440f);
+			return svmul_f32_x(mask, svmul_n_f32_x(mask, t, 0.70710678118654752440f), svadd_n_f32_x(mask, Erf(mask, t), 1.0f));
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate0(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return Activate<type>(value, param0, param1, mask);
+		}
+
+		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate1(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return Activate<type>(value, param0, param1, mask);
+		}
+
+		template<> SIMD_INLINE svfloat32_t Activate1<SimdConvolutionActivationPrelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+		{
+			return Activate<SimdConvolutionActivationPrelu>(value, param1, param1, mask);
+		}
+
+		
+		template <TermType term> struct Term
+		{
+			template<SimdConvolutionActivationType type> static SIMD_INLINE void Save0(float* ptr, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
+			template<SimdConvolutionActivationType type> static SIMD_INLINE void Save1(float* ptr, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
+		};
+
+		template <> struct Term<TermLast>
+		{
+			template<SimdConvolutionActivationType type> static SIMD_INLINE void Save0(float* ptr, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+			{
+				svst1_f32(mask, ptr, Activate0<type>(svadd_f32_x(mask, value, bias), param0, param1, mask));
+			}
+
+			template<SimdConvolutionActivationType type> static SIMD_INLINE void Save1(float* ptr, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+			{
+				svst1_f32(mask, ptr, Activate1<type>(svadd_f32_x(mask, value, bias), param0, param1, mask));
+			}
+		};
+
+		template <> struct Term<TermInterim>
+		{
+			template<SimdConvolutionActivationType type> static SIMD_INLINE void Save0(float* ptr, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+			{
+				svst1_f32(mask, ptr, value);
+			}
+
+			template<SimdConvolutionActivationType type> static SIMD_INLINE void Save1(float* ptr, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
+			{
+				svst1_f32(mask, ptr, value);
+			}
+		};
+
+		//-------------------------------------------------------------------------------------------------------
+
+		template<TermType term, SimdConvolutionActivationType type> void OutputConvolution_2x6(const float* src, size_t srcC, size_t srcS,
+			const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst, size_t dstC, size_t tail, int first)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, s0, w0, w1;
+			if (tail > F)
+			{
+				svbool_t mask0 = svptrue_b32();
+				svbool_t mask1 = svwhilelt_b32((uint64_t)0, (uint64_t)(tail == DF ? F : (tail - F)));
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+					d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+					d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+					d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+					d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+					d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0), d01 = svld1_f32(mask1, dst + 0 * dstC + F);
+					d10 = svld1_f32(mask0, dst + 1 * dstC + 0), d11 = svld1_f32(mask1, dst + 1 * dstC + F);
+					d20 = svld1_f32(mask0, dst + 2 * dstC + 0), d21 = svld1_f32(mask1, dst + 2 * dstC + F);
+					d30 = svld1_f32(mask0, dst + 3 * dstC + 0), d31 = svld1_f32(mask1, dst + 3 * dstC + F);
+					d40 = svld1_f32(mask0, dst + 4 * dstC + 0), d41 = svld1_f32(mask1, dst + 4 * dstC + F);
+					d50 = svld1_f32(mask0, dst + 5 * dstC + 0), d51 = svld1_f32(mask1, dst + 5 * dstC + F);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						w1 = svld1_f32(mask1, weight + F);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						d01 = svmla_f32_x(mask1, d01, s0, w1);
+						s0 = svdup_n_f32(src[i + 1 * F]);
+						d10 = svmla_f32_x(mask0, d10, s0, w0);
+						d11 = svmla_f32_x(mask1, d11, s0, w1);
+						s0 = svdup_n_f32(src[i + 2 * F]);
+						d20 = svmla_f32_x(mask0, d20, s0, w0);
+						d21 = svmla_f32_x(mask1, d21, s0, w1);
+						s0 = svdup_n_f32(src[i + 3 * F]);
+						d30 = svmla_f32_x(mask0, d30, s0, w0);
+						d31 = svmla_f32_x(mask1, d31, s0, w1);
+						s0 = svdup_n_f32(src[i + 4 * F]);
+						d40 = svmla_f32_x(mask0, d40, s0, w0);
+						d41 = svmla_f32_x(mask1, d41, s0, w1);
+						s0 = svdup_n_f32(src[i + 5 * F]);
+						d50 = svmla_f32_x(mask0, d50, s0, w0);
+						d51 = svmla_f32_x(mask1, d51, s0, w1);
+					}
+					src += srcS;
+				}
+				if (tail == DF)
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d11, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d21, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d30, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d31, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d40, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d41, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d50, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d51, bias1, param0, param1, mask1);
+				}
+				else
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d11, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d21, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d30, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d31, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d40, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d41, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d50, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d51, bias1, param0, param1, mask1);
+				}
+			}
+			else
+			{
+				svbool_t mask0 = svwhilelt_b32((uint64_t)0, (uint64_t)tail);
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f);
+					d10 = svdup_n_f32(0.0f);
+					d20 = svdup_n_f32(0.0f);
+					d30 = svdup_n_f32(0.0f);
+					d40 = svdup_n_f32(0.0f);
+					d50 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0);
+					d10 = svld1_f32(mask0, dst + 1 * dstC + 0);
+					d20 = svld1_f32(mask0, dst + 2 * dstC + 0);
+					d30 = svld1_f32(mask0, dst + 3 * dstC + 0);
+					d40 = svld1_f32(mask0, dst + 4 * dstC + 0);
+					d50 = svld1_f32(mask0, dst + 5 * dstC + 0);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						s0 = svdup_n_f32(src[i + 1 * F]);
+						d10 = svmla_f32_x(mask0, d10, s0, w0);
+						s0 = svdup_n_f32(src[i + 2 * F]);
+						d20 = svmla_f32_x(mask0, d20, s0, w0);
+						s0 = svdup_n_f32(src[i + 3 * F]);
+						d30 = svmla_f32_x(mask0, d30, s0, w0);
+						s0 = svdup_n_f32(src[i + 4 * F]);
+						d40 = svmla_f32_x(mask0, d40, s0, w0);
+						s0 = svdup_n_f32(src[i + 5 * F]);
+						d50 = svmla_f32_x(mask0, d50, s0, w0);
+					}
+					src += srcS;
+				}
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d30, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d40, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d50, bias0, param0, param1, mask0);
+				}
+			}
+		}
+
+		template<TermType term, SimdConvolutionActivationType type> void OutputConvolution_2x4(const float* src, size_t srcC, size_t srcS,
+			const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst, size_t dstC, size_t tail, int first)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, s0, w0, w1;
+			if (tail > F)
+			{
+				svbool_t mask0 = svptrue_b32();
+				svbool_t mask1 = svwhilelt_b32((uint64_t)0, (uint64_t)(tail == DF ? F : (tail - F)));
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+					d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+					d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+					d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0), d01 = svld1_f32(mask1, dst + 0 * dstC + F);
+					d10 = svld1_f32(mask0, dst + 1 * dstC + 0), d11 = svld1_f32(mask1, dst + 1 * dstC + F);
+					d20 = svld1_f32(mask0, dst + 2 * dstC + 0), d21 = svld1_f32(mask1, dst + 2 * dstC + F);
+					d30 = svld1_f32(mask0, dst + 3 * dstC + 0), d31 = svld1_f32(mask1, dst + 3 * dstC + F);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						w1 = svld1_f32(mask1, weight + F);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						d01 = svmla_f32_x(mask1, d01, s0, w1);
+						s0 = svdup_n_f32(src[i + 1 * F]);
+						d10 = svmla_f32_x(mask0, d10, s0, w0);
+						d11 = svmla_f32_x(mask1, d11, s0, w1);
+						s0 = svdup_n_f32(src[i + 2 * F]);
+						d20 = svmla_f32_x(mask0, d20, s0, w0);
+						d21 = svmla_f32_x(mask1, d21, s0, w1);
+						s0 = svdup_n_f32(src[i + 3 * F]);
+						d30 = svmla_f32_x(mask0, d30, s0, w0);
+						d31 = svmla_f32_x(mask1, d31, s0, w1);
+					}
+					src += srcS;
+				}
+				if (tail == DF)
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d11, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d21, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d30, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d31, bias1, param0, param1, mask1);
+				}
+				else
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d11, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d21, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d30, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d31, bias1, param0, param1, mask1);
+				}
+			}
+			else
+			{
+				svbool_t mask0 = svwhilelt_b32((uint64_t)0, (uint64_t)tail);
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f);
+					d10 = svdup_n_f32(0.0f);
+					d20 = svdup_n_f32(0.0f);
+					d30 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0);
+					d10 = svld1_f32(mask0, dst + 1 * dstC + 0);
+					d20 = svld1_f32(mask0, dst + 2 * dstC + 0);
+					d30 = svld1_f32(mask0, dst + 3 * dstC + 0);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						s0 = svdup_n_f32(src[i + 1 * F]);
+						d10 = svmla_f32_x(mask0, d10, s0, w0);
+						s0 = svdup_n_f32(src[i + 2 * F]);
+						d20 = svmla_f32_x(mask0, d20, s0, w0);
+						s0 = svdup_n_f32(src[i + 3 * F]);
+						d30 = svmla_f32_x(mask0, d30, s0, w0);
+					}
+					src += srcS;
+				}
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d30, bias0, param0, param1, mask0);
+				}
+			}
+		}
+
+		template<TermType term, SimdConvolutionActivationType type> void OutputConvolution_2x3(const float* src, size_t srcC, size_t srcS,
+			const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst, size_t dstC, size_t tail, int first)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			svfloat32_t d00, d01, d10, d11, d20, d21, s0, w0, w1;
+			if (tail > F)
+			{
+				svbool_t mask0 = svptrue_b32();
+				svbool_t mask1 = svwhilelt_b32((uint64_t)0, (uint64_t)(tail == DF ? F : (tail - F)));
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+					d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+					d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0), d01 = svld1_f32(mask1, dst + 0 * dstC + F);
+					d10 = svld1_f32(mask0, dst + 1 * dstC + 0), d11 = svld1_f32(mask1, dst + 1 * dstC + F);
+					d20 = svld1_f32(mask0, dst + 2 * dstC + 0), d21 = svld1_f32(mask1, dst + 2 * dstC + F);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						w1 = svld1_f32(mask1, weight + F);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						d01 = svmla_f32_x(mask1, d01, s0, w1);
+						s0 = svdup_n_f32(src[i + 1 * F]);
+						d10 = svmla_f32_x(mask0, d10, s0, w0);
+						d11 = svmla_f32_x(mask1, d11, s0, w1);
+						s0 = svdup_n_f32(src[i + 2 * F]);
+						d20 = svmla_f32_x(mask0, d20, s0, w0);
+						d21 = svmla_f32_x(mask1, d21, s0, w1);
+					}
+					src += srcS;
+				}
+				if (tail == DF)
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d11, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d21, bias1, param0, param1, mask1);
+				}
+				else
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d11, bias1, param0, param1, mask1);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d21, bias1, param0, param1, mask1);
+				}
+			}
+			else
+			{
+				svbool_t mask0 = svwhilelt_b32((uint64_t)0, (uint64_t)tail);
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f);
+					d10 = svdup_n_f32(0.0f);
+					d20 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0);
+					d10 = svld1_f32(mask0, dst + 1 * dstC + 0);
+					d20 = svld1_f32(mask0, dst + 2 * dstC + 0);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						s0 = svdup_n_f32(src[i + 1 * F]);
+						d10 = svmla_f32_x(mask0, d10, s0, w0);
+						s0 = svdup_n_f32(src[i + 2 * F]);
+						d20 = svmla_f32_x(mask0, d20, s0, w0);
+					}
+					src += srcS;
+				}
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d10, bias0, param0, param1, mask0);
+					dst += dstC;
+					Term<term>::template Save0<type>(dst + 0, d20, bias0, param0, param1, mask0);
+				}
+			}
+		}
+
+		template<TermType term, SimdConvolutionActivationType type> void OutputConvolution_2x1(const float* src, size_t srcC, size_t srcS,
+			const float* weight, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst, size_t dstC, size_t tail, int first)
+		{
+			const size_t F = svcntw(), DF = 2 * F;
+			svfloat32_t d00, d01, s0, w0, w1;
+			if (tail > F)
+			{
+				svbool_t mask0 = svptrue_b32();
+				svbool_t mask1 = svwhilelt_b32((uint64_t)0, (uint64_t)(tail == DF ? F : (tail - F)));
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0), d01 = svld1_f32(mask1, dst + 0 * dstC + F);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						w1 = svld1_f32(mask1, weight + F);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+						d01 = svmla_f32_x(mask1, d01, s0, w1);
+					}
+					src += srcS;
+				}
+				if (tail == DF)
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+				}
+				else
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+					Term<term>::template Save1<type>(dst + F, d01, bias1, param0, param1, mask1);
+				}
+			}
+			else
+			{
+				svbool_t mask0 = svwhilelt_b32((uint64_t)0, (uint64_t)tail);
+				if (first)
+				{
+					d00 = svdup_n_f32(0.0f);
+				}
+				else
+				{
+					d00 = svld1_f32(mask0, dst + 0 * dstC + 0);
+				}
+				for (size_t c = 0; c < srcC; c += F)
+				{
+					size_t n = Simd::Min(F, srcC - c);
+					for (size_t i = 0; i < n; ++i, weight += DF)
+					{
+						w0 = svld1_f32(mask0, weight + 0);
+						s0 = svdup_n_f32(src[i + 0 * F]);
+						d00 = svmla_f32_x(mask0, d00, s0, w0);
+					}
+					src += srcS;
+				}
+				{
+					Term<term>::template Save0<type>(dst + 0, d00, bias0, param0, param1, mask0);
+				}
+			}
+		}
+
+		template<TermType term, SimdConvolutionActivationType type> void OutputConvolution(const float* src, const SimdConvolutionParameters& p,
+			size_t srcC, size_t yBeg, size_t yEnd, const size_t bufH[2], const float* weight, const float* bias, const float* params, float* dst, int first)
+		{
+			assert(p.group == 1 && p.kernelY == 1 && p.strideY == 1);
+			const size_t F = svcntw(), DF = 2 * F;
+			const svbool_t mask = svptrue_b32();
+			size_t srcH = p.srcH, srcW = p.srcW, dstW = p.dstW, dstC = p.dstC;
+			size_t srcM = (bufH[1] - 1), srcS = bufH[1] * srcW * F;
+			size_t dstW3 = AlignLoAny(dstW, 3), dstW6 = AlignLoAny(dstW, 6);
+			svfloat32_t param0 = svdup_n_f32(params[0]), param1 = svdup_n_f32(0.0f);
+			if (type == SimdConvolutionActivationRestrictRange ||
+				type == SimdConvolutionActivationHswish ||
+				type == SimdConvolutionActivationHardSigmoid)
+				param1 = svdup_n_f32(params[1]);
+
+			dst += yBeg * p.dstW * p.dstC;
+			size_t dc = 0;
+			for (; dc < dstC; dc += DF)
+			{
+				size_t tail = Simd::Min(DF, dstC - dc);
+				svfloat32_t bias0 = svld1_f32(mask, bias + dc + 0);
+				svfloat32_t bias1 = svld1_f32(mask, bias + dc + F);
+				if (type == ::SimdConvolutionActivationPrelu)
+				{
+					param0 = svld1_f32(mask, params + dc + 0);
+					param1 = svld1_f32(mask, params + dc + F);
+				}
+				float* pDst = dst + dc;
+				for (size_t y = yBeg; y < yEnd; ++y)
+				{
+					const float* pSrc = src + (y & srcM) * srcW * F;
+					size_t x = 0;
+					for (; x < dstW6; x += 6, pDst += 6 * dstC, pSrc += 6 * F)
+						OutputConvolution_2x6<term, type>(pSrc, srcC, srcS, weight, bias0, bias1, param0, param1, pDst, dstC, tail, first);
+					if (dstW - dstW6 == 4)
+						OutputConvolution_2x4<term, type>(pSrc, srcC, srcS, weight, bias0, bias1, param0, param1, pDst, dstC, tail, first), pDst += 4 * dstC;
+					else
+					{
+						for (; x < dstW3; x += 3, pDst += 3 * dstC, pSrc += 3 * F)
+							OutputConvolution_2x3<term, type>(pSrc, srcC, srcS, weight, bias0, bias1, param0, param1, pDst, dstC, tail, first);
+						for (; x < dstW; ++x, pDst += dstC, pSrc += F)
+							OutputConvolution_2x1<term, type>(pSrc, srcC, srcS, weight, bias0, bias1, param0, param1, pDst, dstC, tail, first);
+					}
+				}
+				weight += srcC * DF;
+			}
+		}
+
+		//-------------------------------------------------------------------------------------------------------
+
+		template <SimdConvolutionActivationType type> void SetOutput(const ConvParam& p, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution)
+		{
+			convolution[0] = OutputConvolution<TermLast, type>;
+			convolution[1] = OutputConvolution<TermInterim, SimdConvolutionActivationIdentity>;
+		}
+
+		}
+
+		void SetOutput(const ConvParam& p, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution)
+		{
+			switch (p.activation)
+			{
+			case SimdConvolutionActivationIdentity: SetOutput<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+			case SimdConvolutionActivationRelu: SetOutput<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+			case SimdConvolutionActivationLeakyRelu: SetOutput<SimdConvolutionActivationPrelu>(p, convolution); break;
+			case SimdConvolutionActivationRestrictRange: SetOutput<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+			case SimdConvolutionActivationPrelu: SetOutput<SimdConvolutionActivationPrelu>(p, convolution); break;
+			case SimdConvolutionActivationElu: SetOutput<SimdConvolutionActivationElu>(p, convolution); break;
+			case SimdConvolutionActivationHswish: SetOutput<SimdConvolutionActivationHswish>(p, convolution); break;
+			case SimdConvolutionActivationMish: SetOutput<SimdConvolutionActivationMish>(p, convolution); break;
+			case SimdConvolutionActivationHardSigmoid: SetOutput<SimdConvolutionActivationHardSigmoid>(p, convolution); break;
+			case SimdConvolutionActivationSwish: SetOutput<SimdConvolutionActivationSwish>(p, convolution); break;
+			case SimdConvolutionActivationGelu: SetOutput<SimdConvolutionActivationGelu>(p, convolution); break;
+			default: assert(0);
+			}
+		}
+	}
+#endif
+}

--- a/src/Simd/SimdSynetMergedConvolution32f.h
+++ b/src/Simd/SimdSynetMergedConvolution32f.h
@@ -340,5 +340,43 @@ namespace Simd
         void * SynetMergedConvolution32fInit(size_t batch, const SimdConvolutionParameters * convs, size_t count, SimdBool add);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void SetInput(const ConvParam& p, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution);
+
+        void SetDepthwise(const ConvParam& p, bool last, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution);
+
+        void SetOutput(const ConvParam& p, Base::SynetMergedConvolution32f::ConvolutionPtr* convolution);
+
+        //-------------------------------------------------------------------------------------------------
+
+        class SynetMergedConvolution32fCdc : public Base::SynetMergedConvolution32fCdc
+        {
+        public:
+            SynetMergedConvolution32fCdc(const MergConvParam& p);
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        class SynetMergedConvolution32fCd : public Base::SynetMergedConvolution32fCd
+        {
+        public:
+            SynetMergedConvolution32fCd(const MergConvParam& p);
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        class SynetMergedConvolution32fDc : public Base::SynetMergedConvolution32fDc
+        {
+        public:
+            SynetMergedConvolution32fDc(const MergConvParam& p);
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetMergedConvolution32fInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
+    }
+#endif
 }
 #endif

--- a/src/Test/TestSynetMergedConvolution32f.cpp
+++ b/src/Test/TestSynetMergedConvolution32f.cpp
@@ -348,6 +348,11 @@ namespace Test
             result = result && SynetMergedConvolution32fForwardAutoTest(EPS, FUNC_MC(Simd::Neon::SynetMergedConvolution32fInit), FUNC_MC(SimdSynetMergedConvolution32fInit));
 #endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetMergedConvolution32fForwardAutoTest(EPS, FUNC_MC(Simd::Sve2::SynetMergedConvolution32fInit), FUNC_MC(SimdSynetMergedConvolution32fInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE2 implementations of `SynetMergedConvolution32fCdc`, `SynetMergedConvolution32fCd`, and `SynetMergedConvolution32fDc` with scalable Input / Depthwise / Output kernels (`svcntw()`, masked loads/stores, no sizeless-type arrays).
- Wire `SimdSynetMergedConvolution32fInit` via `SIMD_SVE2_FUNC`, extend `Test::SynetMergedConvolution32fAutoTest`, register sources in `prj/vs2022/Sve2.vcxproj` + `.filters`, and note the change in `docs/2026.html` (release 7.2.164).
- Small fix in `prj/sh/GetVersion.sh` so version substitution works when the git branch name contains `/`.

## Validation
- Cross-compiled all four new SVE2 sources with `aarch64-linux-gnu-g++ -march=armv9-a+sve+sve2+i8mm+bf16 -msve-vector-bits=scalable` (success).
- x86_64 Release build succeeded; `./Test "-r=.." -fi=SynetMergedConvolution32f -tt=1 -ts=1` passed (Base/Sse41/Avx2/Avx512bw paths on this host; SVE2 path requires ARM64 hardware).

## Test plan
- On ARM64 with SVE2: `./Test "-r=.." -fi=SynetMergedConvolution32f -tt=1 -ts=1` from `build/` with `LD_LIBRARY_PATH` set when using shared libs.
- Spot-check Cdc / Cd / Dc Preferable topologies for correctness and vs NEON performance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd52f6ed-5a8d-41d1-a911-e01831dd42b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd52f6ed-5a8d-41d1-a911-e01831dd42b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

