### PR TITLE
Remove SVE DeinterleaveUv optimization.

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -200,6 +200,7 @@
  <li>SVE optimization of function InterleaveUv.</li>
  <li>SVE optimization of function InterleaveBgra.</li>
  <li>SVE optimization of function InterleaveBgr.</li>
+ <li>SVE optimization of function DeinterleaveUv.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2205,11 +2205,6 @@ SIMD_API void SimdDeinterleaveUv(const uint8_t * uv, size_t uvStride, size_t wid
         Sve2::DeinterleaveUv(uv, uvStride, width, height, u, uStride, v, vStride);
     else
 #endif
-#ifdef SIMD_SVE_ENABLE
-    if (Sve::Enable)
-        Sve::DeinterleaveUv(uv, uvStride, width, height, u, uStride, v, vStride);
-    else
-#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::DeinterleaveUv(uv, uvStride, width, height, u, uStride, v, vStride);

--- a/src/Simd/SimdSve1.h
+++ b/src/Simd/SimdSve1.h
@@ -31,8 +31,6 @@ namespace Simd
 #ifdef SIMD_SVE_ENABLE
     namespace Sve
     {
-        void DeinterleaveUv(const uint8_t* uv, size_t uvStride, size_t width, size_t height, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride);
-
         void DeinterleaveBgr(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride);
 

--- a/src/Simd/SimdSve1Deinterleave.cpp
+++ b/src/Simd/SimdSve1Deinterleave.cpp
@@ -29,45 +29,6 @@ namespace Simd
 #ifdef SIMD_SVE_ENABLE    
     namespace Sve
     {
-        template <int U, int V> void DeinterleaveUv(const uint8_t * uv, size_t uvStride, size_t width, size_t height, uint8_t * u, size_t uStride, uint8_t * v, size_t vStride)
-        {
-            size_t A = svlen(svuint8_t()), A2 = A * 2;
-            size_t widthA = AlignLo(width, A);
-            const svbool_t body = svwhilelt_b8(size_t(0), A);
-            const svbool_t tail = svwhilelt_b8(widthA, width);
-            for (size_t row = 0; row < height; ++row)
-            {
-                size_t col = 0, offset = 0;
-                for (; col < widthA; col += A, offset += A2)
-                {
-                    svuint8x2_t _uv = svld2_u8(body, uv + offset);
-                    if (U) svst1_u8(body, u + col, svget2(_uv, 0));
-                    if (V) svst1_u8(body, v + col, svget2(_uv, 1));
-                }
-                if (widthA < width)
-                {
-                    svuint8x2_t _uv = svld2_u8(tail, uv + offset);
-                    if (U) svst1_u8(tail, u + col, svget2(_uv, 0));
-                    if (V) svst1_u8(tail, v + col, svget2(_uv, 1));
-                }
-                uv += uvStride;
-                if (U) u += uStride;
-                if (V) v += vStride;
-            }
-        }
-
-        void DeinterleaveUv(const uint8_t* uv, size_t uvStride, size_t width, size_t height, uint8_t* u, size_t uStride, uint8_t* v, size_t vStride)
-        {
-            if (u && v)
-                DeinterleaveUv<1, 1>(uv, uvStride, width, height, u, uStride, v, vStride);
-            else if (u)
-                DeinterleaveUv<1, 0>(uv, uvStride, width, height, u, uStride, v, vStride);
-            else if (v)
-                DeinterleaveUv<0, 1>(uv, uvStride, width, height, u, uStride, v, vStride);
-        }
-
-        //-------------------------------------------------------------------------------------------------
-
         template <int B, int G, int R> void DeinterleaveBgr(const uint8_t * bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t * b, size_t bStride, uint8_t * g, size_t gStride, uint8_t * r, size_t rStride)
         {

--- a/src/Test/TestDeinterleave.cpp
+++ b/src/Test/TestDeinterleave.cpp
@@ -136,11 +136,6 @@ namespace Test
             result = result && DeinterleaveUvAutoTest(FUNC2(Simd::Neon::DeinterleaveUv), FUNC2(SimdDeinterleaveUv));
 #endif 
 
-#ifdef SIMD_SVE_ENABLE
-        if (Simd::Sve::Enable && TestSve(options))
-            result = result && DeinterleaveUvAutoTest(FUNC2(Simd::Sve::DeinterleaveUv), FUNC2(SimdDeinterleaveUv));
-#endif 
-
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
             result = result && DeinterleaveUvAutoTest(FUNC2(Simd::Sve2::DeinterleaveUv), FUNC2(SimdDeinterleaveUv));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the SVE (`Sve::`) optimization of `SimdDeinterleaveUv`, matching recent removals of other SVE paths that are superseded by SVE2.

### Changes
- Remove `Sve::DeinterleaveUv` from `src/Simd/SimdSve1Deinterleave.cpp` (file kept for remaining `DeinterleaveBgr` / `DeinterleaveBgra`)
- Remove declaration from `SimdSve1.h`
- Remove `Sve::DeinterleaveUv` dispatch from `SimdLib.cpp` (SVE2 / NEON / Base remain)
- Drop the SVE auto-test leg in `Test::DeinterleaveUvAutoTest`
- No `prj/vs2022/Sve1.vcxproj` / `.filters` changes (source file not deleted)
- Document under release **7.2.164** Removing section in `docs/2026.html`

## Test plan
- [x] CMake Release build with g++
- [x] Run `./Test "-r=.." -fi=DeinterleaveUv -tt=1 -ts=1` smoke test (passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d4c91b9-dcd1-4575-8d36-cc628dc531a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d4c91b9-dcd1-4575-8d36-cc628dc531a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

