### PR TITLE
Add SVE2 SynetConvolution32fGemmNT optimizations

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -42,6 +42,7 @@
 <h5>New features</h5>
 <ul>
  <li>SVE2 optimizations of class SynetConvolution32fGemmNN.</li>
+ <li>SVE2 optimizations of class SynetConvolution32fGemmNT.</li>
  <li>NEON optimizations of class SynetConvolution32fNhwcGroupedBlock1x2.</li>
 </ul>
 

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetAdd16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution8i.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -554,6 +554,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution8i.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32f.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>

--- a/src/Simd/SimdSve2SynetConvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32f.cpp
@@ -1,0 +1,58 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdNeon.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv)
+        {
+            ConvParam param(batch, conv, SimdSynetCompatibilityDefault);
+            if (!param.Valid(SimdTensorData32f))
+                return NULL;
+            if (Neon::SynetConvolution32fDepthwiseDotProduct::Preferable(param))
+                return new Neon::SynetConvolution32fDepthwiseDotProduct(param);
+            else if (Neon::SynetConvolution32fWinograd::Preferable(param))
+                return new Neon::SynetConvolution32fWinograd(param);
+            else if (Neon::SynetConvolution32fDirectNchw::Preferable(param))
+                return new Neon::SynetConvolution32fDirectNchw(param);
+            else if (SynetConvolution32fGemmNT::Preferable(param))
+                return new SynetConvolution32fGemmNT(param);
+            else if (Neon::SynetConvolution32fNhwcDirect::Preferable(param))
+                return new Neon::SynetConvolution32fNhwcDirect(param);
+            else if (Neon::SynetConvolution32fNhwcDepthwise::Preferable(param))
+                return new Neon::SynetConvolution32fNhwcDepthwise(param);
+            else if (Base::SynetConvolution32fNhwcGroupedBlock1x2::Preferable(param))
+                return new Base::SynetConvolution32fNhwcGroupedBlock1x2(param);
+            else
+                return new SynetConvolution32fGemmNN(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetConvolution32fGemm.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fGemm.cpp
@@ -192,27 +192,21 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv)
+        SynetConvolution32fGemmNT::SynetConvolution32fGemmNT(const ConvParam & p)
+            : Base::SynetConvolution32fGemmNT(p)
         {
-            ConvParam param(batch, conv, SimdSynetCompatibilityDefault);
-            if (!param.Valid(SimdTensorData32f))
-                return NULL;
-            if (Neon::SynetConvolution32fDepthwiseDotProduct::Preferable(param))
-                return new Neon::SynetConvolution32fDepthwiseDotProduct(param);
-            else if (Neon::SynetConvolution32fWinograd::Preferable(param))
-                return new Neon::SynetConvolution32fWinograd(param);
-            else if (Neon::SynetConvolution32fDirectNchw::Preferable(param))
-                return new Neon::SynetConvolution32fDirectNchw(param);
-            else if (Neon::SynetConvolution32fGemmNT::Preferable(param))
-                return new Neon::SynetConvolution32fGemmNT(param);
-            else if (Neon::SynetConvolution32fNhwcDirect::Preferable(param))
-                return new Neon::SynetConvolution32fNhwcDirect(param);
-            else if (Neon::SynetConvolution32fNhwcDepthwise::Preferable(param))
-                return new Neon::SynetConvolution32fNhwcDepthwise(param);
-            else if (Base::SynetConvolution32fNhwcGroupedBlock1x2::Preferable(param))
-                return new Base::SynetConvolution32fNhwcGroupedBlock1x2(param);
+            _gemm.Init(InitGemmFuncs(Sve2::Gemm32fNT, "Sve2"));
+            _biasAndActivation = Neon::ConvolutionBiasAndActivation;
+        }
+
+        bool SynetConvolution32fGemmNT::Preferable(const ConvParam & p)
+        {
+            if (p.group != 1)
+                return false;
+            if (p.trans)
+                return p.Is1x1() && p.dstC == 1;
             else
-                return new SynetConvolution32fGemmNN(param);
+                return p.srcH < 4 && p.srcW < 4;
         }
     }
 #endif

--- a/src/Simd/SimdSynetConvolution32f.h
+++ b/src/Simd/SimdSynetConvolution32f.h
@@ -735,6 +735,15 @@ namespace Simd
             Array32i _index, _nose, _tail, _start;
         };
 
+        class SynetConvolution32fGemmNT : public Base::SynetConvolution32fGemmNT
+        {
+        public:
+            SynetConvolution32fGemmNT(const ConvParam & p);
+            virtual String Ext() const { return "Sve2"; }
+
+            static bool Preferable(const ConvParam & p);
+        };
+
         void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
     }
 #endif//SIMD_SVE2_ENABLE

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -262,6 +262,9 @@ namespace Test
 #endif
 #if 1
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 256, 5, 5, 256, _1, _1, _1, _0, _0, 1, a, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 256, 3, 3, 256, _1, _1, _1, _0, _0, 1, a, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 3, 3, 64, _3, _1, _1, _1, _1, 1, a, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 128, 16, 16, 1, _1, _1, _1, _0, _0, 1, a, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 64, 64, 16, _3, _1, _1, _1, _1, 1, aPr, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 64, 64, 16, _3, _1, _1, _1, _1, 1, aPr, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 128, 128, 256, _3, _1, _1, _1, _1, 1, a, t), f1, f2);
@@ -272,6 +275,9 @@ namespace Test
 #endif
 #else
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 20, 75, 75, 20, Size(1, 11), _1, _1, Size(0, 5), Size(0, 5), 20, aId, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 256, 3, 3, 256, _1, _1, _1, _0, _0, 1, a, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 3, 3, 64, _3, _1, _1, _1, _1, 1, a, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 128, 16, 16, 1, _1, _1, _1, _0, _0, 1, a, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _1, _2, _2, 1, aRe, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _2, _2, _2, 1, aRe, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 49, 29, 29, 98, _7, _1, _2, _3, _3, 49, a, t), f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add SVE2 optimizations for `SynetConvolution32fGemmNT` by wiring `Sve2::Gemm32fNT` (and NEON bias/activation) in `SimdSve2SynetConvolution32fGemm.cpp`, matching the existing Neon/SSE/AVX pattern.
- Move `Sve2::SynetConvolution32fInit` from `SimdSve2SynetConvolution32fGemm.cpp` into new `SimdSve2SynetConvolution32f.cpp`, and dispatch GemmNT via the SVE2 class.
- Extend `Test::SynetConvolution32fForwardAutoTest` with NCHW small-spatial and NHWC 1x1 `dstC==1` cases that select GemmNT; update VS2022 Sve2 project files and release notes for 7.2.165.

## Test plan

- [x] Native x86 Release build + `./Test "-r=.." -fi=SynetConvolution32f -tt=1 -ts=1` — all tests finished successfully; new GemmNT shapes exercised (`1x256x3x3`, `1x64x3x3`, `1x128x16x16-1`)
- [x] aarch64 cross-compile of `SimdSve2SynetConvolution32f.cpp` and `SimdSve2SynetConvolution32fGemm.cpp` with `-march=armv9-a+sve+sve2` — OK
- [ ] ARM64/SVE2 hardware run of SynetConvolution32f AutoTest for end-to-end SVE2 correctness/performance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8be0ea8-b7a3-48c0-9b9d-b5eaf6204a22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8be0ea8-b7a3-48c0-9b9d-b5eaf6204a22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

