### PR TITLE
Add SVE2 optimizations for SynetConvolution32fWinograd

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -43,6 +43,7 @@
 <ul>
  <li>SVE2 optimizations of class SynetConvolution32fGemmNN.</li>
  <li>SVE2 optimizations of class SynetConvolution32fGemmNT.</li>
+ <li>SVE2 optimizations of class SynetConvolution32fWinograd.</li>
  <li>NEON optimizations of class SynetConvolution32fNhwcGroupedBlock1x2.</li>
 </ul>
 

--- a/src/Simd/SimdSve2SynetConvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32f.cpp
@@ -38,8 +38,8 @@ namespace Simd
                 return NULL;
             if (Neon::SynetConvolution32fDepthwiseDotProduct::Preferable(param))
                 return new Neon::SynetConvolution32fDepthwiseDotProduct(param);
-            else if (Neon::SynetConvolution32fWinograd::Preferable(param))
-                return new Neon::SynetConvolution32fWinograd(param);
+            else if (SynetConvolution32fWinograd::Preferable(param))
+                return new SynetConvolution32fWinograd(param);
             else if (Neon::SynetConvolution32fDirectNchw::Preferable(param))
                 return new Neon::SynetConvolution32fDirectNchw(param);
             else if (SynetConvolution32fGemmNT::Preferable(param))

--- a/src/Simd/SimdSve2SynetConvolution32fGemm.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fGemm.cpp
@@ -208,6 +208,129 @@ namespace Simd
             else
                 return p.srcH < 4 && p.srcW < 4;
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetConvolution32fWinograd::SynetConvolution32fWinograd(const ConvParam & p)
+            : Base::SynetConvolution32fWinograd(p)
+        {
+            if (p.kernelY == 1 && p.kernelX == 3)
+            {
+                {
+                    SetBlock(1, 4);
+                    _setFilter = Sve2::WinogradKernel1x3Block1x4SetFilter;
+                    _setInput = Sve2::WinogradKernel1x3Block1x4SetInput;
+                    _setOutput = Sve2::WinogradKernel1x3Block1x4SetOutput;
+                }
+            }
+            else if (p.kernelY == 1 && p.kernelX == 5)
+            {
+                {
+                    SetBlock(1, 4);
+                    _setFilter = Sve2::WinogradKernel1x5Block1x4SetFilter;
+                    _setInput = Sve2::WinogradKernel1x5Block1x4SetInput;
+                    _setOutput = Sve2::WinogradKernel1x5Block1x4SetOutput;
+                }
+            }
+            else if (p.kernelY == 2 && p.kernelX == 2)
+            {
+                if (p.trans && p.srcH >= 8 && p.srcW >= 8 && p.srcH * p.srcW * p.batch >= 144)
+                {
+                    SetBlock(4, 4);
+                    _setFilter = Sve2::WinogradKernel2x2Block4x4SetFilter;
+                    _setInput = Sve2::WinogradKernel2x2Block4x4SetInput;
+                    _setOutput = Sve2::WinogradKernel2x2Block4x4SetOutput;
+                }
+                else
+                {
+                    SetBlock(2, 2);
+                    _setFilter = Sve2::WinogradKernel2x2Block2x2SetFilter;
+                    _setInput = Sve2::WinogradKernel2x2Block2x2SetInput;
+                    _setOutput = Sve2::WinogradKernel2x2Block2x2SetOutput;
+                }
+            }
+            else if (p.kernelY == 3 && p.kernelX == 3)
+            {
+                if (p.trans && p.srcH >= 8 && p.srcW >= 8 && p.srcH * p.srcW * p.batch >= 144)
+                {
+                    SetBlock(4, 4);
+                    _setFilter = Sve2::WinogradKernel3x3Block4x4SetFilter;
+                    _setInput = Sve2::WinogradKernel3x3Block4x4SetInput;
+                    _setOutput = Sve2::WinogradKernel3x3Block4x4SetOutput;
+                }
+                else if (p.trans && p.srcH >= 6 && p.srcW >= 6 && p.srcH * p.srcW * p.batch >= 81 && p.dstH % 3 == 0 && p.dstW % 3 == 0)
+                {
+                    SetBlock(3, 3);
+                    _setFilter = Sve2::WinogradKernel3x3Block3x3SetFilter;
+                    _setInput = Sve2::WinogradKernel3x3Block3x3SetInput;
+                    _setOutput = Sve2::WinogradKernel3x3Block3x3SetOutput;
+                }
+                else
+                {
+                    SetBlock(2, 2);
+                    _setFilter = Sve2::WinogradKernel3x3Block2x2SetFilter;
+                    _setInput = Sve2::WinogradKernel3x3Block2x2SetInput;
+                    _setOutput = Sve2::WinogradKernel3x3Block2x2SetOutput;
+                }
+            }
+            else
+                assert(0);
+            _gemm.Init(InitGemmFuncs(Sve2::Gemm32fNN, "Sve2"));
+            if (_param.trans)
+            {
+                if (NHWC_GEMM_RUNTIME)
+                {
+#if defined(SIMD_ARM64_ENABLE)
+                    _gemmCb.Init(InitGemmCbFuncs(Neon::Gemm32fNNcbBufferSize, Neon::Gemm32fNNcbReorderB, Neon::Gemm32fNNcbRun, "Neon", GemmKernelF2, GemmKernelF4));
+#else
+                    _gemmCb.Init(InitGemmCbFuncs(Neon::Gemm32fNNcbBufferSize, Neon::Gemm32fNNcbReorderB, Neon::Gemm32fNNcbRun, "Neon", GemmKernelF2, GemmKernelF3));
+#endif
+                    _nhwcStrideW = _gemmCb.At(0).BufferSize(_M*_merge, _N, _K);
+                }
+                else
+                    _nhwcStrideW = Neon::Gemm32fNNcbBufferSize(_M*_merge, _N, _K, GemmKernelAny, NHWC_GEMM_COMPATIBLE);
+                _nhwcWeight.Resize(_nhwcStrideW*_count);
+                _nhwcRun = Neon::Gemm32fNNcbRun;
+                _nhwcReorderB = Neon::Gemm32fNNcbReorderB;
+            }
+            _biasAndActivation = Neon::ConvolutionBiasAndActivation;
+        }
+
+        bool SynetConvolution32fWinograd::Preferable(const ConvParam & p)
+        {
+            if (!p.IsDilation(1) || !p.IsStride(1) || p.group != 1 || p.srcC < 10)
+                return false;
+            if (p.IsKernel(1, 3))
+            {
+                if (!(p.IsPad(0) || (p.padX == 1 && p.padW == 1)))
+                    return false;
+                if (p.srcC <= 32)
+                    return false;
+                return p.trans && p.srcW >= 8 && p.srcH * p.srcW * p.batch >= 36;
+            }
+            else if (p.IsKernel(1, 5))
+            {
+                if (!(p.IsPad(0) || (p.padX == 2 && p.padW == 2)))
+                    return false;
+                return p.trans && p.srcW >= 8 && p.srcH * p.srcW * p.batch >= 36;
+            }
+            else if (p.IsKernel(2))
+            {
+                if (!(p.IsPad(0) || (p.padY + p.padH == 1 && p.padX + p.padW == 1)))
+                    return false;
+                return p.trans && p.srcH >= 4 && p.srcW >= 4 && p.srcH * p.srcW * p.batch >= 36;
+            }
+            else if (p.IsKernel(3))
+            {
+                if (!(p.IsPad(0) || p.IsPad(1)))
+                    return false;
+                if (p.trans)
+                    return p.srcH >= 4 && p.srcW >= 4 && p.srcH * p.srcW * p.batch >= 36;
+                else
+                    return p.srcH >= 6 && p.srcW >= 6;
+            }
+            return false;
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSynetConvolution32f.h
+++ b/src/Simd/SimdSynetConvolution32f.h
@@ -744,6 +744,15 @@ namespace Simd
             static bool Preferable(const ConvParam & p);
         };
 
+        class SynetConvolution32fWinograd : public Base::SynetConvolution32fWinograd
+        {
+        public:
+            SynetConvolution32fWinograd(const ConvParam & p);
+            virtual String Ext() const { return "Sve2"; }
+
+            static bool Preferable(const ConvParam & p);
+        };
+
         void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
     }
 #endif//SIMD_SVE2_ENABLE

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -268,6 +268,14 @@ namespace Test
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 64, 64, 16, _3, _1, _1, _1, _1, 1, aPr, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 64, 64, 16, _3, _1, _1, _1, _1, 1, aPr, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 128, 128, 256, _3, _1, _1, _1, _1, 1, a, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 16, 16, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 6, 15, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 4, 9, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 8, 8, 32, _3, _1, _1, _1, _1, 1, aId, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 16, 16, 32, _2, _1, _1, _0, _0, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 4, 9, 32, _2, _1, _1, _0, _0, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 48, 4, 16, 48, Size(1, 3), _1, _1, Size(0, 1), Size(0, 1), 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 4, 16, 32, Size(1, 5), _1, _1, Size(0, 2), Size(0, 2), 1, aId, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1280, 32, 32, 256, _1, _1, _1, _0, _0, 1, aRe, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 384, 7, 7, 768, _3, _1, _1, _1, _1, 384, a, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 152, 32, 32, 152, _7, _1, _1, _3, _3, 152, aRe, t), f1, f2);
@@ -278,6 +286,12 @@ namespace Test
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 256, 3, 3, 256, _1, _1, _1, _0, _0, 1, a, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 3, 3, 64, _3, _1, _1, _1, _1, 1, a, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 128, 16, 16, 1, _1, _1, _1, _0, _0, 1, a, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 16, 16, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 6, 15, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 4, 9, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 8, 8, 32, _3, _1, _1, _1, _1, 1, aId, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 16, 16, 32, _2, _1, _1, _0, _0, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 48, 4, 16, 48, Size(1, 3), _1, _1, Size(0, 1), Size(0, 1), 1, aId, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _1, _2, _2, 1, aRe, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _2, _2, _2, 1, aRe, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 49, 29, 29, 98, _7, _1, _2, _3, _3, 49, a, t), f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add SVE2 optimizations for `SynetConvolution32fWinograd` in `SimdSve2SynetConvolution32fGemm.cpp`: wire `Sve2::WinogradKernel*` SetFilter/SetInput/SetOutput, `Sve2::Gemm32fNN`, and Neon NHWC packed GEMM (`Gemm32fNNcb*`) plus Neon bias/activation (same hybrid pattern as GemmNN/GemmNT).
- Dispatch `Sve2::SynetConvolution32fWinograd` from `Sve2::SynetConvolution32fInit` instead of falling through to Neon Winograd.
- Extend `Test::SynetConvolution32fForwardAutoTest` with 3x3/2x2/1x3/1x5 Winograd shapes (NHWC block 4x4/3x3/2x2 and NCHW 3x3); document in release 7.2.165.

`SimdSve2SynetConvolution32fGemm.cpp` is already listed in `prj/vs2022/Sve2.vcxproj` / `.filters` from prior GemmNN/GemmNT work.

## Test plan

- [ ] Native x86 Release build + `./Test "-r=.." -fi=SynetConvolution32f -tt=1 -ts=1`
- [ ] aarch64 cross-compile syntax check of SVE2 SynetConvolution32f sources with `-march=armv9-a+sve2`
- [ ] ARM64/SVE2 hardware run of SynetConvolution32f AutoTest for end-to-end SVE2 correctness/performance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66315319-d557-4309-86f9-35aed141d06c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66315319-d557-4309-86f9-35aed141d06c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

