### PR TITLE
Add SVE2 optimizations for SynetConvolution32fDirectNchw

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -46,6 +46,7 @@
  <li>SVE2 optimizations of class SynetConvolution32fWinograd.</li>
  <li>NEON optimizations of class SynetConvolution32fNhwcGroupedBlock1x2.</li>
  <li>SVE2 optimizations of class SynetConvolution32fNhwcGroupedBlock1x2.</li>
+ <li>SVE2 optimizations of class SynetConvolution32fDirectNchw.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -106,6 +106,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fDirectNchw.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcGrouped.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -557,6 +557,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32f.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fDirectNchw.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>

--- a/src/Simd/SimdSve2SynetConvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32f.cpp
@@ -40,8 +40,8 @@ namespace Simd
                 return new Neon::SynetConvolution32fDepthwiseDotProduct(param);
             else if (SynetConvolution32fWinograd::Preferable(param))
                 return new SynetConvolution32fWinograd(param);
-            else if (Neon::SynetConvolution32fDirectNchw::Preferable(param))
-                return new Neon::SynetConvolution32fDirectNchw(param);
+            else if (SynetConvolution32fDirectNchw::Preferable(param))
+                return new SynetConvolution32fDirectNchw(param);
             else if (SynetConvolution32fGemmNT::Preferable(param))
                 return new SynetConvolution32fGemmNT(param);
             else if (Neon::SynetConvolution32fNhwcDirect::Preferable(param))

--- a/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
@@ -1,0 +1,414 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        namespace
+        {
+            SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
+            {
+                x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
+                svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
+                svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
+                svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+                svfloat32_t p = svdup_n_f32(1.8775767e-3f);
+                p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
+                p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
+                p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
+                p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
+                p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
+                return svmul_f32_x(mask, expipart, p);
+            }
+
+            SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
+            {
+                return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
+            }
+
+            SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
+            {
+                const svfloat32_t _1 = svdup_n_f32(1.0f);
+                svfloat32_t a = svmin_f32_x(mask, svabs_f32_x(mask, x), svdup_n_f32(9.0f));
+                svfloat32_t p = svdup_n_f32(0.0000430638f);
+                p = svmla_f32_x(mask, svdup_n_f32(0.0002765672f), a, p);
+                p = svmla_f32_x(mask, svdup_n_f32(0.0001520143f), a, p);
+                p = svmla_f32_x(mask, svdup_n_f32(0.0092705272f), a, p);
+                p = svmla_f32_x(mask, svdup_n_f32(0.0422820123f), a, p);
+                p = svmla_f32_x(mask, svdup_n_f32(0.0705230784f), a, p);
+                p = svmla_f32_x(mask, _1, a, p);
+                p = svmul_f32_x(mask, p, p);
+                p = svmul_f32_x(mask, p, p);
+                p = svmul_f32_x(mask, p, p);
+                p = svmul_f32_x(mask, p, p);
+                svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
+                return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
+            }
+
+            template<::SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params);
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationIdentity>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                return value;
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationRelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                return svmax_n_f32_x(mask, value, 0.0f);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationLeakyRelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), params[0], svmin_n_f32_x(mask, value, 0.0f));
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationRestrictRange>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                return svmin_f32_x(mask, svmax_f32_x(mask, params[0], value), params[1]);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationPrelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), params[0], svmin_n_f32_x(mask, value, 0.0f));
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationElu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                svfloat32_t neg = svmul_f32_x(mask, params[0], svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+                return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHswish>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                svfloat32_t upper = svmin_f32_x(mask, value, params[0]);
+                svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, params[0]), 0.0f);
+                return svmul_f32_x(mask, svmul_f32_x(mask, positive, params[1]), value);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationMish>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                svfloat32_t _1 = svdup_n_f32(1.0f);
+                svfloat32_t mish = svadd_f32_x(mask, Exp(mask, value), _1);
+                mish = svmla_f32_x(mask, _1, mish, mish);
+                mish = svmul_f32_x(mask, value, svsub_f32_x(mask, _1, svdiv_f32_x(mask, svdup_n_f32(2.0f), mish)));
+                return svsel_f32(svcmpgt_f32(mask, params[0], value), mish, value);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHardSigmoid>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_f32_x(mask, params[1], value, params[0]), 1.0f), 0.0f);
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationSwish>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, params[0])));
+                return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
+            }
+
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationGelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            {
+                svfloat32_t t = svmul_n_f32_x(mask, value, 0.70710678118654752440f);
+                return svmul_f32_x(mask, svmul_n_f32_x(mask, t, 0.70710678118654752440f), svadd_n_f32_x(mask, Erf(mask, t), 1.0f));
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetConvolution32fDirectNchw::SynetConvolution32fDirectNchw(const ConvParam & p)
+            : Neon::SynetConvolution32fDirectNchw(p)
+        {
+            _convolutionBiasActivation = SetConvolutionBiasActivation();
+        }
+
+        template <size_t size> SIMD_INLINE void LoadWeight(const float * src, svfloat32_t * dst)
+        {
+            for (size_t i = 0; i < size; ++i)
+                dst[i] = svdup_n_f32(src[i]);
+        }
+
+        template<int kernel, int stride> struct Kernel
+        {
+            static svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight);
+        };
+
+        template<> struct Kernel<1, 1>
+        {
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            {
+                return svmul_f32_x(mask, svld1_f32(mask, src), weight[0]);
+            }
+        };
+
+        template<> struct Kernel<2, 1>
+        {
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            {
+                return svmla_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src + 0), weight[0]), svld1_f32(mask, src + 1), weight[1]);
+            }
+
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            {
+                return svadd_f32_x(mask, RowConv(mask, src, weight), RowConv(mask, src + step, weight + 2));
+            }
+        };
+
+        template<> struct Kernel<2, 2>
+        {
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            {
+                svuint32_t index = svindex_u32(0, 2);
+                svfloat32_t s0 = svld1_gather_u32index_f32(mask, src + 0, index);
+                svfloat32_t s1 = svld1_gather_u32index_f32(mask, src + 1, index);
+                return svmla_f32_x(mask, svmul_f32_x(mask, s0, weight[0]), s1, weight[1]);
+            }
+
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            {
+                return svadd_f32_x(mask, RowConv(mask, src, weight), RowConv(mask, src + step, weight + 2));
+            }
+        };
+
+        template<> struct Kernel<3, 1>
+        {
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            {
+                return svmla_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src), weight[0]),
+                    svld1_f32(mask, src + 1), weight[1]), svld1_f32(mask, src + 2), weight[2]);
+            }
+
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            {
+                return svadd_f32_x(mask, RowConv(mask, src, weight),
+                    svadd_f32_x(mask, RowConv(mask, src + step, weight + 3),
+                        RowConv(mask, src + 2 * step, weight + 6)));
+            }
+        };
+
+        template<> struct Kernel<3, 2>
+        {
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            {
+                svuint32_t index = svindex_u32(0, 2);
+                svfloat32_t s0 = svld1_gather_u32index_f32(mask, src + 0, index);
+                svfloat32_t s1 = svld1_gather_u32index_f32(mask, src + 1, index);
+                svfloat32_t s2 = svld1_gather_u32index_f32(mask, src + 2, index);
+                return svmla_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, s0, weight[0]), s1, weight[1]), s2, weight[2]);
+            }
+
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            {
+                return svadd_f32_x(mask, RowConv(mask, src, weight),
+                    svadd_f32_x(mask, RowConv(mask, src + step, weight + 3),
+                        RowConv(mask, src + 2 * step, weight + 6)));
+            }
+        };
+
+        template<> struct Kernel<3, 3>
+        {
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            {
+                svuint32_t index = svindex_u32(0, 3);
+                svfloat32_t s0 = svld1_gather_u32index_f32(mask, src + 0, index);
+                svfloat32_t s1 = svld1_gather_u32index_f32(mask, src + 1, index);
+                svfloat32_t s2 = svld1_gather_u32index_f32(mask, src + 2, index);
+                return svmla_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, s0, weight[0]), s1, weight[1]), s2, weight[2]);
+            }
+
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            {
+                return svadd_f32_x(mask, RowConv(mask, src, weight),
+                    svadd_f32_x(mask, RowConv(mask, src + step, weight + 3),
+                        RowConv(mask, src + 2 * step, weight + 6)));
+            }
+        };
+
+        template<int kernel, int stride, ::SimdConvolutionActivationType type>
+        void ConvolutionBiasActivation(const float * src, size_t srcC, size_t srcH, size_t srcW, const float * weight,
+            const float * bias, const float * params, float * dst, size_t dstC, size_t dstH, size_t dstW)
+        {
+            const size_t F = svcntw();
+            svfloat32_t _weight[kernel * kernel];
+            svfloat32_t _params[2];
+            _params[0] = svdup_n_f32(params[0]);
+            if (type == SimdConvolutionActivationRestrictRange ||
+                type == SimdConvolutionActivationHswish ||
+                type == SimdConvolutionActivationHardSigmoid)
+                _params[1] = svdup_n_f32(params[1]);
+            for (size_t dc = 0; dc < dstC; ++dc)
+            {
+                if (type == ::SimdConvolutionActivationPrelu)
+                    _params[0] = svdup_n_f32(params[dc]);
+                if (srcC == 1)
+                {
+                    const float * ps = src;
+                    float * pd = dst;
+                    LoadWeight<kernel * kernel>(weight, _weight);
+                    svfloat32_t _bias = bias ? svdup_n_f32(bias[dc]) : svdup_n_f32(0.0f);
+                    for (size_t y = 0; y < dstH; ++y)
+                    {
+                        for (size_t x = 0; x < dstW; x += F)
+                        {
+                            svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
+                            svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
+                            svst1_f32(mask, pd + x, Activate<type>(mask, svadd_f32_x(mask, _bias, conv), _params));
+                        }
+                        ps += srcW * stride;
+                        pd += dstW;
+                    }
+                    weight += kernel * kernel;
+                }
+                else
+                {
+                    size_t sc = 0;
+                    for (; sc < 1; ++sc)
+                    {
+                        const float * ps = src;
+                        float * pd = dst;
+                        LoadWeight<kernel * kernel>(weight, _weight);
+                        svfloat32_t _bias = bias ? svdup_n_f32(bias[dc]) : svdup_n_f32(0.0f);
+                        for (size_t y = 0; y < dstH; ++y)
+                        {
+                            for (size_t x = 0; x < dstW; x += F)
+                            {
+                                svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
+                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
+                                svst1_f32(mask, pd + x, svadd_f32_x(mask, _bias, conv));
+                            }
+                            ps += srcW * stride;
+                            pd += dstW;
+                        }
+                        weight += kernel * kernel;
+                    }
+                    for (; sc < srcC - 1; ++sc)
+                    {
+                        const float * ps = src + sc * srcW * srcH;
+                        float * pd = dst;
+                        LoadWeight<kernel * kernel>(weight, _weight);
+                        for (size_t y = 0; y < dstH; ++y)
+                        {
+                            for (size_t x = 0; x < dstW; x += F)
+                            {
+                                svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
+                                svfloat32_t _dst = svld1_f32(mask, pd + x);
+                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
+                                svst1_f32(mask, pd + x, svadd_f32_x(mask, _dst, conv));
+                            }
+                            ps += srcW * stride;
+                            pd += dstW;
+                        }
+                        weight += kernel * kernel;
+                    }
+                    for (; sc < srcC; ++sc)
+                    {
+                        const float * ps = src + sc * srcW * srcH;
+                        float * pd = dst;
+                        LoadWeight<kernel * kernel>(weight, _weight);
+                        for (size_t y = 0; y < dstH; ++y)
+                        {
+                            for (size_t x = 0; x < dstW; x += F)
+                            {
+                                svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
+                                svfloat32_t _dst = svld1_f32(mask, pd + x);
+                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
+                                svst1_f32(mask, pd + x, Activate<type>(mask, svadd_f32_x(mask, _dst, conv), _params));
+                            }
+                            ps += srcW * stride;
+                            pd += dstW;
+                        }
+                        weight += kernel * kernel;
+                    }
+                }
+                dst += dstH * dstW;
+            }
+        }
+
+        bool SynetConvolution32fDirectNchw::Preferable(const ConvParam & p)
+        {
+            return Neon::SynetConvolution32fDirectNchw::Preferable(p);
+        }
+
+        template <int kernel, int stride> SynetConvolution32fDirectNchw::ConvolutionBiasActivationPtr SetConvolutionBiasActivation(::SimdConvolutionActivationType type)
+        {
+            switch (type)
+            {
+            case ::SimdConvolutionActivationIdentity: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationIdentity>;
+            case ::SimdConvolutionActivationRelu: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationRelu>;
+            case ::SimdConvolutionActivationLeakyRelu: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationLeakyRelu>;
+            case ::SimdConvolutionActivationRestrictRange: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationRestrictRange>;
+            case ::SimdConvolutionActivationPrelu: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationPrelu>;
+            case ::SimdConvolutionActivationElu: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationElu>;
+            case ::SimdConvolutionActivationHswish: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationHswish>;
+            case ::SimdConvolutionActivationMish: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationMish>;
+            case ::SimdConvolutionActivationHardSigmoid: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationHardSigmoid>;
+            case ::SimdConvolutionActivationSwish: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationSwish>;
+            case ::SimdConvolutionActivationGelu: return ConvolutionBiasActivation<kernel, stride, ::SimdConvolutionActivationGelu>;
+            default:
+                assert(0);
+                return NULL;
+            }
+        }
+
+        SynetConvolution32fDirectNchw::ConvolutionBiasActivationPtr SynetConvolution32fDirectNchw::SetConvolutionBiasActivation()
+        {
+            const ConvParam & p = _param;
+            const size_t F = svcntw();
+            if (p.dstW < F)
+                return Neon::SynetConvolution32fDirectNchw::SetConvolutionBiasActivation();
+            switch (p.strideX)
+            {
+            case 1:
+                if (p.kernelX == 1)
+                    return Sve2::SetConvolutionBiasActivation<1, 1>(p.activation);
+                if (p.kernelX == 2)
+                    return Sve2::SetConvolutionBiasActivation<2, 1>(p.activation);
+                if (p.kernelX == 3)
+                    return Sve2::SetConvolutionBiasActivation<3, 1>(p.activation);
+                break;
+            case 2:
+                if (p.kernelX == 2)
+                    return Sve2::SetConvolutionBiasActivation<2, 2>(p.activation);
+                if (p.kernelX == 3)
+                    return Sve2::SetConvolutionBiasActivation<3, 2>(p.activation);
+                break;
+            case 3:
+                if (p.kernelX == 3)
+                    return Sve2::SetConvolutionBiasActivation<3, 3>(p.activation);
+                break;
+            default:
+                return Neon::SynetConvolution32fDirectNchw::SetConvolutionBiasActivation();
+            }
+            assert(0);
+            return NULL;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
@@ -74,67 +74,67 @@ namespace Simd
                 return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
             }
 
-            template<::SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params);
+            template<::SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1);
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationIdentity>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationIdentity>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
                 return value;
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationRelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationRelu>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
                 return svmax_n_f32_x(mask, value, 0.0f);
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationLeakyRelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationLeakyRelu>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), params[0], svmin_n_f32_x(mask, value, 0.0f));
+                return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), param0, svmin_n_f32_x(mask, value, 0.0f));
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationRestrictRange>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationRestrictRange>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                return svmin_f32_x(mask, svmax_f32_x(mask, params[0], value), params[1]);
+                return svmin_f32_x(mask, svmax_f32_x(mask, param0, value), param1);
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationPrelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationPrelu>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), params[0], svmin_n_f32_x(mask, value, 0.0f));
+                return svmla_f32_x(mask, svmax_n_f32_x(mask, value, 0.0f), param0, svmin_n_f32_x(mask, value, 0.0f));
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationElu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationElu>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                svfloat32_t neg = svmul_f32_x(mask, params[0], svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+                svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
                 return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHswish>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHswish>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                svfloat32_t upper = svmin_f32_x(mask, value, params[0]);
-                svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, params[0]), 0.0f);
-                return svmul_f32_x(mask, svmul_f32_x(mask, positive, params[1]), value);
+                svfloat32_t upper = svmin_f32_x(mask, value, param0);
+                svfloat32_t positive = svmax_n_f32_x(mask, svadd_f32_x(mask, upper, param0), 0.0f);
+                return svmul_f32_x(mask, svmul_f32_x(mask, positive, param1), value);
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationMish>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationMish>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
                 svfloat32_t _1 = svdup_n_f32(1.0f);
                 svfloat32_t mish = svadd_f32_x(mask, Exp(mask, value), _1);
                 mish = svmla_f32_x(mask, _1, mish, mish);
                 mish = svmul_f32_x(mask, value, svsub_f32_x(mask, _1, svdiv_f32_x(mask, svdup_n_f32(2.0f), mish)));
-                return svsel_f32(svcmpgt_f32(mask, params[0], value), mish, value);
+                return svsel_f32(svcmpgt_f32(mask, param0, value), mish, value);
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHardSigmoid>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHardSigmoid>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_f32_x(mask, params[1], value, params[0]), 1.0f), 0.0f);
+                return svmax_n_f32_x(mask, svmin_n_f32_x(mask, svmla_f32_x(mask, param1, value, param0), 1.0f), 0.0f);
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationSwish>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationSwish>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, params[0])));
+                svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, param0)));
                 return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
             }
 
-            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationGelu>(const svbool_t& mask, svfloat32_t value, const svfloat32_t* params)
+            template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationGelu>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
                 svfloat32_t t = svmul_n_f32_x(mask, value, 0.70710678118654752440f);
                 return svmul_f32_x(mask, svmul_n_f32_x(mask, t, 0.70710678118654752440f), svadd_n_f32_x(mask, Erf(mask, t), 1.0f));
@@ -149,33 +149,27 @@ namespace Simd
             _convolutionBiasActivation = SetConvolutionBiasActivation();
         }
 
-        template <size_t size> SIMD_INLINE void LoadWeight(const float * src, svfloat32_t * dst)
-        {
-            for (size_t i = 0; i < size; ++i)
-                dst[i] = svdup_n_f32(src[i]);
-        }
-
         template<int kernel, int stride> struct Kernel
         {
-            static svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight);
+            static svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight);
         };
 
         template<> struct Kernel<1, 1>
         {
-            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight)
             {
-                return svmul_f32_x(mask, svld1_f32(mask, src), weight[0]);
+                return svmul_n_f32_x(mask, svld1_f32(mask, src), weight[0]);
             }
         };
 
         template<> struct Kernel<2, 1>
         {
-            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const float * weight)
             {
-                return svmla_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src + 0), weight[0]), svld1_f32(mask, src + 1), weight[1]);
+                return svmla_n_f32_x(mask, svmul_n_f32_x(mask, svld1_f32(mask, src + 0), weight[0]), svld1_f32(mask, src + 1), weight[1]);
             }
 
-            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight)
             {
                 return svadd_f32_x(mask, RowConv(mask, src, weight), RowConv(mask, src + step, weight + 2));
             }
@@ -183,15 +177,15 @@ namespace Simd
 
         template<> struct Kernel<2, 2>
         {
-            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const float * weight)
             {
                 svuint32_t index = svindex_u32(0, 2);
                 svfloat32_t s0 = svld1_gather_u32index_f32(mask, src + 0, index);
                 svfloat32_t s1 = svld1_gather_u32index_f32(mask, src + 1, index);
-                return svmla_f32_x(mask, svmul_f32_x(mask, s0, weight[0]), s1, weight[1]);
+                return svmla_n_f32_x(mask, svmul_n_f32_x(mask, s0, weight[0]), s1, weight[1]);
             }
 
-            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight)
             {
                 return svadd_f32_x(mask, RowConv(mask, src, weight), RowConv(mask, src + step, weight + 2));
             }
@@ -199,13 +193,13 @@ namespace Simd
 
         template<> struct Kernel<3, 1>
         {
-            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const float * weight)
             {
-                return svmla_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, svld1_f32(mask, src), weight[0]),
+                return svmla_n_f32_x(mask, svmla_n_f32_x(mask, svmul_n_f32_x(mask, svld1_f32(mask, src), weight[0]),
                     svld1_f32(mask, src + 1), weight[1]), svld1_f32(mask, src + 2), weight[2]);
             }
 
-            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight)
             {
                 return svadd_f32_x(mask, RowConv(mask, src, weight),
                     svadd_f32_x(mask, RowConv(mask, src + step, weight + 3),
@@ -215,16 +209,16 @@ namespace Simd
 
         template<> struct Kernel<3, 2>
         {
-            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const float * weight)
             {
                 svuint32_t index = svindex_u32(0, 2);
                 svfloat32_t s0 = svld1_gather_u32index_f32(mask, src + 0, index);
                 svfloat32_t s1 = svld1_gather_u32index_f32(mask, src + 1, index);
                 svfloat32_t s2 = svld1_gather_u32index_f32(mask, src + 2, index);
-                return svmla_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, s0, weight[0]), s1, weight[1]), s2, weight[2]);
+                return svmla_n_f32_x(mask, svmla_n_f32_x(mask, svmul_n_f32_x(mask, s0, weight[0]), s1, weight[1]), s2, weight[2]);
             }
 
-            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight)
             {
                 return svadd_f32_x(mask, RowConv(mask, src, weight),
                     svadd_f32_x(mask, RowConv(mask, src + step, weight + 3),
@@ -234,16 +228,16 @@ namespace Simd
 
         template<> struct Kernel<3, 3>
         {
-            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t RowConv(const svbool_t & mask, const float * src, const float * weight)
             {
                 svuint32_t index = svindex_u32(0, 3);
                 svfloat32_t s0 = svld1_gather_u32index_f32(mask, src + 0, index);
                 svfloat32_t s1 = svld1_gather_u32index_f32(mask, src + 1, index);
                 svfloat32_t s2 = svld1_gather_u32index_f32(mask, src + 2, index);
-                return svmla_f32_x(mask, svmla_f32_x(mask, svmul_f32_x(mask, s0, weight[0]), s1, weight[1]), s2, weight[2]);
+                return svmla_n_f32_x(mask, svmla_n_f32_x(mask, svmul_n_f32_x(mask, s0, weight[0]), s1, weight[1]), s2, weight[2]);
             }
 
-            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const svfloat32_t * weight)
+            static SIMD_INLINE svfloat32_t SynetConvolution32f(const svbool_t & mask, const float * src, size_t step, const float * weight)
             {
                 return svadd_f32_x(mask, RowConv(mask, src, weight),
                     svadd_f32_x(mask, RowConv(mask, src + step, weight + 3),
@@ -256,30 +250,29 @@ namespace Simd
             const float * bias, const float * params, float * dst, size_t dstC, size_t dstH, size_t dstW)
         {
             const size_t F = svcntw();
-            svfloat32_t _weight[kernel * kernel];
-            svfloat32_t _params[2];
-            _params[0] = svdup_n_f32(params[0]);
+            svfloat32_t param0 = svdup_n_f32(params[0]);
+            svfloat32_t param1 = svdup_n_f32(0.0f);
             if (type == SimdConvolutionActivationRestrictRange ||
                 type == SimdConvolutionActivationHswish ||
                 type == SimdConvolutionActivationHardSigmoid)
-                _params[1] = svdup_n_f32(params[1]);
+                param1 = svdup_n_f32(params[1]);
             for (size_t dc = 0; dc < dstC; ++dc)
             {
                 if (type == ::SimdConvolutionActivationPrelu)
-                    _params[0] = svdup_n_f32(params[dc]);
+                    param0 = svdup_n_f32(params[dc]);
                 if (srcC == 1)
                 {
                     const float * ps = src;
+                    const float * pw = weight;
                     float * pd = dst;
-                    LoadWeight<kernel * kernel>(weight, _weight);
                     svfloat32_t _bias = bias ? svdup_n_f32(bias[dc]) : svdup_n_f32(0.0f);
                     for (size_t y = 0; y < dstH; ++y)
                     {
                         for (size_t x = 0; x < dstW; x += F)
                         {
                             svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
-                            svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
-                            svst1_f32(mask, pd + x, Activate<type>(mask, svadd_f32_x(mask, _bias, conv), _params));
+                            svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, pw);
+                            svst1_f32(mask, pd + x, Activate<type>(mask, svadd_f32_x(mask, _bias, conv), param0, param1));
                         }
                         ps += srcW * stride;
                         pd += dstW;
@@ -292,15 +285,15 @@ namespace Simd
                     for (; sc < 1; ++sc)
                     {
                         const float * ps = src;
+                        const float * pw = weight;
                         float * pd = dst;
-                        LoadWeight<kernel * kernel>(weight, _weight);
                         svfloat32_t _bias = bias ? svdup_n_f32(bias[dc]) : svdup_n_f32(0.0f);
                         for (size_t y = 0; y < dstH; ++y)
                         {
                             for (size_t x = 0; x < dstW; x += F)
                             {
                                 svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
-                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
+                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, pw);
                                 svst1_f32(mask, pd + x, svadd_f32_x(mask, _bias, conv));
                             }
                             ps += srcW * stride;
@@ -311,15 +304,15 @@ namespace Simd
                     for (; sc < srcC - 1; ++sc)
                     {
                         const float * ps = src + sc * srcW * srcH;
+                        const float * pw = weight;
                         float * pd = dst;
-                        LoadWeight<kernel * kernel>(weight, _weight);
                         for (size_t y = 0; y < dstH; ++y)
                         {
                             for (size_t x = 0; x < dstW; x += F)
                             {
                                 svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
                                 svfloat32_t _dst = svld1_f32(mask, pd + x);
-                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
+                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, pw);
                                 svst1_f32(mask, pd + x, svadd_f32_x(mask, _dst, conv));
                             }
                             ps += srcW * stride;
@@ -330,16 +323,16 @@ namespace Simd
                     for (; sc < srcC; ++sc)
                     {
                         const float * ps = src + sc * srcW * srcH;
+                        const float * pw = weight;
                         float * pd = dst;
-                        LoadWeight<kernel * kernel>(weight, _weight);
                         for (size_t y = 0; y < dstH; ++y)
                         {
                             for (size_t x = 0; x < dstW; x += F)
                             {
                                 svbool_t mask = svwhilelt_b32((uint32_t)x, (uint32_t)dstW);
                                 svfloat32_t _dst = svld1_f32(mask, pd + x);
-                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, _weight);
-                                svst1_f32(mask, pd + x, Activate<type>(mask, svadd_f32_x(mask, _dst, conv), _params));
+                                svfloat32_t conv = Kernel<kernel, stride>::SynetConvolution32f(mask, ps + x * stride, srcW, pw);
+                                svst1_f32(mask, pd + x, Activate<type>(mask, svadd_f32_x(mask, _dst, conv), param0, param1));
                             }
                             ps += srcW * stride;
                             pd += dstW;

--- a/src/Simd/SimdSynetConvolution32f.h
+++ b/src/Simd/SimdSynetConvolution32f.h
@@ -760,6 +760,18 @@ namespace Simd
             virtual String Ext() const { return "Sve2"; }
         };
 
+        class SynetConvolution32fDirectNchw : public Neon::SynetConvolution32fDirectNchw
+        {
+        public:
+            SynetConvolution32fDirectNchw(const ConvParam & p);
+            virtual String Ext() const { return "Sve2"; }
+
+            static bool Preferable(const ConvParam & p);
+
+        protected:
+            virtual ConvolutionBiasActivationPtr SetConvolutionBiasActivation();
+        };
+
         void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
     }
 #endif//SIMD_SVE2_ENABLE

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -267,6 +267,10 @@ namespace Test
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 128, 16, 16, 1, _1, _1, _1, _0, _0, 1, a, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 64, 64, 16, _3, _1, _1, _1, _1, 1, aPr, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 64, 64, 16, _3, _1, _1, _1, _1, 1, aPr, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1, 48, 48, 8, _3, _1, _1, _1, _1, 1, aRe, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 40, 40, 16, _2, _1, _1, _0, _0, 1, aId, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1, 33, 33, 4, _3, _1, _2, _1, _1, 1, aRe, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1, 64, 64, 8, _1, _1, _1, _0, _0, 1, aRe, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 128, 128, 256, _3, _1, _1, _1, _1, 1, a, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 16, 16, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 6, 15, 32, _3, _1, _1, _1, _1, 1, aId, tT), f1, f2);
@@ -296,6 +300,8 @@ namespace Test
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 48, 4, 16, 48, Size(1, 3), _1, _1, Size(0, 1), Size(0, 1), 1, aId, tT), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _1, _2, _2, 1, aRe, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _2, _2, _2, 1, aRe, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1, 48, 48, 8, _3, _1, _1, _1, _1, 1, aRe, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 40, 40, 16, _2, _1, _1, _0, _0, 1, aId, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 96, 14, 14, 192, _3, _1, _1, _1, _1, 96, a, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 49, 29, 29, 98, _7, _1, _2, _3, _3, 49, a, t), f1, f2);
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `SimdSve2SynetConvolution32fDirectNchw.cpp` with SVE/SVE2 kernels for `SynetConvolution32fDirectNchw` (kernel 1/2/3, stride 1/2/3), using predicated loads/stores and gather-based strided access instead of interleave loads.
- Wire `Sve2::SynetConvolution32fDirectNchw` into `Sve2::SynetConvolution32fInit`, declare the class in `SimdSynetConvolution32f.h`, and add the source to `prj/vs2022/Sve2.vcxproj` / filters.
- Extend `Test::SynetConvolution32fAutoTest` with NCHW shapes that exercise DirectNchw, and document the feature under release 7.2.165 in `docs/2026.html`.

## Test plan
- [x] x86 Release build (`cmake` + `Test`) and `./Test "-r=.." -fi=SynetConvolution32f -tt=1 -ts=1` (passed)
- [x] Cross-compile SVE2 translation unit with `aarch64-linux-gnu-g++ -march=armv9-a+sve+sve2` (passed after sizeless-type fix)
- [ ] Full ARM/SVE2 correctness/performance run of `Test::SynetConvolution32fAutoTest` on SVE2 hardware when available

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc935115-2adf-42cd-86f1-133472553182?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc935115-2adf-42cd-86f1-133472553182&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

