### PR TITLE
Improve SVE2 InterleaveBgr with svtbl2-based interleave

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -187,6 +187,7 @@
  <li>SSE4.1, AVX2, AVX-512BW, NEON, SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of class SynetConvolution8iNhwcDirect.</li>
  <li>SVE2 optimizations of function InterleaveBgra.</li>
+ <li>SVE2 optimizations of function InterleaveBgr.</li>
 </ul>
 <h5>Removing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2GrayToY.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Int16ToGray.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Interleave.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2InterleaveBgr.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2InterleaveBgra.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -269,6 +269,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Interleave.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2InterleaveBgr.cpp">
+      <Filter>Sve2\Convert</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2InterleaveBgra.cpp">
       <Filter>Sve2\Convert</Filter>
     </ClCompile>

--- a/src/Simd/SimdSve2Interleave.cpp
+++ b/src/Simd/SimdSve2Interleave.cpp
@@ -28,27 +28,6 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE bool InitInterleaveBgrIndex(uint8_t index[3][3][SIMD_SVE2_VECTOR_SIZE_MAX])
-        {
-            size_t A = svlen(svuint8_t());
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
-            for (size_t part = 0; part < 3; ++part)
-            {
-                for (size_t channel = 0; channel < 3; ++channel)
-                {
-                    for (size_t i = 0; i < A; ++i)
-                    {
-                        size_t dst = part * A + i;
-                        index[part][channel][i] = dst % 3 == channel ? (uint8_t)(dst / 3) : 0xFF;
-                    }
-                }
-            }
-            return true;
-        }
-
-        SIMD_ALIGNED(SIMD_ALIGN) uint8_t INTERLEAVE_BGR_INDEX[3][3][SIMD_SVE2_VECTOR_SIZE_MAX];
-        const bool INTERLEAVE_BGR_INDEX_INITED = InitInterleaveBgrIndex(INTERLEAVE_BGR_INDEX);
-
         SIMD_INLINE void InterleaveUv(const uint8_t* u, const uint8_t* v, uint8_t* uv,
             const svbool_t& load, const svbool_t& store0, const svbool_t& store1)
         {
@@ -80,66 +59,6 @@ namespace Simd
                 uv += uvStride;
             }
         }
-
-        //-------------------------------------------------------------------------------------------------
-
-        SIMD_INLINE svuint8_t InterleaveBgr(const svuint8_t& b, const svuint8_t& g, const svuint8_t& r,
-            const svuint8_t& indexB, const svuint8_t& indexG, const svuint8_t& indexR, const svbool_t& mask)
-        {
-            return svorr_u8_x(mask, svorr_u8_x(mask, svtbl_u8(b, indexB), svtbl_u8(g, indexG)), svtbl_u8(r, indexR));
-        }
-
-        SIMD_INLINE void InterleaveBgr(const uint8_t* b, const uint8_t* g, const uint8_t* r, uint8_t* bgr, size_t A,
-            const svuint8_t& indexB0, const svuint8_t& indexG0, const svuint8_t& indexR0,
-            const svuint8_t& indexB1, const svuint8_t& indexG1, const svuint8_t& indexR1,
-            const svuint8_t& indexB2, const svuint8_t& indexG2, const svuint8_t& indexR2,
-            const svbool_t& load, const svbool_t& store0, const svbool_t& store1, const svbool_t& store2)
-        {
-            svuint8_t _b = svld1_u8(load, b);
-            svuint8_t _g = svld1_u8(load, g);
-            svuint8_t _r = svld1_u8(load, r);
-            svst1_u8(store0, bgr + 0 * A, InterleaveBgr(_b, _g, _r, indexB0, indexG0, indexR0, store0));
-            svst1_u8(store1, bgr + 1 * A, InterleaveBgr(_b, _g, _r, indexB1, indexG1, indexR1, store1));
-            svst1_u8(store2, bgr + 2 * A, InterleaveBgr(_b, _g, _r, indexB2, indexG2, indexR2, store2));
-        }
-
-        void InterleaveBgr(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride,
-            size_t width, size_t height, uint8_t* bgr, size_t bgrStride)
-        {
-            size_t A = svcntb(), A3 = A * 3;
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
-            size_t widthA = AlignLo(width, A);
-            const svbool_t body = svptrue_b8();
-            const svbool_t tail = svwhilelt_b8(widthA, width);
-            size_t tailSize = (width - widthA) * 3;
-            const svbool_t tail0 = svwhilelt_b8(size_t(0) * A, tailSize);
-            const svbool_t tail1 = svwhilelt_b8(size_t(1) * A, tailSize);
-            const svbool_t tail2 = svwhilelt_b8(size_t(2) * A, tailSize);
-            const svuint8_t indexB0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][0]);
-            const svuint8_t indexG0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][1]);
-            const svuint8_t indexR0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][2]);
-            const svuint8_t indexB1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][0]);
-            const svuint8_t indexG1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][1]);
-            const svuint8_t indexR1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][2]);
-            const svuint8_t indexB2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][0]);
-            const svuint8_t indexG2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][1]);
-            const svuint8_t indexR2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][2]);
-            for (size_t row = 0; row < height; ++row)
-            {
-                size_t col = 0, offset = 0;
-                for (; col < widthA; col += A, offset += A3)
-                    InterleaveBgr(b + col, g + col, r + col, bgr + offset, A,
-                        indexB0, indexG0, indexR0, indexB1, indexG1, indexR1, indexB2, indexG2, indexR2, body, body, body, body);
-                if (widthA < width)
-                    InterleaveBgr(b + col, g + col, r + col, bgr + offset, A,
-                        indexB0, indexG0, indexR0, indexB1, indexG1, indexR1, indexB2, indexG2, indexR2, tail, tail0, tail1, tail2);
-                b += bStride;
-                g += gStride;
-                r += rStride;
-                bgr += bgrStride;
-            }
-        }
-
     }
 #endif
 }

--- a/src/Simd/SimdSve2InterleaveBgr.cpp
+++ b/src/Simd/SimdSve2InterleaveBgr.cpp
@@ -1,0 +1,117 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE bool InitInterleaveBgrIndex(uint8_t index[3][2][SIMD_SVE2_VECTOR_SIZE_MAX])
+        {
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            for (size_t part = 0; part < 3; ++part)
+            {
+                for (size_t i = 0; i < A; ++i)
+                {
+                    size_t dst = part * A + i;
+                    size_t channel = dst % 3;
+                    size_t pixel = dst / 3;
+                    if (channel == 0)
+                        index[part][0][i] = (uint8_t)pixel;
+                    else if (channel == 1)
+                        index[part][0][i] = (uint8_t)(A + pixel);
+                    else
+                        index[part][0][i] = 0xFF;
+                    if (channel == 2)
+                        index[part][1][i] = (uint8_t)(A + pixel);
+                    else
+                        index[part][1][i] = (uint8_t)i;
+                }
+            }
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t INTERLEAVE_BGR_INDEX[3][2][SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool INTERLEAVE_BGR_INDEX_INITED = InitInterleaveBgrIndex(INTERLEAVE_BGR_INDEX);
+
+        SIMD_INLINE svuint8_t InterleaveBgr(const svuint8x2_t& bg, const svuint8_t& r,
+            const svuint8_t& indexBG, const svuint8_t& indexBGR)
+        {
+            svuint8_t bgPlaced = svtbl2_u8(bg, indexBG);
+            return svtbl2_u8(svcreate2_u8(bgPlaced, r), indexBGR);
+        }
+
+        SIMD_INLINE void InterleaveBgr(const uint8_t* b, const uint8_t* g, const uint8_t* r, uint8_t* bgr, size_t A,
+            const svuint8_t& indexBG0, const svuint8_t& indexBGR0,
+            const svuint8_t& indexBG1, const svuint8_t& indexBGR1,
+            const svuint8_t& indexBG2, const svuint8_t& indexBGR2,
+            const svbool_t& load, const svbool_t& store0, const svbool_t& store1, const svbool_t& store2)
+        {
+            svuint8_t _b = svld1_u8(load, b);
+            svuint8_t _g = svld1_u8(load, g);
+            svuint8_t _r = svld1_u8(load, r);
+            svuint8x2_t bg = svcreate2_u8(_b, _g);
+            svst1_u8(store0, bgr + 0 * A, InterleaveBgr(bg, _r, indexBG0, indexBGR0));
+            svst1_u8(store1, bgr + 1 * A, InterleaveBgr(bg, _r, indexBG1, indexBGR1));
+            svst1_u8(store2, bgr + 2 * A, InterleaveBgr(bg, _r, indexBG2, indexBGR2));
+        }
+
+        void InterleaveBgr(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride,
+            size_t width, size_t height, uint8_t* bgr, size_t bgrStride)
+        {
+            size_t A = svcntb(), A3 = A * 3;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t widthA = AlignLo(width, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
+            size_t tailSize = (width - widthA) * 3;
+            const svbool_t tail0 = svwhilelt_b8(size_t(0) * A, tailSize);
+            const svbool_t tail1 = svwhilelt_b8(size_t(1) * A, tailSize);
+            const svbool_t tail2 = svwhilelt_b8(size_t(2) * A, tailSize);
+            const svuint8_t indexBG0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][0]);
+            const svuint8_t indexBGR0 = svld1_u8(body, INTERLEAVE_BGR_INDEX[0][1]);
+            const svuint8_t indexBG1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][0]);
+            const svuint8_t indexBGR1 = svld1_u8(body, INTERLEAVE_BGR_INDEX[1][1]);
+            const svuint8_t indexBG2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][0]);
+            const svuint8_t indexBGR2 = svld1_u8(body, INTERLEAVE_BGR_INDEX[2][1]);
+            for (size_t row = 0; row < height; ++row)
+            {
+                size_t col = 0, offset = 0;
+                for (; col < widthA; col += A, offset += A3)
+                    InterleaveBgr(b + col, g + col, r + col, bgr + offset, A,
+                        indexBG0, indexBGR0, indexBG1, indexBGR1, indexBG2, indexBGR2, body, body, body, body);
+                if (widthA < width)
+                    InterleaveBgr(b + col, g + col, r + col, bgr + offset, A,
+                        indexBG0, indexBGR0, indexBG1, indexBGR1, indexBG2, indexBGR2, tail, tail0, tail1, tail2);
+                b += bStride;
+                g += gStride;
+                r += rStride;
+                bgr += bgrStride;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2InterleaveBgr.cpp
+++ b/src/Simd/SimdSve2InterleaveBgr.cpp
@@ -57,26 +57,25 @@ namespace Simd
         SIMD_ALIGNED(SIMD_ALIGN) uint8_t INTERLEAVE_BGR_INDEX[3][2][SIMD_SVE2_VECTOR_SIZE_MAX];
         const bool INTERLEAVE_BGR_INDEX_INITED = InitInterleaveBgrIndex(INTERLEAVE_BGR_INDEX);
 
-        SIMD_INLINE svuint8_t InterleaveBgr(const svuint8x2_t& bg, const svuint8_t& r,
-            const svuint8_t& indexBG, const svuint8_t& indexBGR)
+        SIMD_INLINE svuint8_t InterleaveBgr(svuint8_t b, svuint8_t g, svuint8_t r,
+            svuint8_t indexBG, svuint8_t indexBGR)
         {
-            svuint8_t bgPlaced = svtbl2_u8(bg, indexBG);
+            svuint8_t bgPlaced = svtbl2_u8(svcreate2_u8(b, g), indexBG);
             return svtbl2_u8(svcreate2_u8(bgPlaced, r), indexBGR);
         }
 
         SIMD_INLINE void InterleaveBgr(const uint8_t* b, const uint8_t* g, const uint8_t* r, uint8_t* bgr, size_t A,
-            const svuint8_t& indexBG0, const svuint8_t& indexBGR0,
-            const svuint8_t& indexBG1, const svuint8_t& indexBGR1,
-            const svuint8_t& indexBG2, const svuint8_t& indexBGR2,
-            const svbool_t& load, const svbool_t& store0, const svbool_t& store1, const svbool_t& store2)
+            svuint8_t indexBG0, svuint8_t indexBGR0,
+            svuint8_t indexBG1, svuint8_t indexBGR1,
+            svuint8_t indexBG2, svuint8_t indexBGR2,
+            svbool_t load, svbool_t store0, svbool_t store1, svbool_t store2)
         {
             svuint8_t _b = svld1_u8(load, b);
             svuint8_t _g = svld1_u8(load, g);
             svuint8_t _r = svld1_u8(load, r);
-            svuint8x2_t bg = svcreate2_u8(_b, _g);
-            svst1_u8(store0, bgr + 0 * A, InterleaveBgr(bg, _r, indexBG0, indexBGR0));
-            svst1_u8(store1, bgr + 1 * A, InterleaveBgr(bg, _r, indexBG1, indexBGR1));
-            svst1_u8(store2, bgr + 2 * A, InterleaveBgr(bg, _r, indexBG2, indexBGR2));
+            svst1_u8(store0, bgr + 0 * A, InterleaveBgr(_b, _g, _r, indexBG0, indexBGR0));
+            svst1_u8(store1, bgr + 1 * A, InterleaveBgr(_b, _g, _r, indexBG1, indexBGR1));
+            svst1_u8(store2, bgr + 2 * A, InterleaveBgr(_b, _g, _r, indexBG2, indexBGR2));
         }
 
         void InterleaveBgr(const uint8_t* b, size_t bStride, const uint8_t* g, size_t gStride, const uint8_t* r, size_t rStride,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Replace per-channel `svtbl_u8`/`svorr_u8_x` `Sve2::InterleaveBgr` with nested `svtbl2_u8` lookups over `(b,g)` then `(bg,r)`, avoiding OR-merge of three table results.
- Move the implementation into `SimdSve2InterleaveBgr.cpp` and register it in the VS2022 SVE2 project.
- Document the improvement under release 7.2.164.

### Testing
- Python simulation of nested `svtbl2` for VL=8/16/32/64 matches expected BGR layout
- `aarch64-linux-gnu-g++ -std=c++17 -O3 -DNDEBUG -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c src/Simd/SimdSve2InterleaveBgr.cpp` (OK; asm uses dual-vector `tbl`, no `st3`)
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=InterleaveBgr -tt=1 -ts=1` from `build/` (passed; also covers InterleaveBgra)
- `./Test "-r=.." -fi=InterleaveBgra -tt=1 -ts=1` from `build/` (passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9b4c25d-6a5a-4e48-9d94-fbdf6c18008d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9b4c25d-6a5a-4e48-9d94-fbdf6c18008d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

