### PR TITLE
Remove DF k-loop from SVE2 Gemm32fNT kernels

### DIFF
--- a/src/Simd/SimdSve2Gemm32fNT.cpp
+++ b/src/Simd/SimdSve2Gemm32fNT.cpp
@@ -45,22 +45,12 @@ namespace Simd
 
         static void Kernel1x1nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* B0 = B + 0 * ldb;
             const svbool_t body = svptrue_b32();
             const svfloat32_t zero = svdup_n_f32(0.0f);
             svfloat32_t c00 = zero;
-            svfloat32_t c00b = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00b = svmla_f32_x(body, c00b, a0, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -74,12 +64,12 @@ namespace Simd
                 svfloat32_t b0 = svld1_f32(mask, B0 + k);
                 c00 = svmla_f32_m(mask, c00, a0, b0);
             }
-            C[0] += alpha * ExtractSum32f(svadd_f32_x(body, c00, c00b));
+            C[0] += alpha * ExtractSum32f(c00);
         }
 
         static void Kernel1x4nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* B0 = B + 0 * ldb;
             const float* B1 = B + 1 * ldb;
@@ -91,31 +81,6 @@ namespace Simd
             svfloat32_t c01 = zero;
             svfloat32_t c02 = zero;
             svfloat32_t c03 = zero;
-            svfloat32_t c00b = zero;
-            svfloat32_t c01b = zero;
-            svfloat32_t c02b = zero;
-            svfloat32_t c03b = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                b0 = svld1_f32(body, B1 + k);
-                c01 = svmla_f32_x(body, c01, a0, b0);
-                b0 = svld1_f32(body, B2 + k);
-                c02 = svmla_f32_x(body, c02, a0, b0);
-                b0 = svld1_f32(body, B3 + k);
-                c03 = svmla_f32_x(body, c03, a0, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00b = svmla_f32_x(body, c00b, a0, b0);
-                b0 = svld1_f32(body, B1 + k + F);
-                c01b = svmla_f32_x(body, c01b, a0, b0);
-                b0 = svld1_f32(body, B2 + k + F);
-                c02b = svmla_f32_x(body, c02b, a0, b0);
-                b0 = svld1_f32(body, B3 + k + F);
-                c03b = svmla_f32_x(body, c03b, a0, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -141,17 +106,12 @@ namespace Simd
                 b0 = svld1_f32(mask, B3 + k);
                 c03 = svmla_f32_m(mask, c03, a0, b0);
             }
-            Add4ExtractedSums(
-                svadd_f32_x(body, c00, c00b),
-                svadd_f32_x(body, c01, c01b),
-                svadd_f32_x(body, c02, c02b),
-                svadd_f32_x(body, c03, c03b),
-                alpha, C + 0 * ldc);
+            Add4ExtractedSums(c00, c01, c02, c03, alpha, C + 0 * ldc);
         }
 
         static void Kernel2x1nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* A1 = A + 1 * lda;
             const float* B0 = B + 0 * ldb;
@@ -159,21 +119,6 @@ namespace Simd
             const svfloat32_t zero = svdup_n_f32(0.0f);
             svfloat32_t c00 = zero;
             svfloat32_t c10 = zero;
-            svfloat32_t c00b = zero;
-            svfloat32_t c10b = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t a1 = svld1_f32(body, A1 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                a1 = svld1_f32(body, A1 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00b = svmla_f32_x(body, c00b, a0, b0);
-                c10b = svmla_f32_x(body, c10b, a1, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -191,13 +136,13 @@ namespace Simd
                 c00 = svmla_f32_m(mask, c00, a0, b0);
                 c10 = svmla_f32_m(mask, c10, a1, b0);
             }
-            C[0 * ldc] += alpha * ExtractSum32f(svadd_f32_x(body, c00, c00b));
-            C[1 * ldc] += alpha * ExtractSum32f(svadd_f32_x(body, c10, c10b));
+            C[0 * ldc] += alpha * ExtractSum32f(c00);
+            C[1 * ldc] += alpha * ExtractSum32f(c10);
         }
 
         static void Kernel2x4nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* A1 = A + 1 * lda;
             const float* B0 = B + 0 * ldb;
@@ -214,37 +159,6 @@ namespace Simd
             svfloat32_t c11 = zero;
             svfloat32_t c12 = zero;
             svfloat32_t c13 = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t a1 = svld1_f32(body, A1 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                b0 = svld1_f32(body, B1 + k);
-                c01 = svmla_f32_x(body, c01, a0, b0);
-                c11 = svmla_f32_x(body, c11, a1, b0);
-                b0 = svld1_f32(body, B2 + k);
-                c02 = svmla_f32_x(body, c02, a0, b0);
-                c12 = svmla_f32_x(body, c12, a1, b0);
-                b0 = svld1_f32(body, B3 + k);
-                c03 = svmla_f32_x(body, c03, a0, b0);
-                c13 = svmla_f32_x(body, c13, a1, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                a1 = svld1_f32(body, A1 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                b0 = svld1_f32(body, B1 + k + F);
-                c01 = svmla_f32_x(body, c01, a0, b0);
-                c11 = svmla_f32_x(body, c11, a1, b0);
-                b0 = svld1_f32(body, B2 + k + F);
-                c02 = svmla_f32_x(body, c02, a0, b0);
-                c12 = svmla_f32_x(body, c12, a1, b0);
-                b0 = svld1_f32(body, B3 + k + F);
-                c03 = svmla_f32_x(body, c03, a0, b0);
-                c13 = svmla_f32_x(body, c13, a1, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -286,7 +200,7 @@ namespace Simd
 
         static void Kernel3x1nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* A1 = A + 1 * lda;
             const float* A2 = A + 2 * lda;
@@ -296,26 +210,6 @@ namespace Simd
             svfloat32_t c00 = zero;
             svfloat32_t c10 = zero;
             svfloat32_t c20 = zero;
-            svfloat32_t c00b = zero;
-            svfloat32_t c10b = zero;
-            svfloat32_t c20b = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t a1 = svld1_f32(body, A1 + k);
-                svfloat32_t a2 = svld1_f32(body, A2 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                c20 = svmla_f32_x(body, c20, a2, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                a1 = svld1_f32(body, A1 + k + F);
-                a2 = svld1_f32(body, A2 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00b = svmla_f32_x(body, c00b, a0, b0);
-                c10b = svmla_f32_x(body, c10b, a1, b0);
-                c20b = svmla_f32_x(body, c20b, a2, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -337,14 +231,14 @@ namespace Simd
                 c10 = svmla_f32_m(mask, c10, a1, b0);
                 c20 = svmla_f32_m(mask, c20, a2, b0);
             }
-            C[0 * ldc] += alpha * ExtractSum32f(svadd_f32_x(body, c00, c00b));
-            C[1 * ldc] += alpha * ExtractSum32f(svadd_f32_x(body, c10, c10b));
-            C[2 * ldc] += alpha * ExtractSum32f(svadd_f32_x(body, c20, c20b));
+            C[0 * ldc] += alpha * ExtractSum32f(c00);
+            C[1 * ldc] += alpha * ExtractSum32f(c10);
+            C[2 * ldc] += alpha * ExtractSum32f(c20);
         }
 
         static void Kernel3x4nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* A1 = A + 1 * lda;
             const float* A2 = A + 2 * lda;
@@ -366,47 +260,6 @@ namespace Simd
             svfloat32_t c21 = zero;
             svfloat32_t c22 = zero;
             svfloat32_t c23 = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t a1 = svld1_f32(body, A1 + k);
-                svfloat32_t a2 = svld1_f32(body, A2 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                c20 = svmla_f32_x(body, c20, a2, b0);
-                b0 = svld1_f32(body, B1 + k);
-                c01 = svmla_f32_x(body, c01, a0, b0);
-                c11 = svmla_f32_x(body, c11, a1, b0);
-                c21 = svmla_f32_x(body, c21, a2, b0);
-                b0 = svld1_f32(body, B2 + k);
-                c02 = svmla_f32_x(body, c02, a0, b0);
-                c12 = svmla_f32_x(body, c12, a1, b0);
-                c22 = svmla_f32_x(body, c22, a2, b0);
-                b0 = svld1_f32(body, B3 + k);
-                c03 = svmla_f32_x(body, c03, a0, b0);
-                c13 = svmla_f32_x(body, c13, a1, b0);
-                c23 = svmla_f32_x(body, c23, a2, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                a1 = svld1_f32(body, A1 + k + F);
-                a2 = svld1_f32(body, A2 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                c20 = svmla_f32_x(body, c20, a2, b0);
-                b0 = svld1_f32(body, B1 + k + F);
-                c01 = svmla_f32_x(body, c01, a0, b0);
-                c11 = svmla_f32_x(body, c11, a1, b0);
-                c21 = svmla_f32_x(body, c21, a2, b0);
-                b0 = svld1_f32(body, B2 + k + F);
-                c02 = svmla_f32_x(body, c02, a0, b0);
-                c12 = svmla_f32_x(body, c12, a1, b0);
-                c22 = svmla_f32_x(body, c22, a2, b0);
-                b0 = svld1_f32(body, B3 + k + F);
-                c03 = svmla_f32_x(body, c03, a0, b0);
-                c13 = svmla_f32_x(body, c13, a1, b0);
-                c23 = svmla_f32_x(body, c23, a2, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -459,7 +312,7 @@ namespace Simd
 
         static void Kernel6x1nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* A1 = A + 1 * lda;
             const float* A2 = A + 2 * lda;
@@ -475,35 +328,6 @@ namespace Simd
             svfloat32_t c30 = zero;
             svfloat32_t c40 = zero;
             svfloat32_t c50 = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                svfloat32_t a1 = svld1_f32(body, A1 + k);
-                svfloat32_t a2 = svld1_f32(body, A2 + k);
-                svfloat32_t a3 = svld1_f32(body, A3 + k);
-                svfloat32_t a4 = svld1_f32(body, A4 + k);
-                svfloat32_t a5 = svld1_f32(body, A5 + k);
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                c20 = svmla_f32_x(body, c20, a2, b0);
-                c30 = svmla_f32_x(body, c30, a3, b0);
-                c40 = svmla_f32_x(body, c40, a4, b0);
-                c50 = svmla_f32_x(body, c50, a5, b0);
-                a0 = svld1_f32(body, A0 + k + F);
-                a1 = svld1_f32(body, A1 + k + F);
-                a2 = svld1_f32(body, A2 + k + F);
-                a3 = svld1_f32(body, A3 + k + F);
-                a4 = svld1_f32(body, A4 + k + F);
-                a5 = svld1_f32(body, A5 + k + F);
-                b0 = svld1_f32(body, B0 + k + F);
-                c00 = svmla_f32_x(body, c00, a0, b0);
-                c10 = svmla_f32_x(body, c10, a1, b0);
-                c20 = svmla_f32_x(body, c20, a2, b0);
-                c30 = svmla_f32_x(body, c30, a3, b0);
-                c40 = svmla_f32_x(body, c40, a4, b0);
-                c50 = svmla_f32_x(body, c50, a5, b0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t a0 = svld1_f32(body, A0 + k);
@@ -547,7 +371,7 @@ namespace Simd
 
         static void Kernel6x4nt(size_t K, float alpha, const float* A, size_t lda, const float* B, size_t ldb, float* C, size_t ldc)
         {
-            size_t F = svcntw(), DF = 2 * F, k = 0;
+            size_t F = svcntw(), k = 0;
             const float* A0 = A + 0 * lda;
             const float* A1 = A + 1 * lda;
             const float* A2 = A + 2 * lda;
@@ -584,77 +408,6 @@ namespace Simd
             svfloat32_t c51 = zero;
             svfloat32_t c52 = zero;
             svfloat32_t c53 = zero;
-            for (; k + DF <= K; k += DF)
-            {
-                svfloat32_t b0 = svld1_f32(body, B0 + k);
-                svfloat32_t b1 = svld1_f32(body, B1 + k);
-                svfloat32_t b2 = svld1_f32(body, B2 + k);
-                svfloat32_t b3 = svld1_f32(body, B3 + k);
-                svfloat32_t a0 = svld1_f32(body, A0 + k);
-                c00 = svmla_f32_x(body, c00, b0, a0);
-                c01 = svmla_f32_x(body, c01, b1, a0);
-                c02 = svmla_f32_x(body, c02, b2, a0);
-                c03 = svmla_f32_x(body, c03, b3, a0);
-                a0 = svld1_f32(body, A1 + k);
-                c10 = svmla_f32_x(body, c10, b0, a0);
-                c11 = svmla_f32_x(body, c11, b1, a0);
-                c12 = svmla_f32_x(body, c12, b2, a0);
-                c13 = svmla_f32_x(body, c13, b3, a0);
-                a0 = svld1_f32(body, A2 + k);
-                c20 = svmla_f32_x(body, c20, b0, a0);
-                c21 = svmla_f32_x(body, c21, b1, a0);
-                c22 = svmla_f32_x(body, c22, b2, a0);
-                c23 = svmla_f32_x(body, c23, b3, a0);
-                a0 = svld1_f32(body, A3 + k);
-                c30 = svmla_f32_x(body, c30, b0, a0);
-                c31 = svmla_f32_x(body, c31, b1, a0);
-                c32 = svmla_f32_x(body, c32, b2, a0);
-                c33 = svmla_f32_x(body, c33, b3, a0);
-                a0 = svld1_f32(body, A4 + k);
-                c40 = svmla_f32_x(body, c40, b0, a0);
-                c41 = svmla_f32_x(body, c41, b1, a0);
-                c42 = svmla_f32_x(body, c42, b2, a0);
-                c43 = svmla_f32_x(body, c43, b3, a0);
-                a0 = svld1_f32(body, A5 + k);
-                c50 = svmla_f32_x(body, c50, b0, a0);
-                c51 = svmla_f32_x(body, c51, b1, a0);
-                c52 = svmla_f32_x(body, c52, b2, a0);
-                c53 = svmla_f32_x(body, c53, b3, a0);
-                b0 = svld1_f32(body, B0 + k + F);
-                b1 = svld1_f32(body, B1 + k + F);
-                b2 = svld1_f32(body, B2 + k + F);
-                b3 = svld1_f32(body, B3 + k + F);
-                a0 = svld1_f32(body, A0 + k + F);
-                c00 = svmla_f32_x(body, c00, b0, a0);
-                c01 = svmla_f32_x(body, c01, b1, a0);
-                c02 = svmla_f32_x(body, c02, b2, a0);
-                c03 = svmla_f32_x(body, c03, b3, a0);
-                a0 = svld1_f32(body, A1 + k + F);
-                c10 = svmla_f32_x(body, c10, b0, a0);
-                c11 = svmla_f32_x(body, c11, b1, a0);
-                c12 = svmla_f32_x(body, c12, b2, a0);
-                c13 = svmla_f32_x(body, c13, b3, a0);
-                a0 = svld1_f32(body, A2 + k + F);
-                c20 = svmla_f32_x(body, c20, b0, a0);
-                c21 = svmla_f32_x(body, c21, b1, a0);
-                c22 = svmla_f32_x(body, c22, b2, a0);
-                c23 = svmla_f32_x(body, c23, b3, a0);
-                a0 = svld1_f32(body, A3 + k + F);
-                c30 = svmla_f32_x(body, c30, b0, a0);
-                c31 = svmla_f32_x(body, c31, b1, a0);
-                c32 = svmla_f32_x(body, c32, b2, a0);
-                c33 = svmla_f32_x(body, c33, b3, a0);
-                a0 = svld1_f32(body, A4 + k + F);
-                c40 = svmla_f32_x(body, c40, b0, a0);
-                c41 = svmla_f32_x(body, c41, b1, a0);
-                c42 = svmla_f32_x(body, c42, b2, a0);
-                c43 = svmla_f32_x(body, c43, b3, a0);
-                a0 = svld1_f32(body, A5 + k + F);
-                c50 = svmla_f32_x(body, c50, b0, a0);
-                c51 = svmla_f32_x(body, c51, b1, a0);
-                c52 = svmla_f32_x(body, c52, b2, a0);
-                c53 = svmla_f32_x(body, c53, b3, a0);
-            }
             for (; k + F <= K; k += F)
             {
                 svfloat32_t b0 = svld1_f32(body, B0 + k);
@@ -748,4 +501,3 @@ namespace Simd
     }
 #endif
 }
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Further improves ARM SVE/SVE2 optimizations of `SimdGemm32fNT` in `SimdSve2Gemm32fNT.cpp` on top of #827/#828.

## Changes

- Remove the dual-vector DF unroll loop `for (; k + DF <= K; k += DF)` from all microkernels.
- Drop DF-related dual accumulators (`c00b`, etc.); keep a single F-wide body loop plus a masked remainder.
- Keep kernels macro-free (explicit NEON/AVX-512BW-style code).
- Preserve `Kernel6x4nt` B-first / `svmla(c, b, a)` register-pressure layout from #828.

## Test plan

- [ ] Native x86 Release: `./Test "-r=.." -fi=Gemm32fNT -tt=1 -ts=1`
- [ ] aarch64 cross-build with `-DSIMD_SVE2=ON` for `SimdSve2Gemm32fNT.cpp`
- [ ] QEMU aarch64 (`-cpu max,sve=on`) Gemm32fNT AutoTest when available

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3df4f1-c072-4fd1-8aa0-407ea3dea185?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3df4f1-c072-4fd1-8aa0-407ea3dea185&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

