### PR TITLE
Improve SVE2 Base64Decode performance

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -189,6 +189,7 @@
  <li>SVE2 optimizations of function InterleaveBgra.</li>
  <li>SVE2 optimizations of function InterleaveBgr.</li>
  <li>SVE2 optimizations of function AlphaUnpremultiply.</li>
+ <li>SVE2 optimizations of function Base64Decode.</li>
 </ul>
 <h5>Removing</h5>
 <ul>

--- a/src/Simd/SimdSve2Base64.cpp
+++ b/src/Simd/SimdSve2Base64.cpp
@@ -29,27 +29,45 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE bool InitBase64DecodeCompactIndex(uint8_t index[SIMD_SVE2_VECTOR_SIZE_MAX])
-        {
-            size_t A = svlen(svuint8_t());
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
-            size_t dstSize = A * 3 / 4;
-            for (size_t i = 0; i < dstSize; ++i)
-                index[i] = (uint8_t)(i + i / 3);
-            for (size_t i = dstSize; i < A; ++i)
-                index[i] = 0xFF;
-            return true;
-        }
-
-        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BASE64_DECODE_COMPACT_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
-        const bool BASE64_DECODE_COMPACT_INDEX_INITED = InitBase64DecodeCompactIndex(BASE64_DECODE_COMPACT_INDEX);
-
         const uint8_t BASE64_FROM_DIG_SHUFFLE[16] = {
             62, 0xFF, 0xFF, 0xFF, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0xFF };
 
-        SIMD_INLINE svuint8_t FromBase64(const svuint8_t& src, const svbool_t& mask, const svuint8_t& fromDig)
+        // Per 16-byte lane shuffle patterns from the SSE4.1 Base64Decode pack.
+        const uint8_t BASE64_DECODE_SHUFFLE_LO[16] = {
+            0x1, 0x3, 0x2, 0x5, 0x7, 0x6, 0x9, 0xB, 0xA, 0xD, 0xF, 0xE, 0xFF, 0xFF, 0xFF, 0xFF };
+        const uint8_t BASE64_DECODE_SHUFFLE_HI[16] = {
+            0x1, 0x0, 0x2, 0x5, 0x4, 0x6, 0x9, 0x8, 0xA, 0xD, 0xC, 0xE, 0xFF, 0xFF, 0xFF, 0xFF };
+
+        SIMD_INLINE bool InitBase64DecodeShuffleIndex(uint8_t shuffleLo[SIMD_SVE2_VECTOR_SIZE_MAX],
+            uint8_t shuffleHi[SIMD_SVE2_VECTOR_SIZE_MAX], uint8_t compact[SIMD_SVE2_VECTOR_SIZE_MAX])
         {
-            const svuint8_t zero = svdup_n_u8(0);
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX && (A % 16) == 0);
+            for (size_t i = 0; i < A; ++i)
+            {
+                size_t lane = i / 16, j = i % 16;
+                uint8_t lo = BASE64_DECODE_SHUFFLE_LO[j];
+                uint8_t hi = BASE64_DECODE_SHUFFLE_HI[j];
+                shuffleLo[i] = lo == 0xFF ? 0xFF : (uint8_t)(lane * 16 + lo);
+                shuffleHi[i] = hi == 0xFF ? 0xFF : (uint8_t)(lane * 16 + hi);
+            }
+            size_t dstSize = A * 3 / 4;
+            for (size_t i = 0; i < dstSize; ++i)
+                compact[i] = (uint8_t)((i / 12) * 16 + (i % 12));
+            for (size_t i = dstSize; i < A; ++i)
+                compact[i] = 0xFF;
+            return true;
+        }
+
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BASE64_DECODE_SHUFFLE_LO_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BASE64_DECODE_SHUFFLE_HI_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BASE64_DECODE_COMPACT_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool BASE64_DECODE_INDEX_INITED = InitBase64DecodeShuffleIndex(
+            BASE64_DECODE_SHUFFLE_LO_INDEX, BASE64_DECODE_SHUFFLE_HI_INDEX, BASE64_DECODE_COMPACT_INDEX);
+
+        SIMD_INLINE svuint8_t FromBase64(svuint8_t src, svbool_t mask, svuint8_t fromDig)
+        {
+            svuint8_t zero = svdup_n_u8(0);
             svbool_t letMask = svcmpgt_n_u8(mask, src, '9');
             svbool_t lowMask = svcmpgt_n_u8(mask, src, 'Z');
             svuint8_t lowValue = svsel_u8(lowMask, svsub_n_u8_x(mask, src, 'a' - 26), zero);
@@ -61,26 +79,30 @@ namespace Simd
             return svsel_u8(svcmpeq_n_u8(mask, src, '_'), svdup_n_u8(63), dst);
         }
 
-        SIMD_INLINE void Base64Decode(const uint8_t* src, uint8_t* dst, const svbool_t& load,
-            const svbool_t& store, const svbool_t& mask32, const svuint8_t& fromDig, const svuint8_t& compact)
+        SIMD_INLINE svuint8_t Base64DecodePack(svuint8_t from,
+            svuint16_t mulLoK, svuint16_t mulHiK, svuint8_t shuffleLo, svuint8_t shuffleHi)
         {
-            svuint8_t from = FromBase64(svld1_u8(load, src), load, fromDig);
+            const svbool_t mask16 = svptrue_b16();
+            svuint16_t words = svreinterpret_u16_u8(from);
+            svuint16_t mulLo = svmul_u16_x(mask16, svand_n_u16_x(mask16, words, 0x003F), mulLoK);
+            svuint16_t mulHi = svmulh_u16_x(mask16, svand_n_u16_x(mask16, words, 0x3F00), mulHiK);
+            const svbool_t mask8 = svptrue_b8();
+            return svorr_u8_x(mask8,
+                svtbl_u8(svreinterpret_u8_u16(mulHi), shuffleHi),
+                svtbl_u8(svreinterpret_u8_u16(mulLo), shuffleLo));
+        }
 
-            svuint32_t v = svreinterpret_u32_u8(from);
-            svuint32_t s0 = svand_n_u32_x(mask32, v, 0xFF);
-            svuint32_t s1 = svand_n_u32_x(mask32, svlsr_n_u32_x(mask32, v, 8), 0xFF);
-            svuint32_t s2 = svand_n_u32_x(mask32, svlsr_n_u32_x(mask32, v, 16), 0xFF);
-            svuint32_t s3 = svlsr_n_u32_x(mask32, v, 24);
-
-            svuint32_t d0 = svorr_u32_x(mask32, svlsl_n_u32_x(mask32, s0, 2), svlsr_n_u32_x(mask32, s1, 4));
-            svuint32_t d1 = svorr_u32_x(mask32, svlsl_n_u32_x(mask32, svand_n_u32_x(mask32, s1, 0x0F), 4),
-                svlsr_n_u32_x(mask32, s2, 2));
-            svuint32_t d2 = svorr_u32_x(mask32, svlsl_n_u32_x(mask32, svand_n_u32_x(mask32, s2, 0x03), 6), s3);
-
-            svuint32_t out = svorr_u32_x(mask32, d0, svlsl_n_u32_x(mask32, d1, 8));
-            out = svorr_u32_x(mask32, out, svlsl_n_u32_x(mask32, d2, 16));
-
-            svst1_u8(store, dst, svtbl_u8(svreinterpret_u8_u32(out), compact));
+        template<bool narrow> SIMD_INLINE void Base64Decode(const uint8_t* src, uint8_t* dst, svbool_t mask,
+            svuint8_t fromDig, svuint16_t mulLoK, svuint16_t mulHiK,
+            svuint8_t shuffleLo, svuint8_t shuffleHi, svuint8_t compact)
+        {
+            svuint8_t packed = Base64DecodePack(FromBase64(svld1_u8(mask, src), mask, fromDig),
+                mulLoK, mulHiK, shuffleLo, shuffleHi);
+            if (narrow)
+                packed = svtbl_u8(packed, compact);
+            // Full-vector store: only the first 3/4 lanes are valid; the next overlapping
+            // store (or scalar tail) overwrites the garbage, matching SSE4.1/AVX.
+            svst1_u8(mask, dst, packed);
         }
 
         void Base64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst, size_t* dstSize)
@@ -88,19 +110,36 @@ namespace Simd
             assert(srcSize % 4 == 0 && srcSize >= 4);
 
             size_t A = svlen(svuint8_t()), dstStep = A * 3 / 4;
-            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX && (A % 4) == 0);
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX && (A % 16) == 0);
 
-            size_t srcSize4 = srcSize - 4;
-            size_t srcSizeA = AlignLo(srcSize4, A);
+            size_t srcSizeA = srcSize >= A ? AlignLoAny(srcSize - (A - 1), A) : 0;
 
             const svbool_t body = svptrue_b8();
-            const svbool_t body32 = svptrue_b32();
-            const svbool_t store = svwhilelt_b8((size_t)0, dstStep);
             const svuint8_t fromDig = svld1rq_u8(body, BASE64_FROM_DIG_SHUFFLE);
+            const svuint16_t mulLoK = svreinterpret_u16_u32(svdup_n_u32(0x00400400));
+            const svuint16_t mulHiK = svreinterpret_u16_u32(svdup_n_u32(0x01001000));
+            const svuint8_t shuffleLo = svld1_u8(body, BASE64_DECODE_SHUFFLE_LO_INDEX);
+            const svuint8_t shuffleHi = svld1_u8(body, BASE64_DECODE_SHUFFLE_HI_INDEX);
             const svuint8_t compact = svld1_u8(body, BASE64_DECODE_COMPACT_INDEX);
 
-            for (const uint8_t* bodyA = src + srcSizeA; src < bodyA; src += A, dst += dstStep)
-                Base64Decode(src, dst, body, store, body32, fromDig, compact);
+            if (A == 16)
+            {
+                size_t srcSize64 = AlignLo(srcSizeA, 64);
+                for (const uint8_t* body64 = src + srcSize64; src < body64; src += 64, dst += 48)
+                {
+                    Base64Decode<false>(src + 0, dst + 0, body, fromDig, mulLoK, mulHiK, shuffleLo, shuffleHi, compact);
+                    Base64Decode<false>(src + 16, dst + 12, body, fromDig, mulLoK, mulHiK, shuffleLo, shuffleHi, compact);
+                    Base64Decode<false>(src + 32, dst + 24, body, fromDig, mulLoK, mulHiK, shuffleLo, shuffleHi, compact);
+                    Base64Decode<false>(src + 48, dst + 36, body, fromDig, mulLoK, mulHiK, shuffleLo, shuffleHi, compact);
+                }
+                for (const uint8_t* bodyA = src + srcSizeA - srcSize64; src < bodyA; src += A, dst += dstStep)
+                    Base64Decode<false>(src, dst, body, fromDig, mulLoK, mulHiK, shuffleLo, shuffleHi, compact);
+            }
+            else
+            {
+                for (const uint8_t* bodyA = src + srcSizeA; src < bodyA; src += A, dst += dstStep)
+                    Base64Decode<true>(src, dst, body, fromDig, mulLoK, mulHiK, shuffleLo, shuffleHi, compact);
+            }
             for (const uint8_t* tail = src + srcSize - srcSizeA - 4; src < tail; src += 4, dst += 3)
                 Base::Base64Decode3(src, dst);
             *dstSize = srcSize / 4 * 3 + Base::Base64DecodeTail(src, dst) - 3;

--- a/src/Simd/SimdSve2Base64.cpp
+++ b/src/Simd/SimdSve2Base64.cpp
@@ -29,48 +29,78 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint8_t FromBase64(const svuint8_t& src, const svbool_t& mask)
+        SIMD_INLINE bool InitBase64DecodeCompactIndex(uint8_t index[SIMD_SVE2_VECTOR_SIZE_MAX])
         {
-            const svuint8_t zero = svdup_n_u8(0);
-            svuint8_t dst = zero;
-
-            svbool_t upper = svand_b_z(mask, svcmpgt_n_u8(mask, src, 'A' - 1), svnot_b_z(mask, svcmpgt_n_u8(mask, src, 'Z')));
-            svbool_t lower = svand_b_z(mask, svcmpgt_n_u8(mask, src, 'a' - 1), svnot_b_z(mask, svcmpgt_n_u8(mask, src, 'z')));
-            svbool_t digit = svand_b_z(mask, svcmpgt_n_u8(mask, src, '0' - 1), svnot_b_z(mask, svcmpgt_n_u8(mask, src, '9')));
-            svbool_t slash = svorr_b_z(mask, svcmpeq_n_u8(mask, src, '/'), svcmpeq_n_u8(mask, src, '_'));
-
-            dst = svsel_u8(upper, svsub_n_u8_x(mask, src, 'A'), dst);
-            dst = svsel_u8(lower, svsub_n_u8_x(mask, src, 'a' - 26), dst);
-            dst = svsel_u8(digit, svadd_n_u8_x(mask, src, 52 - '0'), dst);
-            dst = svsel_u8(svcmpeq_n_u8(mask, src, '+'), svdup_n_u8(62), dst);
-            dst = svsel_u8(slash, svdup_n_u8(63), dst);
-            return dst;
+            size_t A = svlen(svuint8_t());
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX);
+            size_t dstSize = A * 3 / 4;
+            for (size_t i = 0; i < dstSize; ++i)
+                index[i] = (uint8_t)(i + i / 3);
+            for (size_t i = dstSize; i < A; ++i)
+                index[i] = 0xFF;
+            return true;
         }
 
-        SIMD_INLINE void Base64Decode(const uint8_t* src, uint8_t* dst, const svbool_t& mask)
+        SIMD_ALIGNED(SIMD_ALIGN) uint8_t BASE64_DECODE_COMPACT_INDEX[SIMD_SVE2_VECTOR_SIZE_MAX];
+        const bool BASE64_DECODE_COMPACT_INDEX_INITED = InitBase64DecodeCompactIndex(BASE64_DECODE_COMPACT_INDEX);
+
+        const uint8_t BASE64_FROM_DIG_SHUFFLE[16] = {
+            62, 0xFF, 0xFF, 0xFF, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0xFF };
+
+        SIMD_INLINE svuint8_t FromBase64(const svuint8_t& src, const svbool_t& mask, const svuint8_t& fromDig)
         {
-            svuint8x4_t _src = svld4_u8(mask, src);
-            svuint8_t src0 = FromBase64(svget4(_src, 0), mask);
-            svuint8_t src1 = FromBase64(svget4(_src, 1), mask);
-            svuint8_t src2 = FromBase64(svget4(_src, 2), mask);
-            svuint8_t src3 = FromBase64(svget4(_src, 3), mask);
+            const svuint8_t zero = svdup_n_u8(0);
+            svbool_t letMask = svcmpgt_n_u8(mask, src, '9');
+            svbool_t lowMask = svcmpgt_n_u8(mask, src, 'Z');
+            svuint8_t lowValue = svsel_u8(lowMask, svsub_n_u8_x(mask, src, 'a' - 26), zero);
+            svuint8_t uppValue = svsel_u8(svand_b_z(mask, letMask, svnot_b_z(mask, lowMask)),
+                svsub_n_u8_x(mask, src, 'A'), zero);
+            svuint8_t digValue = svsel_u8(svnot_b_z(mask, letMask),
+                svtbl_u8(fromDig, svsub_n_u8_x(mask, src, '+')), zero);
+            svuint8_t dst = svorr_u8_x(mask, svorr_u8_x(mask, uppValue, lowValue), digValue);
+            return svsel_u8(svcmpeq_n_u8(mask, src, '_'), svdup_n_u8(63), dst);
+        }
 
-            svuint8_t dst0 = svorr_u8_x(mask, svlsl_n_u8_x(mask, src0, 2), svlsr_n_u8_x(mask, svand_n_u8_x(mask, src1, 0x30), 4));
-            svuint8_t dst1 = svorr_u8_x(mask, svlsl_n_u8_x(mask, svand_n_u8_x(mask, src1, 0x0F), 4), svlsr_n_u8_x(mask, svand_n_u8_x(mask, src2, 0x3C), 2));
-            svuint8_t dst2 = svorr_u8_x(mask, svlsl_n_u8_x(mask, svand_n_u8_x(mask, src2, 0x03), 6), src3);
+        SIMD_INLINE void Base64Decode(const uint8_t* src, uint8_t* dst, const svbool_t& load,
+            const svbool_t& store, const svbool_t& mask32, const svuint8_t& fromDig, const svuint8_t& compact)
+        {
+            svuint8_t from = FromBase64(svld1_u8(load, src), load, fromDig);
 
-            svst3_u8(mask, dst, svcreate3_u8(dst0, dst1, dst2));
+            svuint32_t v = svreinterpret_u32_u8(from);
+            svuint32_t s0 = svand_n_u32_x(mask32, v, 0xFF);
+            svuint32_t s1 = svand_n_u32_x(mask32, svlsr_n_u32_x(mask32, v, 8), 0xFF);
+            svuint32_t s2 = svand_n_u32_x(mask32, svlsr_n_u32_x(mask32, v, 16), 0xFF);
+            svuint32_t s3 = svlsr_n_u32_x(mask32, v, 24);
+
+            svuint32_t d0 = svorr_u32_x(mask32, svlsl_n_u32_x(mask32, s0, 2), svlsr_n_u32_x(mask32, s1, 4));
+            svuint32_t d1 = svorr_u32_x(mask32, svlsl_n_u32_x(mask32, svand_n_u32_x(mask32, s1, 0x0F), 4),
+                svlsr_n_u32_x(mask32, s2, 2));
+            svuint32_t d2 = svorr_u32_x(mask32, svlsl_n_u32_x(mask32, svand_n_u32_x(mask32, s2, 0x03), 6), s3);
+
+            svuint32_t out = svorr_u32_x(mask32, d0, svlsl_n_u32_x(mask32, d1, 8));
+            out = svorr_u32_x(mask32, out, svlsl_n_u32_x(mask32, d2, 16));
+
+            svst1_u8(store, dst, svtbl_u8(svreinterpret_u8_u32(out), compact));
         }
 
         void Base64Decode(const uint8_t* src, size_t srcSize, uint8_t* dst, size_t* dstSize)
         {
             assert(srcSize % 4 == 0 && srcSize >= 4);
 
-            size_t A = svlen(svuint8_t()), srcStep = A * 4, dstStep = A * 3;
-            size_t srcSizeA = srcSize > srcStep ? AlignLoAny(srcSize - srcStep, srcStep) : 0;
+            size_t A = svlen(svuint8_t()), dstStep = A * 3 / 4;
+            assert(A <= SIMD_SVE2_VECTOR_SIZE_MAX && (A % 4) == 0);
+
+            size_t srcSize4 = srcSize - 4;
+            size_t srcSizeA = AlignLo(srcSize4, A);
+
             const svbool_t body = svptrue_b8();
-            for (const uint8_t* bodyA = src + srcSizeA; src < bodyA; src += srcStep, dst += dstStep)
-                Base64Decode(src, dst, body);
+            const svbool_t body32 = svptrue_b32();
+            const svbool_t store = svwhilelt_b8((size_t)0, dstStep);
+            const svuint8_t fromDig = svld1rq_u8(body, BASE64_FROM_DIG_SHUFFLE);
+            const svuint8_t compact = svld1_u8(body, BASE64_DECODE_COMPACT_INDEX);
+
+            for (const uint8_t* bodyA = src + srcSizeA; src < bodyA; src += A, dst += dstStep)
+                Base64Decode(src, dst, body, store, body32, fromDig, compact);
             for (const uint8_t* tail = src + srcSize - srcSizeA - 4; src < tail; src += 4, dst += 3)
                 Base::Base64Decode3(src, dst);
             *dstSize = srcSize / 4 * 3 + Base::Base64DecodeTail(src, dst) - 3;
@@ -128,4 +158,3 @@ namespace Simd
     }
 #endif
 }
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Rewrite `Sve2::Base64Decode` to avoid slow `svld4`/`svst3` and the previous uint32 + predicated-store path.
- Port the SSE4.1 contiguous algorithm: NEON-style `FromBase64` (`svtbl` digit map), `mul`/`umulh` + lane shuffles to pack 4→3, then full-vector overlapping `svst1` (same as SSE/AVX).
- When VL is 16 bytes, unroll 64-byte blocks (4×16) to match NEON’s chunk size; for wider VL, compact 16-byte lanes with one `svtbl` before the store.
- Document the improvement under release 7.2.164.

### Testing
- Python simulation of the SSE pack/compact path for VL=16/32/64
- `aarch64-linux-gnu-g++ -std=c++17 -O3 -DNDEBUG -I./src -march=armv9-a+sve2 -msve-vector-bits=scalable -c/-S src/Simd/SimdSve2Base64.cpp` (OK; hot loop uses `ld1b`/`mul`/`umulh`/`tbl`/`st1b` with full `p0`, no `ld4`/`st3`)
- Static QEMU harness vs `Base::Base64Decode` for VL=16/32/64: `tests=516 fails=0` (sizes 1..512 plus large)
- `cmake ./prj/cmake -B build ... && cmake --build build --parallel$(nproc)`
- `export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH" && ./Test "-r=.." -fi=Base64Decode -tt=1 -ts=1` from `build/` (passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37f2c9c1-fb9b-4dec-ab22-8a906e840ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37f2c9c1-fb9b-4dec-ab22-8a906e840ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

