### PR TITLE
Add SVE2 SynetConvolution32fGemmNN optimizations

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -37,6 +37,21 @@
 
 <a href="#HOME">Home</a>
 <hr/>
+<h3 id="R165">August 3, 2026 (version 7.2.165)</h3> 
+<h4>Algorithms</h4>
+<h5>New features</h5>
+<ul>
+ <li>SVE2 optimizations of class SynetConvolution32fGemmNN.</li>
+</ul>
+
+<h4>Test framework</h4>
+<h5>New features</h5>
+<ul>
+ <li>Tests for verifying functionality of SVE2 version of class SynetConvolution32fGemmNN.</li>
+</ul>
+
+<a href="#HOME">Home</a>
+<hr/>
 <h3 id="R164">August 3, 2026 (version 7.2.164)</h3> 
 <h4>Algorithms</h4>
 <h5>New features</h5>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution8i.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32f.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -554,6 +554,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution8i.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetScale.cpp">
       <Filter>Sve2\Synet\Other</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6197,7 +6197,7 @@ SIMD_API void * SimdSynetConvolution32fInit(size_t batch, const SimdConvolutionP
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetConvolution32fInitPtr) (size_t batch, const SimdConvolutionParameters * params);
-    const static SimdSynetConvolution32fInitPtr simdSynetConvolution32fInit = SIMD_FUNC4(SynetConvolution32fInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetConvolution32fInitPtr simdSynetConvolution32fInit = SIMD_FUNC5(SynetConvolution32fInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetConvolution32fInit(batch, params);
 #else

--- a/src/Simd/SimdSve2SynetConvolution32fGemm.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fGemm.cpp
@@ -1,0 +1,219 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdGemm.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SynetConvolution32fGemmNN::SynetConvolution32fGemmNN(const ConvParam & p)
+            : Base::SynetConvolution32fGemmNN(p)
+        {
+            const size_t F = svcntw();
+            _index.Resize(F);
+            for (size_t i = 0; i < F; ++i)
+                _index[i] = int(i * p.strideX);
+            _nose.Resize(p.kernelX);
+            _tail.Resize(p.kernelX);
+            _start.Resize(p.kernelX);
+            for (size_t kx = 0; kx < p.kernelX; ++kx)
+            {
+                _nose[kx] = 0;
+                _tail[kx] = int(p.dstW);
+                ptrdiff_t sx = kx * p.dilationX - p.padX;
+                for (size_t dx = 0; dx < p.dstW; ++dx)
+                {
+                    if (sx < 0)
+                        _nose[kx]++;
+                    if (sx >= ptrdiff_t(p.srcW))
+                        _tail[kx]--;
+                    sx += p.strideX;
+                }
+                _start[kx] = int(kx * p.dilationX - p.padX + _nose[kx] * p.strideX);
+            }
+            _gemm.Init(InitGemmFuncs(Sve2::Gemm32fNN, "Sve2"));
+            _biasAndActivation = Neon::ConvolutionBiasAndActivation;
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void SynetConvolution32fGemmNN::ImgToCol(const float * src, float * dst)
+        {
+            const ConvParam & p = _param;
+            size_t srcSize = p.srcW * p.srcH;
+            if (p.dilationX == 1 && p.dilationY == 1 && p.strideX == 2 && p.strideY == 2 && p.padX == 0 && p.padY == 0 && p.padW == 0 && p.padH == 0 && p.kernelX == 1 && p.kernelY == 1)
+            {
+                for (size_t c = 0; c < p.srcC; ++c)
+                {
+                    for (size_t dy = 0; dy < p.dstH; ++dy)
+                    {
+                        const float * psrc = src + 2 * dy * p.srcW;
+                        for (size_t dx = 0, sx = 0; dx < p.dstW; ++dx, sx += 2)
+                            *(dst++) = psrc[sx];
+                    }
+                    src += srcSize;
+                }
+            }
+            else if (p.dilationX * p.dilationY * p.strideX * p.strideY != 1)
+            {
+                const size_t F = svcntw();
+                svbool_t all = svptrue_b32();
+                svuint32_t index = svld1_u32(all, (const uint32_t*)_index.data);
+                for (size_t c = 0; c < p.srcC; ++c)
+                {
+                    for (size_t ky = 0; ky < p.kernelY; ky++)
+                    {
+                        for (size_t kx = 0; kx < p.kernelX; kx++)
+                        {
+                            size_t noseDx = _nose[kx];
+                            size_t tailDx = _tail[kx];
+                            size_t bodyDx = AlignLo(tailDx - noseDx, F) + noseDx;
+                            size_t sx0 = _start[kx];
+                            size_t sy = ky * p.dilationY - p.padY;
+                            for (size_t dy = 0; dy < p.dstH; ++dy)
+                            {
+                                if (sy < p.srcH)
+                                {
+                                    size_t dx = 0, sx = sx0 + sy * p.srcW;
+                                    for (; dx < noseDx; ++dx)
+                                        *(dst++) = 0;
+                                    for (; dx < bodyDx; dx += F, sx += p.strideX * F, dst += F)
+                                        svst1_f32(all, dst, svld1_gather_u32index_f32(all, src + sx, index));
+                                    for (; dx < tailDx; ++dx, sx += p.strideX)
+                                        *(dst++) = src[sx];
+                                    for (; dx < p.dstW; ++dx)
+                                        *(dst++) = 0;
+                                }
+                                else
+                                {
+                                    memset(dst, 0, p.dstW * sizeof(float));
+                                    dst += p.dstW;
+                                }
+                                sy += p.strideY;
+                            }
+                        }
+                    }
+                    src += srcSize;
+                }
+            }
+            else
+            {
+                Base::SynetConvolution32fGemmNN::ImgToCol(src, dst);
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void SynetConvolution32fGemmNN::ImgToRow(const float * src, float * dst)
+        {
+            const ConvParam & p = _param;
+            assert(p.trans);
+            const size_t F = svcntw();
+            size_t size = p.srcC / p.group;
+            for (size_t g = 0; g < p.group; ++g)
+            {
+                for (size_t dy = 0; dy < p.dstH; ++dy)
+                {
+                    for (size_t dx = 0; dx < p.dstW; ++dx)
+                    {
+                        for (size_t ky = 0; ky < p.kernelY; ky++)
+                        {
+                            size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                            if (sy < p.srcH)
+                            {
+                                for (size_t kx = 0; kx < p.kernelX; kx++)
+                                {
+                                    size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                    if (sx < p.srcW)
+                                    {
+                                        const float * s = src + (sy * p.srcW + sx) * p.srcC;
+                                        for (size_t i = 0; i < size; i += F)
+                                        {
+                                            svbool_t mask = svwhilelt_b32(i, size);
+                                            svst1_f32(mask, dst + i, svld1_f32(mask, s + i));
+                                        }
+                                        dst += size;
+                                    }
+                                    else
+                                    {
+                                        for (size_t i = 0; i < size; i += F)
+                                        {
+                                            svbool_t mask = svwhilelt_b32(i, size);
+                                            svst1_f32(mask, dst + i, svdup_n_f32(0.0f));
+                                        }
+                                        dst += size;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                size_t n = p.kernelX * size;
+                                for (size_t i = 0; i < n; i += F)
+                                {
+                                    svbool_t mask = svwhilelt_b32(i, n);
+                                    svst1_f32(mask, dst + i, svdup_n_f32(0.0f));
+                                }
+                                dst += n;
+                            }
+                        }
+                    }
+                }
+                src += size;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv)
+        {
+            ConvParam param(batch, conv, SimdSynetCompatibilityDefault);
+            if (!param.Valid(SimdTensorData32f))
+                return NULL;
+            if (Neon::SynetConvolution32fDepthwiseDotProduct::Preferable(param))
+                return new Neon::SynetConvolution32fDepthwiseDotProduct(param);
+            else if (Neon::SynetConvolution32fWinograd::Preferable(param))
+                return new Neon::SynetConvolution32fWinograd(param);
+            else if (Neon::SynetConvolution32fDirectNchw::Preferable(param))
+                return new Neon::SynetConvolution32fDirectNchw(param);
+            else if (Neon::SynetConvolution32fGemmNT::Preferable(param))
+                return new Neon::SynetConvolution32fGemmNT(param);
+            else if (Neon::SynetConvolution32fNhwcDirect::Preferable(param))
+                return new Neon::SynetConvolution32fNhwcDirect(param);
+            else if (Neon::SynetConvolution32fNhwcDepthwise::Preferable(param))
+                return new Neon::SynetConvolution32fNhwcDepthwise(param);
+            else if (Base::SynetConvolution32fNhwcGroupedBlock1x2::Preferable(param))
+                return new Base::SynetConvolution32fNhwcGroupedBlock1x2(param);
+            else
+                return new SynetConvolution32fGemmNN(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetConvolution32f.h
+++ b/src/Simd/SimdSynetConvolution32f.h
@@ -711,6 +711,26 @@ namespace Simd
         void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class SynetConvolution32fGemmNN : public Base::SynetConvolution32fGemmNN
+        {
+        public:
+            SynetConvolution32fGemmNN(const ConvParam & p);
+            virtual String Ext() const { return "Sve2"; }
+
+        protected:
+            virtual void ImgToCol(const float * src, float * dst);
+            virtual void ImgToRow(const float * src, float * dst);
+        private:
+            Array32i _index, _nose, _tail, _start;
+        };
+
+        void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
+    }
+#endif//SIMD_SVE2_ENABLE
 }
 
 #endif

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -262,9 +262,13 @@ namespace Test
 #endif
 #if 1
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1280, 32, 32, 256, _1, _1, _1, _0, _0, 1, aRe, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _1, _2, _2, 1, aRe, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _2, _2, _2, 1, aRe, tF), f1, f2);
 #endif
 #else
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 20, 75, 75, 20, Size(1, 11), _1, _1, Size(0, 5), Size(0, 5), 20, aId, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _1, _2, _2, 1, aRe, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _2, _2, _2, 1, aRe, tF), f1, f2);
 #endif
         return result;
     }

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -318,6 +318,11 @@ namespace Test
             result = result && SynetConvolution32fForwardAutoTest(2 * EPS, FUNC_C(Simd::Neon::SynetConvolution32fInit), FUNC_C(SimdSynetConvolution32fInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetConvolution32fForwardAutoTest(2 * EPS, FUNC_C(Simd::Sve2::SynetConvolution32fInit), FUNC_C(SimdSynetConvolution32fInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE2 `SynetConvolution32fGemmNN` with `Sve2::Gemm32fNN`, Neon bias/activation, and SVE2 `ImgToCol`/`ImgToRow`.
- Register SVE2 dispatch for `SimdSynetConvolution32fInit`, keep Neon Preferable paths for non-Gemm algorithms, and add SVE2 AutoTest coverage (including dilated NHWC/NCHW GemmNN cases).
- Add the new source to the VS2022 SVE2 project and document the change in release 7.2.165.

## Validation
- `aarch64-linux-gnu-g++ -march=armv9-a+sve2+i8mm -msve-vector-bits=scalable -std=c++11 -fsyntax-only -I /workspace/src src/Simd/SimdSve2SynetConvolution32fGemm.cpp`
- `cmake ./prj/cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DSIMD_TOOLCHAIN="g++" -DSIMD_TARGET="" -DSIMD_AVX512VNNI=ON -DSIMD_AMXBF16=ON -DSIMD_TEST_FLAGS="-march=native" -DSIMD_SHARED=ON`
- `cmake --build build --parallel$(nproc)` (x86_64 host, success)
- `LD_LIBRARY_PATH=/workspace/build:$LD_LIBRARY_PATH ./Test "-r=.." -fi=SynetConvolution32fForward -tt=1 -ts=1` (x86_64 host, success)
- SVE2 runtime path requires ARM64+SVE2 hardware; validated via aarch64 syntax-only compile on this host.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-863632eb-6f8a-449b-9c0e-dd70aa4db160?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-863632eb-6f8a-449b-9c0e-dd70aa4db160&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

