### PR TITLE
Fix SVE2 ResizerByteBilinear Debug buffer overrun

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -218,6 +218,7 @@
 <h5>Bug fixing</h5>
 <ul>
  <li>Error in NEON optimization of function CosineDistance16f.</li>
+ <li>Error in SVE2 optimizations of class ResizerByteBilinear (buffer overrun in Debug for some destination widths).</li>
 </ul>
 <h5>Deprecation</h5>
 <ul>

--- a/src/Simd/SimdSve2ResizerBilinear.cpp
+++ b/src/Simd/SimdSve2ResizerBilinear.cpp
@@ -50,8 +50,7 @@ namespace Simd
             if (_param.channels == 1 && _param.srcW < 4 * _param.dstW)
                 _blocks = BlockCountMax(A);
             float scale = (float)_param.srcW / _param.dstW;
-            size_t size = _param.dstW * _param.channels * 2;
-            _ax.Resize(AlignHi(size, A), false, _param.align);
+            _ax.Resize(AlignHi(_param.dstW, A) * _param.channels * 2, false, _param.align);
             uint8_t* alphas = _ax.data;
             if (_blocks)
             {
@@ -125,8 +124,9 @@ namespace Simd
                     alphas += 2 * _param.channels;
                 }
             }
-            _bx[0].Resize(AlignHi(size, A), false, _param.align);
-            _bx[1].Resize(AlignHi(size, A), false, _param.align);
+            size_t size = AlignHi(_param.dstW, _param.align) * _param.channels * 2 + SIMD_ALIGN;
+            _bx[0].Resize(size, false, _param.align);
+            _bx[1].Resize(size, false, _param.align);
         }
 
         SIMD_INLINE void ResizerByteBilinearInterpolateX(const uint8_t* alpha, uint8_t* buffer)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fix undersized `_ax` / `_bx` buffers in SVE2 `ResizerByteBilinear::EstimateParams`.
- Match SSE/NEON sizing (`AlignHi(dstW, align) * channels * 2` + padding) so `RunG` full-vector stores at the last block cannot write past the buffer into `NO_MANS_LAND` watermarks.
- Document the fix under release **7.2.164** in `docs/2026.html`.

### Root cause
`DetectionLbpDetect32fiAutoTest` on ARM64 Debug (Neoverse-N2, SVE128) aborted with:
`Assertion tail[i] == NO_MANS_LAND_WATERMARK failed` in `Simd::Free`.

The failure happened during `GetSample()` → `Simd::Resize()` for some destination widths (e.g. 71), not inside `DetectionLbpDetect32fi` itself. SVE2 used `AlignHi(2*dstW, A)` for row buffers, which is shorter than the worst-case store `last_block.dst + A` when `src`-driven block splits place the last block near the end.

### Testing
- Reproduced under `qemu-aarch64 -cpu max,sve128=on` Debug build before the fix.
- Passed after fix: `./Test "-r=.." -fi=DetectionLbpDetect32fi -tt=1 -ts=1 -w=640 -h=480`
- Passed after fix: all `Detection*` tests with the same flags.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c32a6b9d-1b3a-4481-88e9-931c7716ec62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c32a6b9d-1b3a-4481-88e9-931c7716ec62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

