### PR TITLE
Add SVE2 optimizations for SynetConvolution32fDepthwiseDotProduct

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -47,6 +47,7 @@
  <li>NEON, SVE2 optimizations of class SynetConvolution32fNhwcGroupedBlock1x2.</li>
  <li>SVE2 optimizations of class SynetConvolution32fDirectNchw.</li>
  <li>SVE2 optimizations of class SynetConvolution32fNhwcDepthwise.</li>
+ <li>SVE2 optimizations of class SynetConvolution32fDepthwiseDotProduct.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/src/Simd/SimdSve2SynetConvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32f.cpp
@@ -36,8 +36,8 @@ namespace Simd
             ConvParam param(batch, conv, SimdSynetCompatibilityDefault);
             if (!param.Valid(SimdTensorData32f))
                 return NULL;
-            if (Neon::SynetConvolution32fDepthwiseDotProduct::Preferable(param))
-                return new Neon::SynetConvolution32fDepthwiseDotProduct(param);
+            if (SynetConvolution32fDepthwiseDotProduct::Preferable(param))
+                return new SynetConvolution32fDepthwiseDotProduct(param);
             else if (SynetConvolution32fWinograd::Preferable(param))
                 return new SynetConvolution32fWinograd(param);
             else if (SynetConvolution32fDirectNchw::Preferable(param))

--- a/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
@@ -402,6 +402,66 @@ namespace Simd
             assert(0);
             return NULL;
         }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SynetConvolution32fDepthwiseDotProduct::SynetConvolution32fDepthwiseDotProduct(const ConvParam& p)
+            : Neon::SynetConvolution32fDepthwiseDotProduct(p)
+        {
+        }
+
+        SIMD_INLINE void DotProduct(const float* a, const float* b, const svbool_t& mask, svfloat32_t& sum)
+        {
+            svfloat32_t _a = svld1_f32(mask, a);
+            svfloat32_t _b = svld1_f32(mask, b);
+            sum = svmla_f32_m(mask, sum, _a, _b);
+        }
+
+        SIMD_INLINE float DotProduct(const float* a, const float* b, size_t size)
+        {
+            const size_t F = svcntw();
+            const size_t QF = 4 * F;
+            const svbool_t body = svptrue_b32();
+            size_t sizeQF = AlignLo(size, QF);
+            size_t sizeF = AlignLo(size, F);
+            size_t i = 0;
+            svfloat32_t sums0 = svdup_n_f32(0.0f), sums1 = svdup_n_f32(0.0f);
+            svfloat32_t sums2 = svdup_n_f32(0.0f), sums3 = svdup_n_f32(0.0f);
+            for (; i < sizeQF; i += QF)
+            {
+                DotProduct(a + i + 0 * F, b + i + 0 * F, body, sums0);
+                DotProduct(a + i + 1 * F, b + i + 1 * F, body, sums1);
+                DotProduct(a + i + 2 * F, b + i + 2 * F, body, sums2);
+                DotProduct(a + i + 3 * F, b + i + 3 * F, body, sums3);
+            }
+            sums0 = svadd_f32_x(body, svadd_f32_x(body, sums0, sums1), svadd_f32_x(body, sums2, sums3));
+            for (; i < sizeF; i += F)
+                DotProduct(a + i, b + i, body, sums0);
+            if (i < size)
+                DotProduct(a + i, b + i, svwhilelt_b32(i, size), sums0);
+            return svaddv_f32(body, sums0);
+        }
+
+        void SynetConvolution32fDepthwiseDotProduct::Forward(const float* src, float* buf, float* dst)
+        {
+            for (size_t b = 0; b < _batch; ++b)
+            {
+                if (_bias)
+                {
+                    for (size_t i = 0; i < _count; ++i)
+                        dst[i] = DotProduct(src + i * _size, _weight + i * _size, _size) + _bias[i];
+                }
+                else
+                {
+                    for (size_t i = 0; i < _count; ++i)
+                        dst[i] = DotProduct(src + i * _size, _weight + i * _size, _size);
+                }
+                if (_param.activation)
+                    Neon::ConvolutionBiasAndActivation(NULL, _count, 1, _param.activation, _params, ::SimdFalse, dst);
+                src += _sizeS;
+                dst += _sizeD;
+            }
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSynetConvolution32f.h
+++ b/src/Simd/SimdSynetConvolution32f.h
@@ -779,6 +779,14 @@ namespace Simd
             virtual String Ext() const { return "Sve2"; }
         };
 
+        class SynetConvolution32fDepthwiseDotProduct : public Neon::SynetConvolution32fDepthwiseDotProduct
+        {
+        public:
+            SynetConvolution32fDepthwiseDotProduct(const ConvParam & p);
+            virtual String Ext() const { return "Sve2"; }
+            virtual void Forward(const float * src, float * buf, float * dst);
+        };
+
         void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
     }
 #endif//SIMD_SVE2_ENABLE

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -268,11 +268,15 @@ namespace Test
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 1280, 32, 32, 256, _1, _1, _1, _0, _0, 1, aRe, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 384, 7, 7, 768, _3, _1, _1, _1, _1, 384, a, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 152, 32, 32, 152, _7, _1, _1, _3, _3, 152, aRe, t), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 7, 7, 64, _7, _1, _1, _0, _0, 64, aRe, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 128, 5, 5, 128, _5, _1, _1, _0, _0, 128, a, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 49, 3, 3, 49, _3, _1, _1, _0, _0, 49, aHi, tF), f1, f2);
 #endif
 #else
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 20, 75, 75, 20, Size(1, 11), _1, _1, Size(0, 5), Size(0, 5), 20, aId, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _1, _2, _2, 1, aRe, t), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 9, 9, 16, _3, Size(2, 2), _2, _2, _2, 1, aRe, tF), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 7, 7, 64, _7, _1, _1, _0, _0, 64, aRe, tF), f1, f2);
 #endif
         return result;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE/SVE2 kernels for `SynetConvolution32fDepthwiseDotProduct` in `SimdSve2SynetConvolution32fDirectNchw.cpp`, using 4-way unrolled `svmla_f32_m` accumulation and predicated tails via `svwhilelt_b32` / `svaddv_f32`.
- Wire `Sve2::SynetConvolution32fDepthwiseDotProduct` into `Sve2::SynetConvolution32fInit` and declare the class in `SimdSynetConvolution32f.h` (source already listed in `prj/vs2022/Sve2.vcxproj`).
- Extend `Test::SynetConvolution32fAutoTest` with NCHW depthwise-dot shapes (`group == srcC == dstC`, kernel == spatial), including a non-multiple-of-VL channel count (49), and document the feature under release 7.2.165 in `docs/2026.html`.

## Test plan
- [x] Cross-compile SVE2 translation units with `aarch64-linux-gnu-g++ -march=armv9-a+sve+sve2+i8mm` (passed)
- [x] x86 Release build (`cmake` + `Test`) and `./Test "-r=.." -fi=SynetConvolution32f -tt=1 -ts=1` (passed; includes new DepthwiseDotProduct shapes)
- [ ] Full ARM/SVE2 correctness/performance run of `Test::SynetConvolution32fAutoTest` on SVE2 hardware when available

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40b0c5ab-f38e-4c95-9327-bd4040be7805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40b0c5ab-f38e-4c95-9327-bd4040be7805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

