### PR TITLE
Add SVE2 optimizations for SynetConvolution32fNhwcDirect

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -48,6 +48,7 @@
  <li>SVE2 optimizations of class SynetConvolution32fDirectNchw.</li>
  <li>SVE2 optimizations of class SynetConvolution32fNhwcDepthwise.</li>
  <li>SVE2 optimizations of class SynetConvolution32fDepthwiseDotProduct.</li>
+ <li>SVE2 optimizations of class SynetConvolution32fNhwcDirect.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -109,6 +109,11 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fDirectNchw.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDepthwise.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect2f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect2r.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect3r.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect4r.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcGrouped.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConversion.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -566,6 +566,21 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDepthwise.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect2f.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect2r.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect3r.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcDirect4r.cpp">
+      <Filter>Sve2\Synet\Convolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetConvolution32fNhwcGrouped.cpp">
       <Filter>Sve2\Synet\Convolution</Filter>
     </ClCompile>

--- a/src/Simd/SimdSve2SynetConvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32f.cpp
@@ -44,8 +44,8 @@ namespace Simd
                 return new SynetConvolution32fDirectNchw(param);
             else if (SynetConvolution32fGemmNT::Preferable(param))
                 return new SynetConvolution32fGemmNT(param);
-            else if (Neon::SynetConvolution32fNhwcDirect::Preferable(param))
-                return new Neon::SynetConvolution32fNhwcDirect(param);
+            else if (SynetConvolution32fNhwcDirect::Preferable(param))
+                return new SynetConvolution32fNhwcDirect(param);
             else if (SynetConvolution32fNhwcDepthwise::Preferable(param))
                 return new SynetConvolution32fNhwcDepthwise(param);
             else if (SynetConvolution32fNhwcGroupedBlock1x2::Preferable(param))

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDirect.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDirect.cpp
@@ -1,0 +1,83 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        SynetConvolution32fNhwcDirect::SynetConvolution32fNhwcDirect(const ConvParam& p)
+            : Base::SynetConvolution32fNhwcDirect(p)
+        {
+            const size_t F = svcntw();
+            //_old.enable = true;
+            if (_old.enable)
+            {
+                if (Set2f(p, _old.convolution))
+                    OldSetAlgParam(F);
+            }
+            else
+            {
+                RunFuncs funcs;
+                for (size_t n = 2; n <= 4; ++n)
+                {
+                    funcs.push_back(RunFunc(Ext() + "-" + ToStr(n)));
+                    SetAlgParam(F, n, funcs.back().alg);
+                    if (!SetRt(p, funcs.back().alg))
+                        return;
+                }
+                _run.Init(funcs);
+            }
+        }
+
+        bool SynetConvolution32fNhwcDirect::SetRt(const ConvParam& p, AlgParam& a)
+        {
+            if (a.microD == 2 * a.F)
+                return Set2r(p, a);
+            if (a.microD == 3 * a.F)
+                return Set3r(p, a);
+            if (a.microD == 4 * a.F)
+                return Set4r(p, a);
+            return false;
+        }
+
+        bool SynetConvolution32fNhwcDirect::Preferable(const ConvParam& p)
+        {
+            if (p.trans != SimdTrue || p.group != 1 || !p.IsDilation(1))
+                return false;
+            if (!p.Is1x1() && p.dstW < 6 + p.padX + p.padY)
+                return false;
+            if (p.Is1x1() && (p.srcC >= 2 * p.dstC || (p.activation == SimdConvolutionActivationIdentity && p.srcC > 128) || p.srcC > 256))
+                return false;
+            if (p.kernelY > p.srcH || p.kernelX > p.srcW)
+                return false;
+            return true;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDirect2f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDirect2f.cpp
@@ -1,0 +1,712 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Sve2
+    {
+        using AlgParam = SynetConvolution32fNhwcDirect::AlgParam;
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2x6(const float* src0, const ConvParam& p,
+            size_t kernelH, size_t kernelW, size_t srcC, size_t dstC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, s0, w0, w1;
+            size_t dS = p.srcC * p.strideX, dW = DF * (p.kernelX - kernelW) * srcC, dY = p.srcW * p.srcC, dX = p.srcC, dD = p.dstC;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            const float* src4 = src0 + 4 * dS;
+            const float* src5 = src0 + 5 * dS;
+            if (dstC > F)
+            {
+                if (first)
+                {
+                    d00 = svdup_n_f32(0.0f); d01 = svdup_n_f32(0.0f);
+                    d10 = svdup_n_f32(0.0f); d11 = svdup_n_f32(0.0f);
+                    d20 = svdup_n_f32(0.0f); d21 = svdup_n_f32(0.0f);
+                    d30 = svdup_n_f32(0.0f); d31 = svdup_n_f32(0.0f);
+                    d40 = svdup_n_f32(0.0f); d41 = svdup_n_f32(0.0f);
+                    d50 = svdup_n_f32(0.0f); d51 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + F);
+                    d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + F);
+                    d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + F);
+                    d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + F);
+                    d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + F);
+                    d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + F);
+                }
+                for (size_t ky = 0; ky < kernelH; ++ky)
+                {
+                    for (size_t kx = 0; kx < kernelW; ++kx)
+                    {
+                        for (size_t offset = ky * dY + kx * dX, end = offset + srcC; offset < end; ++offset)
+                        {
+                            w0 = svld1_f32(svptrue_b32(), weight + 0);
+                            w1 = svld1_f32(svptrue_b32(), weight + F);
+                            s0 = svdup_n_f32(src0[offset]);
+                            d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                            s0 = svdup_n_f32(src1[offset]);
+                            d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                            d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                            s0 = svdup_n_f32(src2[offset]);
+                            d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                            d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                            s0 = svdup_n_f32(src3[offset]);
+                            d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                            d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                            s0 = svdup_n_f32(src4[offset]);
+                            d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                            d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                            s0 = svdup_n_f32(src5[offset]);
+                            d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                            d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                            weight += DF;
+                        }
+                    }
+                    weight += dW;
+                }
+                if (dstC == DF)
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d31, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d41, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d51, bias, params);
+                }
+                else
+                {
+                    dstC -= F;
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d31, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d41, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d51, bias, params, dstC);
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    d00 = svdup_n_f32(0.0f);
+                    d10 = svdup_n_f32(0.0f);
+                    d20 = svdup_n_f32(0.0f);
+                    d30 = svdup_n_f32(0.0f);
+                    d40 = svdup_n_f32(0.0f);
+                    d50 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0);
+                    d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0);
+                    d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0);
+                    d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0);
+                    d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0);
+                    d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0);
+                }
+                for (size_t ky = 0; ky < kernelH; ++ky)
+                {
+                    for (size_t kx = 0; kx < kernelW; ++kx)
+                    {
+                        for (size_t offset = ky * dY + kx * dX, end = offset + srcC; offset < end; ++offset)
+                        {
+                            w0 = svld1_f32(svptrue_b32(), weight + 0);
+                            s0 = svdup_n_f32(src0[offset]);
+                            d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            s0 = svdup_n_f32(src1[offset]);
+                            d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                            s0 = svdup_n_f32(src2[offset]);
+                            d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                            s0 = svdup_n_f32(src3[offset]);
+                            d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                            s0 = svdup_n_f32(src4[offset]);
+                            d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                            s0 = svdup_n_f32(src5[offset]);
+                            d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                            weight += DF;
+                        }
+                    }
+                    weight += dW;
+                }
+                if (dstC == F)
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params);
+                }
+                else
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params, dstC);
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2x3(const float* src0, const ConvParam& p,
+            size_t kernelH, size_t kernelW, size_t srcC, size_t dstC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            svfloat32_t d00, d01, d10, d11, d20, d21, s0, w0, w1;
+            size_t dS = p.srcC * p.strideX, dW = DF * (p.kernelX - kernelW) * srcC, dY = p.srcW * p.srcC, dX = p.srcC, dD = p.dstC;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            if (dstC > F)
+            {
+                if (first)
+                {
+                    d00 = svdup_n_f32(0.0f); d01 = svdup_n_f32(0.0f);
+                    d10 = svdup_n_f32(0.0f); d11 = svdup_n_f32(0.0f);
+                    d20 = svdup_n_f32(0.0f); d21 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + F);
+                    d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + F);
+                    d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + F);
+                }
+                for (size_t ky = 0; ky < kernelH; ++ky)
+                {
+                    for (size_t kx = 0; kx < kernelW; ++kx)
+                    {
+                        for (size_t offset = ky * dY + kx * dX, end = offset + srcC; offset < end; ++offset)
+                        {
+                            w0 = svld1_f32(svptrue_b32(), weight + 0);
+                            w1 = svld1_f32(svptrue_b32(), weight + F);
+                            s0 = svdup_n_f32(src0[offset]);
+                            d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                            s0 = svdup_n_f32(src1[offset]);
+                            d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                            d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                            s0 = svdup_n_f32(src2[offset]);
+                            d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                            d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                            weight += DF;
+                        }
+                    }
+                    weight += dW;
+                }
+                if (dstC == DF)
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params);
+                }
+                else
+                {
+                    dstC -= F;
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC);
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    d00 = svdup_n_f32(0.0f);
+                    d10 = svdup_n_f32(0.0f);
+                    d20 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0);
+                    d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0);
+                    d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0);
+                }
+                for (size_t ky = 0; ky < kernelH; ++ky)
+                {
+                    for (size_t kx = 0; kx < kernelW; ++kx)
+                    {
+                        for (size_t offset = ky * dY + kx * dX, end = offset + srcC; offset < end; ++offset)
+                        {
+                            w0 = svld1_f32(svptrue_b32(), weight + 0);
+                            s0 = svdup_n_f32(src0[offset]);
+                            d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            s0 = svdup_n_f32(src1[offset]);
+                            d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                            s0 = svdup_n_f32(src2[offset]);
+                            d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                            weight += DF;
+                        }
+                    }
+                    weight += dW;
+                }
+                if (dstC == F)
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                }
+                else
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC);
+                    dst += dD;
+                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC);
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2x1(const float* src0, const ConvParam& p,
+            size_t kernelH, size_t kernelW, size_t srcC, size_t dstC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            svfloat32_t d00, d01, s0, w0, w1;
+            size_t dW = DF * (p.kernelX - kernelW) * srcC, dY = p.srcW * p.srcC, dX = p.srcC;
+            if (dstC > F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0), d01 = svld1_f32(svptrue_b32(), dst + F);
+                for (size_t ky = 0; ky < kernelH; ++ky)
+                {
+                    for (size_t kx = 0; kx < kernelW; ++kx)
+                    {
+                        for (size_t offset = ky * dY + kx * dX, end = offset + srcC; offset < end; ++offset)
+                        {
+                            w0 = svld1_f32(svptrue_b32(), weight + 0);
+                            w1 = svld1_f32(svptrue_b32(), weight + F);
+                            s0 = svdup_n_f32(src0[offset]);
+                            d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                            weight += DF;
+                        }
+                    }
+                    weight += dW;
+                }
+                if (dstC == DF)
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params);
+                }
+                else
+                {
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC - F);
+                }
+            }
+            else
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0);
+                for (size_t ky = 0; ky < kernelH; ++ky)
+                {
+                    for (size_t kx = 0; kx < kernelW; ++kx)
+                    {
+                        for (size_t offset = ky * dY + kx * dX, end = offset + srcC; offset < end; ++offset)
+                        {
+                            w0 = svld1_f32(svptrue_b32(), weight + 0);
+                            s0 = svdup_n_f32(src0[offset]);
+                            d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            weight += DF;
+                        }
+                    }
+                    weight += dW;
+                }
+                if (dstC == F)
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                else
+                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2(const float* src, const ConvParam& p,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            size_t noseH = p.padY, noseW = p.padX;
+            size_t bodyH = p.srcH - p.kernelY + 1 + noseH, bodyW = p.srcW - p.kernelX + 1 + noseW;
+            size_t bodyW3 = AlignLoAny(bodyW - noseW, 3 * p.strideX) + noseW;
+            size_t bodyW6 = AlignLoAny(bodyW - noseW, 6 * p.strideX) + noseW;
+            size_t tailH = bodyH + p.padH, tailW = bodyW + p.padW;
+            size_t kY = p.kernelY - noseH, kX = p.kernelX - noseW, kH = bodyH + p.kernelY - 1, kW = bodyW + p.kernelX - 1;
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                float* d = dst + dc + yBeg * p.dstW * p.dstC;
+                size_t dy = yBeg, sy = dy * p.strideY;
+                for (; sy < noseH && dy < yEnd; sy += p.strideY, dy++)
+                {
+                    size_t sx = 0;
+                    const float* s = src;
+                    const float* w = weight + (noseH - sy) * p.kernelX * srcC * DF;
+                    for (; sx < noseW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s, p, kY + sy, kX + sx, srcC, dC, w + (noseW - sx) * srcC * DF, _bias, _params, d, first);
+                    for (; sx < bodyW6; sx += 6 * p.strideX, d += 6 * p.dstC)
+                        ConvolutionNhwcDirect_2x6<term, type>(s + (sx - noseW) * p.srcC, p, kY + sy, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < bodyW3; sx += 3 * p.strideX, d += 3 * p.dstC)
+                        ConvolutionNhwcDirect_2x3<term, type>(s + (sx - noseW) * p.srcC, p, kY + sy, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < bodyW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s + (sx - noseW) * p.srcC, p, kY + sy, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < tailW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s + (sx - noseW) * p.srcC, p, kY + sy, kW - sx, srcC, dC, w, _bias, _params, d, first);
+                }
+                for (; sy < bodyH && dy < yEnd; sy += p.strideY, dy++)
+                {
+                    size_t sx = 0;
+                    const float* s = src + (sy - noseH) * p.srcW * p.srcC;
+                    const float* w = weight;
+                    for (; sx < noseW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s, p, p.kernelY, kX + sx, srcC, dC, w + (noseW - sx) * srcC * DF, _bias, _params, d, first);
+                    for (; sx < bodyW6; sx += 6 * p.strideX, d += 6 * p.dstC)
+                        ConvolutionNhwcDirect_2x6<term, type>(s + (sx - noseW) * p.srcC, p, p.kernelY, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < bodyW3; sx += 3 * p.strideX, d += 3 * p.dstC)
+                        ConvolutionNhwcDirect_2x3<term, type>(s + (sx - noseW) * p.srcC, p, p.kernelY, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < bodyW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s + (sx - noseW) * p.srcC, p, p.kernelY, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < tailW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s + (sx - noseW) * p.srcC, p, p.kernelY, kW - sx, srcC, dC, w, _bias, _params, d, first);
+                }
+                for (; sy < tailH && dy < yEnd; sy += p.strideY, dy++)
+                {
+                    size_t sx = 0;
+                    const float* s = src + (sy - noseH) * p.srcW * p.srcC;
+                    const float* w = weight;
+                    for (; sx < noseW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s, p, kH - sy, kX + sx, srcC, dC, w + (noseW - sx) * srcC * DF, _bias, _params, d, first);
+                    for (; sx < bodyW6; sx += 6 * p.strideX, d += 6 * p.dstC)
+                        ConvolutionNhwcDirect_2x6<term, type>(s + (sx - noseW) * p.srcC, p, kH - sy, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < bodyW3; sx += 3 * p.strideX, d += 3 * p.dstC)
+                        ConvolutionNhwcDirect_2x3<term, type>(s + (sx - noseW) * p.srcC, p, kH - sy, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < bodyW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s + (sx - noseW) * p.srcC, p, kH - sy, p.kernelX, srcC, dC, w, _bias, _params, d, first);
+                    for (; sx < tailW; sx += p.strideX, d += p.dstC)
+                        ConvolutionNhwcDirect_2x1<term, type>(s + (sx - noseW) * p.srcC, p, kH - sy, kW - sx, srcC, dC, w, _bias, _params, d, first);
+                }
+                weight += p.kernelY * p.kernelX * srcC * DF;
+            }
+        }
+
+        template<SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2(const float* src, const ConvParam& p,
+            const SynetConvolution32fNhwcDirect::AlgParam& a, const float* weight, const float* bias, const float* params, float* dst)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            for (size_t dc = 0; dc < p.dstC; dc += a.macroD)
+            {
+                size_t macroD = Simd::Min(p.dstC, dc + a.macroD) - dc;
+                for (size_t sc = 0; sc < p.srcC; sc += a.macroC)
+                {
+                    size_t macroC = Simd::Min(p.srcC, sc + a.macroC) - sc;
+                    size_t macroK = p.kernelY * p.kernelX * macroC;
+                    for (size_t yBeg = 0; yBeg < p.dstH;)
+                    {
+                        size_t yEnd = Simd::Min(yBeg + a.macroH, p.dstH);
+                        if (sc + macroC == p.srcC)
+                            ConvolutionNhwcDirect_2<TermLast, type>(src + sc, p, macroD, yBeg, yEnd, macroC, weight, bias + dc, params, dst + dc, macroC == p.srcC ? 1 : 0);
+                        else
+                            ConvolutionNhwcDirect_2<TermInterim, SimdConvolutionActivationIdentity>(src + sc, p, macroD, yBeg, yEnd, macroC, weight, bias + dc, params, dst + dc, sc == 0 ? 1 : 0);
+                        yBeg = yEnd;
+                    }
+                    weight += AlignHiAny(macroD, a.microD) * macroK;
+                }
+                if (type == ::SimdConvolutionActivationPrelu)
+                    params += macroD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_2xM(const float* src0, const ConvParam& p,
+            size_t srcC, size_t dstC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, s0, w0, w1;
+            size_t dS = p.srcC, dD = p.dstC;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            const float* src4 = src0 + 4 * dS;
+            const float* src5 = src0 + 5 * dS;
+            if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0x0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 0x1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 0x2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 0x3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 0x4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 0x5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + 0), d01 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + F);
+                    if (M > 0x1) d10 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + 0), d11 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + F);
+                    if (M > 0x2) d20 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + 0), d21 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + F);
+                    if (M > 0x3) d30 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + 0), d31 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + F);
+                    if (M > 0x4) d40 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + 0), d41 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + F);
+                    if (M > 0x5) d50 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + 0), d51 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + F);
+                } 
+                for (size_t offset = 0; offset < srcC; ++offset)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight + 0);
+                    w1 = svld1_f32(svptrue_b32(), weight + F);
+                    if (M > 0) s0 = svdup_n_f32(src0[offset]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                    if (M > 1) s0 = svdup_n_f32(src1[offset]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                    if (M > 2) s0 = svdup_n_f32(src2[offset]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                    if (M > 3) s0 = svdup_n_f32(src3[offset]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                    if (M > 4) s0 = svdup_n_f32(src4[offset]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                    if (M > 5) s0 = svdup_n_f32(src5[offset]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                    weight += DF;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params), Term<term>::template Save<type, 1>(dst + F, d01, bias, params), dst += dD;
+                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params), Term<term>::template Save<type, 1>(dst + F, d11, bias, params), dst += dD;
+                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params), Term<term>::template Save<type, 1>(dst + F, d21, bias, params), dst += dD;
+                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params), Term<term>::template Save<type, 1>(dst + F, d31, bias, params), dst += dD;
+                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params), Term<term>::template Save<type, 1>(dst + F, d41, bias, params), dst += dD;
+                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params), Term<term>::template Save<type, 1>(dst + F, d51, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params), Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC), dst += dD;
+                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params), Term<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC), dst += dD;
+                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params), Term<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC), dst += dD;
+                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params), Term<term>::template Save<type, 1>(dst + F, d31, bias, params, dstC), dst += dD;
+                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params), Term<term>::template Save<type, 1>(dst + F, d41, bias, params, dstC), dst += dD;
+                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params), Term<term>::template Save<type, 1>(dst + F, d51, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0x0) d00 = svdup_n_f32(0.0f);
+                    if (M > 0x1) d10 = svdup_n_f32(0.0f);
+                    if (M > 0x2) d20 = svdup_n_f32(0.0f);
+                    if (M > 0x3) d30 = svdup_n_f32(0.0f);
+                    if (M > 0x4) d40 = svdup_n_f32(0.0f);
+                    if (M > 0x5) d50 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + 0);
+                    if (M > 0x1) d10 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + 0);
+                    if (M > 0x2) d20 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + 0);
+                    if (M > 0x3) d30 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + 0);
+                    if (M > 0x4) d40 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + 0);
+                    if (M > 0x5) d50 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + 0);
+                }
+                for (size_t offset = 0; offset < srcC; ++offset)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight + 0);
+                    if (M > 0) s0 = svdup_n_f32(src0[offset]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                    if (M > 1) s0 = svdup_n_f32(src1[offset]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                    if (M > 2) s0 = svdup_n_f32(src2[offset]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                    if (M > 3) s0 = svdup_n_f32(src3[offset]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                    if (M > 4) s0 = svdup_n_f32(src4[offset]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                    if (M > 5) s0 = svdup_n_f32(src5[offset]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                    weight += DF;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params), dst += dD;
+                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params), dst += dD;
+                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params), dst += dD;
+                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params), dst += dD;
+                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params), dst += dD;
+                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC), dst += dD;
+                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC), dst += dD;
+                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC), dst += dD;
+                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params, dstC), dst += dD;
+                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params, dstC), dst += dD;
+                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        typedef void(*ConvolutionNhwcDirect1x1_2xM_Ptr)(const float* src0, const ConvParam& p, size_t srcC, size_t dstC, const float* weight, const float* bias, const float* params, float* dst, int first);
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect1x1_2xM_Ptr GetConvolutionNhwcDirect1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return ConvolutionNhwcDirect1x1_2xM<term, type, 1>;
+            case 2: return ConvolutionNhwcDirect1x1_2xM<term, type, 2>;
+            case 3: return ConvolutionNhwcDirect1x1_2xM<term, type, 3>;
+            case 4: return ConvolutionNhwcDirect1x1_2xM<term, type, 4>;
+            case 5: return ConvolutionNhwcDirect1x1_2xM<term, type, 5>;
+            case 6: return ConvolutionNhwcDirect1x1_2xM<term, type, 6>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect1x1_2(const float* src, const ConvParam& p,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = svcntw(), DF = 2 * F;
+            size_t n1 = (yEnd - yBeg) * p.dstW;
+            size_t n6 = AlignLoAny(n1, 6);
+            size_t nTail = n1 - n6;
+            ConvolutionNhwcDirect1x1_2xM_Ptr bodyN = GetConvolutionNhwcDirect1x1_2xM<term, type>(6);
+            ConvolutionNhwcDirect1x1_2xM_Ptr tailN = GetConvolutionNhwcDirect1x1_2xM<term, type>(nTail);
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                const float* ps = src + yBeg * p.srcW * p.srcC;
+                float* pd = dst + dc + yBeg * p.dstW * p.dstC;
+                size_t i = 0;
+                for (; i < n6; i += 6, ps += 6 * p.srcC, pd += 6 * p.dstC)
+                    bodyN(ps, p, srcC, dC, weight, _bias, _params, pd, first);
+                if (nTail)
+                    tailN(ps, p, srcC, dC, weight, _bias, _params, pd, first), ps += nTail * p.srcC, pd += nTail * p.dstC;
+                weight += srcC * DF;
+            }
+        }
+
+        template<SimdConvolutionActivationType type> void ConvolutionNhwcDirect1x1_2(const float* src, const ConvParam& p,
+            const SynetConvolution32fNhwcDirect::AlgParam& a, const float* weight, const float* bias, const float* params, float* dst)
+        {
+            for (size_t dc = 0; dc < p.dstC; dc += a.macroD)
+            {
+                size_t macroD = Simd::Min(p.dstC, dc + a.macroD) - dc;
+                for (size_t sc = 0; sc < p.srcC; sc += a.macroC)
+                {
+                    size_t macroC = Simd::Min(p.srcC, sc + a.macroC) - sc;
+                    for (size_t yBeg = 0; yBeg < p.dstH;)
+                    {
+                        size_t yEnd = Simd::Min(yBeg + a.macroH, p.dstH);
+                        if (sc + macroC == p.srcC)
+                            ConvolutionNhwcDirect1x1_2<TermLast, type>(src + sc, p, macroD, yBeg, yEnd, macroC, weight, bias + dc, params, dst + dc, macroC == p.srcC ? 1 : 0);
+                        else
+                            ConvolutionNhwcDirect1x1_2<TermInterim, SimdConvolutionActivationIdentity>(src + sc, p, macroD, yBeg, yEnd, macroC, weight, bias + dc, params, dst + dc, sc == 0 ? 1 : 0);
+                        yBeg = yEnd;
+                    }
+                    weight += AlignHiAny(macroD, a.microD) * macroC;
+                }
+                if (type == ::SimdConvolutionActivationPrelu)
+                    params += macroD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template <SimdConvolutionActivationType type> SIMD_INLINE void Set(const ConvParam& p, SynetConvolution32fNhwcDirect::OldConvolutionPtr & convolution)
+        {
+            if (p.Is1x1())
+                convolution = ConvolutionNhwcDirect1x1_2<type>;
+            else
+                convolution = ConvolutionNhwcDirect_2<type>;
+        }
+
+        bool SynetConvolution32fNhwcDirect::Set2f(const ConvParam& p, OldConvolutionPtr& convolution)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, convolution); break;
+            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, convolution); break;
+            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, convolution); break;
+            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, convolution); break;
+            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, convolution); break;
+            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, convolution); break;
+            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, convolution); break;
+            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, convolution); break;
+            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, convolution); break;
+            default: assert(0);
+            }
+            return true;
+        }
+    }
+#endif//SIMD_SVE2_ENABLE
+}

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDirect2f.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDirect2f.cpp
@@ -97,44 +97,44 @@ namespace Simd
                 }
                 if (dstC == DF)
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d11, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d21, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d31, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d31, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d41, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d41, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d51, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d51, bias, params);
                 }
                 else
                 {
                     dstC -= F;
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d31, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d31, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d41, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d41, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d51, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d51, bias, params, dstC);
                 }
             }
             else
@@ -183,31 +183,31 @@ namespace Simd
                 }
                 if (dstC == F)
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params);
                 }
                 else
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d30, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d40, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d50, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params, dstC);
                 }
             }
         }
@@ -258,26 +258,26 @@ namespace Simd
                 }
                 if (dstC == DF)
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d11, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d21, bias, params);
                 }
                 else
                 {
                     dstC -= F;
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC);
                 }
             }
             else
@@ -314,19 +314,19 @@ namespace Simd
                 }
                 if (dstC == F)
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params);
                 }
                 else
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC);
                     dst += dD;
-                    Term<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC);
                 }
             }
         }
@@ -361,13 +361,13 @@ namespace Simd
                 }
                 if (dstC == DF)
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params);
                 }
                 else
                 {
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
-                    Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC - F);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC - F);
                 }
             }
             else
@@ -391,9 +391,9 @@ namespace Simd
                     weight += dW;
                 }
                 if (dstC == F)
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params);
                 else
-                    Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
+                    ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC);
             }
         }
 
@@ -540,22 +540,22 @@ namespace Simd
                 }
                 if (dstC == DF)
                 {
-                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params), Term<term>::template Save<type, 1>(dst + F, d01, bias, params), dst += dD;
-                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params), Term<term>::template Save<type, 1>(dst + F, d11, bias, params), dst += dD;
-                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params), Term<term>::template Save<type, 1>(dst + F, d21, bias, params), dst += dD;
-                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params), Term<term>::template Save<type, 1>(dst + F, d31, bias, params), dst += dD;
-                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params), Term<term>::template Save<type, 1>(dst + F, d41, bias, params), dst += dD;
-                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params), Term<term>::template Save<type, 1>(dst + F, d51, bias, params), dst += dD;
+                    if (M > 0) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params), dst += dD;
+                    if (M > 1) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d11, bias, params), dst += dD;
+                    if (M > 2) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d21, bias, params), dst += dD;
+                    if (M > 3) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d31, bias, params), dst += dD;
+                    if (M > 4) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d41, bias, params), dst += dD;
+                    if (M > 5) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d51, bias, params), dst += dD;
                 }
                 else
                 {
                     dstC -= F;
-                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params), Term<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC), dst += dD;
-                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params), Term<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC), dst += dD;
-                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params), Term<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC), dst += dD;
-                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params), Term<term>::template Save<type, 1>(dst + F, d31, bias, params, dstC), dst += dD;
-                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params), Term<term>::template Save<type, 1>(dst + F, d41, bias, params, dstC), dst += dD;
-                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params), Term<term>::template Save<type, 1>(dst + F, d51, bias, params, dstC), dst += dD;
+                    if (M > 0) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d01, bias, params, dstC), dst += dD;
+                    if (M > 1) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d11, bias, params, dstC), dst += dD;
+                    if (M > 2) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d21, bias, params, dstC), dst += dD;
+                    if (M > 3) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d31, bias, params, dstC), dst += dD;
+                    if (M > 4) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d41, bias, params, dstC), dst += dD;
+                    if (M > 5) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params), ConvolutionTerm<term>::template Save<type, 1>(dst + F, d51, bias, params, dstC), dst += dD;
                 }
             }
             else
@@ -591,21 +591,21 @@ namespace Simd
                 }
                 if (dstC == F)
                 {
-                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params), dst += dD;
-                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params), dst += dD;
-                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params), dst += dD;
-                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params), dst += dD;
-                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params), dst += dD;
-                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params), dst += dD;
+                    if (M > 0) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params), dst += dD;
+                    if (M > 1) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params), dst += dD;
+                    if (M > 2) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params), dst += dD;
+                    if (M > 3) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params), dst += dD;
+                    if (M > 4) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params), dst += dD;
+                    if (M > 5) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params), dst += dD;
                 }
                 else
                 {
-                    if (M > 0) Term<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC), dst += dD;
-                    if (M > 1) Term<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC), dst += dD;
-                    if (M > 2) Term<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC), dst += dD;
-                    if (M > 3) Term<term>::template Save<type, 0>(dst + 0, d30, bias, params, dstC), dst += dD;
-                    if (M > 4) Term<term>::template Save<type, 0>(dst + 0, d40, bias, params, dstC), dst += dD;
-                    if (M > 5) Term<term>::template Save<type, 0>(dst + 0, d50, bias, params, dstC), dst += dD;
+                    if (M > 0) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d00, bias, params, dstC), dst += dD;
+                    if (M > 1) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d10, bias, params, dstC), dst += dD;
+                    if (M > 2) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d20, bias, params, dstC), dst += dD;
+                    if (M > 3) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d30, bias, params, dstC), dst += dD;
+                    if (M > 4) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d40, bias, params, dstC), dst += dD;
+                    if (M > 5) ConvolutionTerm<term>::template Save<type, 0>(dst + 0, d50, bias, params, dstC), dst += dD;
                 }
             }
         }

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDirect2r.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDirect2r.cpp
@@ -1,0 +1,626 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Sve2
+    {
+        using AlgParam = SynetConvolution32fNhwcDirect::AlgParam;
+
+        typedef void(*ConvolutionNhwcDirect_NxM_Ptr)(const float* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first);
+        typedef void(*ConvolutionNhwcDirect1x1_NxM_Ptr)(const float* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first);
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2x1(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, s0, w0, w1;
+            size_t srcH = p.srcH, srcW = p.srcW, dilY = p.dilationY, dilX = p.dilationX;
+            size_t dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dW = p.srcC * F;
+            size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const float* weight1 = weight0 + a.stepW;
+            if (dstC > F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 1 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                            }
+                        }
+                        weight0 += dW, weight1 += dW;
+                    }
+                }
+                if (dstC == DF)
+                    Save2<term, type>(dst, d00, d01, bias, params);
+                else
+                    Save2<term, type>(dst, d00, d01, bias, params, dstC - F);
+            }
+            else
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            }
+                        }
+                        weight0 += dW;
+                    }
+                }
+                if (dstC == F)
+                    Save1<term, type>(dst, d00, bias, params);
+                else
+                    Save1<term, type>(dst, d00, bias, params, dstC);
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect_2xM(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, d60, d61, d70, d71, d80, d81, d90, d91, da0, da1, db0, db1, s0, w0, w1;
+            size_t srcH = p.srcH, srcW = p.srcW, dilY = p.dilationY, dilX = p.dilationX;
+            size_t dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dW = p.srcC * F, dWz = p.kernelX * p.srcC * F, dD = p.dstC;
+            size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const float* weight1 = weight0 + a.stepW;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            const float* src4 = src0 + 4 * dS;
+            const float* src5 = src0 + 5 * dS;
+            if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0x0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 0x1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 0x2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 0x3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 0x4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 0x5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                    if (M > 0x6) d60 = svdup_n_f32(0.0f), d61 = svdup_n_f32(0.0f);
+                    if (M > 0x7) d70 = svdup_n_f32(0.0f), d71 = svdup_n_f32(0.0f);
+                    if (M > 0x8) d80 = svdup_n_f32(0.0f), d81 = svdup_n_f32(0.0f);
+                    if (M > 0x9) d90 = svdup_n_f32(0.0f), d91 = svdup_n_f32(0.0f);
+                    if (M > 0xa) da0 = svdup_n_f32(0.0f), da1 = svdup_n_f32(0.0f);
+                    if (M > 0xb) db0 = svdup_n_f32(0.0f), db1 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + 0), d01 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + F);
+                    if (M > 0x1) d10 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + 0), d11 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + F);
+                    if (M > 0x2) d20 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + 0), d21 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + F);
+                    if (M > 0x3) d30 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + 0), d31 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + F);
+                    if (M > 0x4) d40 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + 0), d41 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + F);
+                    if (M > 0x5) d50 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + 0), d51 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + F);
+                    if (M > 0x6) d60 = svld1_f32(svptrue_b32(), dst + 0x6 * dD + 0), d61 = svld1_f32(svptrue_b32(), dst + 0x6 * dD + F);
+                    if (M > 0x7) d70 = svld1_f32(svptrue_b32(), dst + 0x7 * dD + 0), d71 = svld1_f32(svptrue_b32(), dst + 0x7 * dD + F);
+                    if (M > 0x8) d80 = svld1_f32(svptrue_b32(), dst + 0x8 * dD + 0), d81 = svld1_f32(svptrue_b32(), dst + 0x8 * dD + F);
+                    if (M > 0x9) d90 = svld1_f32(svptrue_b32(), dst + 0x9 * dD + 0), d91 = svld1_f32(svptrue_b32(), dst + 0x9 * dD + F);
+                    if (M > 0xa) da0 = svld1_f32(svptrue_b32(), dst + 0xa * dD + 0), da1 = svld1_f32(svptrue_b32(), dst + 0xa * dD + F);
+                    if (M > 0xb) db0 = svld1_f32(svptrue_b32(), dst + 0xb * dD + 0), db1 = svld1_f32(svptrue_b32(), dst + 0xb * dD + F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t off0 = beg + kx * dX, end = off0 + srcC, off6 = off0 + 6 * dS, offw = 0;
+                            for (; off0 < end; ++off0, ++off6, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                if (M > 0x0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                                if (M > 0x1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                                if (M > 0x2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                                if (M > 0x3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                                if (M > 0x4) s0 = svdup_n_f32(src4[off0]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                                if (M > 0x5) s0 = svdup_n_f32(src5[off0]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                                if (M > 0x6) s0 = svdup_n_f32(src0[off6]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0), d61 = svmla_f32_x(svptrue_b32(), d61, s0, w1);
+                                if (M > 0x7) s0 = svdup_n_f32(src1[off6]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0), d71 = svmla_f32_x(svptrue_b32(), d71, s0, w1);
+                                if (M > 0x8) s0 = svdup_n_f32(src2[off6]), d80 = svmla_f32_x(svptrue_b32(), d80, s0, w0), d81 = svmla_f32_x(svptrue_b32(), d81, s0, w1);
+                                if (M > 0x9) s0 = svdup_n_f32(src3[off6]), d90 = svmla_f32_x(svptrue_b32(), d90, s0, w0), d91 = svmla_f32_x(svptrue_b32(), d91, s0, w1);
+                                if (M > 0xa) s0 = svdup_n_f32(src4[off6]), da0 = svmla_f32_x(svptrue_b32(), da0, s0, w0), da1 = svmla_f32_x(svptrue_b32(), da1, s0, w1);
+                                if (M > 0xb) s0 = svdup_n_f32(src5[off6]), db0 = svmla_f32_x(svptrue_b32(), db0, s0, w0), db1 = svmla_f32_x(svptrue_b32(), db1, s0, w1);
+                            }
+                            weight0 += dW, weight1 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz, weight1 += dWz;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0x0) Save2<term, type>(dst, d00, d01, bias, params), dst += dD;
+                    if (M > 0x1) Save2<term, type>(dst, d10, d11, bias, params), dst += dD;
+                    if (M > 0x2) Save2<term, type>(dst, d20, d21, bias, params), dst += dD;
+                    if (M > 0x3) Save2<term, type>(dst, d30, d31, bias, params), dst += dD;
+                    if (M > 0x4) Save2<term, type>(dst, d40, d41, bias, params), dst += dD;
+                    if (M > 0x5) Save2<term, type>(dst, d50, d51, bias, params), dst += dD;
+                    if (M > 0x6) Save2<term, type>(dst, d60, d61, bias, params), dst += dD;
+                    if (M > 0x7) Save2<term, type>(dst, d70, d71, bias, params), dst += dD;
+                    if (M > 0x8) Save2<term, type>(dst, d80, d81, bias, params), dst += dD;
+                    if (M > 0x9) Save2<term, type>(dst, d90, d91, bias, params), dst += dD;
+                    if (M > 0xa) Save2<term, type>(dst, da0, da1, bias, params), dst += dD;
+                    if (M > 0xb) Save2<term, type>(dst, db0, db1, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0x0) Save2<term, type>(dst, d00, d01, bias, params, dstC), dst += dD;
+                    if (M > 0x1) Save2<term, type>(dst, d10, d11, bias, params, dstC), dst += dD;
+                    if (M > 0x2) Save2<term, type>(dst, d20, d21, bias, params, dstC), dst += dD;
+                    if (M > 0x3) Save2<term, type>(dst, d30, d31, bias, params, dstC), dst += dD;
+                    if (M > 0x4) Save2<term, type>(dst, d40, d41, bias, params, dstC), dst += dD;
+                    if (M > 0x5) Save2<term, type>(dst, d50, d51, bias, params, dstC), dst += dD;
+                    if (M > 0x6) Save2<term, type>(dst, d60, d61, bias, params, dstC), dst += dD;
+                    if (M > 0x7) Save2<term, type>(dst, d70, d71, bias, params, dstC), dst += dD;
+                    if (M > 0x8) Save2<term, type>(dst, d80, d81, bias, params, dstC), dst += dD;
+                    if (M > 0x9) Save2<term, type>(dst, d90, d91, bias, params, dstC), dst += dD;
+                    if (M > 0xa) Save2<term, type>(dst, da0, da1, bias, params, dstC), dst += dD;
+                    if (M > 0xb) Save2<term, type>(dst, db0, db1, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0x0) d00 = svdup_n_f32(0.0f);
+                    if (M > 0x1) d10 = svdup_n_f32(0.0f);
+                    if (M > 0x2) d20 = svdup_n_f32(0.0f);
+                    if (M > 0x3) d30 = svdup_n_f32(0.0f);
+                    if (M > 0x4) d40 = svdup_n_f32(0.0f);
+                    if (M > 0x5) d50 = svdup_n_f32(0.0f);
+                    if (M > 0x6) d60 = svdup_n_f32(0.0f);
+                    if (M > 0x7) d70 = svdup_n_f32(0.0f);
+                    if (M > 0x8) d80 = svdup_n_f32(0.0f);
+                    if (M > 0x9) d90 = svdup_n_f32(0.0f);
+                    if (M > 0xa) da0 = svdup_n_f32(0.0f);
+                    if (M > 0xb) db0 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + 0);
+                    if (M > 0x1) d10 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + 0);
+                    if (M > 0x2) d20 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + 0);
+                    if (M > 0x3) d30 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + 0);
+                    if (M > 0x4) d40 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + 0);
+                    if (M > 0x5) d50 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + 0);
+                    if (M > 0x6) d60 = svld1_f32(svptrue_b32(), dst + 0x6 * dD + 0);
+                    if (M > 0x7) d70 = svld1_f32(svptrue_b32(), dst + 0x7 * dD + 0);
+                    if (M > 0x8) d80 = svld1_f32(svptrue_b32(), dst + 0x8 * dD + 0);
+                    if (M > 0x9) d90 = svld1_f32(svptrue_b32(), dst + 0x9 * dD + 0);
+                    if (M > 0xa) da0 = svld1_f32(svptrue_b32(), dst + 0xa * dD + 0);
+                    if (M > 0xb) db0 = svld1_f32(svptrue_b32(), dst + 0xb * dD + 0);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t off0 = beg + kx * dX, end = off0 + srcC, off6 = off0 + 6 * dS, offw = 0;
+                            for (; off0 < end; ++off0, ++off6, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                if (M > 0x0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                                if (M > 0x1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                                if (M > 0x2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                                if (M > 0x3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                                if (M > 0x4) s0 = svdup_n_f32(src4[off0]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                                if (M > 0x5) s0 = svdup_n_f32(src5[off0]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                                if (M > 0x6) s0 = svdup_n_f32(src0[off6]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0);
+                                if (M > 0x7) s0 = svdup_n_f32(src1[off6]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0);
+                                if (M > 0x8) s0 = svdup_n_f32(src2[off6]), d80 = svmla_f32_x(svptrue_b32(), d80, s0, w0);
+                                if (M > 0x9) s0 = svdup_n_f32(src3[off6]), d90 = svmla_f32_x(svptrue_b32(), d90, s0, w0);
+                                if (M > 0xa) s0 = svdup_n_f32(src4[off6]), da0 = svmla_f32_x(svptrue_b32(), da0, s0, w0);
+                                if (M > 0xb) s0 = svdup_n_f32(src5[off6]), db0 = svmla_f32_x(svptrue_b32(), db0, s0, w0);
+                            }
+                            weight0 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0x0) Save1<term, type>(dst, d00, bias, params), dst += dD;
+                    if (M > 0x1) Save1<term, type>(dst, d10, bias, params), dst += dD;
+                    if (M > 0x2) Save1<term, type>(dst, d20, bias, params), dst += dD;
+                    if (M > 0x3) Save1<term, type>(dst, d30, bias, params), dst += dD;
+                    if (M > 0x4) Save1<term, type>(dst, d40, bias, params), dst += dD;
+                    if (M > 0x5) Save1<term, type>(dst, d50, bias, params), dst += dD;
+                    if (M > 0x6) Save1<term, type>(dst, d60, bias, params), dst += dD;
+                    if (M > 0x7) Save1<term, type>(dst, d70, bias, params), dst += dD;
+                    if (M > 0x8) Save1<term, type>(dst, d80, bias, params), dst += dD;
+                    if (M > 0x9) Save1<term, type>(dst, d90, bias, params), dst += dD;
+                    if (M > 0xa) Save1<term, type>(dst, da0, bias, params), dst += dD;
+                    if (M > 0xb) Save1<term, type>(dst, db0, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0x0) Save1<term, type>(dst, d00, bias, params, dstC), dst += dD;
+                    if (M > 0x1) Save1<term, type>(dst, d10, bias, params, dstC), dst += dD;
+                    if (M > 0x2) Save1<term, type>(dst, d20, bias, params, dstC), dst += dD;
+                    if (M > 0x3) Save1<term, type>(dst, d30, bias, params, dstC), dst += dD;
+                    if (M > 0x4) Save1<term, type>(dst, d40, bias, params, dstC), dst += dD;
+                    if (M > 0x5) Save1<term, type>(dst, d50, bias, params, dstC), dst += dD;
+                    if (M > 0x6) Save1<term, type>(dst, d60, bias, params, dstC), dst += dD;
+                    if (M > 0x7) Save1<term, type>(dst, d70, bias, params, dstC), dst += dD;
+                    if (M > 0x8) Save1<term, type>(dst, d80, bias, params, dstC), dst += dD;
+                    if (M > 0x9) Save1<term, type>(dst, d90, bias, params, dstC), dst += dD;
+                    if (M > 0xa) Save1<term, type>(dst, da0, bias, params, dstC), dst += dD;
+                    if (M > 0xb) Save1<term, type>(dst, db0, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect_NxM_Ptr GetConvolutionNhwcDirect_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0x0: return NULL;
+            case 0x1: return ConvolutionNhwcDirect_2xM<term, type, 0x1>;
+            case 0x2: return ConvolutionNhwcDirect_2xM<term, type, 0x2>;
+            case 0x3: return ConvolutionNhwcDirect_2xM<term, type, 0x3>;
+            case 0x4: return ConvolutionNhwcDirect_2xM<term, type, 0x4>;
+            case 0x5: return ConvolutionNhwcDirect_2xM<term, type, 0x5>;
+            case 0x6: return ConvolutionNhwcDirect_2xM<term, type, 0x6>;
+            case 0x7: return ConvolutionNhwcDirect_2xM<term, type, 0x7>;
+            case 0x8: return ConvolutionNhwcDirect_2xM<term, type, 0x8>;
+            case 0x9: return ConvolutionNhwcDirect_2xM<term, type, 0x9>;
+            case 0xa: return ConvolutionNhwcDirect_2xM<term, type, 0xa>;
+            case 0xb: return ConvolutionNhwcDirect_2xM<term, type, 0xb>;
+            case 0xc: return ConvolutionNhwcDirect_2xM<term, type, 0xc>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_2(const float* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            size_t noseH = p.NoseH(), noseW = p.NoseW(), bodyH = p.BodyH(), bodyW = p.BodyW();
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_2x1 = ConvolutionNhwcDirect_2x1<term, type>;
+            size_t n = 12, bodyWn = AlignLoAny(bodyW - noseW, n) + noseW, m = bodyW - bodyWn;
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_2xN = GetConvolutionNhwcDirect_2xM<term, type>(n);
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_2xM = GetConvolutionNhwcDirect_2xM<term, type>(m);
+            size_t tailH = p.dstH, tailW = p.dstW;
+            size_t kY = p.kernelY - noseH, kX = p.kernelX - noseW, kH = bodyH + p.kernelY - 1, kW = bodyW + p.kernelX - 1;
+            for (size_t dc = 0; dc < dstC; dc += a.microD)
+            {
+                size_t dC = Simd::Min(a.microD, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                float* d = dst + dc + yBeg * p.dstW * p.dstC;
+                for (size_t dy = yBeg; dy < yEnd; dy++)
+                {
+                    size_t dx = 0;
+                    for (; dx < noseW; dx++, d += p.dstC)
+                        convolutionNhwcDirect_2x1(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < bodyWn; dx += n, d += p.dstC * n)
+                        convolutionNhwcDirect_2xN(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < bodyW; dx += m, d += p.dstC * m)
+                        convolutionNhwcDirect_2xM(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < tailW; dx++, d += p.dstC)
+                        convolutionNhwcDirect_2x1(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                }
+                weight += p.kernelY * p.kernelX * p.srcC * a.microD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_2xM(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, d50, d51, d60, d61, d70, d71, d80, d81, d90, d91, da0, da1, db0, db1, s0, w0, w1;
+            size_t dS = p.srcC, dD = p.dstC;
+            const float* weight1 = weight0 + a.stepW;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            const float* src4 = src0 + 4 * dS;
+            const float* src5 = src0 + 5 * dS;
+            if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0x0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 0x1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 0x2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 0x3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 0x4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 0x5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                    if (M > 0x6) d60 = svdup_n_f32(0.0f), d61 = svdup_n_f32(0.0f);
+                    if (M > 0x7) d70 = svdup_n_f32(0.0f), d71 = svdup_n_f32(0.0f);
+                    if (M > 0x8) d80 = svdup_n_f32(0.0f), d81 = svdup_n_f32(0.0f);
+                    if (M > 0x9) d90 = svdup_n_f32(0.0f), d91 = svdup_n_f32(0.0f);
+                    if (M > 0xa) da0 = svdup_n_f32(0.0f), da1 = svdup_n_f32(0.0f);
+                    if (M > 0xb) db0 = svdup_n_f32(0.0f), db1 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + 0), d01 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + F);
+                    if (M > 0x1) d10 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + 0), d11 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + F);
+                    if (M > 0x2) d20 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + 0), d21 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + F);
+                    if (M > 0x3) d30 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + 0), d31 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + F);
+                    if (M > 0x4) d40 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + 0), d41 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + F);
+                    if (M > 0x5) d50 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + 0), d51 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + F);
+                    if (M > 0x6) d60 = svld1_f32(svptrue_b32(), dst + 0x6 * dD + 0), d61 = svld1_f32(svptrue_b32(), dst + 0x6 * dD + F);
+                    if (M > 0x7) d70 = svld1_f32(svptrue_b32(), dst + 0x7 * dD + 0), d71 = svld1_f32(svptrue_b32(), dst + 0x7 * dD + F);
+                    if (M > 0x8) d80 = svld1_f32(svptrue_b32(), dst + 0x8 * dD + 0), d81 = svld1_f32(svptrue_b32(), dst + 0x8 * dD + F);
+                    if (M > 0x9) d90 = svld1_f32(svptrue_b32(), dst + 0x9 * dD + 0), d91 = svld1_f32(svptrue_b32(), dst + 0x9 * dD + F);
+                    if (M > 0xa) da0 = svld1_f32(svptrue_b32(), dst + 0xa * dD + 0), da1 = svld1_f32(svptrue_b32(), dst + 0xa * dD + F);
+                    if (M > 0xb) db0 = svld1_f32(svptrue_b32(), dst + 0xb * dD + 0), db1 = svld1_f32(svptrue_b32(), dst + 0xb * dD + F);
+                }
+                for (size_t off0 = 0, off6 = 6 * dS, offw = 0; off0 < srcC; ++off0, ++off6, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                    if (M > 0x0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                    if (M > 0x1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                    if (M > 0x2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                    if (M > 0x3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                    if (M > 0x4) s0 = svdup_n_f32(src4[off0]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                    if (M > 0x5) s0 = svdup_n_f32(src5[off0]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                    if (M > 0x6) s0 = svdup_n_f32(src0[off6]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0), d61 = svmla_f32_x(svptrue_b32(), d61, s0, w1);
+                    if (M > 0x7) s0 = svdup_n_f32(src1[off6]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0), d71 = svmla_f32_x(svptrue_b32(), d71, s0, w1);
+                    if (M > 0x8) s0 = svdup_n_f32(src2[off6]), d80 = svmla_f32_x(svptrue_b32(), d80, s0, w0), d81 = svmla_f32_x(svptrue_b32(), d81, s0, w1);
+                    if (M > 0x9) s0 = svdup_n_f32(src3[off6]), d90 = svmla_f32_x(svptrue_b32(), d90, s0, w0), d91 = svmla_f32_x(svptrue_b32(), d91, s0, w1);
+                    if (M > 0xa) s0 = svdup_n_f32(src4[off6]), da0 = svmla_f32_x(svptrue_b32(), da0, s0, w0), da1 = svmla_f32_x(svptrue_b32(), da1, s0, w1);
+                    if (M > 0xb) s0 = svdup_n_f32(src5[off6]), db0 = svmla_f32_x(svptrue_b32(), db0, s0, w0), db1 = svmla_f32_x(svptrue_b32(), db1, s0, w1);
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0x0) Save2<term, type>(dst, d00, d01, bias, params), dst += dD;
+                    if (M > 0x1) Save2<term, type>(dst, d10, d11, bias, params), dst += dD;
+                    if (M > 0x2) Save2<term, type>(dst, d20, d21, bias, params), dst += dD;
+                    if (M > 0x3) Save2<term, type>(dst, d30, d31, bias, params), dst += dD;
+                    if (M > 0x4) Save2<term, type>(dst, d40, d41, bias, params), dst += dD;
+                    if (M > 0x5) Save2<term, type>(dst, d50, d51, bias, params), dst += dD;
+                    if (M > 0x6) Save2<term, type>(dst, d60, d61, bias, params), dst += dD;
+                    if (M > 0x7) Save2<term, type>(dst, d70, d71, bias, params), dst += dD;
+                    if (M > 0x8) Save2<term, type>(dst, d80, d81, bias, params), dst += dD;
+                    if (M > 0x9) Save2<term, type>(dst, d90, d91, bias, params), dst += dD;
+                    if (M > 0xa) Save2<term, type>(dst, da0, da1, bias, params), dst += dD;
+                    if (M > 0xb) Save2<term, type>(dst, db0, db1, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0x0) Save2<term, type>(dst, d00, d01, bias, params, dstC), dst += dD;
+                    if (M > 0x1) Save2<term, type>(dst, d10, d11, bias, params, dstC), dst += dD;
+                    if (M > 0x2) Save2<term, type>(dst, d20, d21, bias, params, dstC), dst += dD;
+                    if (M > 0x3) Save2<term, type>(dst, d30, d31, bias, params, dstC), dst += dD;
+                    if (M > 0x4) Save2<term, type>(dst, d40, d41, bias, params, dstC), dst += dD;
+                    if (M > 0x5) Save2<term, type>(dst, d50, d51, bias, params, dstC), dst += dD;
+                    if (M > 0x6) Save2<term, type>(dst, d60, d61, bias, params, dstC), dst += dD;
+                    if (M > 0x7) Save2<term, type>(dst, d70, d71, bias, params, dstC), dst += dD;
+                    if (M > 0x8) Save2<term, type>(dst, d80, d81, bias, params, dstC), dst += dD;
+                    if (M > 0x9) Save2<term, type>(dst, d90, d91, bias, params, dstC), dst += dD;
+                    if (M > 0xa) Save2<term, type>(dst, da0, da1, bias, params, dstC), dst += dD;
+                    if (M > 0xb) Save2<term, type>(dst, db0, db1, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0x0) d00 = svdup_n_f32(0.0f);
+                    if (M > 0x1) d10 = svdup_n_f32(0.0f);
+                    if (M > 0x2) d20 = svdup_n_f32(0.0f);
+                    if (M > 0x3) d30 = svdup_n_f32(0.0f);
+                    if (M > 0x4) d40 = svdup_n_f32(0.0f);
+                    if (M > 0x5) d50 = svdup_n_f32(0.0f);
+                    if (M > 0x6) d60 = svdup_n_f32(0.0f);
+                    if (M > 0x7) d70 = svdup_n_f32(0.0f);
+                    if (M > 0x8) d80 = svdup_n_f32(0.0f);
+                    if (M > 0x9) d90 = svdup_n_f32(0.0f);
+                    if (M > 0xa) da0 = svdup_n_f32(0.0f);
+                    if (M > 0xb) db0 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = svld1_f32(svptrue_b32(), dst + 0x0 * dD + 0);
+                    if (M > 0x1) d10 = svld1_f32(svptrue_b32(), dst + 0x1 * dD + 0);
+                    if (M > 0x2) d20 = svld1_f32(svptrue_b32(), dst + 0x2 * dD + 0);
+                    if (M > 0x3) d30 = svld1_f32(svptrue_b32(), dst + 0x3 * dD + 0);
+                    if (M > 0x4) d40 = svld1_f32(svptrue_b32(), dst + 0x4 * dD + 0);
+                    if (M > 0x5) d50 = svld1_f32(svptrue_b32(), dst + 0x5 * dD + 0);
+                    if (M > 0x6) d60 = svld1_f32(svptrue_b32(), dst + 0x6 * dD + 0);
+                    if (M > 0x7) d70 = svld1_f32(svptrue_b32(), dst + 0x7 * dD + 0);
+                    if (M > 0x8) d80 = svld1_f32(svptrue_b32(), dst + 0x8 * dD + 0);
+                    if (M > 0x9) d90 = svld1_f32(svptrue_b32(), dst + 0x9 * dD + 0);
+                    if (M > 0xa) da0 = svld1_f32(svptrue_b32(), dst + 0xa * dD + 0);
+                    if (M > 0xb) db0 = svld1_f32(svptrue_b32(), dst + 0xb * dD + 0);
+                }
+                for (size_t off0 = 0, off6 = 6 * dS, offw = 0; off0 < srcC; ++off0, ++off6, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    if (M > 0x0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                    if (M > 0x1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                    if (M > 0x2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                    if (M > 0x3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                    if (M > 0x4) s0 = svdup_n_f32(src4[off0]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                    if (M > 0x5) s0 = svdup_n_f32(src5[off0]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                    if (M > 0x6) s0 = svdup_n_f32(src0[off6]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0);
+                    if (M > 0x7) s0 = svdup_n_f32(src1[off6]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0);
+                    if (M > 0x8) s0 = svdup_n_f32(src2[off6]), d80 = svmla_f32_x(svptrue_b32(), d80, s0, w0);
+                    if (M > 0x9) s0 = svdup_n_f32(src3[off6]), d90 = svmla_f32_x(svptrue_b32(), d90, s0, w0);
+                    if (M > 0xa) s0 = svdup_n_f32(src4[off6]), da0 = svmla_f32_x(svptrue_b32(), da0, s0, w0);
+                    if (M > 0xb) s0 = svdup_n_f32(src5[off6]), db0 = svmla_f32_x(svptrue_b32(), db0, s0, w0);
+                }
+                if (dstC == F)
+                {
+                    if (M > 0x0) Save1<term, type>(dst, d00, bias, params), dst += dD;
+                    if (M > 0x1) Save1<term, type>(dst, d10, bias, params), dst += dD;
+                    if (M > 0x2) Save1<term, type>(dst, d20, bias, params), dst += dD;
+                    if (M > 0x3) Save1<term, type>(dst, d30, bias, params), dst += dD;
+                    if (M > 0x4) Save1<term, type>(dst, d40, bias, params), dst += dD;
+                    if (M > 0x5) Save1<term, type>(dst, d50, bias, params), dst += dD;
+                    if (M > 0x6) Save1<term, type>(dst, d60, bias, params), dst += dD;
+                    if (M > 0x7) Save1<term, type>(dst, d70, bias, params), dst += dD;
+                    if (M > 0x8) Save1<term, type>(dst, d80, bias, params), dst += dD;
+                    if (M > 0x9) Save1<term, type>(dst, d90, bias, params), dst += dD;
+                    if (M > 0xa) Save1<term, type>(dst, da0, bias, params), dst += dD;
+                    if (M > 0xb) Save1<term, type>(dst, db0, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0x0) Save1<term, type>(dst, d00, bias, params, dstC), dst += dD;
+                    if (M > 0x1) Save1<term, type>(dst, d10, bias, params, dstC), dst += dD;
+                    if (M > 0x2) Save1<term, type>(dst, d20, bias, params, dstC), dst += dD;
+                    if (M > 0x3) Save1<term, type>(dst, d30, bias, params, dstC), dst += dD;
+                    if (M > 0x4) Save1<term, type>(dst, d40, bias, params, dstC), dst += dD;
+                    if (M > 0x5) Save1<term, type>(dst, d50, bias, params, dstC), dst += dD;
+                    if (M > 0x6) Save1<term, type>(dst, d60, bias, params, dstC), dst += dD;
+                    if (M > 0x7) Save1<term, type>(dst, d70, bias, params, dstC), dst += dD;
+                    if (M > 0x8) Save1<term, type>(dst, d80, bias, params, dstC), dst += dD;
+                    if (M > 0x9) Save1<term, type>(dst, d90, bias, params, dstC), dst += dD;
+                    if (M > 0xa) Save1<term, type>(dst, da0, bias, params, dstC), dst += dD;
+                    if (M > 0xb) Save1<term, type>(dst, db0, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect1x1_NxM_Ptr GetConvolutionNhwcDirect1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 0x1: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x1>;
+            case 0x2: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x2>;
+            case 0x3: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x3>;
+            case 0x4: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x4>;
+            case 0x5: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x5>;
+            case 0x6: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x6>;
+            case 0x7: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x7>;
+            case 0x8: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x8>;
+            case 0x9: return ConvolutionNhwcDirect1x1_2xM<term, type, 0x9>;
+            case 0xa: return ConvolutionNhwcDirect1x1_2xM<term, type, 0xa>;
+            case 0xb: return ConvolutionNhwcDirect1x1_2xM<term, type, 0xb>;
+            case 0xc: return ConvolutionNhwcDirect1x1_2xM<term, type, 0xc>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect1x1_2(const float* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            size_t n = 12, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            ConvolutionNhwcDirect1x1_NxM_Ptr convolutionNhwcDirect1x1_2xN = GetConvolutionNhwcDirect1x1_2xM<term, type>(n);
+            ConvolutionNhwcDirect1x1_NxM_Ptr convolutionNhwcDirect1x1_2xM = GetConvolutionNhwcDirect1x1_2xM<term, type>(m);
+            for (size_t dc = 0; dc < dstC; dc += a.microD)
+            {
+                size_t dC = Simd::Min(a.microD, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                const float* ps = src + yBeg * p.srcW * p.srcC;
+                float* pd = dst + dc + yBeg * p.dstW * p.dstC;
+                size_t i = 0;
+                for (; i < nn; i += n, ps += n * p.srcC, pd += n * p.dstC)
+                    convolutionNhwcDirect1x1_2xN(ps, p, a, srcC, dC, weight, _bias, _params, pd, first);
+                for (; i < n1; i += m, ps += m * p.srcC, pd += m * p.dstC)
+                    convolutionNhwcDirect1x1_2xM(ps, p, a, srcC, dC, weight, _bias, _params, pd, first);
+                weight += p.srcC * a.microD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template <TermType term, SimdConvolutionActivationType type> static SIMD_INLINE void Set(const ConvParam& p, AlgParam& a)
+        {
+            a.convolutions[term] = p.Is1x1() ? ConvolutionNhwcDirect1x1_2<term, type> : ConvolutionNhwcDirect_2<term, type>;
+        }
+
+        template <SimdConvolutionActivationType type> static SIMD_INLINE void Set(const ConvParam& p, AlgParam& a)
+        {
+            Set<TermLast, type>(p, a);
+            Set<TermInterim, SimdConvolutionActivationIdentity>(p, a);
+        }
+
+        bool SynetConvolution32fNhwcDirect::Set2r(const ConvParam& p, AlgParam& a)
+        {
+            assert(a.microD == 2 * a.F);
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, a); break;
+            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, a); break;
+            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, a); break;
+            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, a); break;
+            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, a); break;
+            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, a); break;
+            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, a); break;
+            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, a); break;
+            default: assert(0);
+            }
+            return true;
+        }
+    }
+#endif//SIMD_SVE2_ENABLE
+}

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDirect3r.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDirect3r.cpp
@@ -1,0 +1,709 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)    
+    namespace Sve2
+    {
+        using AlgParam = SynetConvolution32fNhwcDirect::AlgParam;
+
+        typedef void(*ConvolutionNhwcDirect_NxM_Ptr)(const float* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first);
+        typedef void(*ConvolutionNhwcDirect1x1_NxM_Ptr)(const float* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first);
+
+        //---------------------------------------------------------------------
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_3x1(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            svfloat32_t d00, d01, d02, s0, w0, w1, w2;
+            size_t srcH = p.srcH, srcW = p.srcW, dilY = p.dilationY, dilX = p.dilationX;
+            size_t dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dW = p.srcC * F;
+            size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const float* weight1 = weight0 + a.stepW;
+            const float* weight2 = weight1 + a.stepW;
+            if (dstC > 2 * F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 2 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2);
+                            }
+                        }
+                        weight0 += dW, weight1 += dW, weight2 += dW;
+                    }
+                }
+                if (dstC == 3 * F)
+                    Save3<term, type>(dst, d00, d01, d02, bias, params);
+                else
+                    Save3<term, type>(dst, d00, d01, d02, bias, params, dstC - 2 * F);
+            }
+            else if (dstC > F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 1 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                            }
+                        }
+                        weight0 += dW, weight1 += dW;
+                    }
+                }
+                if (dstC == 2 * F)
+                    Save2<term, type>(dst, d00, d01, bias, params);
+                else
+                    Save2<term, type>(dst, d00, d01, bias, params, dstC - F);
+            }
+            else
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            }
+                        }
+                        weight0 += dW;
+                    }
+                }
+                if (dstC == F)
+                    Save1<term, type>(dst, d00, bias, params);
+                else
+                    Save1<term, type>(dst, d00, bias, params, dstC);
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect_3xM(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, d02, d10, d11, d12, d20, d21, d22, d30, d31, d32, d40, d41, d42, d50, d51, d52, d60, d61, d62, d70, d71, d72, s0, w0, w1, w2;
+            size_t srcH = p.srcH, srcW = p.srcW, dilY = p.dilationY, dilX = p.dilationX;
+            size_t dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dW = p.srcC * F, dWz = p.kernelX * p.srcC * F, dD = p.dstC;
+            size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const float* weight1 = weight0 + a.stepW;
+            const float* weight2 = weight1 + a.stepW;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            if (dstC > 2 * F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f), d12 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f), d22 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f), d32 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f), d42 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f), d52 = svdup_n_f32(0.0f);
+                    if (M > 6) d60 = svdup_n_f32(0.0f), d61 = svdup_n_f32(0.0f), d62 = svdup_n_f32(0.0f);
+                    if (M > 7) d70 = svdup_n_f32(0.0f), d71 = svdup_n_f32(0.0f), d72 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 0 * dD + 2 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F), d12 = svld1_f32(svptrue_b32(), dst + 1 * dD + 2 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F), d22 = svld1_f32(svptrue_b32(), dst + 2 * dD + 2 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F), d32 = svld1_f32(svptrue_b32(), dst + 3 * dD + 2 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F), d42 = svld1_f32(svptrue_b32(), dst + 4 * dD + 2 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F), d52 = svld1_f32(svptrue_b32(), dst + 5 * dD + 2 * F);
+                    if (M > 6) d60 = svld1_f32(svptrue_b32(), dst + 6 * dD + 0 * F), d61 = svld1_f32(svptrue_b32(), dst + 6 * dD + 1 * F), d62 = svld1_f32(svptrue_b32(), dst + 6 * dD + 2 * F);
+                    if (M > 7) d70 = svld1_f32(svptrue_b32(), dst + 7 * dD + 0 * F), d71 = svld1_f32(svptrue_b32(), dst + 7 * dD + 1 * F), d72 = svld1_f32(svptrue_b32(), dst + 7 * dD + 2 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t off0 = beg + kx * dX, end = off0 + srcC, off4 = off0 + 4 * dS, offw = 0;
+                            for (; off0 < end; ++off0, ++off4, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2);
+                                if (M > 1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1), d12 = svmla_f32_x(svptrue_b32(), d12, s0, w2);
+                                if (M > 2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1), d22 = svmla_f32_x(svptrue_b32(), d22, s0, w2);
+                                if (M > 3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1), d32 = svmla_f32_x(svptrue_b32(), d32, s0, w2);
+                                if (M > 4) s0 = svdup_n_f32(src0[off4]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1), d42 = svmla_f32_x(svptrue_b32(), d42, s0, w2);
+                                if (M > 5) s0 = svdup_n_f32(src1[off4]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1), d52 = svmla_f32_x(svptrue_b32(), d52, s0, w2);
+                                if (M > 6) s0 = svdup_n_f32(src2[off4]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0), d61 = svmla_f32_x(svptrue_b32(), d61, s0, w1), d62 = svmla_f32_x(svptrue_b32(), d62, s0, w2);
+                                if (M > 7) s0 = svdup_n_f32(src3[off4]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0), d71 = svmla_f32_x(svptrue_b32(), d71, s0, w1), d72 = svmla_f32_x(svptrue_b32(), d72, s0, w2);
+                            }
+                            weight0 += dW, weight1 += dW, weight2 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz, weight1 += dWz, weight2 += dWz;
+                }
+                if (dstC == 3 * F)
+                {
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params), dst += dD;
+                    if (M > 6) Save3<term, type>(dst, d60, d61, d62, bias, params), dst += dD;
+                    if (M > 7) Save3<term, type>(dst, d70, d71, d72, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= 2 * F;
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params, dstC), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params, dstC), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params, dstC), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params, dstC), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params, dstC), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params, dstC), dst += dD;
+                    if (M > 6) Save3<term, type>(dst, d60, d61, d62, bias, params, dstC), dst += dD;
+                    if (M > 7) Save3<term, type>(dst, d70, d71, d72, bias, params, dstC), dst += dD;
+                }
+            }
+            else if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                    if (M > 6) d60 = svdup_n_f32(0.0f), d61 = svdup_n_f32(0.0f);
+                    if (M > 7) d70 = svdup_n_f32(0.0f), d71 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F);
+                    if (M > 6) d60 = svld1_f32(svptrue_b32(), dst + 6 * dD + 0 * F), d61 = svld1_f32(svptrue_b32(), dst + 6 * dD + 1 * F);
+                    if (M > 7) d70 = svld1_f32(svptrue_b32(), dst + 7 * dD + 0 * F), d71 = svld1_f32(svptrue_b32(), dst + 7 * dD + 1 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t off0 = beg + kx * dX, end = off0 + srcC, off4 = off0 + 4 * dS, offw = 0;
+                            for (; off0 < end; ++off0, ++off4, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                                if (M > 1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                                if (M > 2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                                if (M > 3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                                if (M > 4) s0 = svdup_n_f32(src0[off4]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                                if (M > 5) s0 = svdup_n_f32(src1[off4]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                                if (M > 6) s0 = svdup_n_f32(src2[off4]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0), d61 = svmla_f32_x(svptrue_b32(), d61, s0, w1);
+                                if (M > 7) s0 = svdup_n_f32(src3[off4]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0), d71 = svmla_f32_x(svptrue_b32(), d71, s0, w1);
+                            }
+                            weight0 += dW, weight1 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz, weight1 += dWz;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params), dst += dD;
+                    if (M > 6) Save2<term, type>(dst, d60, d61, bias, params), dst += dD;
+                    if (M > 7) Save2<term, type>(dst, d70, d71, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params, dstC), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params, dstC), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params, dstC), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params, dstC), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params, dstC), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params, dstC), dst += dD;
+                    if (M > 6) Save2<term, type>(dst, d60, d61, bias, params, dstC), dst += dD;
+                    if (M > 7) Save2<term, type>(dst, d70, d71, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f);
+                    if (M > 6) d60 = svdup_n_f32(0.0f);
+                    if (M > 7) d70 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F);
+                    if (M > 6) d60 = svld1_f32(svptrue_b32(), dst + 6 * dD + 0 * F);
+                    if (M > 7) d70 = svld1_f32(svptrue_b32(), dst + 7 * dD + 0 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t off0 = beg + kx * dX, end = off0 + srcC, off4 = off0 + 4 * dS, offw = 0;
+                            for (; off0 < end; ++off0, ++off4, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                                if (M > 1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                                if (M > 2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                                if (M > 3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                                if (M > 4) s0 = svdup_n_f32(src0[off4]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                                if (M > 5) s0 = svdup_n_f32(src1[off4]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                                if (M > 6) s0 = svdup_n_f32(src2[off4]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0);
+                                if (M > 7) s0 = svdup_n_f32(src3[off4]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0);
+                            }
+                            weight0 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params), dst += dD;
+                    if (M > 6) Save1<term, type>(dst, d60, bias, params), dst += dD;
+                    if (M > 7) Save1<term, type>(dst, d70, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params, dstC), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params, dstC), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params, dstC), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params, dstC), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params, dstC), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params, dstC), dst += dD;
+                    if (M > 6) Save1<term, type>(dst, d60, bias, params, dstC), dst += dD;
+                    if (M > 7) Save1<term, type>(dst, d70, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect_NxM_Ptr GetConvolutionNhwcDirect_3xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0x0: return NULL;
+            case 0x1: return ConvolutionNhwcDirect_3xM<term, type, 0x1>;
+            case 0x2: return ConvolutionNhwcDirect_3xM<term, type, 0x2>;
+            case 0x3: return ConvolutionNhwcDirect_3xM<term, type, 0x3>;
+            case 0x4: return ConvolutionNhwcDirect_3xM<term, type, 0x4>;
+            case 0x5: return ConvolutionNhwcDirect_3xM<term, type, 0x5>;
+            case 0x6: return ConvolutionNhwcDirect_3xM<term, type, 0x6>;
+            case 0x7: return ConvolutionNhwcDirect_3xM<term, type, 0x7>;
+            case 0x8: return ConvolutionNhwcDirect_3xM<term, type, 0x8>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_3(const float* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            size_t noseH = p.NoseH(), noseW = p.NoseW(), bodyH = p.BodyH(), bodyW = p.BodyW();
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_3x1 = ConvolutionNhwcDirect_3x1<term, type>;
+            size_t n = 8, bodyWn = AlignLoAny(bodyW - noseW, n) + noseW, m = bodyW - bodyWn;
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_3xN = GetConvolutionNhwcDirect_3xM<term, type>(n);
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_3xM = GetConvolutionNhwcDirect_3xM<term, type>(m);
+            size_t tailH = p.dstH, tailW = p.dstW;
+            size_t kY = p.kernelY - noseH, kX = p.kernelX - noseW, kH = bodyH + p.kernelY - 1, kW = bodyW + p.kernelX - 1;
+            for (size_t dc = 0; dc < dstC; dc += a.microD)
+            {
+                size_t dC = Simd::Min(a.microD, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                float* d = dst + dc + yBeg * p.dstW * p.dstC;
+                for (size_t dy = yBeg; dy < yEnd; dy++)
+                {
+                    size_t dx = 0;
+                    for (; dx < noseW; dx++, d += p.dstC)
+                        convolutionNhwcDirect_3x1(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < bodyWn; dx += n, d += p.dstC * n)
+                        convolutionNhwcDirect_3xN(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < bodyW; dx += m, d += p.dstC * m)
+                        convolutionNhwcDirect_3xM(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < tailW; dx++, d += p.dstC)
+                        convolutionNhwcDirect_3x1(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                }
+                weight += p.kernelY * p.kernelX * p.srcC * a.microD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_3xM(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, d02, d10, d11, d12, d20, d21, d22, d30, d31, d32, d40, d41, d42, d50, d51, d52, d60, d61, d62, d70, d71, d72, s0, w0, w1, w2;
+            size_t dS = p.srcC, dD = p.dstC;
+            const float* weight1 = weight0 + a.stepW;
+            const float* weight2 = weight1 + a.stepW;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            if (dstC > 2 * F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f), d12 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f), d22 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f), d32 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f), d42 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f), d52 = svdup_n_f32(0.0f);
+                    if (M > 6) d60 = svdup_n_f32(0.0f), d61 = svdup_n_f32(0.0f), d62 = svdup_n_f32(0.0f);
+                    if (M > 7) d70 = svdup_n_f32(0.0f), d71 = svdup_n_f32(0.0f), d72 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 0 * dD + 2 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F), d12 = svld1_f32(svptrue_b32(), dst + 1 * dD + 2 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F), d22 = svld1_f32(svptrue_b32(), dst + 2 * dD + 2 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F), d32 = svld1_f32(svptrue_b32(), dst + 3 * dD + 2 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F), d42 = svld1_f32(svptrue_b32(), dst + 4 * dD + 2 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F), d52 = svld1_f32(svptrue_b32(), dst + 5 * dD + 2 * F);
+                    if (M > 6) d60 = svld1_f32(svptrue_b32(), dst + 6 * dD + 0 * F), d61 = svld1_f32(svptrue_b32(), dst + 6 * dD + 1 * F), d62 = svld1_f32(svptrue_b32(), dst + 6 * dD + 2 * F);
+                    if (M > 7) d70 = svld1_f32(svptrue_b32(), dst + 7 * dD + 0 * F), d71 = svld1_f32(svptrue_b32(), dst + 7 * dD + 1 * F), d72 = svld1_f32(svptrue_b32(), dst + 7 * dD + 2 * F);
+                }
+                for (size_t off0 = 0, off4 = 4 * dS, offw = 0; off0 < srcC; ++off0, ++off4, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                    w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2);
+                    if (M > 1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1), d12 = svmla_f32_x(svptrue_b32(), d12, s0, w2);
+                    if (M > 2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1), d22 = svmla_f32_x(svptrue_b32(), d22, s0, w2);
+                    if (M > 3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1), d32 = svmla_f32_x(svptrue_b32(), d32, s0, w2);
+                    if (M > 4) s0 = svdup_n_f32(src0[off4]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1), d42 = svmla_f32_x(svptrue_b32(), d42, s0, w2);
+                    if (M > 5) s0 = svdup_n_f32(src1[off4]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1), d52 = svmla_f32_x(svptrue_b32(), d52, s0, w2);
+                    if (M > 6) s0 = svdup_n_f32(src2[off4]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0), d61 = svmla_f32_x(svptrue_b32(), d61, s0, w1), d62 = svmla_f32_x(svptrue_b32(), d62, s0, w2);
+                    if (M > 7) s0 = svdup_n_f32(src3[off4]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0), d71 = svmla_f32_x(svptrue_b32(), d71, s0, w1), d72 = svmla_f32_x(svptrue_b32(), d72, s0, w2);
+                }
+                if (dstC == 3 * F)
+                {
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params), dst += dD;
+                    if (M > 6) Save3<term, type>(dst, d60, d61, d62, bias, params), dst += dD;
+                    if (M > 7) Save3<term, type>(dst, d70, d71, d72, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= 2 * F;
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params, dstC), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params, dstC), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params, dstC), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params, dstC), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params, dstC), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params, dstC), dst += dD;
+                    if (M > 6) Save3<term, type>(dst, d60, d61, d62, bias, params, dstC), dst += dD;
+                    if (M > 7) Save3<term, type>(dst, d70, d71, d72, bias, params, dstC), dst += dD;
+                }
+            }
+            else if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                    if (M > 6) d60 = svdup_n_f32(0.0f), d61 = svdup_n_f32(0.0f);
+                    if (M > 7) d70 = svdup_n_f32(0.0f), d71 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F);
+                    if (M > 6) d60 = svld1_f32(svptrue_b32(), dst + 6 * dD + 0 * F), d61 = svld1_f32(svptrue_b32(), dst + 6 * dD + 1 * F);
+                    if (M > 7) d70 = svld1_f32(svptrue_b32(), dst + 7 * dD + 0 * F), d71 = svld1_f32(svptrue_b32(), dst + 7 * dD + 1 * F);
+                }
+                for (size_t off0 = 0, off4 = 4 * dS, offw = 0; off0 < srcC; ++off0, ++off4, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                    if (M > 1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                    if (M > 2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                    if (M > 3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                    if (M > 4) s0 = svdup_n_f32(src0[off4]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                    if (M > 5) s0 = svdup_n_f32(src1[off4]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                    if (M > 6) s0 = svdup_n_f32(src2[off4]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0), d61 = svmla_f32_x(svptrue_b32(), d61, s0, w1);
+                    if (M > 7) s0 = svdup_n_f32(src3[off4]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0), d71 = svmla_f32_x(svptrue_b32(), d71, s0, w1);
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params), dst += dD;
+                    if (M > 6) Save2<term, type>(dst, d60, d61, bias, params), dst += dD;
+                    if (M > 7) Save2<term, type>(dst, d70, d71, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params, dstC), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params, dstC), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params, dstC), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params, dstC), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params, dstC), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params, dstC), dst += dD;
+                    if (M > 6) Save2<term, type>(dst, d60, d61, bias, params, dstC), dst += dD;
+                    if (M > 7) Save2<term, type>(dst, d70, d71, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f);
+                    if (M > 6) d60 = svdup_n_f32(0.0f);
+                    if (M > 7) d70 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F);
+                    if (M > 6) d60 = svld1_f32(svptrue_b32(), dst + 6 * dD + 0 * F);
+                    if (M > 7) d70 = svld1_f32(svptrue_b32(), dst + 7 * dD + 0 * F);
+                }
+                for (size_t off0 = 0, off4 = 4 * dS, offw = 0; off0 < srcC; ++off0, ++off4, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[off0]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                    if (M > 1) s0 = svdup_n_f32(src1[off0]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                    if (M > 2) s0 = svdup_n_f32(src2[off0]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                    if (M > 3) s0 = svdup_n_f32(src3[off0]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                    if (M > 4) s0 = svdup_n_f32(src0[off4]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                    if (M > 5) s0 = svdup_n_f32(src1[off4]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                    if (M > 6) s0 = svdup_n_f32(src2[off4]), d60 = svmla_f32_x(svptrue_b32(), d60, s0, w0);
+                    if (M > 7) s0 = svdup_n_f32(src3[off4]), d70 = svmla_f32_x(svptrue_b32(), d70, s0, w0);
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params), dst += dD;
+                    if (M > 6) Save1<term, type>(dst, d60, bias, params), dst += dD;
+                    if (M > 7) Save1<term, type>(dst, d70, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params, dstC), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params, dstC), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params, dstC), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params, dstC), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params, dstC), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params, dstC), dst += dD;
+                    if (M > 6) Save1<term, type>(dst, d60, bias, params, dstC), dst += dD;
+                    if (M > 7) Save1<term, type>(dst, d70, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect1x1_NxM_Ptr GetConvolutionNhwcDirect1x1_3xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return ConvolutionNhwcDirect1x1_3xM<term, type, 1>;
+            case 2: return ConvolutionNhwcDirect1x1_3xM<term, type, 2>;
+            case 3: return ConvolutionNhwcDirect1x1_3xM<term, type, 3>;
+            case 4: return ConvolutionNhwcDirect1x1_3xM<term, type, 4>;
+            case 5: return ConvolutionNhwcDirect1x1_3xM<term, type, 5>;
+            case 6: return ConvolutionNhwcDirect1x1_3xM<term, type, 6>;
+            case 7: return ConvolutionNhwcDirect1x1_3xM<term, type, 7>;
+            case 8: return ConvolutionNhwcDirect1x1_3xM<term, type, 8>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect1x1_3(const float* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            size_t n = 8, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            ConvolutionNhwcDirect1x1_NxM_Ptr convolutionNhwcDirect1x1_3xN = GetConvolutionNhwcDirect1x1_3xM<term, type>(n);
+            ConvolutionNhwcDirect1x1_NxM_Ptr convolutionNhwcDirect1x1_3xM = GetConvolutionNhwcDirect1x1_3xM<term, type>(m);
+            for (size_t dc = 0; dc < dstC; dc += a.microD)
+            {
+                size_t dC = Simd::Min(a.microD, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                const float* ps = src + yBeg * p.srcW * p.srcC;
+                float* pd = dst + dc + yBeg * p.dstW * p.dstC;
+                size_t i = 0;
+                for (; i < nn; i += n, ps += n * p.srcC, pd += n * p.dstC)
+                    convolutionNhwcDirect1x1_3xN(ps, p, a, srcC, dC, weight, _bias, _params, pd, first);
+                for (; i < n1; i += m, ps += m * p.srcC, pd += m * p.dstC)
+                    convolutionNhwcDirect1x1_3xM(ps, p, a, srcC, dC, weight, _bias, _params, pd, first);
+                weight += p.srcC * a.microD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template <TermType term, SimdConvolutionActivationType type> static SIMD_INLINE void Set(const ConvParam& p, AlgParam& a)
+        {
+            a.convolutions[term] = p.Is1x1() ? ConvolutionNhwcDirect1x1_3<term, type> : ConvolutionNhwcDirect_3<term, type>;
+        }
+
+        template <SimdConvolutionActivationType type> static SIMD_INLINE void Set(const ConvParam& p, AlgParam& a)
+        {
+            Set<TermLast, type>(p, a);
+            Set<TermInterim, SimdConvolutionActivationIdentity>(p, a);
+        }
+
+        bool SynetConvolution32fNhwcDirect::Set3r(const ConvParam& p, AlgParam& a)
+        {
+            assert(a.microD == 3 * a.F);
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, a); break;
+            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, a); break;
+            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, a); break;
+            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, a); break;
+            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, a); break;
+            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, a); break;
+            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, a); break;
+            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, a); break;
+            default: assert(0);
+            }
+            return true;
+        }
+    }
+#endif//SIMD_SVE2_ENABLE
+}

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDirect4r.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDirect4r.cpp
@@ -1,0 +1,803 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)    
+    namespace Sve2
+    {
+        using AlgParam = SynetConvolution32fNhwcDirect::AlgParam;
+
+        typedef void(*ConvolutionNhwcDirect_NxM_Ptr)(const float* src0, const ConvParam& p, const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first);
+        typedef void(*ConvolutionNhwcDirect1x1_NxM_Ptr)(const float* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first);
+
+        //---------------------------------------------------------------------
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_4x1(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            svfloat32_t d00, d01, d02, d03, s0, w0, w1, w2, w3;
+            size_t srcH = p.srcH, srcW = p.srcW, dilY = p.dilationY, dilX = p.dilationX;
+            size_t dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dW = p.srcC * F;
+            size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const float* weight1 = weight0 + a.stepW;
+            const float* weight2 = weight1 + a.stepW;
+            const float* weight3 = weight2 + a.stepW;
+            if (dstC > 3 * F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f), d03 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 2 * F), d03 = svld1_f32(svptrue_b32(), dst + 3 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                w3 = svld1_f32(svptrue_b32(), weight3 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2), d03 = svmla_f32_x(svptrue_b32(), d03, s0, w3);
+                            }
+                        }
+                        weight0 += dW, weight1 += dW, weight2 += dW, weight3 += dW;
+                    }
+                }
+                if (dstC == 4 * F)
+                    Save4<term, type>(dst, d00, d01, d02, d03, bias, params);
+                else
+                    Save4<term, type>(dst, d00, d01, d02, d03, bias, params, dstC - 3 * F);
+            }
+            else if (dstC > 2 * F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 2 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2);
+                            }
+                        }
+                        weight0 += dW, weight1 += dW, weight2 += dW;
+                    }
+                }
+                if (dstC == 3 * F)
+                    Save3<term, type>(dst, d00, d01, d02, bias, params);
+                else
+                    Save3<term, type>(dst, d00, d01, d02, bias, params, dstC - 2 * F);
+            }
+            else if (dstC > F)
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 1 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                            }
+                        }
+                        weight0 += dW, weight1 += dW;
+                    }
+                }
+                if (dstC == 2 * F)
+                    Save2<term, type>(dst, d00, d01, bias, params);
+                else
+                    Save2<term, type>(dst, d00, d01, bias, params, dstC - F);
+            }
+            else
+            {
+                if (first)
+                    d00 = svdup_n_f32(0.0f);
+                else
+                    d00 = svld1_f32(svptrue_b32(), dst + 0 * F);
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    size_t beg = (sy + ky) * dY + sx * dX;
+                    for (size_t kx = 0; kx < kX; kx += dilX)
+                    {
+                        if (sy + ky < srcH && sx + kx < srcW)
+                        {
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                            }
+                        }
+                        weight0 += dW;
+                    }
+                }
+                if (dstC == F)
+                    Save1<term, type>(dst, d00, bias, params);
+                else
+                    Save1<term, type>(dst, d00, bias, params, dstC);
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect_4xM(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t dy, size_t dx, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, d02, d03, d10, d11, d12, d13, d20, d21, d22, d23, d30, d31, d32, d33, d40, d41, d42, d43, d50, d51, d52, d53, s0, w0, w1, w2, w3;
+            size_t srcH = p.srcH, srcW = p.srcW, dilY = p.dilationY, dilX = p.dilationX;
+            size_t dY = p.srcW * p.srcC, dX = p.srcC, dS = p.srcC * p.strideX, dW = p.srcC * F, dWz = p.kernelX * p.srcC * F, dD = p.dstC;
+            size_t sy = dy * p.strideY - p.padY, sx = dx * p.strideX - p.padX;
+            size_t kY = p.kernelY * p.dilationY, kX = p.kernelX * p.dilationX;
+            const float* weight1 = weight0 + a.stepW;
+            const float* weight2 = weight1 + a.stepW;
+            const float* weight3 = weight2 + a.stepW;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            const float* src4 = src0 + 4 * dS;
+            const float* src5 = src0 + 5 * dS;
+            if (dstC > 3 * F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f), d03 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f), d12 = svdup_n_f32(0.0f), d13 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f), d22 = svdup_n_f32(0.0f), d23 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f), d32 = svdup_n_f32(0.0f), d33 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f), d42 = svdup_n_f32(0.0f), d43 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f), d52 = svdup_n_f32(0.0f), d53 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 0 * dD + 2 * F), d03 = svld1_f32(svptrue_b32(), dst + 0 * dD + 3 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F), d12 = svld1_f32(svptrue_b32(), dst + 1 * dD + 2 * F), d13 = svld1_f32(svptrue_b32(), dst + 1 * dD + 3 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F), d22 = svld1_f32(svptrue_b32(), dst + 2 * dD + 2 * F), d23 = svld1_f32(svptrue_b32(), dst + 2 * dD + 3 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F), d32 = svld1_f32(svptrue_b32(), dst + 3 * dD + 2 * F), d33 = svld1_f32(svptrue_b32(), dst + 3 * dD + 3 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F), d42 = svld1_f32(svptrue_b32(), dst + 4 * dD + 2 * F), d43 = svld1_f32(svptrue_b32(), dst + 4 * dD + 3 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F), d52 = svld1_f32(svptrue_b32(), dst + 5 * dD + 2 * F), d53 = svld1_f32(svptrue_b32(), dst + 5 * dD + 3 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                w3 = svld1_f32(svptrue_b32(), weight3 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2), d03 = svmla_f32_x(svptrue_b32(), d03, s0, w3);
+                                if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1), d12 = svmla_f32_x(svptrue_b32(), d12, s0, w2), d13 = svmla_f32_x(svptrue_b32(), d13, s0, w3);
+                                if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1), d22 = svmla_f32_x(svptrue_b32(), d22, s0, w2), d23 = svmla_f32_x(svptrue_b32(), d23, s0, w3);
+                                if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1), d32 = svmla_f32_x(svptrue_b32(), d32, s0, w2), d33 = svmla_f32_x(svptrue_b32(), d33, s0, w3);
+                                if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1), d42 = svmla_f32_x(svptrue_b32(), d42, s0, w2), d43 = svmla_f32_x(svptrue_b32(), d43, s0, w3);
+                                if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1), d52 = svmla_f32_x(svptrue_b32(), d52, s0, w2), d53 = svmla_f32_x(svptrue_b32(), d53, s0, w3);
+                            }
+                            weight0 += dW, weight1 += dW, weight2 += dW, weight3 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz, weight1 += dWz, weight2 += dWz, weight3 += dWz;
+                }
+                if (dstC == 4 * F)
+                {
+                    if (M > 0) Save4<term, type>(dst, d00, d01, d02, d03, bias, params), dst += dD;
+                    if (M > 1) Save4<term, type>(dst, d10, d11, d12, d13, bias, params), dst += dD;
+                    if (M > 2) Save4<term, type>(dst, d20, d21, d22, d23, bias, params), dst += dD;
+                    if (M > 3) Save4<term, type>(dst, d30, d31, d32, d33, bias, params), dst += dD;
+                    if (M > 4) Save4<term, type>(dst, d40, d41, d42, d43, bias, params), dst += dD;
+                    if (M > 5) Save4<term, type>(dst, d50, d51, d52, d53, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= 3 * F;
+                    if (M > 0) Save4<term, type>(dst, d00, d01, d02, d03, bias, params, dstC), dst += dD;
+                    if (M > 1) Save4<term, type>(dst, d10, d11, d12, d13, bias, params, dstC), dst += dD;
+                    if (M > 2) Save4<term, type>(dst, d20, d21, d22, d23, bias, params, dstC), dst += dD;
+                    if (M > 3) Save4<term, type>(dst, d30, d31, d32, d33, bias, params, dstC), dst += dD;
+                    if (M > 4) Save4<term, type>(dst, d40, d41, d42, d43, bias, params, dstC), dst += dD;
+                    if (M > 5) Save4<term, type>(dst, d50, d51, d52, d53, bias, params, dstC), dst += dD;
+                }
+            }
+            else if (dstC > 2 * F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f), d12 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f), d22 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f), d32 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f), d42 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f), d52 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 0 * dD + 2 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F), d12 = svld1_f32(svptrue_b32(), dst + 1 * dD + 2 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F), d22 = svld1_f32(svptrue_b32(), dst + 2 * dD + 2 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F), d32 = svld1_f32(svptrue_b32(), dst + 3 * dD + 2 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F), d42 = svld1_f32(svptrue_b32(), dst + 4 * dD + 2 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F), d52 = svld1_f32(svptrue_b32(), dst + 5 * dD + 2 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2);
+                                if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1), d12 = svmla_f32_x(svptrue_b32(), d12, s0, w2);
+                                if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1), d22 = svmla_f32_x(svptrue_b32(), d22, s0, w2);
+                                if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1), d32 = svmla_f32_x(svptrue_b32(), d32, s0, w2);
+                                if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1), d42 = svmla_f32_x(svptrue_b32(), d42, s0, w2);
+                                if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1), d52 = svmla_f32_x(svptrue_b32(), d52, s0, w2);
+                            }
+                            weight0 += dW, weight1 += dW, weight2 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz, weight1 += dWz, weight2 += dWz;
+                }
+                if (dstC == 3 * F)
+                {
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= 2 * F;
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params, dstC), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params, dstC), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params, dstC), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params, dstC), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params, dstC), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params, dstC), dst += dD;
+                }
+            }
+            else if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                                if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                                if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                                if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                                if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                                if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                            }
+                            weight0 += dW, weight1 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz, weight1 += dWz;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params, dstC), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params, dstC), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params, dstC), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params, dstC), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params, dstC), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F);
+                }
+                for (size_t ky = 0; ky < kY; ky += dilY)
+                {
+                    if (sy + ky < srcH)
+                    {
+                        size_t beg = (sy + ky) * dY + sx * dX;
+                        for (size_t kx = 0; kx < kX; kx += dilX)
+                        {
+                            assert(sx + kx < srcW && sx + kx + M <= srcW);
+                            size_t offs = beg + kx * dX, end = offs + srcC, offw = 0;
+                            for (; offs < end; ++offs, offw += F)
+                            {
+                                w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                                if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                                if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                                if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                                if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                                if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                                if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                            }
+                            weight0 += dW;
+                        }
+                    }
+                    else
+                        weight0 += dWz;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params, dstC), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params, dstC), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params, dstC), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params, dstC), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params, dstC), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect_NxM_Ptr GetConvolutionNhwcDirect_4xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return ConvolutionNhwcDirect_4xM<term, type, 1>;
+            case 2: return ConvolutionNhwcDirect_4xM<term, type, 2>;
+            case 3: return ConvolutionNhwcDirect_4xM<term, type, 3>;
+            case 4: return ConvolutionNhwcDirect_4xM<term, type, 4>;
+            case 5: return ConvolutionNhwcDirect_4xM<term, type, 5>;
+            case 6: return ConvolutionNhwcDirect_4xM<term, type, 6>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect_4(const float* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            size_t noseH = p.NoseH(), noseW = p.NoseW(), bodyH = p.BodyH(), bodyW = p.BodyW();
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_4x1 = ConvolutionNhwcDirect_4x1<term, type>;
+            size_t n = 6, bodyWn = AlignLoAny(bodyW - noseW, n) + noseW, m = bodyW - bodyWn;
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_4xN = GetConvolutionNhwcDirect_4xM<term, type>(n);
+            ConvolutionNhwcDirect_NxM_Ptr convolutionNhwcDirect_4xM = GetConvolutionNhwcDirect_4xM<term, type>(m);
+            size_t tailH = p.dstH, tailW = p.dstW;
+            size_t kY = p.kernelY - noseH, kX = p.kernelX - noseW, kH = bodyH + p.kernelY - 1, kW = bodyW + p.kernelX - 1;
+            for (size_t dc = 0; dc < dstC; dc += a.microD)
+            {
+                size_t dC = Simd::Min(a.microD, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                float* d = dst + dc + yBeg * p.dstW * p.dstC;
+                for (size_t dy = yBeg; dy < yEnd; dy++)
+                {
+                    size_t dx = 0;
+                    for (; dx < noseW; dx++, d += p.dstC)
+                        convolutionNhwcDirect_4x1(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < bodyWn; dx += n, d += p.dstC * n)
+                        convolutionNhwcDirect_4xN(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < bodyW; dx += m, d += p.dstC * m)
+                        convolutionNhwcDirect_4xM(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                    for (; dx < tailW; dx++, d += p.dstC)
+                        convolutionNhwcDirect_4x1(src, p, a, dy, dx, srcC, dC, weight, _bias, _params, d, first);
+                }
+                weight += p.kernelY * p.kernelX * p.srcC * a.microD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<TermType term, SimdConvolutionActivationType type, int M> void ConvolutionNhwcDirect1x1_4xM(const float* src0, const ConvParam& p,
+            const AlgParam& a, size_t srcC, size_t dstC, const float* weight0, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F, DF = 2 * F;
+            svfloat32_t d00, d01, d02, d03, d10, d11, d12, d13, d20, d21, d22, d23, d30, d31, d32, d33, d40, d41, d42, d43, d50, d51, d52, d53, s0, w0, w1, w2, w3;
+            size_t dS = p.srcC, dD = p.dstC;
+            const float* weight1 = weight0 + a.stepW;
+            const float* weight2 = weight1 + a.stepW;
+            const float* weight3 = weight2 + a.stepW;
+            const float* src1 = src0 + 1 * dS;
+            const float* src2 = src0 + 2 * dS;
+            const float* src3 = src0 + 3 * dS;
+            const float* src4 = src0 + 4 * dS;
+            const float* src5 = src0 + 5 * dS;
+            if (dstC > 3 * F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f), d03 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f), d12 = svdup_n_f32(0.0f), d13 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f), d22 = svdup_n_f32(0.0f), d23 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f), d32 = svdup_n_f32(0.0f), d33 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f), d42 = svdup_n_f32(0.0f), d43 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f), d52 = svdup_n_f32(0.0f), d53 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 0 * dD + 2 * F), d03 = svld1_f32(svptrue_b32(), dst + 0 * dD + 3 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F), d12 = svld1_f32(svptrue_b32(), dst + 1 * dD + 2 * F), d13 = svld1_f32(svptrue_b32(), dst + 1 * dD + 3 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F), d22 = svld1_f32(svptrue_b32(), dst + 2 * dD + 2 * F), d23 = svld1_f32(svptrue_b32(), dst + 2 * dD + 3 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F), d32 = svld1_f32(svptrue_b32(), dst + 3 * dD + 2 * F), d33 = svld1_f32(svptrue_b32(), dst + 3 * dD + 3 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F), d42 = svld1_f32(svptrue_b32(), dst + 4 * dD + 2 * F), d43 = svld1_f32(svptrue_b32(), dst + 4 * dD + 3 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F), d52 = svld1_f32(svptrue_b32(), dst + 5 * dD + 2 * F), d53 = svld1_f32(svptrue_b32(), dst + 5 * dD + 3 * F);
+                }
+                for (size_t offs = 0, offw = 0; offs < srcC; ++offs, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                    w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                    w3 = svld1_f32(svptrue_b32(), weight3 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2), d03 = svmla_f32_x(svptrue_b32(), d03, s0, w3);
+                    if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1), d12 = svmla_f32_x(svptrue_b32(), d12, s0, w2), d13 = svmla_f32_x(svptrue_b32(), d13, s0, w3);
+                    if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1), d22 = svmla_f32_x(svptrue_b32(), d22, s0, w2), d23 = svmla_f32_x(svptrue_b32(), d23, s0, w3);
+                    if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1), d32 = svmla_f32_x(svptrue_b32(), d32, s0, w2), d33 = svmla_f32_x(svptrue_b32(), d33, s0, w3);
+                    if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1), d42 = svmla_f32_x(svptrue_b32(), d42, s0, w2), d43 = svmla_f32_x(svptrue_b32(), d43, s0, w3);
+                    if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1), d52 = svmla_f32_x(svptrue_b32(), d52, s0, w2), d53 = svmla_f32_x(svptrue_b32(), d53, s0, w3);
+                }
+                if (dstC == 4 * F)
+                {
+                    if (M > 0) Save4<term, type>(dst, d00, d01, d02, d03, bias, params), dst += dD;
+                    if (M > 1) Save4<term, type>(dst, d10, d11, d12, d13, bias, params), dst += dD;
+                    if (M > 2) Save4<term, type>(dst, d20, d21, d22, d23, bias, params), dst += dD;
+                    if (M > 3) Save4<term, type>(dst, d30, d31, d32, d33, bias, params), dst += dD;
+                    if (M > 4) Save4<term, type>(dst, d40, d41, d42, d43, bias, params), dst += dD;
+                    if (M > 5) Save4<term, type>(dst, d50, d51, d52, d53, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= 3 * F;
+                    if (M > 0) Save4<term, type>(dst, d00, d01, d02, d03, bias, params, dstC), dst += dD;
+                    if (M > 1) Save4<term, type>(dst, d10, d11, d12, d13, bias, params, dstC), dst += dD;
+                    if (M > 2) Save4<term, type>(dst, d20, d21, d22, d23, bias, params, dstC), dst += dD;
+                    if (M > 3) Save4<term, type>(dst, d30, d31, d32, d33, bias, params, dstC), dst += dD;
+                    if (M > 4) Save4<term, type>(dst, d40, d41, d42, d43, bias, params, dstC), dst += dD;
+                    if (M > 5) Save4<term, type>(dst, d50, d51, d52, d53, bias, params, dstC), dst += dD;
+                }
+            }
+            else if (dstC > 2 * F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f), d02 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f), d12 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f), d22 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f), d32 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f), d42 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f), d52 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F), d02 = svld1_f32(svptrue_b32(), dst + 0 * dD + 2 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F), d12 = svld1_f32(svptrue_b32(), dst + 1 * dD + 2 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F), d22 = svld1_f32(svptrue_b32(), dst + 2 * dD + 2 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F), d32 = svld1_f32(svptrue_b32(), dst + 3 * dD + 2 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F), d42 = svld1_f32(svptrue_b32(), dst + 4 * dD + 2 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F), d52 = svld1_f32(svptrue_b32(), dst + 5 * dD + 2 * F);
+                }
+                for (size_t offs = 0, offw = 0; offs < srcC; ++offs, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                    w2 = svld1_f32(svptrue_b32(), weight2 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1), d02 = svmla_f32_x(svptrue_b32(), d02, s0, w2);
+                    if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1), d12 = svmla_f32_x(svptrue_b32(), d12, s0, w2);
+                    if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1), d22 = svmla_f32_x(svptrue_b32(), d22, s0, w2);
+                    if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1), d32 = svmla_f32_x(svptrue_b32(), d32, s0, w2);
+                    if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1), d42 = svmla_f32_x(svptrue_b32(), d42, s0, w2);
+                    if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1), d52 = svmla_f32_x(svptrue_b32(), d52, s0, w2);
+                }
+                if (dstC == 3 * F)
+                {
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= 2 * F;
+                    if (M > 0) Save3<term, type>(dst, d00, d01, d02, bias, params, dstC), dst += dD;
+                    if (M > 1) Save3<term, type>(dst, d10, d11, d12, bias, params, dstC), dst += dD;
+                    if (M > 2) Save3<term, type>(dst, d20, d21, d22, bias, params, dstC), dst += dD;
+                    if (M > 3) Save3<term, type>(dst, d30, d31, d32, bias, params, dstC), dst += dD;
+                    if (M > 4) Save3<term, type>(dst, d40, d41, d42, bias, params, dstC), dst += dD;
+                    if (M > 5) Save3<term, type>(dst, d50, d51, d52, bias, params, dstC), dst += dD;
+                }
+            }
+            else if (dstC > F)
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f), d51 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F), d01 = svld1_f32(svptrue_b32(), dst + 0 * dD + 1 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F), d11 = svld1_f32(svptrue_b32(), dst + 1 * dD + 1 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F), d21 = svld1_f32(svptrue_b32(), dst + 2 * dD + 1 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F), d31 = svld1_f32(svptrue_b32(), dst + 3 * dD + 1 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F), d41 = svld1_f32(svptrue_b32(), dst + 4 * dD + 1 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F), d51 = svld1_f32(svptrue_b32(), dst + 5 * dD + 1 * F);
+                }
+                for (size_t offs = 0, offw = 0; offs < srcC; ++offs, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    w1 = svld1_f32(svptrue_b32(), weight1 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0), d01 = svmla_f32_x(svptrue_b32(), d01, s0, w1);
+                    if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0), d11 = svmla_f32_x(svptrue_b32(), d11, s0, w1);
+                    if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0), d21 = svmla_f32_x(svptrue_b32(), d21, s0, w1);
+                    if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0), d31 = svmla_f32_x(svptrue_b32(), d31, s0, w1);
+                    if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0), d41 = svmla_f32_x(svptrue_b32(), d41, s0, w1);
+                    if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0), d51 = svmla_f32_x(svptrue_b32(), d51, s0, w1);
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params), dst += dD;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Save2<term, type>(dst, d00, d01, bias, params, dstC), dst += dD;
+                    if (M > 1) Save2<term, type>(dst, d10, d11, bias, params, dstC), dst += dD;
+                    if (M > 2) Save2<term, type>(dst, d20, d21, bias, params, dstC), dst += dD;
+                    if (M > 3) Save2<term, type>(dst, d30, d31, bias, params, dstC), dst += dD;
+                    if (M > 4) Save2<term, type>(dst, d40, d41, bias, params, dstC), dst += dD;
+                    if (M > 5) Save2<term, type>(dst, d50, d51, bias, params, dstC), dst += dD;
+                }
+            }
+            else
+            {
+                if (first)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f);
+                    if (M > 5) d50 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(svptrue_b32(), dst + 0 * dD + 0 * F);
+                    if (M > 1) d10 = svld1_f32(svptrue_b32(), dst + 1 * dD + 0 * F);
+                    if (M > 2) d20 = svld1_f32(svptrue_b32(), dst + 2 * dD + 0 * F);
+                    if (M > 3) d30 = svld1_f32(svptrue_b32(), dst + 3 * dD + 0 * F);
+                    if (M > 4) d40 = svld1_f32(svptrue_b32(), dst + 4 * dD + 0 * F);
+                    if (M > 5) d50 = svld1_f32(svptrue_b32(), dst + 5 * dD + 0 * F);
+                }
+                for (size_t offs = 0, offw = 0; offs < srcC; ++offs, offw += F)
+                {
+                    w0 = svld1_f32(svptrue_b32(), weight0 + offw);
+                    if (M > 0) s0 = svdup_n_f32(src0[offs]), d00 = svmla_f32_x(svptrue_b32(), d00, s0, w0);
+                    if (M > 1) s0 = svdup_n_f32(src1[offs]), d10 = svmla_f32_x(svptrue_b32(), d10, s0, w0);
+                    if (M > 2) s0 = svdup_n_f32(src2[offs]), d20 = svmla_f32_x(svptrue_b32(), d20, s0, w0);
+                    if (M > 3) s0 = svdup_n_f32(src3[offs]), d30 = svmla_f32_x(svptrue_b32(), d30, s0, w0);
+                    if (M > 4) s0 = svdup_n_f32(src4[offs]), d40 = svmla_f32_x(svptrue_b32(), d40, s0, w0);
+                    if (M > 5) s0 = svdup_n_f32(src5[offs]), d50 = svmla_f32_x(svptrue_b32(), d50, s0, w0);
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params), dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, d00, bias, params, dstC), dst += dD;
+                    if (M > 1) Save1<term, type>(dst, d10, bias, params, dstC), dst += dD;
+                    if (M > 2) Save1<term, type>(dst, d20, bias, params, dstC), dst += dD;
+                    if (M > 3) Save1<term, type>(dst, d30, bias, params, dstC), dst += dD;
+                    if (M > 4) Save1<term, type>(dst, d40, bias, params, dstC), dst += dD;
+                    if (M > 5) Save1<term, type>(dst, d50, bias, params, dstC), dst += dD;
+                }
+            }
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> ConvolutionNhwcDirect1x1_NxM_Ptr GetConvolutionNhwcDirect1x1_4xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return ConvolutionNhwcDirect1x1_4xM<term, type, 1>;
+            case 2: return ConvolutionNhwcDirect1x1_4xM<term, type, 2>;
+            case 3: return ConvolutionNhwcDirect1x1_4xM<term, type, 3>;
+            case 4: return ConvolutionNhwcDirect1x1_4xM<term, type, 4>;
+            case 5: return ConvolutionNhwcDirect1x1_4xM<term, type, 5>;
+            case 6: return ConvolutionNhwcDirect1x1_4xM<term, type, 6>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> void ConvolutionNhwcDirect1x1_4(const float* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t yBeg, size_t yEnd, size_t srcC, const float* weight, const float* bias, const float* params, float* dst, int first)
+        {
+            const size_t F = a.F;
+            size_t n = 6, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            ConvolutionNhwcDirect1x1_NxM_Ptr convolutionNhwcDirect1x1_4xN = GetConvolutionNhwcDirect1x1_4xM<term, type>(n);
+            ConvolutionNhwcDirect1x1_NxM_Ptr convolutionNhwcDirect1x1_4xM = GetConvolutionNhwcDirect1x1_4xM<term, type>(m);
+            for (size_t dc = 0; dc < dstC; dc += a.microD)
+            {
+                size_t dC = Simd::Min(a.microD, dstC - dc);
+                const float* _bias = bias + dc;
+                const float* _params = type == ::SimdConvolutionActivationPrelu ? params + dc : params;
+                const float* ps = src + yBeg * p.srcW * p.srcC;
+                float* pd = dst + dc + yBeg * p.dstW * p.dstC;
+                size_t i = 0;
+                for (; i < nn; i += n, ps += n * p.srcC, pd += n * p.dstC)
+                    convolutionNhwcDirect1x1_4xN(ps, p, a, srcC, dC, weight, _bias, _params, pd, first);
+                for (; i < n1; i += m, ps += m * p.srcC, pd += m * p.dstC)
+                    convolutionNhwcDirect1x1_4xM(ps, p, a, srcC, dC, weight, _bias, _params, pd, first);
+                weight += p.srcC * a.microD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template <TermType term, SimdConvolutionActivationType type> static SIMD_INLINE void Set(const ConvParam& p, AlgParam& a)
+        {
+            a.convolutions[term] = p.Is1x1() ? ConvolutionNhwcDirect1x1_4<term, type> : ConvolutionNhwcDirect_4<term, type>;
+        }
+
+        template <SimdConvolutionActivationType type> static SIMD_INLINE void Set(const ConvParam& p, AlgParam& a)
+        {
+            Set<TermLast, type>(p, a);
+            Set<TermInterim, SimdConvolutionActivationIdentity>(p, a);
+        }
+
+        bool SynetConvolution32fNhwcDirect::Set4r(const ConvParam& p, AlgParam& a)
+        {
+            assert(a.microD == 4 * a.F);
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, a); break;
+            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, a); break;
+            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, a); break;
+            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, a); break;
+            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, a); break;
+            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, a); break;
+            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, a); break;
+            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, a); break;
+            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, a); break;
+            default: assert(0);
+            }
+            return true;
+        }
+    }
+#endif//SIMD_SVE2_ENABLE
+}

--- a/src/Simd/SimdSynetConvolution32f.h
+++ b/src/Simd/SimdSynetConvolution32f.h
@@ -787,6 +787,21 @@ namespace Simd
             virtual void Forward(const float * src, float * buf, float * dst);
         };
 
+        class SynetConvolution32fNhwcDirect : public Base::SynetConvolution32fNhwcDirect
+        {
+        public:
+            SynetConvolution32fNhwcDirect(const ConvParam & p);
+            virtual String Ext() const { return "Sve2"; }
+
+            static bool Preferable(const ConvParam & p);
+        private:
+            static bool Set2f(const ConvParam& p, OldConvolutionPtr& convolution);
+            static bool SetRt(const ConvParam& p, AlgParam& a);
+            static bool Set2r(const ConvParam& p, AlgParam& a);
+            static bool Set3r(const ConvParam& p, AlgParam& a);
+            static bool Set4r(const ConvParam& p, AlgParam& a);
+        };
+
         void * SynetConvolution32fInit(size_t batch, const SimdConvolutionParameters * conv);
     }
 #endif//SIMD_SVE2_ENABLE

--- a/src/Simd/SimdSynetConvolution32fCommon.h
+++ b/src/Simd/SimdSynetConvolution32fCommon.h
@@ -437,5 +437,135 @@ namespace Simd
         }
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t LoadActParam0(const float* params, size_t index, const svbool_t& mask)
+        {
+            return svdup_n_f32(params[0]);
+        }
+
+        template<> SIMD_INLINE svfloat32_t LoadActParam0<SimdConvolutionActivationPrelu>(const float* params, size_t index, const svbool_t& mask)
+        {
+            return svld1_f32(mask, params + index * svcntw());
+        }
+
+        template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t LoadActParam1(const float* params, size_t index, const svbool_t& mask)
+        {
+            return svdup_n_f32(params[1]);
+        }
+
+        template<> SIMD_INLINE svfloat32_t LoadActParam1<SimdConvolutionActivationPrelu>(const float* params, size_t index, const svbool_t& mask)
+        {
+            return svld1_f32(mask, params + index * svcntw());
+        }
+
+        template <TermType term> struct Term
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, const svbool_t& mask);
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params);
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, size_t tail);
+        };
+
+        template <> struct Term<TermLast>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, const svbool_t& mask)
+            {
+                const size_t F = svcntw();
+                svfloat32_t param0 = LoadActParam0<type>(params, index, mask);
+                svfloat32_t param1 = LoadActParam1<type>(params, index, mask);
+                svfloat32_t sum = svadd_f32_x(mask, value, svld1_f32(mask, bias + index * F));
+                svst1_f32(mask, ptr, Activate<type>(sum, param0, param1, 0, mask));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params)
+            {
+                Save<type, index>(ptr, value, bias, params, svptrue_b32());
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, size_t tail)
+            {
+                Save<type, index>(ptr, value, bias, params, svwhilelt_b32((size_t)0, tail));
+            }
+        };
+
+        template <> struct Term<TermInterim>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, const svbool_t& mask)
+            {
+                svst1_f32(mask, ptr, value);
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params)
+            {
+                Save<type, index>(ptr, value, bias, params, svptrue_b32());
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, size_t tail)
+            {
+                Save<type, index>(ptr, value, bias, params, svwhilelt_b32((size_t)0, tail));
+            }
+        };
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(float* dst, svfloat32_t val0, const float* bias, const float* params)
+        {
+            Term<term>::template Save<type, 0>(dst, val0, bias, params, svptrue_b32());
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(float* dst, svfloat32_t val0, const float* bias, const float* params, size_t tail)
+        {
+            Term<term>::template Save<type, 0>(dst, val0, bias, params, svwhilelt_b32((size_t)0, tail));
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(float* dst, svfloat32_t val0, svfloat32_t val1, const float* bias, const float* params)
+        {
+            const size_t F = svcntw();
+            Term<term>::template Save<type, 0>(dst + 0, val0, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 1>(dst + F, val1, bias, params, svptrue_b32());
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(float* dst, svfloat32_t val0, svfloat32_t val1, const float* bias, const float* params, size_t tail)
+        {
+            const size_t F = svcntw();
+            Term<term>::template Save<type, 0>(dst + 0, val0, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 1>(dst + F, val1, bias, params, svwhilelt_b32((size_t)0, tail));
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save3(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, const float* bias, const float* params)
+        {
+            const size_t F = svcntw();
+            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save3(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, const float* bias, const float* params, size_t tail)
+        {
+            const size_t F = svcntw();
+            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svwhilelt_b32((size_t)0, tail));
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save4(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, svfloat32_t val3, const float* bias, const float* params)
+        {
+            const size_t F = svcntw();
+            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 3>(dst + 3 * F, val3, bias, params, svptrue_b32());
+        }
+
+        template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save4(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, svfloat32_t val3, const float* bias, const float* params, size_t tail)
+        {
+            const size_t F = svcntw();
+            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
+            Term<term>::template Save<type, 3>(dst + 3 * F, val3, bias, params, svwhilelt_b32((size_t)0, tail));
+        }
+    }
+#endif
 }
 #endif

--- a/src/Simd/SimdSynetConvolution32fCommon.h
+++ b/src/Simd/SimdSynetConvolution32fCommon.h
@@ -461,14 +461,14 @@ namespace Simd
             return svld1_f32(mask, params + index * svcntw());
         }
 
-        template <TermType term> struct Term
+        template <TermType term> struct ConvolutionTerm
         {
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, const svbool_t& mask);
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params);
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, size_t tail);
         };
 
-        template <> struct Term<TermLast>
+        template <> struct ConvolutionTerm<TermLast>
         {
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, const svbool_t& mask)
             {
@@ -490,7 +490,7 @@ namespace Simd
             }
         };
 
-        template <> struct Term<TermInterim>
+        template <> struct ConvolutionTerm<TermInterim>
         {
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float* ptr, svfloat32_t value, const float* bias, const float* params, const svbool_t& mask)
             {
@@ -510,60 +510,60 @@ namespace Simd
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(float* dst, svfloat32_t val0, const float* bias, const float* params)
         {
-            Term<term>::template Save<type, 0>(dst, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 0>(dst, val0, bias, params, svptrue_b32());
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(float* dst, svfloat32_t val0, const float* bias, const float* params, size_t tail)
         {
-            Term<term>::template Save<type, 0>(dst, val0, bias, params, svwhilelt_b32((size_t)0, tail));
+            ConvolutionTerm<term>::template Save<type, 0>(dst, val0, bias, params, svwhilelt_b32((size_t)0, tail));
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(float* dst, svfloat32_t val0, svfloat32_t val1, const float* bias, const float* params)
         {
             const size_t F = svcntw();
-            Term<term>::template Save<type, 0>(dst + 0, val0, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 1>(dst + F, val1, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 0>(dst + 0, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 1>(dst + F, val1, bias, params, svptrue_b32());
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(float* dst, svfloat32_t val0, svfloat32_t val1, const float* bias, const float* params, size_t tail)
         {
             const size_t F = svcntw();
-            Term<term>::template Save<type, 0>(dst + 0, val0, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 1>(dst + F, val1, bias, params, svwhilelt_b32((size_t)0, tail));
+            ConvolutionTerm<term>::template Save<type, 0>(dst + 0, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 1>(dst + F, val1, bias, params, svwhilelt_b32((size_t)0, tail));
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save3(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, const float* bias, const float* params)
         {
             const size_t F = svcntw();
-            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save3(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, const float* bias, const float* params, size_t tail)
         {
             const size_t F = svcntw();
-            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svwhilelt_b32((size_t)0, tail));
+            ConvolutionTerm<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svwhilelt_b32((size_t)0, tail));
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save4(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, svfloat32_t val3, const float* bias, const float* params)
         {
             const size_t F = svcntw();
-            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 3>(dst + 3 * F, val3, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 3>(dst + 3 * F, val3, bias, params, svptrue_b32());
         }
 
         template<TermType term, SimdConvolutionActivationType type> SIMD_INLINE void Save4(float* dst, svfloat32_t val0, svfloat32_t val1, svfloat32_t val2, svfloat32_t val3, const float* bias, const float* params, size_t tail)
         {
             const size_t F = svcntw();
-            Term<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
-            Term<term>::template Save<type, 3>(dst + 3 * F, val3, bias, params, svwhilelt_b32((size_t)0, tail));
+            ConvolutionTerm<term>::template Save<type, 0>(dst + 0 * F, val0, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 1>(dst + 1 * F, val1, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 2>(dst + 2 * F, val2, bias, params, svptrue_b32());
+            ConvolutionTerm<term>::template Save<type, 3>(dst + 3 * F, val3, bias, params, svwhilelt_b32((size_t)0, tail));
         }
     }
 #endif

--- a/src/Test/TestSynetConvolution32f.cpp
+++ b/src/Test/TestSynetConvolution32f.cpp
@@ -271,6 +271,11 @@ namespace Test
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 7, 7, 64, _7, _1, _1, _0, _0, 64, aRe, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 128, 5, 5, 128, _5, _1, _1, _0, _0, 128, a, tF), f1, f2);
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 49, 3, 3, 49, _3, _1, _1, _0, _0, 49, aHi, tF), f1, f2);
+        // NHWC Direct (Preferable): 3x3, 1x1, and small-srcC old-f path
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 32, 28, 28, 64, _3, _1, _1, _1, _1, 1, aRe, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 64, 16, 16, 64, _1, _1, _1, _0, _0, 1, aId, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 16, 20, 20, 32, _3, _1, _1, _1, _1, 1, aPr, tT), f1, f2);
+        result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 3, 32, 32, 16, _3, _1, _1, _1, _1, 1, aRe, tT), f1, f2);
 #endif
 #else
         result = result && SynetConvolution32fForwardAutoTest(eps, Param(1, 20, 75, 75, 20, Size(1, 11), _1, _1, Size(0, 5), Size(0, 5), 20, aId, t), f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE2 implementation of `SynetConvolution32fNhwcDirect` based on the Neon NHWC direct kernels (`2f`, `2r`, `3r`, `4r`).
- Introduce SVE2 `ConvolutionTerm`/`Save` helpers in `SimdSynetConvolution32fCommon.h` (named to avoid clashing with local `Term` in Deconvolution/MergedConvolution).
- Wire the new class into `Sve2::SynetConvolution32fInit`, VS2022 project files, release notes (`docs/2026.html` 7.2.165), and AutoTest cases that hit Preferable NHWC-direct shapes.

## Validation
- aarch64 cross-compile of NhwcDirect units plus `SimdSve2SynetDeconvolution32f.cpp` / MergedConvolution output (no `Term` redefinition).
- x86 Release build + `./Test "-r=.." -fi=SynetConvolution32f -tt=1 -ts=1` — all tests finished successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb4000e5-c056-4655-84e7-68900fe20d47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb4000e5-c056-4655-84e7-68900fe20d47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

