### PR TITLE
Remove SVE DeinterleaveBgra optimization.

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -201,6 +201,7 @@
  <li>SVE optimization of function InterleaveBgra.</li>
  <li>SVE optimization of function InterleaveBgr.</li>
  <li>SVE optimization of function DeinterleaveUv.</li>
+ <li>SVE optimization of function DeinterleaveBgra.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -2284,11 +2284,6 @@ SIMD_API void SimdDeinterleaveBgra(const uint8_t * bgra, size_t bgraStride, size
         Sve2::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
     else
 #endif
-#ifdef SIMD_SVE_ENABLE
-    if (Sve::Enable)
-        Sve::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-    else
-#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::A)
         Neon::DeinterleaveBgra(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);

--- a/src/Simd/SimdSve1.h
+++ b/src/Simd/SimdSve1.h
@@ -34,9 +34,6 @@ namespace Simd
         void DeinterleaveBgr(const uint8_t* bgr, size_t bgrStride, size_t width, size_t height,
             uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride);
 
-        void DeinterleaveBgra(const uint8_t* bgra, size_t bgraStride, size_t width, size_t height,
-            uint8_t* b, size_t bStride, uint8_t* g, size_t gStride, uint8_t* r, size_t rStride, uint8_t* a, size_t aStride);
-
         void OperationBinary8u(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride, SimdOperationBinary8uType type);
 
         void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdOperationBinary16iType type);

--- a/src/Simd/SimdSve1Deinterleave.cpp
+++ b/src/Simd/SimdSve1Deinterleave.cpp
@@ -71,62 +71,6 @@ namespace Simd
             else if (g) DeinterleaveBgr<0, 1, 0>(bgr, bgrStride, width, height, b, bStride, g, gStride, r, rStride);
             else if (r) DeinterleaveBgr<0, 0, 1>(bgr, bgrStride, width, height, b, bStride, g, gStride, r, rStride);
         }
-
-        //-------------------------------------------------------------------------------------------------
-
-        template <int B, int G, int R, int A> void DeinterleaveBgra(const uint8_t * bgra, size_t bgraStride, size_t width, size_t height,
-            uint8_t * b, size_t bStride, uint8_t * g, size_t gStride, uint8_t * r, size_t rStride, uint8_t * a, size_t aStride)
-        {
-            size_t VL = svlen(svuint8_t()), VL4 = VL * 4;
-            size_t widthA = AlignLo(width, VL);
-            const svbool_t body = svwhilelt_b8(size_t(0), VL);
-            const svbool_t tail = svwhilelt_b8(widthA, width);
-            for (size_t row = 0; row < height; ++row)
-            {
-                size_t col = 0, offset = 0;
-                for (; col < widthA; col += VL, offset += VL4)
-                {
-                    svuint8x4_t _bgra = svld4_u8(body, bgra + offset);
-                    if (B) svst1_u8(body, b + col, svget4(_bgra, 0));
-                    if (G) svst1_u8(body, g + col, svget4(_bgra, 1));
-                    if (R) svst1_u8(body, r + col, svget4(_bgra, 2));
-                    if (A) svst1_u8(body, a + col, svget4(_bgra, 3));
-                }
-                if (widthA < width)
-                {
-                    svuint8x4_t _bgra = svld4_u8(tail, bgra + offset);
-                    if (B) svst1_u8(tail, b + col, svget4(_bgra, 0));
-                    if (G) svst1_u8(tail, g + col, svget4(_bgra, 1));
-                    if (R) svst1_u8(tail, r + col, svget4(_bgra, 2));
-                    if (A) svst1_u8(tail, a + col, svget4(_bgra, 3));
-                }
-                bgra += bgraStride;
-                if (B) b += bStride;
-                if (G) g += gStride;
-                if (R) r += rStride;
-                if (A) a += aStride;
-            }
-        }
-
-        void DeinterleaveBgra(const uint8_t * bgra, size_t bgraStride, size_t width, size_t height,
-            uint8_t * b, size_t bStride, uint8_t * g, size_t gStride, uint8_t * r, size_t rStride, uint8_t * a, size_t aStride)
-        {
-            if (b && g && r && a) DeinterleaveBgra<1, 1, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b && g && r) DeinterleaveBgra<1, 1, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b && g && a) DeinterleaveBgra<1, 1, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b && g) DeinterleaveBgra<1, 1, 0, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b && r && a) DeinterleaveBgra<1, 0, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b && r) DeinterleaveBgra<1, 0, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b && a) DeinterleaveBgra<1, 0, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (b) DeinterleaveBgra<1, 0, 0, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (g && r && a) DeinterleaveBgra<0, 1, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (g && r) DeinterleaveBgra<0, 1, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (g && a) DeinterleaveBgra<0, 1, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (g) DeinterleaveBgra<0, 1, 0, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (r && a) DeinterleaveBgra<0, 0, 1, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (r) DeinterleaveBgra<0, 0, 1, 0>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-            else if (a) DeinterleaveBgra<0, 0, 0, 1>(bgra, bgraStride, width, height, b, bStride, g, gStride, r, rStride, a, aStride);
-        }
     }
 #endif
 }

--- a/src/Test/TestDeinterleave.cpp
+++ b/src/Test/TestDeinterleave.cpp
@@ -404,11 +404,6 @@ namespace Test
             result = result && DeinterleaveBgraAutoTest(FUNC4(Simd::Neon::DeinterleaveBgra), FUNC4(SimdDeinterleaveBgra));
 #endif 
 
-#ifdef SIMD_SVE_ENABLE
-        if (Simd::Sve::Enable && TestSve(options))
-            result = result && DeinterleaveBgraAutoTest(FUNC4(Simd::Sve::DeinterleaveBgra), FUNC4(SimdDeinterleaveBgra));
-#endif
-
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
             result = result && DeinterleaveBgraAutoTest(FUNC4(Simd::Sve2::DeinterleaveBgra), FUNC4(SimdDeinterleaveBgra));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the SVE (`Sve::`) optimization of `SimdDeinterleaveBgra`, matching recent removals of other SVE paths that are superseded by SVE2.

### Changes
- Remove `Sve::DeinterleaveBgra` from `src/Simd/SimdSve1Deinterleave.cpp` (file kept for remaining `DeinterleaveBgr`)
- Remove declaration from `SimdSve1.h`
- Remove `Sve::DeinterleaveBgra` dispatch from `SimdLib.cpp` (SVE2 / NEON / Base remain)
- Drop the SVE auto-test leg in `Test::DeinterleaveBgraAutoTest`
- No `prj/vs2022/Sve1.vcxproj` / `.filters` changes (source file not deleted)
- Document under release **7.2.164** Removing section in `docs/2026.html`

## Test plan
- [x] CMake Release build with g++
- [x] Run `./Test "-r=.." -fi=DeinterleaveBgra -tt=1 -ts=1` smoke test (passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e757e02-75e9-467c-8ef6-6c9e492639d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e757e02-75e9-467c-8ef6-6c9e492639d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

