### PR TITLE
Add SVE2 optimizations for SynetInnerProduct32fGemm

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -49,6 +49,7 @@
  <li>SVE2 optimizations of class SynetConvolution32fNhwcDepthwise.</li>
  <li>SVE2 optimizations of class SynetConvolution32fDepthwiseDotProduct.</li>
  <li>SVE2 optimizations of class SynetConvolution32fNhwcDirect.</li>
+ <li>SVE2 optimizations of class SynetInnerProduct32fGemm.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution8iInput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution8iOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetGridSample2d32fBlZ.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetNormalize16b.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -545,6 +545,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution8iOutput.cpp">
       <Filter>Sve2\Synet\MergedConvolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct32f.cpp">
+      <Filter>Sve2\Synet\InnerProduct</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetInnerProduct8i.cpp">
       <Filter>Sve2\Synet\InnerProduct</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6702,7 +6702,7 @@ SIMD_API void* SimdSynetInnerProduct32fInit(size_t M, size_t N, size_t K, SimdBo
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetInnerProduct32fInitPtr) (size_t M, size_t N, size_t K, SimdBool transB, SimdBool constB, SimdBool bias, SimdConvolutionActivationType activation);
-    const static SimdSynetInnerProduct32fInitPtr simdSynetInnerProduct32fInit = SIMD_FUNC4(SynetInnerProduct32fInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetInnerProduct32fInitPtr simdSynetInnerProduct32fInit = SIMD_FUNC5(SynetInnerProduct32fInit, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetInnerProduct32fInit(M, N, K, transB, constB, bias, activation);
 #else

--- a/src/Simd/SimdSve2SynetInnerProduct32f.cpp
+++ b/src/Simd/SimdSve2SynetInnerProduct32f.cpp
@@ -1,0 +1,73 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdSynetInnerProduct32f.h"
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdNeon.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)      
+    namespace Sve2
+    {
+        SynetInnerProduct32fGemm::SynetInnerProduct32fGemm(const InnerProductParam32f& p)
+            : Base::SynetInnerProduct32fGemm(p)
+        {
+            _biasAndActivation = Neon::ConvolutionBiasAndActivation;
+            if (_param.transB)
+            {
+                _gemm = Sve2::Gemm32fNT;
+                if (_M == 1 && _param.activation == SimdConvolutionActivationIdentity && _param.constB)
+                    _prod = Sve2::SynetInnerProductLayerForward;
+                else
+                    _prod = NULL;
+            }
+            else
+            {
+                _gemm = Sve2::Gemm32fNN;
+            }
+            if (_param.N > Neon::F && _prod == NULL && _param.constB)
+            {
+                _cbRun = Neon::Gemm32fNNcbRun;
+                _cbPack = Neon::Gemm32fNNcbReorderB;
+                _cbWeight.Resize(Neon::Gemm32fNNcbBufferSize(_M, _N, _K, GemmKernelAny, NHWC_GEMM_COMPATIBLE));
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        void* SynetInnerProduct32fInit(size_t M, size_t N, size_t K, SimdBool transB, SimdBool constB, SimdBool bias, SimdConvolutionActivationType activation)
+        {
+            InnerProductParam32f param(M, N, K, transB, constB, bias, activation);
+            if (!param.Valid())
+                return NULL;
+            return new SynetInnerProduct32fGemm(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetInnerProduct32f.h
+++ b/src/Simd/SimdSynetInnerProduct32f.h
@@ -266,6 +266,21 @@ namespace Simd
         void* SynetInnerProduct32fInit(size_t M, size_t N, size_t K, SimdBool transB, SimdBool constB, SimdBool bias, SimdConvolutionActivationType activation);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        class SynetInnerProduct32fGemm : public Base::SynetInnerProduct32fGemm
+        {
+        public:
+            SynetInnerProduct32fGemm(const InnerProductParam32f& p);
+
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        void* SynetInnerProduct32fInit(size_t M, size_t N, size_t K, SimdBool transB, SimdBool constB, SimdBool bias, SimdConvolutionActivationType activation);
+    }
+#endif
 }
 
 #endif

--- a/src/Test/TestSynetInnerProduct.cpp
+++ b/src/Test/TestSynetInnerProduct.cpp
@@ -176,6 +176,11 @@ namespace Test
             result = result && SynetInnerProduct32fForwardAutoTest(EPS, FUNC_IP32F(Simd::Neon::SynetInnerProduct32fInit), FUNC_IP32F(SimdSynetInnerProduct32fInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetInnerProduct32fForwardAutoTest(EPS, FUNC_IP32F(Simd::Sve2::SynetInnerProduct32fInit), FUNC_IP32F(SimdSynetInnerProduct32fInit));
+#endif
+
         return result;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds SVE/SVE2 optimizations for `Base::SynetInnerProduct32fGemm` on ARM/ARM64, following the existing Neon and SVE2 SynetConvolution32f Gemm patterns.

### Changes
- **New** `src/Simd/SimdSve2SynetInnerProduct32f.cpp` — `Sve2::SynetInnerProduct32fGemm` uses `Sve2::Gemm32fNN` / `Gemm32fNT` and `Sve2::SynetInnerProductLayerForward` for the `M==1` identity path; bias/activation and packed NNcb helpers reuse Neon (no SVE2 NNcb yet).
- **Header** `SimdSynetInnerProduct32f.h` — declare `Sve2::SynetInnerProduct32fGemm` and `SynetInnerProduct32fInit`.
- **Dispatch** `SimdLib.cpp` — include `SIMD_SVE2_FUNC` in `SimdSynetInnerProduct32fInit`.
- **Tests** `TestSynetInnerProduct.cpp` — register SVE2 Autotest for `SynetInnerProduct32fForward`.
- **VS2022** — add file to `Sve2.vcxproj` / `.filters` under `Sve2\Synet\InnerProduct`.
- **Docs** — note under release **7.2.165** in `docs/2026.html`.

### Validation
- x86_64 host: Release CMake build succeeded; `./Test "-r=.." -fi=SynetInnerProduct32f -tt=1 -ts=1` finished successfully (Base/Sse41/Avx2/Avx512bw paths).
- SVE2 path is compile-gated and needs ARM64 SVE2 hardware/CI for correctness and performance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76f4d170-a7e3-4d8a-b6f3-a83b1ac2dfaa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76f4d170-a7e3-4d8a-b6f3-a83b1ac2dfaa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

