### PR TITLE
Add NEON optimizations for SynetMergedConvolution16b Cdc/Cd/Dc

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -201,6 +201,7 @@
  <li>SVE2 optimizations of function SynetHardSigmoid32f.</li>
  <li>SVE2 optimizations of function SynetHswish32f.</li>
  <li>SVE2 optimizations of classes SynetMergedConvolution32fCdc, SynetMergedConvolution32fCd and SynetMergedConvolution32fDc.</li>
+ <li>NEON optimizations of classes SynetMergedConvolution16bCdc, SynetMergedConvolution16bCd and SynetMergedConvolution16bDc.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCdc, SynetMergedConvolution8iCd and SynetMergedConvolution8iDc.</li>
  <li>SVE2 optimizations of function SynetMish32f.</li>
  <li>SVE2 optimizations of function SynetPreluLayerForward.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -129,6 +129,10 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct16bGemmNN.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetInnerProduct8i.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16b.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16bDepthwise.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16bInput.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16bOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32fDepthwise.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32fInput.cpp" />
@@ -234,6 +238,7 @@
     <ClInclude Include="..\..\src\Simd\SimdSynetConvParam.h" />
     <ClInclude Include="..\..\src\Simd\SimdSynetDeconvolution32f.h" />
     <ClInclude Include="..\..\src\Simd\SimdSynetInnerProduct32f.h" />
+    <ClInclude Include="..\..\src\Simd\SimdSynetMergedConvolution16b.h" />
     <ClInclude Include="..\..\src\Simd\SimdSynetMergedConvolution32f.h" />
     <ClInclude Include="..\..\src\Simd\SimdSynetMergedConvolution8i.h" />
     <ClInclude Include="..\..\src\Simd\SimdSynetPermute.h" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -313,6 +313,18 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32fNhwcDirect4r.cpp">
       <Filter>Neon\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16b.cpp">
+      <Filter>Neon\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16bDepthwise.cpp">
+      <Filter>Neon\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16bInput.cpp">
+      <Filter>Neon\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution16bOutput.cpp">
+      <Filter>Neon\Synet\MergedConvolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution32f.cpp">
       <Filter>Neon\Synet\MergedConvolution</Filter>
     </ClCompile>
@@ -615,6 +627,9 @@
       <Filter>Inc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdSynetDeconvolution32f.h">
+      <Filter>Inc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Simd\SimdSynetMergedConvolution16b.h">
       <Filter>Inc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Simd\SimdSynetMergedConvolution32f.h">

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6937,7 +6937,7 @@ SIMD_API void* SimdSynetMergedConvolution16bInit(size_t batch, const SimdConvolu
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetMergedConvolution16bInitPtr) (size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
-    const static SimdSynetMergedConvolution16bInitPtr simdSynetMergedConvolution16bInit = SIMD_FUNC4(SynetMergedConvolution16bInit, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetMergedConvolution16bInitPtr simdSynetMergedConvolution16bInit = SIMD_FUNC5(SynetMergedConvolution16bInit, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetMergedConvolution16bInit(batch, convs, count, add);
 #else

--- a/src/Simd/SimdNeonSynetMergedConvolution16b.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16b.cpp
@@ -1,0 +1,179 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdUpdate.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdMath.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Neon
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+
+        //-----------------------------------------------------------------------------------------
+
+        static void ConvertFp32ToBf16(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
+        {
+            const float* src = (float*)src8;
+            size_t srcC = AlignHi(p.srcC, a.miK);
+            if (srcC == p.srcC)
+            {
+                size_t size = p.srcW * p.srcC;
+                Float32ToBFloat16(src + yBeg * size, (yEnd - yBeg) * size, dst);
+            }
+            else
+            {
+                size_t srcCDF = Simd::AlignLo(p.srcC, DF);
+                size_t srcCF = Simd::AlignLo(p.srcC, F);
+                for (size_t y = yBeg; y < yEnd; ++y)
+                {
+                    const float* ps = src + y * p.srcW * p.srcC;
+                    uint16_t* pd = dst + (y - yBeg) * p.srcW * srcC;
+                    for (size_t x = 0; x < p.srcW; ++x)
+                    {
+                        size_t c = 0;
+                        for (; c < srcCDF; c += DF)
+                        {
+                            uint32x4_t d0 = Float32ToBFloat16(Load<false>(ps + c + 0));
+                            uint32x4_t d1 = Float32ToBFloat16(Load<false>(ps + c + F));
+                            Store<false>(pd + c, PackU32(d0, d1));
+                        }
+                        for (; c < srcCF; c += F)
+                        {
+                            uint32x4_t d0 = Float32ToBFloat16(Load<false>(ps + c));
+                            Store<false>(pd + c, vmovn_u32(d0));
+                        }
+                        for (; c < p.srcC; ++c)
+                            pd[c] = Base::Float32ToBFloat16(ps[c]);
+                        for (; c < srcC; ++c)
+                            pd[c] = 0;
+                        ps += p.srcC;
+                        pd += srcC;
+                    }
+                }
+            }
+        }
+
+        static void ReorderBf16(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
+        {
+            const uint16_t* src = (uint16_t*)src8;
+            size_t srcC = AlignHi(p.srcC, a.miK);
+            size_t srcCDF = Simd::AlignLo(p.srcC, DF);
+            for (size_t y = yBeg; y < yEnd; ++y)
+            {
+                const uint16_t* ps = src + y * p.srcW * p.srcC;
+                uint16_t* pd = dst + (y - yBeg) * p.srcW * srcC;
+                for (size_t x = 0; x < p.srcW; ++x)
+                {
+                    size_t c = 0;
+                    for (; c < srcCDF; c += DF)
+                        Store<false>(pd + c, Load<false>(ps + c));
+                    for (; c < p.srcC; ++c)
+                        pd[c] = ps[c];
+                    for (; c < srcC; ++c)
+                        pd[c] = 0;
+                    ps += p.srcC;
+                    pd += srcC;
+                }
+            }
+        }
+
+        static void ConvertBf16ToFp32(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, float* dst)
+        {
+            const uint16_t* src = (uint16_t*)src8;
+            size_t rowSize = p.srcW * p.srcC;
+            for (size_t y = yBeg; y < yEnd; ++y)
+                BFloat16ToFloat32(src + y * rowSize, rowSize, dst + y * rowSize);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetMergedConvolution16bCdc::SynetMergedConvolution16bCdc(const MergConvParam& p)
+            : Base::SynetMergedConvolution16bCdc(p)
+        {
+            SetSize(F, 2);
+            if (!_src16b)
+                _toBf16 = ConvertFp32ToBf16;
+            else if (!Aligned(p.conv[0].srcC, 2))
+                _toBf16 = ReorderBf16;
+            else
+                _toBf16 = NULL;
+            if (_src16b)
+                _toFp32 = ConvertBf16ToFp32;
+            SetInput(_param.conv[0], _input);
+            SetDepthwise(_param.conv[1], _depthwise);
+            SetOutput(_param.conv[2], _output);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetMergedConvolution16bCd::SynetMergedConvolution16bCd(const MergConvParam& p)
+            : Base::SynetMergedConvolution16bCd(p)
+        {
+            SetSize(F, 2);
+            if (!_src16b)
+                _toBf16 = ConvertFp32ToBf16;
+            else if (!Aligned(p.conv[0].srcC, 2))
+                _toBf16 = ReorderBf16;
+            else
+                _toBf16 = NULL;
+            SetInput(_param.conv[0], _input);
+            SetDepthwise(_param.conv[1], _depthwise);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetMergedConvolution16bDc::SynetMergedConvolution16bDc(const MergConvParam& p)
+            : Base::SynetMergedConvolution16bDc(p)
+        {
+            SetSize(F, 2);
+            SetDepthwise(_param.conv[0], _depthwise);
+            SetOutput(_param.conv[1], _output);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        void* SynetMergedConvolution16bInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add)
+        {
+            MergConvParam param(batch, convs, count, add);
+            if (!param.Valid(SimdTensorData32f, SimdTensorData16b))
+                return NULL;
+            if (SynetMergedConvolution16bCdc::Preferable(param))
+                return new Neon::SynetMergedConvolution16bCdc(param);
+            else if (SynetMergedConvolution16bCd::Preferable(param))
+                return new Neon::SynetMergedConvolution16bCd(param);
+            else if (SynetMergedConvolution16bDc::Preferable(param))
+                return new Neon::SynetMergedConvolution16bDc(param);
+            else
+                return new Base::SynetMergedConvolution16b(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdNeonSynetMergedConvolution16bDepthwise.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16bDepthwise.cpp
@@ -42,6 +42,19 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         template<typename T, Term16bType term, SimdConvolutionActivationType type> void DepthwiseConvolution(const uint8_t* src8, const ConvParam& p, const AlgParam& a,
             size_t maC, size_t yBeg, size_t yEnd, const float* weight, const float* bias, const float* params, uint8_t* dst)
         {
@@ -89,7 +102,7 @@ namespace Simd
                                         {
                                             const float* pw = weight + (ky * p.kernelX + kx) * F;
                                             const T* ps = src + (sy & sM) * sY + sx * sX;
-                                            sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                            sum = vaddq_f32(vmulq_f32(LoadSrc(ps), Load<false>(pw)), sum);
                                         }
                                     }
                                 }
@@ -118,7 +131,7 @@ namespace Simd
                                     {
                                         const float* pw = weight + (ky * p.kernelX + kx) * F;
                                         const T* ps = src + (sy & sM) * sY + sx * sX;
-                                        sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                        sum = vaddq_f32(vmulq_f32(LoadSrc(ps), Load<false>(pw)), sum);
                                     }
                                 }
                             }
@@ -142,14 +155,14 @@ namespace Simd
                                 for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
                                 {
                                     float32x4_t w0 = Load<false>(pw);
-                                    sum0 = vmlaq_f32(sum0, LoadSrc(ps + 0 * ssX), w0);
-                                    sum1 = vmlaq_f32(sum1, LoadSrc(ps + 1 * ssX), w0);
-                                    sum2 = vmlaq_f32(sum2, LoadSrc(ps + 2 * ssX), w0);
-                                    sum3 = vmlaq_f32(sum3, LoadSrc(ps + 3 * ssX), w0);
-                                    sum4 = vmlaq_f32(sum4, LoadSrc(ps + 4 * ssX), w0);
-                                    sum5 = vmlaq_f32(sum5, LoadSrc(ps + 5 * ssX), w0);
-                                    sum6 = vmlaq_f32(sum6, LoadSrc(ps + 6 * ssX), w0);
-                                    sum7 = vmlaq_f32(sum7, LoadSrc(ps + 7 * ssX), w0);
+                                    sum0 = vaddq_f32(vmulq_f32(LoadSrc(ps + 0 * ssX), w0), sum0);
+                                    sum1 = vaddq_f32(vmulq_f32(LoadSrc(ps + 1 * ssX), w0), sum1);
+                                    sum2 = vaddq_f32(vmulq_f32(LoadSrc(ps + 2 * ssX), w0), sum2);
+                                    sum3 = vaddq_f32(vmulq_f32(LoadSrc(ps + 3 * ssX), w0), sum3);
+                                    sum4 = vaddq_f32(vmulq_f32(LoadSrc(ps + 4 * ssX), w0), sum4);
+                                    sum5 = vaddq_f32(vmulq_f32(LoadSrc(ps + 5 * ssX), w0), sum5);
+                                    sum6 = vaddq_f32(vmulq_f32(LoadSrc(ps + 6 * ssX), w0), sum6);
+                                    sum7 = vaddq_f32(vmulq_f32(LoadSrc(ps + 7 * ssX), w0), sum7);
                                 }
                             }
                             Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params);
@@ -175,10 +188,10 @@ namespace Simd
                                 for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
                                 {
                                     float32x4_t w0 = Load<false>(pw);
-                                    sum0 = vmlaq_f32(sum0, LoadSrc(ps + 0 * ssX), w0);
-                                    sum1 = vmlaq_f32(sum1, LoadSrc(ps + 1 * ssX), w0);
-                                    sum2 = vmlaq_f32(sum2, LoadSrc(ps + 2 * ssX), w0);
-                                    sum3 = vmlaq_f32(sum3, LoadSrc(ps + 3 * ssX), w0);
+                                    sum0 = vaddq_f32(vmulq_f32(LoadSrc(ps + 0 * ssX), w0), sum0);
+                                    sum1 = vaddq_f32(vmulq_f32(LoadSrc(ps + 1 * ssX), w0), sum1);
+                                    sum2 = vaddq_f32(vmulq_f32(LoadSrc(ps + 2 * ssX), w0), sum2);
+                                    sum3 = vaddq_f32(vmulq_f32(LoadSrc(ps + 3 * ssX), w0), sum3);
                                 }
                             }
                             Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params);
@@ -198,8 +211,8 @@ namespace Simd
                                 for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
                                 {
                                     float32x4_t w0 = Load<false>(pw);
-                                    sum0 = vmlaq_f32(sum0, LoadSrc(ps + 0 * ssX), w0);
-                                    sum1 = vmlaq_f32(sum1, LoadSrc(ps + 1 * ssX), w0);
+                                    sum0 = vaddq_f32(vmulq_f32(LoadSrc(ps + 0 * ssX), w0), sum0);
+                                    sum1 = vaddq_f32(vmulq_f32(LoadSrc(ps + 1 * ssX), w0), sum1);
                                 }
                             }
                             Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params);
@@ -216,7 +229,7 @@ namespace Simd
                                 for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
                                 {
                                     float32x4_t w0 = Load<false>(pw);
-                                    sum = vmlaq_f32(sum, LoadSrc(ps), w0);
+                                    sum = vaddq_f32(vmulq_f32(LoadSrc(ps), w0), sum);
                                 }
                             }
                             Save1<term, type>(pd, NULL, sum, _bias, _params);
@@ -234,7 +247,7 @@ namespace Simd
                                     {
                                         const float* pw = weight + (ky * p.kernelX + kx) * F;
                                         const T* ps = src + (sy & sM) * sY + sx * sX;
-                                        sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                        sum = vaddq_f32(vmulq_f32(LoadSrc(ps), Load<false>(pw)), sum);
                                     }
                                 }
                             }
@@ -258,7 +271,7 @@ namespace Simd
                                         {
                                             const float* pw = weight + (ky * p.kernelX + kx) * F;
                                             const T* ps = src + (sy & sM) * sY + sx * sX;
-                                            sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                            sum = vaddq_f32(vmulq_f32(LoadSrc(ps), Load<false>(pw)), sum);
                                         }
                                     }
                                 }
@@ -290,10 +303,10 @@ namespace Simd
             else
             {
                 float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum1);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum1);
                 Save1<term, type>(dst, NULL, vaddq_f32(sum0, sum1), bias, params);
             }
         }
@@ -315,12 +328,12 @@ namespace Simd
             else
             {
                 float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f), sum2 = vdupq_n_f32(0.0f);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
-                sum2 = vmlaq_f32(sum2, LoadSrc(src0 + 2 * sX), weight[2]);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
-                sum2 = vmlaq_f32(sum2, LoadSrc(src1 + 2 * sX), weight[5]);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum1);
+                sum2 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 2 * sX), weight[2]), sum2);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum1);
+                sum2 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 2 * sX), weight[5]), sum2);
                 Save1<term, type>(dst, NULL, vaddq_f32(vaddq_f32(sum0, sum1), sum2), bias, params);
             }
         }
@@ -342,12 +355,12 @@ namespace Simd
             else
             {
                 float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src2 + 0 * sX), weight[6]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src2 + 1 * sX), weight[7]);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum1);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum1);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src2 + 0 * sX), weight[6]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src2 + 1 * sX), weight[7]), sum1);
                 Save1<term, type>(dst, NULL, vaddq_f32(sum0, sum1), bias, params);
             }
         }
@@ -372,15 +385,15 @@ namespace Simd
             else
             {
                 float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f), sum2 = vdupq_n_f32(0.0f);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
-                sum2 = vmlaq_f32(sum2, LoadSrc(src0 + 2 * sX), weight[2]);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
-                sum2 = vmlaq_f32(sum2, LoadSrc(src1 + 2 * sX), weight[5]);
-                sum0 = vmlaq_f32(sum0, LoadSrc(src2 + 0 * sX), weight[6]);
-                sum1 = vmlaq_f32(sum1, LoadSrc(src2 + 1 * sX), weight[7]);
-                sum2 = vmlaq_f32(sum2, LoadSrc(src2 + 2 * sX), weight[8]);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum1);
+                sum2 = vaddq_f32(vmulq_f32(LoadSrc(src0 + 2 * sX), weight[2]), sum2);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum1);
+                sum2 = vaddq_f32(vmulq_f32(LoadSrc(src1 + 2 * sX), weight[5]), sum2);
+                sum0 = vaddq_f32(vmulq_f32(LoadSrc(src2 + 0 * sX), weight[6]), sum0);
+                sum1 = vaddq_f32(vmulq_f32(LoadSrc(src2 + 1 * sX), weight[7]), sum1);
+                sum2 = vaddq_f32(vmulq_f32(LoadSrc(src2 + 2 * sX), weight[8]), sum2);
                 Save1<term, type>(dst, NULL, vaddq_f32(vaddq_f32(sum0, sum1), sum2), bias, params);
             }
         }

--- a/src/Simd/SimdNeonSynetMergedConvolution16bDepthwise.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16bDepthwise.cpp
@@ -1,0 +1,515 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdBFloat16.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Neon
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+        using DepthwisePtr = Base::SynetMergedConvolution16b::DepthwiseConvolutionPtr;
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type> void DepthwiseConvolution(const uint8_t* src8, const ConvParam& p, const AlgParam& a,
+            size_t maC, size_t yBeg, size_t yEnd, const float* weight, const float* bias, const float* params, uint8_t* dst)
+        {
+            const T* src = (T*)src8;
+            size_t strideY = p.strideY, strideX = p.strideX, padY = p.padY, padX = p.padX, padH = p.padH, padW = p.padW;
+            size_t sM = (a.bufH[1] - 1), sD = a.bufH[1] ? a.bufH[1] * p.srcW * F : F, sX = a.bufH[1] ? F : p.srcC, sY = sX * p.srcW, dstC = maC;
+            size_t dX = (a.bufH[2] ? a.maC * 2 : p.dstC * a.elem[1]), dY = p.dstW * dX, dy0 = a.bufH[2] ? yBeg : 0, dD = a.bufH[2] ? F * 2 : F * a.elem[1];
+            size_t wD = p.kernelY * p.kernelX * F, ssX = strideX * sX;
+            size_t noseY = NoseH(p), bodyY = BodyH(p), noseX = NoseW(p), bodyX = BodyW(p);
+            size_t bodyS = bodyX > noseX ? bodyX - noseX : 0;
+            size_t bodyX2 = AlignLo(bodyS, 2) + noseX;
+            size_t bodyX4 = AlignLo(bodyS, 4) + noseX;
+            size_t bodyX8 = AlignLo(bodyS, 8) + noseX;
+            size_t dstCF = AlignLo(dstC, F);
+
+            float32x4_t _params[2], _bias[1];
+            _params[0] = vdupq_n_f32(params[0]);
+            if (type == SimdConvolutionActivationRestrictRange ||
+                type == SimdConvolutionActivationHswish ||
+                type == SimdConvolutionActivationHardSigmoid)
+                _params[1] = vdupq_n_f32(params[1]);
+            for (size_t c = 0; c < dstC; c += F)
+            {
+                _bias[0] = Load<false>(bias + c);
+                if (type == ::SimdConvolutionActivationPrelu)
+                    _params[0] = Load<false>(params + c);
+                if (c == dstCF)
+                {
+                    size_t tail = dstC - dstCF;
+                    for (size_t dy = yBeg; dy < yEnd; ++dy)
+                    {
+                        uint8_t* pd = dst + (dy - dy0) * dY;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, pd += dX)
+                        {
+                            float32x4_t sum = vdupq_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                if (sy < p.srcH)
+                                {
+                                    for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                    {
+                                        size_t sx = dx * strideX + kx - padX;
+                                        if (sx < p.srcW)
+                                        {
+                                            const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                            const T* ps = src + (sy & sM) * sY + sx * sX;
+                                            sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                        }
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params, tail);
+                        }
+                    }
+                    return;
+                }
+                for (size_t dy = yBeg; dy < yEnd; ++dy)
+                {
+                    uint8_t* pd = dst + (dy - dy0) * dY;
+                    if (dy >= noseY && dy < bodyY)
+                    {
+                        size_t dx = 0;
+                        for (; dx < noseX; dx += 1, pd += dX)
+                        {
+                            float32x4_t sum = vdupq_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * p.strideY + ky - padY;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                {
+                                    size_t sx = dx * p.strideX + kx - padX;
+                                    if (sx < p.srcW)
+                                    {
+                                        const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                        const T* ps = src + (sy & sM) * sY + sx * sX;
+                                        sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params);
+                        }
+                        for (; dx < bodyX8; dx += 8, pd += 8 * dX)
+                        {
+                            float32x4_t sum0 = vdupq_n_f32(0.0f);
+                            float32x4_t sum1 = vdupq_n_f32(0.0f);
+                            float32x4_t sum2 = vdupq_n_f32(0.0f);
+                            float32x4_t sum3 = vdupq_n_f32(0.0f);
+                            float32x4_t sum4 = vdupq_n_f32(0.0f);
+                            float32x4_t sum5 = vdupq_n_f32(0.0f);
+                            float32x4_t sum6 = vdupq_n_f32(0.0f);
+                            float32x4_t sum7 = vdupq_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    float32x4_t w0 = Load<false>(pw);
+                                    sum0 = vmlaq_f32(sum0, LoadSrc(ps + 0 * ssX), w0);
+                                    sum1 = vmlaq_f32(sum1, LoadSrc(ps + 1 * ssX), w0);
+                                    sum2 = vmlaq_f32(sum2, LoadSrc(ps + 2 * ssX), w0);
+                                    sum3 = vmlaq_f32(sum3, LoadSrc(ps + 3 * ssX), w0);
+                                    sum4 = vmlaq_f32(sum4, LoadSrc(ps + 4 * ssX), w0);
+                                    sum5 = vmlaq_f32(sum5, LoadSrc(ps + 5 * ssX), w0);
+                                    sum6 = vmlaq_f32(sum6, LoadSrc(ps + 6 * ssX), w0);
+                                    sum7 = vmlaq_f32(sum7, LoadSrc(ps + 7 * ssX), w0);
+                                }
+                            }
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params);
+                            Save1<term, type>(pd + 2 * dX, NULL, sum2, _bias, _params);
+                            Save1<term, type>(pd + 3 * dX, NULL, sum3, _bias, _params);
+                            Save1<term, type>(pd + 4 * dX, NULL, sum4, _bias, _params);
+                            Save1<term, type>(pd + 5 * dX, NULL, sum5, _bias, _params);
+                            Save1<term, type>(pd + 6 * dX, NULL, sum6, _bias, _params);
+                            Save1<term, type>(pd + 7 * dX, NULL, sum7, _bias, _params);
+                        }
+                        for (; dx < bodyX4; dx += 4, pd += 4 * dX)
+                        {
+                            float32x4_t sum0 = vdupq_n_f32(0.0f);
+                            float32x4_t sum1 = vdupq_n_f32(0.0f);
+                            float32x4_t sum2 = vdupq_n_f32(0.0f);
+                            float32x4_t sum3 = vdupq_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    float32x4_t w0 = Load<false>(pw);
+                                    sum0 = vmlaq_f32(sum0, LoadSrc(ps + 0 * ssX), w0);
+                                    sum1 = vmlaq_f32(sum1, LoadSrc(ps + 1 * ssX), w0);
+                                    sum2 = vmlaq_f32(sum2, LoadSrc(ps + 2 * ssX), w0);
+                                    sum3 = vmlaq_f32(sum3, LoadSrc(ps + 3 * ssX), w0);
+                                }
+                            }
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params);
+                            Save1<term, type>(pd + 2 * dX, NULL, sum2, _bias, _params);
+                            Save1<term, type>(pd + 3 * dX, NULL, sum3, _bias, _params);
+                        }
+                        for (; dx < bodyX2; dx += 2, pd += 2 * dX)
+                        {
+                            float32x4_t sum0 = vdupq_n_f32(0.0f);
+                            float32x4_t sum1 = vdupq_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    float32x4_t w0 = Load<false>(pw);
+                                    sum0 = vmlaq_f32(sum0, LoadSrc(ps + 0 * ssX), w0);
+                                    sum1 = vmlaq_f32(sum1, LoadSrc(ps + 1 * ssX), w0);
+                                }
+                            }
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params);
+                        }
+                        for (; dx < bodyX; dx += 1, pd += dX)
+                        {
+                            float32x4_t sum = vdupq_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    float32x4_t w0 = Load<false>(pw);
+                                    sum = vmlaq_f32(sum, LoadSrc(ps), w0);
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params);
+                        }
+                        for (; dx < p.dstW; dx += 1, pd += dX)
+                        {
+                            float32x4_t sum = vdupq_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                {
+                                    size_t sx = dx * strideX + kx - padX;
+                                    if (sx < p.srcW)
+                                    {
+                                        const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                        const T* ps = src + (sy & sM) * sY + sx * sX;
+                                        sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params);
+                        }
+                    }
+                    else
+                    {
+                        for (size_t dx = 0; dx < p.dstW; ++dx, pd += dX)
+                        {
+                            float32x4_t sum = vdupq_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                if (sy < p.srcH)
+                                {
+                                    for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                    {
+                                        size_t sx = dx * strideX + kx - padX;
+                                        if (sx < p.srcW)
+                                        {
+                                            const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                            const T* ps = src + (sy & sM) * sY + sx * sX;
+                                            sum = vmlaq_f32(sum, LoadSrc(ps), Load<false>(pw));
+                                        }
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params);
+                        }
+                    }
+                }
+                src += sD;
+                dst += dD;
+                weight += wD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge2x2(const T* src0,
+            const T* src1, size_t sX, const float32x4_t* weight, const float32x4_t* bias, const float32x4_t* params, uint8_t* dst)
+        {
+            if (nofma)
+            {
+                float32x4_t sum = vdupq_n_f32(0.0f);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum);
+                Save1<term, type>(dst, NULL, sum, bias, params);
+            }
+            else
+            {
+                float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
+                Save1<term, type>(dst, NULL, vaddq_f32(sum0, sum1), bias, params);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge2x3(const T* src0,
+            const T* src1, size_t sX, const float32x4_t* weight, const float32x4_t* bias, const float32x4_t* params, uint8_t* dst)
+        {
+            if (nofma)
+            {
+                float32x4_t sum = vdupq_n_f32(0.0f);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 2 * sX), weight[2]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 2 * sX), weight[5]), sum);
+                Save1<term, type>(dst, NULL, sum, bias, params);
+            }
+            else
+            {
+                float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f), sum2 = vdupq_n_f32(0.0f);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
+                sum2 = vmlaq_f32(sum2, LoadSrc(src0 + 2 * sX), weight[2]);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
+                sum2 = vmlaq_f32(sum2, LoadSrc(src1 + 2 * sX), weight[5]);
+                Save1<term, type>(dst, NULL, vaddq_f32(vaddq_f32(sum0, sum1), sum2), bias, params);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge3x2(const T* src0,
+            const T* src1, const T* src2, size_t sX, const float32x4_t* weight, const float32x4_t* bias, const float32x4_t* params, uint8_t* dst)
+        {
+            if (nofma)
+            {
+                float32x4_t sum = vdupq_n_f32(0.0f);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src2 + 0 * sX), weight[6]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src2 + 1 * sX), weight[7]), sum);
+                Save1<term, type>(dst, NULL, sum, bias, params);
+            }
+            else
+            {
+                float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src2 + 0 * sX), weight[6]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src2 + 1 * sX), weight[7]);
+                Save1<term, type>(dst, NULL, vaddq_f32(sum0, sum1), bias, params);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Main1x1(const T* src0,
+            const T* src1, const T* src2, size_t sX, const float32x4_t* weight, const float32x4_t* bias, const float32x4_t* params, uint8_t* dst)
+        {
+            if (nofma)
+            {
+                float32x4_t sum = vdupq_n_f32(0.0f);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 0 * sX), weight[0]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 1 * sX), weight[1]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src0 + 2 * sX), weight[2]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 0 * sX), weight[3]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 1 * sX), weight[4]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src1 + 2 * sX), weight[5]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src2 + 0 * sX), weight[6]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src2 + 1 * sX), weight[7]), sum);
+                sum = vaddq_f32(vmulq_f32(LoadSrc(src2 + 2 * sX), weight[8]), sum);
+                Save1<term, type>(dst, NULL, sum, bias, params);
+            }
+            else
+            {
+                float32x4_t sum0 = vdupq_n_f32(0.0f), sum1 = vdupq_n_f32(0.0f), sum2 = vdupq_n_f32(0.0f);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src0 + 0 * sX), weight[0]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src0 + 1 * sX), weight[1]);
+                sum2 = vmlaq_f32(sum2, LoadSrc(src0 + 2 * sX), weight[2]);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src1 + 0 * sX), weight[3]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src1 + 1 * sX), weight[4]);
+                sum2 = vmlaq_f32(sum2, LoadSrc(src1 + 2 * sX), weight[5]);
+                sum0 = vmlaq_f32(sum0, LoadSrc(src2 + 0 * sX), weight[6]);
+                sum1 = vmlaq_f32(sum1, LoadSrc(src2 + 1 * sX), weight[7]);
+                sum2 = vmlaq_f32(sum2, LoadSrc(src2 + 2 * sX), weight[8]);
+                Save1<term, type>(dst, NULL, vaddq_f32(vaddq_f32(sum0, sum1), sum2), bias, params);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> void DepthwiseConvolution3x3(const uint8_t* src8, const ConvParam& p, const AlgParam& a,
+            size_t maC, size_t yBeg, size_t yEnd, const float* weight, const float* bias, const float* params, uint8_t* dst)
+        {
+            const T* src = (T*)src8;
+            size_t strideY = p.strideY, padY = p.padY, padX = p.padX, padH = p.padH, padW = p.padW, dstC = maC;
+            size_t sM = (a.bufH[1] - 1), sD = a.bufH[1] ? a.bufH[1] * p.srcW * F : F, sX = a.bufH[1] ? F : p.srcC, sY = sX * p.srcW;
+            size_t dX = (a.bufH[2] ? a.maC * 2 : p.dstC * a.elem[1]), dY = p.dstW * dX, dy0 = a.bufH[2] ? yBeg : 0, dD = a.bufH[2] ? F * 2 : F * a.elem[1];
+            size_t wD = p.kernelY * p.kernelX * F, ssX = p.strideX * sX, ssX0 = (p.strideX - p.padX) * sX;
+            size_t xMainEnd = p.dstW - p.padW, yMainEnd = yEnd == p.dstH && p.padH ? yEnd - 1 : yEnd;
+
+            float32x4_t _params[2], _bias[1];
+            _params[0] = vdupq_n_f32(params[0]);
+            if (type == SimdConvolutionActivationRestrictRange ||
+                type == SimdConvolutionActivationHswish ||
+                type == SimdConvolutionActivationHardSigmoid)
+                _params[1] = vdupq_n_f32(params[1]);
+            for (size_t c = 0; c < dstC; c += F)
+            {
+                float32x4_t _weight[9];
+                for (size_t i = 0; i < 9; ++i)
+                    _weight[i] = Load<false>(weight + i * F);
+                _bias[0] = Load<false>(bias + c);
+                if (type == ::SimdConvolutionActivationPrelu)
+                    _params[0] = Load<false>(params + c);
+
+                size_t dy = yBeg;
+                if (yBeg == 0 && padY)
+                {
+                    size_t sy = 0, dx = 0;
+                    const T* src0 = src + ((sy + 0) & sM) * sY;
+                    const T* src1 = src + ((sy + 1) & sM) * sY;
+                    uint8_t* pDst = dst + (dy - dy0) * dY;
+                    if (padX)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 4, _bias, _params, pDst),
+                        pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
+                    for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
+                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, _weight + 3, _bias, _params, pDst);
+                    if (padW)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 3, _bias, _params, pDst);
+                    dy++;
+                }
+                for (; dy < yMainEnd; ++dy)
+                {
+                    size_t sy = dy * strideY - padY, dx = 0;
+                    const T* src0 = src + ((sy + 0) & sM) * sY;
+                    const T* src1 = src + ((sy + 1) & sM) * sY;
+                    const T* src2 = src + ((sy + 2) & sM) * sY;
+                    uint8_t* pDst = dst + (dy - dy0) * dY;
+                    if (padX)
+                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, _weight + 1, _bias, _params, pDst),
+                        pDst += dX, dx++, src0 += ssX0, src1 += ssX0, src2 += ssX0;
+                    for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX, src2 += ssX)
+                        DepthwiseConvolution3x3Main1x1<T, term, type, nofma>(src0, src1, src2, sX, _weight + 0, _bias, _params, pDst);
+                    if (padW)
+                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, _weight + 0, _bias, _params, pDst);
+                }
+                if (dy < yEnd)
+                {
+                    size_t sy = dy * strideY - padY, dx = 0;
+                    const T* src0 = src + ((sy + 0) & sM) * sY;
+                    const T* src1 = src + ((sy + 1) & sM) * sY;
+                    uint8_t* pDst = dst + (dy - dy0) * dY;
+                    if (padX)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 1, _bias, _params, pDst),
+                        pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
+                    for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
+                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, _weight + 0, _bias, _params, pDst);
+                    if (padW)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 0, _bias, _params, pDst);
+                }
+                src += sD;
+                dst += dD;
+                weight += wD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type> static void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
+        {
+            if (IsKernel(p, 3) && IsDilation(p, 1) && Aligned(p.dstC, F))
+            {
+                if (Base::FmaAvoid(p.compatibility))
+                    depthwise = p.srcT == SimdTensorData16b ?
+                    DepthwiseConvolution3x3<uint16_t, term, type, true> :
+                    DepthwiseConvolution3x3<float, term, type, true>;
+                else
+                    depthwise = p.srcT == SimdTensorData16b ?
+                    DepthwiseConvolution3x3<uint16_t, term, type, false> :
+                    DepthwiseConvolution3x3<float, term, type, false>;
+            }
+            else
+            {
+                if (p.srcT == SimdTensorData16b)
+                    depthwise = DepthwiseConvolution<uint16_t, term, type>;
+                else
+                    depthwise = DepthwiseConvolution<float, term, type>;
+            }
+        }
+
+        template<SimdConvolutionActivationType type> static void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
+        {
+            if (p.dstT == SimdTensorData32f)
+                SetDepthwise<Term16bLast32f, type>(p, depthwise);
+            else
+                SetDepthwise<Term16bLast16b, type>(p, depthwise);
+        }
+
+        void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, depthwise); break;
+            case SimdConvolutionActivationRelu: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, depthwise); break;
+            case SimdConvolutionActivationLeakyRelu: SetDepthwise<SimdConvolutionActivationPrelu>(p, depthwise); break;
+            case SimdConvolutionActivationRestrictRange: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, depthwise); break;
+            case SimdConvolutionActivationPrelu: SetDepthwise<SimdConvolutionActivationPrelu>(p, depthwise); break;
+            case SimdConvolutionActivationElu: SetDepthwise<SimdConvolutionActivationElu>(p, depthwise); break;
+            case SimdConvolutionActivationHswish: SetDepthwise<SimdConvolutionActivationHswish>(p, depthwise); break;
+            case SimdConvolutionActivationMish: SetDepthwise<SimdConvolutionActivationMish>(p, depthwise); break;
+            case SimdConvolutionActivationHardSigmoid: SetDepthwise<SimdConvolutionActivationHardSigmoid>(p, depthwise); break;
+            case SimdConvolutionActivationSwish: SetDepthwise<SimdConvolutionActivationSwish>(p, depthwise); break;
+            case SimdConvolutionActivationGelu: SetDepthwise<SimdConvolutionActivationGelu>(p, depthwise); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdNeonSynetMergedConvolution16bInput.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16bInput.cpp
@@ -89,37 +89,37 @@ namespace Simd
                     if (M > 0)
                     {
                         s0 = BroadcastBf16(src0[offs + 0]);
-                        d00 = vmlaq_f32(d00, s0, w00); d01 = vmlaq_f32(d01, s0, w10);
+                        d00 = vaddq_f32(vmulq_f32(s0, w00), d00); d01 = vaddq_f32(vmulq_f32(s0, w10), d01);
                         s0 = BroadcastBf16(src0[offs + 1]);
-                        d00 = vmlaq_f32(d00, s0, w01); d01 = vmlaq_f32(d01, s0, w11);
+                        d00 = vaddq_f32(vmulq_f32(s0, w01), d00); d01 = vaddq_f32(vmulq_f32(s0, w11), d01);
                     }
                     if (M > 1)
                     {
                         s0 = BroadcastBf16(src1[offs + 0]);
-                        d10 = vmlaq_f32(d10, s0, w00); d11 = vmlaq_f32(d11, s0, w10);
+                        d10 = vaddq_f32(vmulq_f32(s0, w00), d10); d11 = vaddq_f32(vmulq_f32(s0, w10), d11);
                         s0 = BroadcastBf16(src1[offs + 1]);
-                        d10 = vmlaq_f32(d10, s0, w01); d11 = vmlaq_f32(d11, s0, w11);
+                        d10 = vaddq_f32(vmulq_f32(s0, w01), d10); d11 = vaddq_f32(vmulq_f32(s0, w11), d11);
                     }
                     if (M > 2)
                     {
                         s0 = BroadcastBf16(src2[offs + 0]);
-                        d20 = vmlaq_f32(d20, s0, w00); d21 = vmlaq_f32(d21, s0, w10);
+                        d20 = vaddq_f32(vmulq_f32(s0, w00), d20); d21 = vaddq_f32(vmulq_f32(s0, w10), d21);
                         s0 = BroadcastBf16(src2[offs + 1]);
-                        d20 = vmlaq_f32(d20, s0, w01); d21 = vmlaq_f32(d21, s0, w11);
+                        d20 = vaddq_f32(vmulq_f32(s0, w01), d20); d21 = vaddq_f32(vmulq_f32(s0, w11), d21);
                     }
                     if (M > 3)
                     {
                         s0 = BroadcastBf16(src3[offs + 0]);
-                        d30 = vmlaq_f32(d30, s0, w00); d31 = vmlaq_f32(d31, s0, w10);
+                        d30 = vaddq_f32(vmulq_f32(s0, w00), d30); d31 = vaddq_f32(vmulq_f32(s0, w10), d31);
                         s0 = BroadcastBf16(src3[offs + 1]);
-                        d30 = vmlaq_f32(d30, s0, w01); d31 = vmlaq_f32(d31, s0, w11);
+                        d30 = vaddq_f32(vmulq_f32(s0, w01), d30); d31 = vaddq_f32(vmulq_f32(s0, w11), d31);
                     }
                     if (M > 4)
                     {
                         s0 = BroadcastBf16(src4[offs + 0]);
-                        d40 = vmlaq_f32(d40, s0, w00); d41 = vmlaq_f32(d41, s0, w10);
+                        d40 = vaddq_f32(vmulq_f32(s0, w00), d40); d41 = vaddq_f32(vmulq_f32(s0, w10), d41);
                         s0 = BroadcastBf16(src4[offs + 1]);
-                        d40 = vmlaq_f32(d40, s0, w01); d41 = vmlaq_f32(d41, s0, w11);
+                        d40 = vaddq_f32(vmulq_f32(s0, w01), d40); d41 = vaddq_f32(vmulq_f32(s0, w11), d41);
                     }
                     weight0 += DF;
                     weight1 += DF;
@@ -145,37 +145,37 @@ namespace Simd
                     if (M > 0)
                     {
                         s0 = BroadcastBf16(src0[offs + 0]);
-                        d00 = vmlaq_f32(d00, s0, w00);
+                        d00 = vaddq_f32(vmulq_f32(s0, w00), d00);
                         s0 = BroadcastBf16(src0[offs + 1]);
-                        d00 = vmlaq_f32(d00, s0, w01);
+                        d00 = vaddq_f32(vmulq_f32(s0, w01), d00);
                     }
                     if (M > 1)
                     {
                         s0 = BroadcastBf16(src1[offs + 0]);
-                        d10 = vmlaq_f32(d10, s0, w00);
+                        d10 = vaddq_f32(vmulq_f32(s0, w00), d10);
                         s0 = BroadcastBf16(src1[offs + 1]);
-                        d10 = vmlaq_f32(d10, s0, w01);
+                        d10 = vaddq_f32(vmulq_f32(s0, w01), d10);
                     }
                     if (M > 2)
                     {
                         s0 = BroadcastBf16(src2[offs + 0]);
-                        d20 = vmlaq_f32(d20, s0, w00);
+                        d20 = vaddq_f32(vmulq_f32(s0, w00), d20);
                         s0 = BroadcastBf16(src2[offs + 1]);
-                        d20 = vmlaq_f32(d20, s0, w01);
+                        d20 = vaddq_f32(vmulq_f32(s0, w01), d20);
                     }
                     if (M > 3)
                     {
                         s0 = BroadcastBf16(src3[offs + 0]);
-                        d30 = vmlaq_f32(d30, s0, w00);
+                        d30 = vaddq_f32(vmulq_f32(s0, w00), d30);
                         s0 = BroadcastBf16(src3[offs + 1]);
-                        d30 = vmlaq_f32(d30, s0, w01);
+                        d30 = vaddq_f32(vmulq_f32(s0, w01), d30);
                     }
                     if (M > 4)
                     {
                         s0 = BroadcastBf16(src4[offs + 0]);
-                        d40 = vmlaq_f32(d40, s0, w00);
+                        d40 = vaddq_f32(vmulq_f32(s0, w00), d40);
                         s0 = BroadcastBf16(src4[offs + 1]);
-                        d40 = vmlaq_f32(d40, s0, w01);
+                        d40 = vaddq_f32(vmulq_f32(s0, w01), d40);
                     }
                     weight0 += DF;
                 }

--- a/src/Simd/SimdNeonSynetMergedConvolution16bInput.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16bInput.cpp
@@ -1,0 +1,283 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdStore.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Neon
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+        using InputPtr = Base::SynetMergedConvolution16b::InputConvolutionPtr;
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE float32x4_t BroadcastBf16(uint16_t value)
+        {
+            return vreinterpretq_f32_u32(vdupq_n_u32(uint32_t(value) << Base::Bf16::SHIFT));
+        }
+
+        template<SimdConvolutionActivationType type>
+        SIMD_INLINE void SaveInput1(float* dst, float32x4_t sum, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Store<false>(dst, Activate<type>(vaddq_f32(sum, bias[0]), params, 0));
+        }
+
+        template<SimdConvolutionActivationType type>
+        SIMD_INLINE void SaveInput2(float* dst0, float* dst1, float32x4_t sum0, float32x4_t sum1, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Store<false>(dst0, Activate<type>(vaddq_f32(sum0, bias[0]), params, 0));
+            Store<false>(dst1, Activate<type>(vaddq_f32(sum1, bias[1]), params, 1));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type, int M> void InputConvolution1x1_2xM(const uint16_t* src0, const ConvParam& p,
+            const AlgParam& a, size_t dstC, const uint16_t* weight0, const float32x4_t* bias, const float32x4_t* params, float* dst0, float* dst1)
+        {
+            float32x4_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, s0, w00, w01, w10, w11;
+            size_t srcC = AlignHi(p.srcC, a.miK);
+            const uint16_t* weight1 = weight0 + srcC * F;
+            const uint16_t* src1 = src0 + 1 * srcC;
+            const uint16_t* src2 = src0 + 2 * srcC;
+            const uint16_t* src3 = src0 + 3 * srcC;
+            const uint16_t* src4 = src0 + 4 * srcC;
+            if (dstC > F)
+            {
+                if (M > 0) d00 = vdupq_n_f32(0.0f), d01 = vdupq_n_f32(0.0f);
+                if (M > 1) d10 = vdupq_n_f32(0.0f), d11 = vdupq_n_f32(0.0f);
+                if (M > 2) d20 = vdupq_n_f32(0.0f), d21 = vdupq_n_f32(0.0f);
+                if (M > 3) d30 = vdupq_n_f32(0.0f), d31 = vdupq_n_f32(0.0f);
+                if (M > 4) d40 = vdupq_n_f32(0.0f), d41 = vdupq_n_f32(0.0f);
+                for (size_t offs = 0, end = srcC; offs < end; offs += 2)
+                {
+                    w01 = Load<false>((float*)weight0);
+                    w00 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w01), Base::Bf16::SHIFT));
+                    w01 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w01), Bf16::MASK));
+                    w11 = Load<false>((float*)weight1);
+                    w10 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w11), Base::Bf16::SHIFT));
+                    w11 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w11), Bf16::MASK));
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16(src0[offs + 0]);
+                        d00 = vmlaq_f32(d00, s0, w00); d01 = vmlaq_f32(d01, s0, w10);
+                        s0 = BroadcastBf16(src0[offs + 1]);
+                        d00 = vmlaq_f32(d00, s0, w01); d01 = vmlaq_f32(d01, s0, w11);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16(src1[offs + 0]);
+                        d10 = vmlaq_f32(d10, s0, w00); d11 = vmlaq_f32(d11, s0, w10);
+                        s0 = BroadcastBf16(src1[offs + 1]);
+                        d10 = vmlaq_f32(d10, s0, w01); d11 = vmlaq_f32(d11, s0, w11);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16(src2[offs + 0]);
+                        d20 = vmlaq_f32(d20, s0, w00); d21 = vmlaq_f32(d21, s0, w10);
+                        s0 = BroadcastBf16(src2[offs + 1]);
+                        d20 = vmlaq_f32(d20, s0, w01); d21 = vmlaq_f32(d21, s0, w11);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16(src3[offs + 0]);
+                        d30 = vmlaq_f32(d30, s0, w00); d31 = vmlaq_f32(d31, s0, w10);
+                        s0 = BroadcastBf16(src3[offs + 1]);
+                        d30 = vmlaq_f32(d30, s0, w01); d31 = vmlaq_f32(d31, s0, w11);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16(src4[offs + 0]);
+                        d40 = vmlaq_f32(d40, s0, w00); d41 = vmlaq_f32(d41, s0, w10);
+                        s0 = BroadcastBf16(src4[offs + 1]);
+                        d40 = vmlaq_f32(d40, s0, w01); d41 = vmlaq_f32(d41, s0, w11);
+                    }
+                    weight0 += DF;
+                    weight1 += DF;
+                }
+                if (M > 0) SaveInput2<type>(dst0 + 0 * F, dst1 + 0 * F, d00, d01, bias, params);
+                if (M > 1) SaveInput2<type>(dst0 + 1 * F, dst1 + 1 * F, d10, d11, bias, params);
+                if (M > 2) SaveInput2<type>(dst0 + 2 * F, dst1 + 2 * F, d20, d21, bias, params);
+                if (M > 3) SaveInput2<type>(dst0 + 3 * F, dst1 + 3 * F, d30, d31, bias, params);
+                if (M > 4) SaveInput2<type>(dst0 + 4 * F, dst1 + 4 * F, d40, d41, bias, params);
+            }
+            else
+            {
+                if (M > 0) d00 = vdupq_n_f32(0.0f);
+                if (M > 1) d10 = vdupq_n_f32(0.0f);
+                if (M > 2) d20 = vdupq_n_f32(0.0f);
+                if (M > 3) d30 = vdupq_n_f32(0.0f);
+                if (M > 4) d40 = vdupq_n_f32(0.0f);
+                for (size_t offs = 0, end = srcC; offs < end; offs += 2)
+                {
+                    w01 = Load<false>((float*)weight0);
+                    w00 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w01), Base::Bf16::SHIFT));
+                    w01 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w01), Bf16::MASK));
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16(src0[offs + 0]);
+                        d00 = vmlaq_f32(d00, s0, w00);
+                        s0 = BroadcastBf16(src0[offs + 1]);
+                        d00 = vmlaq_f32(d00, s0, w01);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16(src1[offs + 0]);
+                        d10 = vmlaq_f32(d10, s0, w00);
+                        s0 = BroadcastBf16(src1[offs + 1]);
+                        d10 = vmlaq_f32(d10, s0, w01);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16(src2[offs + 0]);
+                        d20 = vmlaq_f32(d20, s0, w00);
+                        s0 = BroadcastBf16(src2[offs + 1]);
+                        d20 = vmlaq_f32(d20, s0, w01);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16(src3[offs + 0]);
+                        d30 = vmlaq_f32(d30, s0, w00);
+                        s0 = BroadcastBf16(src3[offs + 1]);
+                        d30 = vmlaq_f32(d30, s0, w01);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16(src4[offs + 0]);
+                        d40 = vmlaq_f32(d40, s0, w00);
+                        s0 = BroadcastBf16(src4[offs + 1]);
+                        d40 = vmlaq_f32(d40, s0, w01);
+                    }
+                    weight0 += DF;
+                }
+                if (M > 0) SaveInput1<type>(dst0 + 0 * F, d00, bias, params);
+                if (M > 1) SaveInput1<type>(dst0 + 1 * F, d10, bias, params);
+                if (M > 2) SaveInput1<type>(dst0 + 2 * F, d20, bias, params);
+                if (M > 3) SaveInput1<type>(dst0 + 3 * F, d30, bias, params);
+                if (M > 4) SaveInput1<type>(dst0 + 4 * F, d40, bias, params);
+            }
+        }
+
+        typedef void(*InputConvolution1x1_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a, size_t dstC,
+            const uint16_t* weight0, const float32x4_t* bias, const float32x4_t* params, float* dst0, float* dst1);
+
+        template<SimdConvolutionActivationType type> InputConvolution1x1_2xM_Ptr GetInputConvolution1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return InputConvolution1x1_2xM<type, 1>;
+            case 2: return InputConvolution1x1_2xM<type, 2>;
+            case 3: return InputConvolution1x1_2xM<type, 3>;
+            case 4: return InputConvolution1x1_2xM<type, 4>;
+            case 5: return InputConvolution1x1_2xM<type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<SimdConvolutionActivationType type> void InputConvolution1x1_2(const uint16_t* src, const ConvParam& p,
+            const AlgParam& a, size_t maC, size_t yBeg, size_t yEnd, const uint16_t* weight, const float* bias, const float* params, float* sum, float* dst)
+        {
+            size_t dstM = a.bufH[1] - 1, dstS = a.bufH[1] * p.dstW * F, srcC = AlignHi(p.srcC, a.miK), y0 = a.bufH[0] ? yBeg : 0;
+            float32x4_t _bias[2], _params[2];
+            _params[0] = vdupq_n_f32(params[0]);
+            _params[1] = vdupq_n_f32(params[1]);
+            size_t yInt = Simd::Max(yBeg, AlignLo(yEnd, a.bufH[1])), n = 5;
+            size_t i1 = (yInt - yBeg) * p.dstW, in = AlignLoAny(i1, n), i = i1 - in;
+            size_t e1 = (yEnd - yInt) * p.dstW, en = AlignLoAny(e1, n), e = e1 - en;
+            InputConvolution1x1_2xM_Ptr inputConvolution1x1_2xN = GetInputConvolution1x1_2xM<type>(n);
+            InputConvolution1x1_2xM_Ptr inputConvolution1x1_2xI = GetInputConvolution1x1_2xM<type>(i);
+            InputConvolution1x1_2xM_Ptr inputConvolution1x1_2xE = GetInputConvolution1x1_2xM<type>(e);
+            for (size_t dc = 0; dc < maC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, maC - dc);
+                _bias[0] = Load<false>(bias + dc + 0);
+                _bias[1] = Load<false>(bias + dc + F);
+                if (type == ::SimdConvolutionActivationPrelu)
+                {
+                    _params[0] = Load<false>(params + dc + 0);
+                    _params[1] = Load<false>(params + dc + F);
+                }
+                if (yInt > yBeg)
+                {
+                    const uint16_t* src0 = src + (yBeg - y0) * p.srcW * srcC;
+                    float* dst0 = dst + (yBeg & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
+                    for (size_t j = 0; j < in; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
+                        inputConvolution1x1_2xN(src0, p, a, dC, weight, _bias, _params, dst0, dst1);
+                    if (in < i1)
+                        inputConvolution1x1_2xI(src0, p, a, dC, weight, _bias, _params, dst0, dst1);
+                }
+                if (yEnd > yInt)
+                {
+                    const uint16_t* src0 = src + (yInt - y0) * p.srcW * srcC;
+                    float* dst0 = dst + (yInt & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
+                    for (size_t j = 0; j < en; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
+                        inputConvolution1x1_2xN(src0, p, a, dC, weight, _bias, _params, dst0, dst1);
+                    if (en < e1)
+                        inputConvolution1x1_2xE(src0, p, a, dC, weight, _bias, _params, dst0, dst1);
+                }
+                dst += a.bufH[1] * p.dstW * DF;
+                weight += srcC * DF;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type> static void SetInput(const ConvParam& p, InputPtr& input)
+        {
+            if (Is1x1(p))
+                input = InputConvolution1x1_2<type>;
+            else
+                assert(0);
+        }
+
+        void SetInput(const ConvParam& p, InputPtr& input)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetInput<SimdConvolutionActivationRestrictRange>(p, input); break;
+            case SimdConvolutionActivationRelu: SetInput<SimdConvolutionActivationRestrictRange>(p, input); break;
+            case SimdConvolutionActivationLeakyRelu: SetInput<SimdConvolutionActivationPrelu>(p, input); break;
+            case SimdConvolutionActivationRestrictRange: SetInput<SimdConvolutionActivationRestrictRange>(p, input); break;
+            case SimdConvolutionActivationPrelu: SetInput<SimdConvolutionActivationPrelu>(p, input); break;
+            case SimdConvolutionActivationElu: SetInput<SimdConvolutionActivationElu>(p, input); break;
+            case SimdConvolutionActivationHswish: SetInput<SimdConvolutionActivationHswish>(p, input); break;
+            case SimdConvolutionActivationMish: SetInput<SimdConvolutionActivationMish>(p, input); break;
+            case SimdConvolutionActivationHardSigmoid: SetInput<SimdConvolutionActivationHardSigmoid>(p, input); break;
+            case SimdConvolutionActivationSwish: SetInput<SimdConvolutionActivationSwish>(p, input); break;
+            case SimdConvolutionActivationGelu: SetInput<SimdConvolutionActivationGelu>(p, input); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdNeonSynetMergedConvolution16bOutput.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16bOutput.cpp
@@ -1,0 +1,297 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdStore.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Neon
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+        using OutputPtr = Base::SynetMergedConvolution16b::OutputConvolutionPtr;
+
+        //---------------------------------------------------------------------
+
+        SIMD_INLINE float32x4_t BroadcastBf16(uint16_t value)
+        {
+            return vreinterpretq_f32_u32(vdupq_n_u32(uint32_t(value) << Base::Bf16::SHIFT));
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type, int M> void OutputConvolution1x1_2xM(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const float32x4_t* bias, const float32x4_t* params, float* buf, uint8_t* dst)
+        {
+            float32x4_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, s0, w00, w01, w10, w11;
+            size_t dS = a.maC * p.strideX, dB = p.dstC, dD = p.dstC * a.elem[1];
+            const uint16_t* weight1 = weight0 + AlignHi(srcC, 2) * F;
+            const uint16_t* src1 = src0 + 1 * dS;
+            const uint16_t* src2 = src0 + 2 * dS;
+            const uint16_t* src3 = src0 + 3 * dS;
+            const uint16_t* src4 = src0 + 4 * dS;
+            if (dstC > F)
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = vdupq_n_f32(0.0f), d01 = vdupq_n_f32(0.0f);
+                    if (M > 1) d10 = vdupq_n_f32(0.0f), d11 = vdupq_n_f32(0.0f);
+                    if (M > 2) d20 = vdupq_n_f32(0.0f), d21 = vdupq_n_f32(0.0f);
+                    if (M > 3) d30 = vdupq_n_f32(0.0f), d31 = vdupq_n_f32(0.0f);
+                    if (M > 4) d40 = vdupq_n_f32(0.0f), d41 = vdupq_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = Load<false>(buf + 0 * dB + 0), d01 = Load<false>(buf + 0 * dB + F);
+                    if (M > 1) d10 = Load<false>(buf + 1 * dB + 0), d11 = Load<false>(buf + 1 * dB + F);
+                    if (M > 2) d20 = Load<false>(buf + 2 * dB + 0), d21 = Load<false>(buf + 2 * dB + F);
+                    if (M > 3) d30 = Load<false>(buf + 3 * dB + 0), d31 = Load<false>(buf + 3 * dB + F);
+                    if (M > 4) d40 = Load<false>(buf + 4 * dB + 0), d41 = Load<false>(buf + 4 * dB + F);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 2)
+                {
+                    w01 = Load<false>((float*)weight0);
+                    w00 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w01), Base::Bf16::SHIFT));
+                    w01 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w01), Bf16::MASK));
+                    w11 = Load<false>((float*)weight1);
+                    w10 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w11), Base::Bf16::SHIFT));
+                    w11 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w11), Bf16::MASK));
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16(src0[offs + 0]);
+                        d00 = vmlaq_f32(d00, s0, w00); d01 = vmlaq_f32(d01, s0, w10);
+                        s0 = BroadcastBf16(src0[offs + 1]);
+                        d00 = vmlaq_f32(d00, s0, w01); d01 = vmlaq_f32(d01, s0, w11);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16(src1[offs + 0]);
+                        d10 = vmlaq_f32(d10, s0, w00); d11 = vmlaq_f32(d11, s0, w10);
+                        s0 = BroadcastBf16(src1[offs + 1]);
+                        d10 = vmlaq_f32(d10, s0, w01); d11 = vmlaq_f32(d11, s0, w11);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16(src2[offs + 0]);
+                        d20 = vmlaq_f32(d20, s0, w00); d21 = vmlaq_f32(d21, s0, w10);
+                        s0 = BroadcastBf16(src2[offs + 1]);
+                        d20 = vmlaq_f32(d20, s0, w01); d21 = vmlaq_f32(d21, s0, w11);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16(src3[offs + 0]);
+                        d30 = vmlaq_f32(d30, s0, w00); d31 = vmlaq_f32(d31, s0, w10);
+                        s0 = BroadcastBf16(src3[offs + 1]);
+                        d30 = vmlaq_f32(d30, s0, w01); d31 = vmlaq_f32(d31, s0, w11);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16(src4[offs + 0]);
+                        d40 = vmlaq_f32(d40, s0, w00); d41 = vmlaq_f32(d41, s0, w10);
+                        s0 = BroadcastBf16(src4[offs + 1]);
+                        d40 = vmlaq_f32(d40, s0, w01); d41 = vmlaq_f32(d41, s0, w11);
+                    }
+                    weight0 += DF;
+                    weight1 += DF;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params), buf += dB, dst += dD;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params), buf += dB, dst += dD;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params), buf += dB, dst += dD;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params), buf += dB, dst += dD;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params), buf += dB, dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, dstC - F), buf += dB, dst += dD;
+                }
+            }
+            else
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = vdupq_n_f32(0.0f);
+                    if (M > 1) d10 = vdupq_n_f32(0.0f);
+                    if (M > 2) d20 = vdupq_n_f32(0.0f);
+                    if (M > 3) d30 = vdupq_n_f32(0.0f);
+                    if (M > 4) d40 = vdupq_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = Load<false>(buf + 0 * dB + 0);
+                    if (M > 1) d10 = Load<false>(buf + 1 * dB + 0);
+                    if (M > 2) d20 = Load<false>(buf + 2 * dB + 0);
+                    if (M > 3) d30 = Load<false>(buf + 3 * dB + 0);
+                    if (M > 4) d40 = Load<false>(buf + 4 * dB + 0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 2)
+                {
+                    w01 = Load<false>((float*)weight0);
+                    w00 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w01), Base::Bf16::SHIFT));
+                    w01 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w01), Bf16::MASK));
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16(src0[offs + 0]);
+                        d00 = vmlaq_f32(d00, s0, w00);
+                        s0 = BroadcastBf16(src0[offs + 1]);
+                        d00 = vmlaq_f32(d00, s0, w01);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16(src1[offs + 0]);
+                        d10 = vmlaq_f32(d10, s0, w00);
+                        s0 = BroadcastBf16(src1[offs + 1]);
+                        d10 = vmlaq_f32(d10, s0, w01);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16(src2[offs + 0]);
+                        d20 = vmlaq_f32(d20, s0, w00);
+                        s0 = BroadcastBf16(src2[offs + 1]);
+                        d20 = vmlaq_f32(d20, s0, w01);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16(src3[offs + 0]);
+                        d30 = vmlaq_f32(d30, s0, w00);
+                        s0 = BroadcastBf16(src3[offs + 1]);
+                        d30 = vmlaq_f32(d30, s0, w01);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16(src4[offs + 0]);
+                        d40 = vmlaq_f32(d40, s0, w00);
+                        s0 = BroadcastBf16(src4[offs + 1]);
+                        d40 = vmlaq_f32(d40, s0, w01);
+                    }
+                    weight0 += DF;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params), buf += dB, dst += dD;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params), buf += dB, dst += dD;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params), buf += dB, dst += dD;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params), buf += dB, dst += dD;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params), buf += dB, dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, dstC), buf += dB, dst += dD;
+                }
+            }
+        }
+
+        typedef void(*OutputConvolution1x1_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const float32x4_t* bias, const float32x4_t* params, float* buf, uint8_t* dst);
+
+        template<Term16bType term, SimdConvolutionActivationType type> OutputConvolution1x1_2xM_Ptr GetOutputConvolution1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return OutputConvolution1x1_2xM<term, type, 1>;
+            case 2: return OutputConvolution1x1_2xM<term, type, 2>;
+            case 3: return OutputConvolution1x1_2xM<term, type, 3>;
+            case 4: return OutputConvolution1x1_2xM<term, type, 4>;
+            case 5: return OutputConvolution1x1_2xM<term, type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> void OutputConvolution1x1_2(const uint16_t* src, const ConvParam& p, const AlgParam& a,
+            size_t maC, size_t yBeg, size_t yEnd, int zero, const uint16_t* weight, const float* bias, const float* params, float* buf, float*, uint8_t* dst)
+        {
+            size_t n = 5, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            OutputConvolution1x1_2xM_Ptr outputConvolution1x1_2xN = GetOutputConvolution1x1_2xM<term, type>(n);
+            OutputConvolution1x1_2xM_Ptr outputConvolution1x1_2xM = GetOutputConvolution1x1_2xM<term, type>(m);
+            float32x4_t _bias[2], _params[2];
+            _params[0] = vdupq_n_f32(params[0]);
+            _params[1] = vdupq_n_f32(params[1]);
+            for (size_t dc = 0; dc < p.dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, p.dstC - dc);
+                _bias[0] = Load<false>(bias + dc + 0);
+                _bias[1] = Load<false>(bias + dc + F);
+                if (type == ::SimdConvolutionActivationPrelu)
+                {
+                    _params[0] = Load<false>(params + dc + 0);
+                    _params[1] = Load<false>(params + dc + F);
+                }
+                const uint16_t* s = src;
+                float* b = buf + dc + yBeg * p.dstW * p.dstC;
+                uint8_t* d = dst + (dc + yBeg * p.dstW * p.dstC) * a.elem[1];
+                size_t i = 0;
+                for (; i < nn; i += n, s += a.maC * n, b += p.dstC * n, d += p.dstC * a.elem[1] * n)
+                    outputConvolution1x1_2xN(s, p, a, maC, dC, zero, weight, _bias, _params, b, d);
+                for (; i < n1; i += m, s += a.maC * m, b += p.dstC * m, d += p.dstC * a.elem[1] * m)
+                    outputConvolution1x1_2xM(s, p, a, maC, dC, zero, weight, _bias, _params, b, d);
+                weight += AlignHi(maC, 2) * DF;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type> static void SetOutput(const ConvParam& p, OutputPtr* output)
+        {
+            if (p.dstT == SimdTensorData16b)
+                output[0] = OutputConvolution1x1_2<Term16bLast16b, type>;
+            else
+                output[0] = OutputConvolution1x1_2<Term16bLast32f, type>;
+            output[1] = OutputConvolution1x1_2<Term16bInterim, SimdConvolutionActivationIdentity>;
+        }
+
+        void SetOutput(const ConvParam& p, OutputPtr* output)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetOutput<SimdConvolutionActivationRestrictRange>(p, output); break;
+            case SimdConvolutionActivationRelu: SetOutput<SimdConvolutionActivationRestrictRange>(p, output); break;
+            case SimdConvolutionActivationLeakyRelu: SetOutput<SimdConvolutionActivationPrelu>(p, output); break;
+            case SimdConvolutionActivationRestrictRange: SetOutput<SimdConvolutionActivationRestrictRange>(p, output); break;
+            case SimdConvolutionActivationPrelu: SetOutput<SimdConvolutionActivationPrelu>(p, output); break;
+            case SimdConvolutionActivationElu: SetOutput<SimdConvolutionActivationElu>(p, output); break;
+            case SimdConvolutionActivationHswish: SetOutput<SimdConvolutionActivationHswish>(p, output); break;
+            case SimdConvolutionActivationMish: SetOutput<SimdConvolutionActivationMish>(p, output); break;
+            case SimdConvolutionActivationHardSigmoid: SetOutput<SimdConvolutionActivationHardSigmoid>(p, output); break;
+            case SimdConvolutionActivationSwish: SetOutput<SimdConvolutionActivationSwish>(p, output); break;
+            case SimdConvolutionActivationGelu: SetOutput<SimdConvolutionActivationGelu>(p, output); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdNeonSynetMergedConvolution16bOutput.cpp
+++ b/src/Simd/SimdNeonSynetMergedConvolution16bOutput.cpp
@@ -40,6 +40,31 @@ namespace Simd
 
         //---------------------------------------------------------------------
 
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, tail);
+        }
+
+        //---------------------------------------------------------------------
+
         SIMD_INLINE float32x4_t BroadcastBf16(uint16_t value)
         {
             return vreinterpretq_f32_u32(vdupq_n_u32(uint32_t(value) << Base::Bf16::SHIFT));
@@ -84,37 +109,37 @@ namespace Simd
                     if (M > 0)
                     {
                         s0 = BroadcastBf16(src0[offs + 0]);
-                        d00 = vmlaq_f32(d00, s0, w00); d01 = vmlaq_f32(d01, s0, w10);
+                        d00 = vaddq_f32(vmulq_f32(s0, w00), d00); d01 = vaddq_f32(vmulq_f32(s0, w10), d01);
                         s0 = BroadcastBf16(src0[offs + 1]);
-                        d00 = vmlaq_f32(d00, s0, w01); d01 = vmlaq_f32(d01, s0, w11);
+                        d00 = vaddq_f32(vmulq_f32(s0, w01), d00); d01 = vaddq_f32(vmulq_f32(s0, w11), d01);
                     }
                     if (M > 1)
                     {
                         s0 = BroadcastBf16(src1[offs + 0]);
-                        d10 = vmlaq_f32(d10, s0, w00); d11 = vmlaq_f32(d11, s0, w10);
+                        d10 = vaddq_f32(vmulq_f32(s0, w00), d10); d11 = vaddq_f32(vmulq_f32(s0, w10), d11);
                         s0 = BroadcastBf16(src1[offs + 1]);
-                        d10 = vmlaq_f32(d10, s0, w01); d11 = vmlaq_f32(d11, s0, w11);
+                        d10 = vaddq_f32(vmulq_f32(s0, w01), d10); d11 = vaddq_f32(vmulq_f32(s0, w11), d11);
                     }
                     if (M > 2)
                     {
                         s0 = BroadcastBf16(src2[offs + 0]);
-                        d20 = vmlaq_f32(d20, s0, w00); d21 = vmlaq_f32(d21, s0, w10);
+                        d20 = vaddq_f32(vmulq_f32(s0, w00), d20); d21 = vaddq_f32(vmulq_f32(s0, w10), d21);
                         s0 = BroadcastBf16(src2[offs + 1]);
-                        d20 = vmlaq_f32(d20, s0, w01); d21 = vmlaq_f32(d21, s0, w11);
+                        d20 = vaddq_f32(vmulq_f32(s0, w01), d20); d21 = vaddq_f32(vmulq_f32(s0, w11), d21);
                     }
                     if (M > 3)
                     {
                         s0 = BroadcastBf16(src3[offs + 0]);
-                        d30 = vmlaq_f32(d30, s0, w00); d31 = vmlaq_f32(d31, s0, w10);
+                        d30 = vaddq_f32(vmulq_f32(s0, w00), d30); d31 = vaddq_f32(vmulq_f32(s0, w10), d31);
                         s0 = BroadcastBf16(src3[offs + 1]);
-                        d30 = vmlaq_f32(d30, s0, w01); d31 = vmlaq_f32(d31, s0, w11);
+                        d30 = vaddq_f32(vmulq_f32(s0, w01), d30); d31 = vaddq_f32(vmulq_f32(s0, w11), d31);
                     }
                     if (M > 4)
                     {
                         s0 = BroadcastBf16(src4[offs + 0]);
-                        d40 = vmlaq_f32(d40, s0, w00); d41 = vmlaq_f32(d41, s0, w10);
+                        d40 = vaddq_f32(vmulq_f32(s0, w00), d40); d41 = vaddq_f32(vmulq_f32(s0, w10), d41);
                         s0 = BroadcastBf16(src4[offs + 1]);
-                        d40 = vmlaq_f32(d40, s0, w01); d41 = vmlaq_f32(d41, s0, w11);
+                        d40 = vaddq_f32(vmulq_f32(s0, w01), d40); d41 = vaddq_f32(vmulq_f32(s0, w11), d41);
                     }
                     weight0 += DF;
                     weight1 += DF;
@@ -162,37 +187,37 @@ namespace Simd
                     if (M > 0)
                     {
                         s0 = BroadcastBf16(src0[offs + 0]);
-                        d00 = vmlaq_f32(d00, s0, w00);
+                        d00 = vaddq_f32(vmulq_f32(s0, w00), d00);
                         s0 = BroadcastBf16(src0[offs + 1]);
-                        d00 = vmlaq_f32(d00, s0, w01);
+                        d00 = vaddq_f32(vmulq_f32(s0, w01), d00);
                     }
                     if (M > 1)
                     {
                         s0 = BroadcastBf16(src1[offs + 0]);
-                        d10 = vmlaq_f32(d10, s0, w00);
+                        d10 = vaddq_f32(vmulq_f32(s0, w00), d10);
                         s0 = BroadcastBf16(src1[offs + 1]);
-                        d10 = vmlaq_f32(d10, s0, w01);
+                        d10 = vaddq_f32(vmulq_f32(s0, w01), d10);
                     }
                     if (M > 2)
                     {
                         s0 = BroadcastBf16(src2[offs + 0]);
-                        d20 = vmlaq_f32(d20, s0, w00);
+                        d20 = vaddq_f32(vmulq_f32(s0, w00), d20);
                         s0 = BroadcastBf16(src2[offs + 1]);
-                        d20 = vmlaq_f32(d20, s0, w01);
+                        d20 = vaddq_f32(vmulq_f32(s0, w01), d20);
                     }
                     if (M > 3)
                     {
                         s0 = BroadcastBf16(src3[offs + 0]);
-                        d30 = vmlaq_f32(d30, s0, w00);
+                        d30 = vaddq_f32(vmulq_f32(s0, w00), d30);
                         s0 = BroadcastBf16(src3[offs + 1]);
-                        d30 = vmlaq_f32(d30, s0, w01);
+                        d30 = vaddq_f32(vmulq_f32(s0, w01), d30);
                     }
                     if (M > 4)
                     {
                         s0 = BroadcastBf16(src4[offs + 0]);
-                        d40 = vmlaq_f32(d40, s0, w00);
+                        d40 = vaddq_f32(vmulq_f32(s0, w00), d40);
                         s0 = BroadcastBf16(src4[offs + 1]);
-                        d40 = vmlaq_f32(d40, s0, w01);
+                        d40 = vaddq_f32(vmulq_f32(s0, w01), d40);
                     }
                     weight0 += DF;
                 }

--- a/src/Simd/SimdSynetConvolution16bCommon.h
+++ b/src/Simd/SimdSynetConvolution16bCommon.h
@@ -1341,29 +1341,6 @@ namespace Simd
             }
         };
 
-        //-------------------------------------------------------------------------------------------------
-
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params)
-        {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
-        }
-
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params, size_t tail)
-        {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
-        }
-
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params)
-        {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params);
-        }
-
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params, size_t tail)
-        {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, tail);
-        }
     }
 #endif
 }

--- a/src/Simd/SimdSynetConvolution16bCommon.h
+++ b/src/Simd/SimdSynetConvolution16bCommon.h
@@ -1267,5 +1267,104 @@ namespace Simd
         }
     }
 #endif
+
+#ifdef SIMD_NEON_ENABLE
+    namespace Neon
+    {
+        template <class T> SIMD_INLINE float32x4_t LoadSrc(const T* src);
+
+        template <> SIMD_INLINE float32x4_t LoadSrc<float>(const float* src)
+        {
+            return Load<false>(src);
+        }
+
+        template <> SIMD_INLINE float32x4_t LoadSrc<uint16_t>(const uint16_t* src)
+        {
+            return BFloat16ToFloat32(vmovl_u16(vld1_u16(src)));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <Term16bType term> struct Term16b
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params);
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params, size_t tail);
+        };
+
+        template <> struct Term16b<Term16bLast16b>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params)
+            {
+                float32x4_t f32 = Activate<type>(vaddq_f32(value, bias[index]), params, index);
+                Store<false>((uint16_t*)(ptr + 8 * index), vmovn_u32(Float32ToBFloat16(f32)));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+            {
+                float32x4_t f32 = Activate<type>(vaddq_f32(value, bias[index]), params, index);
+                uint16_t tmp[F];
+                Store<false>(tmp, vmovn_u32(Float32ToBFloat16(f32)));
+                for (size_t i = 0; i < tail; ++i)
+                    ((uint16_t*)ptr)[index * F + i] = tmp[i];
+            }
+        };
+
+        template <> struct Term16b<Term16bLast32f>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params)
+            {
+                Store<false>((float*)ptr + index * F, Activate<type>(vaddq_f32(value, bias[index]), params, index));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+            {
+                float tmp[F];
+                Store<false>(tmp, Activate<type>(vaddq_f32(value, bias[index]), params, index));
+                for (size_t i = 0; i < tail; ++i)
+                    ((float*)ptr)[index * F + i] = tmp[i];
+            }
+        };
+
+        template <> struct Term16b<Term16bInterim>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params)
+            {
+                Store<false>(buf + index * F, value);
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, float32x4_t value, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+            {
+                float tmp[F];
+                Store<false>(tmp, value);
+                for (size_t i = 0; i < tail; ++i)
+                    buf[index * F + i] = tmp[i];
+            }
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, tail);
+        }
+    }
+#endif
 }
 #endif

--- a/src/Simd/SimdSynetMergedConvolution16b.h
+++ b/src/Simd/SimdSynetMergedConvolution16b.h
@@ -316,5 +316,43 @@ namespace Simd
         void* SynetMergedConvolution16bInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
     }
 #endif
+
+#ifdef SIMD_NEON_ENABLE    
+    namespace Neon
+    {
+        void SetInput(const ConvParam& p, Base::SynetMergedConvolution16b::InputConvolutionPtr& input);
+
+        void SetDepthwise(const ConvParam& p, Base::SynetMergedConvolution16b::DepthwiseConvolutionPtr& depthwise);
+
+        void SetOutput(const ConvParam& p, Base::SynetMergedConvolution16b::OutputConvolutionPtr* output);
+
+        //-------------------------------------------------------------------------------------------------
+
+        class SynetMergedConvolution16bCdc : public Base::SynetMergedConvolution16bCdc
+        {
+        public:
+            SynetMergedConvolution16bCdc(const MergConvParam& p);
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        class SynetMergedConvolution16bCd : public Base::SynetMergedConvolution16bCd
+        {
+        public:
+            SynetMergedConvolution16bCd(const MergConvParam& p);
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        class SynetMergedConvolution16bDc : public Base::SynetMergedConvolution16bDc
+        {
+        public:
+            SynetMergedConvolution16bDc(const MergConvParam& p);
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetMergedConvolution16bInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
+    }
+#endif
 }
 #endif

--- a/src/Test/TestSynetMergedConvolution16b.cpp
+++ b/src/Test/TestSynetMergedConvolution16b.cpp
@@ -376,6 +376,11 @@ namespace Test
             result = result && SynetMergedConvolution16bForwardAutoTest(EPS, FUNC_MC(Simd::AmxBf16::SynetMergedConvolution16bInit), FUNC_MC(SimdSynetMergedConvolution16bInit));
 #endif
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetMergedConvolution16bForwardAutoTest(EPS, FUNC_MC(Simd::Neon::SynetMergedConvolution16bInit), FUNC_MC(SimdSynetMergedConvolution16bInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds NEON (ARM/ARM64) optimizations for `SynetMergedConvolution16bCdc`, `SynetMergedConvolution16bCd`, and `SynetMergedConvolution16bDc`, following the existing SSE4.1 structure.

## Changes
- New NEON sources:
  - `SimdNeonSynetMergedConvolution16b.cpp`
  - `SimdNeonSynetMergedConvolution16bInput.cpp`
  - `SimdNeonSynetMergedConvolution16bDepthwise.cpp`
  - `SimdNeonSynetMergedConvolution16bOutput.cpp`
- Wire Neon Init/dispatch in `SimdSynetMergedConvolution16b.h` and `SimdLib.cpp`
- Neon `LoadSrc` / `Term16b` helpers in `SimdSynetConvolution16bCommon.h`
- Test coverage for Neon in `TestSynetMergedConvolution16b.cpp`
- VS2022 Neon project/filter entries
- Release notes in `docs/2026.html` (7.2.164)

## Implementation notes
- Micro-kernel shape matches SSE4.1 (F=4, DF=8, M<=5)
- Accumulation uses separate `vmulq_f32` + `vaddq_f32` (not fused `vmlaq`) to match SSE mul-add order
- Local `Save1`/`Save2` wrappers live in Depthwise/Output files to avoid Neon namespace clashes with InnerProduct16b

## Validation
Cross-compiled for aarch64 and run under `qemu-aarch64`:
- Default NDEBUG case (`32x16x16` RestrictRange Cdc, bf16): **pass**
- Curated Cdc/Cd/Dc suite (f32/bf16, Identity/ReLU/PReLU/Hswish/RestrictRange, 3x3 and 5x5 depthwise): **pass**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4225952-8c10-423c-b54a-eeb21ab16139?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4225952-8c10-423c-b54a-eeb21ab16139&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

