### PR TITLE
Remove SVE OperationBinary16i optimization.

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -203,6 +203,7 @@
  <li>SVE optimization of function DeinterleaveUv.</li>
  <li>SVE optimization of function DeinterleaveBgra.</li>
  <li>SVE optimization of function DeinterleaveBgr.</li>
+ <li>SVE optimization of function OperationBinary16i.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -4673,11 +4673,6 @@ SIMD_API void SimdOperationBinary16i(const uint8_t * a, size_t aStride, const ui
         Sve2::OperationBinary16i(a, aStride, b, bStride, width, height, dst, dstStride, type);
     else
 #endif
-#ifdef SIMD_SVE_ENABLE
-    if (Sve::Enable)
-        Sve::OperationBinary16i(a, aStride, b, bStride, width, height, dst, dstStride, type);
-    else
-#endif
 #ifdef SIMD_NEON_ENABLE
     if (Neon::Enable && width >= Neon::HA)
         Neon::OperationBinary16i(a, aStride, b, bStride, width, height, dst, dstStride, type);

--- a/src/Simd/SimdSve1.h
+++ b/src/Simd/SimdSve1.h
@@ -33,8 +33,6 @@ namespace Simd
     {
         void OperationBinary8u(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, size_t channelCount, uint8_t* dst, size_t dstStride, SimdOperationBinary8uType type);
 
-        void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdOperationBinary16iType type);
-
         void GetStatistic(const uint8_t* src, size_t stride, size_t width, size_t height, uint8_t* min, uint8_t* max, uint8_t* average);
     }
 #endif

--- a/src/Simd/SimdSve1Operation.cpp
+++ b/src/Simd/SimdSve1Operation.cpp
@@ -123,60 +123,6 @@ namespace Simd
                 assert(0);
             }
         }
-
-        //-------------------------------------------------------------------------------------------------
-
-        template <SimdOperationBinary16iType type> SIMD_INLINE svint16_t OperationBinary16i(const svbool_t& mask, const svint16_t& a, const svint16_t& b);
-
-        template <> SIMD_INLINE svint16_t OperationBinary16i<SimdOperationBinary16iAddition>(const svbool_t& mask, const svint16_t& a, const svint16_t& b)
-        {
-            return svadd_x(mask, a, b);
-        }
-
-        template <> SIMD_INLINE svint16_t OperationBinary16i<SimdOperationBinary16iSubtraction>(const svbool_t& mask, const svint16_t& a, const svint16_t& b)
-        {
-            return svsub_x(mask, a, b);
-        }
-
-        template <SimdOperationBinary16iType type> void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
-        {
-            size_t A = svlen(svint16_t());
-            size_t widthA = Simd::AlignLo(width, A);
-            const svbool_t body = svwhilelt_b16(size_t(0), A);
-            const svbool_t tail = svwhilelt_b16(widthA, width);
-            for (size_t row = 0; row < height; ++row)
-            {
-                size_t col = 0;
-                for (; col < widthA; col += A)
-                {
-                    const svint16_t _a = svld1_s16(body, (int16_t*)a + col);
-                    const svint16_t _b = svld1_s16(body, (int16_t*)b + col);
-                    svst1_s16(body, (int16_t*)dst + col, OperationBinary16i<type>(body, _a, _b));
-                }
-                if (widthA < width)
-                {
-                    const svint16_t _a = svld1_s16(tail, (int16_t*)a + col);
-                    const svint16_t _b = svld1_s16(tail, (int16_t*)b + col);
-                    svst1_s16(tail, (int16_t*)dst + col, OperationBinary16i<type>(tail, _a, _b));
-                }
-                a += aStride;
-                b += bStride;
-                dst += dstStride;
-            }
-        }
-
-        void OperationBinary16i(const uint8_t* a, size_t aStride, const uint8_t* b, size_t bStride, size_t width, size_t height, uint8_t* dst, size_t dstStride, SimdOperationBinary16iType type)
-        {
-            switch (type)
-            {
-            case SimdOperationBinary16iAddition:
-                return OperationBinary16i<SimdOperationBinary16iAddition>(a, aStride, b, bStride, width, height, dst, dstStride);
-            case SimdOperationBinary16iSubtraction:
-                return OperationBinary16i<SimdOperationBinary16iSubtraction>(a, aStride, b, bStride, width, height, dst, dstStride);
-            default:
-                assert(0);
-            }
-        }
     }
 #endif
 }

--- a/src/Test/TestOperation.cpp
+++ b/src/Test/TestOperation.cpp
@@ -268,11 +268,6 @@ namespace Test
             result = result && OperationBinary16iAutoTest(FUNC_OB16I(Simd::Neon::OperationBinary16i), FUNC_OB16I(SimdOperationBinary16i));
 #endif
 
-#ifdef SIMD_SVE_ENABLE
-        if (Simd::Sve::Enable && TestSve(options))
-            result = result && OperationBinary16iAutoTest(FUNC_OB16I(Simd::Sve::OperationBinary16i), FUNC_OB16I(SimdOperationBinary16i));
-#endif
-
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
             result = result && OperationBinary16iAutoTest(FUNC_OB16I(Simd::Sve2::OperationBinary16i), FUNC_OB16I(SimdOperationBinary16i));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove `Sve::OperationBinary16i` from `SimdSve1Operation.cpp` (file kept for remaining `OperationBinary8u`).
- Drop the SVE declaration, dispatch path in `SimdLib.cpp`, and `OperationBinary16iAutoTest` SVE coverage.
- No `Sve1.vcxproj` / filters changes — the source file is not empty and remains in the project.
- Document the removal under release **7.2.164** in `docs/2026.html`.

SVE2 `OperationBinary16i` is unchanged.

## Test plan
- [x] Build with CMake (Release, g++)
- [x] Run `./Test "-r=.." -fi=OperationBinary16i -tt=1 -ts=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f0ced5-3ba9-4d86-8f83-ff86d79a6f98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f0ced5-3ba9-4d86-8f83-ff86d79a6f98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

