### PR TITLE
Add SVE2 optimizations for SynetMergedConvolution16b Cdc/Cd/Dc

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -56,6 +56,9 @@
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCdc.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCd.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iDc.</li>
+ <li>NEON, SVE2 optimizations of classes SynetMergedConvolution16bCdc.</li>
+ <li>NEON, SVE2 optimizations of classes SynetMergedConvolution16bCd.</li>
+ <li>NEON, SVE2 optimizations of classes SynetMergedConvolution16bDc.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -121,6 +121,10 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution16bNhwcGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16b.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16bDepthwise.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16bInput.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16bOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32f.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fDepthwise.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32fInput.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -530,6 +530,18 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetDeconvolution32f.cpp">
       <Filter>Sve2\Synet\Other</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16b.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16bDepthwise.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16bInput.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution16bOutput.cpp">
+      <Filter>Sve2\Synet\MergedConvolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetMergedConvolution32f.cpp">
       <Filter>Sve2\Synet\MergedConvolution</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6937,7 +6937,7 @@ SIMD_API void* SimdSynetMergedConvolution16bInit(size_t batch, const SimdConvolu
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetMergedConvolution16bInitPtr) (size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
-    const static SimdSynetMergedConvolution16bInitPtr simdSynetMergedConvolution16bInit = SIMD_FUNC5(SynetMergedConvolution16bInit, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetMergedConvolution16bInitPtr simdSynetMergedConvolution16bInit = SIMD_FUNC6(SynetMergedConvolution16bInit, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetMergedConvolution16bInit(batch, convs, count, add);
 #else

--- a/src/Simd/SimdSve2SynetMergedConvolution16b.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16b.cpp
@@ -39,6 +39,13 @@ namespace Simd
 
         //-----------------------------------------------------------------------------------------
 
+        SIMD_INLINE svuint32_t Float32ToBFloat16Vec(svfloat32_t value, const svbool_t& mask)
+        {
+            svuint32_t bits = svreinterpret_u32_f32(value);
+            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+        }
+
         static void ConvertFp32ToBf16(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
         {
             const float* src = (float*)src8;
@@ -60,11 +67,11 @@ namespace Simd
                     {
                         size_t c = 0;
                         for (; c + F <= p.srcC; c += F)
-                            svst1h_u32(body, pd + c, Float32ToBFloat16(svld1_f32(body, ps + c), body));
+                            svst1h_u32(body, pd + c, Float32ToBFloat16Vec(svld1_f32(body, ps + c), body));
                         if (c < p.srcC)
                         {
                             svbool_t mask = svwhilelt_b32(c, p.srcC);
-                            svst1h_u32(mask, pd + c, Float32ToBFloat16(svld1_f32(mask, ps + c), mask));
+                            svst1h_u32(mask, pd + c, Float32ToBFloat16Vec(svld1_f32(mask, ps + c), mask));
                             c = p.srcC;
                         }
                         for (; c < srcC; ++c)

--- a/src/Simd/SimdSve2SynetMergedConvolution16b.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16b.cpp
@@ -1,0 +1,175 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdUpdate.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdMath.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Sve2
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+
+        //-----------------------------------------------------------------------------------------
+
+        static void ConvertFp32ToBf16(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
+        {
+            const float* src = (float*)src8;
+            size_t srcC = AlignHi(p.srcC, a.miK);
+            if (srcC == p.srcC)
+            {
+                size_t size = p.srcW * p.srcC;
+                Float32ToBFloat16(src + yBeg * size, (yEnd - yBeg) * size, dst);
+            }
+            else
+            {
+                const size_t F = svcntw();
+                const svbool_t body = svptrue_b32();
+                for (size_t y = yBeg; y < yEnd; ++y)
+                {
+                    const float* ps = src + y * p.srcW * p.srcC;
+                    uint16_t* pd = dst + (y - yBeg) * p.srcW * srcC;
+                    for (size_t x = 0; x < p.srcW; ++x)
+                    {
+                        size_t c = 0;
+                        for (; c + F <= p.srcC; c += F)
+                            svst1h_u32(body, pd + c, Float32ToBFloat16(svld1_f32(body, ps + c), body));
+                        if (c < p.srcC)
+                        {
+                            svbool_t mask = svwhilelt_b32(c, p.srcC);
+                            svst1h_u32(mask, pd + c, Float32ToBFloat16(svld1_f32(mask, ps + c), mask));
+                            c = p.srcC;
+                        }
+                        for (; c < srcC; ++c)
+                            pd[c] = 0;
+                        ps += p.srcC;
+                        pd += srcC;
+                    }
+                }
+            }
+        }
+
+        static void ReorderBf16(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
+        {
+            const uint16_t* src = (uint16_t*)src8;
+            size_t srcC = AlignHi(p.srcC, a.miK);
+            const size_t A = svcnth();
+            const svbool_t body = svptrue_b16();
+            for (size_t y = yBeg; y < yEnd; ++y)
+            {
+                const uint16_t* ps = src + y * p.srcW * p.srcC;
+                uint16_t* pd = dst + (y - yBeg) * p.srcW * srcC;
+                for (size_t x = 0; x < p.srcW; ++x)
+                {
+                    size_t c = 0;
+                    for (; c + A <= p.srcC; c += A)
+                        svst1_u16(body, pd + c, svld1_u16(body, ps + c));
+                    for (; c < p.srcC; ++c)
+                        pd[c] = ps[c];
+                    for (; c < srcC; ++c)
+                        pd[c] = 0;
+                    ps += p.srcC;
+                    pd += srcC;
+                }
+            }
+        }
+
+        static void ConvertBf16ToFp32(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, float* dst)
+        {
+            const uint16_t* src = (uint16_t*)src8;
+            size_t rowSize = p.srcW * p.srcC;
+            for (size_t y = yBeg; y < yEnd; ++y)
+                BFloat16ToFloat32(src + y * rowSize, rowSize, dst + y * rowSize);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetMergedConvolution16bCdc::SynetMergedConvolution16bCdc(const MergConvParam& p)
+            : Base::SynetMergedConvolution16bCdc(p)
+        {
+            SetSize(svcntw(), 2);
+            if (!_src16b)
+                _toBf16 = ConvertFp32ToBf16;
+            else if (!Aligned(p.conv[0].srcC, 2))
+                _toBf16 = ReorderBf16;
+            else
+                _toBf16 = NULL;
+            if (_src16b)
+                _toFp32 = ConvertBf16ToFp32;
+            SetInput(_param.conv[0], _input);
+            SetDepthwise(_param.conv[1], _depthwise);
+            SetOutput(_param.conv[2], _output);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetMergedConvolution16bCd::SynetMergedConvolution16bCd(const MergConvParam& p)
+            : Base::SynetMergedConvolution16bCd(p)
+        {
+            SetSize(svcntw(), 2);
+            if (!_src16b)
+                _toBf16 = ConvertFp32ToBf16;
+            else if (!Aligned(p.conv[0].srcC, 2))
+                _toBf16 = ReorderBf16;
+            else
+                _toBf16 = NULL;
+            SetInput(_param.conv[0], _input);
+            SetDepthwise(_param.conv[1], _depthwise);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetMergedConvolution16bDc::SynetMergedConvolution16bDc(const MergConvParam& p)
+            : Base::SynetMergedConvolution16bDc(p)
+        {
+            SetSize(svcntw(), 2);
+            SetDepthwise(_param.conv[0], _depthwise);
+            SetOutput(_param.conv[1], _output);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        void* SynetMergedConvolution16bInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add)
+        {
+            MergConvParam param(batch, convs, count, add);
+            if (!param.Valid(SimdTensorData32f, SimdTensorData16b))
+                return NULL;
+            if (SynetMergedConvolution16bCdc::Preferable(param))
+                return new Sve2::SynetMergedConvolution16bCdc(param);
+            else if (SynetMergedConvolution16bCd::Preferable(param))
+                return new Sve2::SynetMergedConvolution16bCd(param);
+            else if (SynetMergedConvolution16bDc::Preferable(param))
+                return new Sve2::SynetMergedConvolution16bDc(param);
+            else
+                return new Base::SynetMergedConvolution16b(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution16bDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16bDepthwise.cpp
@@ -51,14 +51,14 @@ namespace Simd
                 return svmla_f32_x(mask, sum, src, weight);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, mask);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, param0, param1, mask);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, size_t tail)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, param0, param1, tail);
         }
 
         //-------------------------------------------------------------------------------------------------
@@ -80,18 +80,13 @@ namespace Simd
             size_t bodyX8 = AlignLo(bodyS, 8) + noseX;
             size_t dstCF = AlignLo(dstC, F);
 
-            svfloat32_t _params[2], _bias[1];
-            _params[0] = svdup_n_f32(params[0]);
-            _params[1] = svdup_n_f32(params[1]);
-            if (type == SimdConvolutionActivationRestrictRange ||
-                type == SimdConvolutionActivationHswish ||
-                type == SimdConvolutionActivationHardSigmoid)
-                _params[1] = svdup_n_f32(params[1]);
+            svfloat32_t param0 = svdup_n_f32(params[0]);
+            svfloat32_t param1 = svdup_n_f32(params[1]);
             for (size_t c = 0; c < dstC; c += F)
             {
-                _bias[0] = svld1_f32(body, bias + c);
+                svfloat32_t bias0 = svld1_f32(body, bias + c);
                 if (type == ::SimdConvolutionActivationPrelu)
-                    _params[0] = svld1_f32(body, params + c);
+                    param0 = svld1_f32(body, params + c);
                 if (c == dstCF)
                 {
                     size_t tail = dstC - dstCF;
@@ -119,7 +114,7 @@ namespace Simd
                                     }
                                 }
                             }
-                            Save1<term, type>(pd, NULL, sum, _bias, _params, mask);
+                            Save1<term, type>(pd, NULL, sum, bias0, param0, param1, mask);
                         }
                     }
                     return;
@@ -147,7 +142,7 @@ namespace Simd
                                     }
                                 }
                             }
-                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                            Save1<term, type>(pd, NULL, sum, bias0, param0, param1, body);
                         }
                         for (; dx < bodyX8; dx += 8, pd += 8 * dX)
                         {
@@ -177,14 +172,14 @@ namespace Simd
                                     sum7 = Madd<nofma>(body, sum7, LoadSrc(ps + 7 * ssX, body), w0);
                                 }
                             }
-                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params, body);
-                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params, body);
-                            Save1<term, type>(pd + 2 * dX, NULL, sum2, _bias, _params, body);
-                            Save1<term, type>(pd + 3 * dX, NULL, sum3, _bias, _params, body);
-                            Save1<term, type>(pd + 4 * dX, NULL, sum4, _bias, _params, body);
-                            Save1<term, type>(pd + 5 * dX, NULL, sum5, _bias, _params, body);
-                            Save1<term, type>(pd + 6 * dX, NULL, sum6, _bias, _params, body);
-                            Save1<term, type>(pd + 7 * dX, NULL, sum7, _bias, _params, body);
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 2 * dX, NULL, sum2, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 3 * dX, NULL, sum3, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 4 * dX, NULL, sum4, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 5 * dX, NULL, sum5, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 6 * dX, NULL, sum6, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 7 * dX, NULL, sum7, bias0, param0, param1, body);
                         }
                         for (; dx < bodyX4; dx += 4, pd += 4 * dX)
                         {
@@ -206,10 +201,10 @@ namespace Simd
                                     sum3 = Madd<nofma>(body, sum3, LoadSrc(ps + 3 * ssX, body), w0);
                                 }
                             }
-                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params, body);
-                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params, body);
-                            Save1<term, type>(pd + 2 * dX, NULL, sum2, _bias, _params, body);
-                            Save1<term, type>(pd + 3 * dX, NULL, sum3, _bias, _params, body);
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 2 * dX, NULL, sum2, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 3 * dX, NULL, sum3, bias0, param0, param1, body);
                         }
                         for (; dx < bodyX2; dx += 2, pd += 2 * dX)
                         {
@@ -227,8 +222,8 @@ namespace Simd
                                     sum1 = Madd<nofma>(body, sum1, LoadSrc(ps + 1 * ssX, body), w0);
                                 }
                             }
-                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params, body);
-                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params, body);
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, bias0, param0, param1, body);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, bias0, param0, param1, body);
                         }
                         for (; dx < bodyX; dx += 1, pd += dX)
                         {
@@ -244,7 +239,7 @@ namespace Simd
                                     sum = Madd<nofma>(body, sum, LoadSrc(ps, body), w0);
                                 }
                             }
-                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                            Save1<term, type>(pd, NULL, sum, bias0, param0, param1, body);
                         }
                         for (; dx < p.dstW; dx += 1, pd += dX)
                         {
@@ -263,7 +258,7 @@ namespace Simd
                                     }
                                 }
                             }
-                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                            Save1<term, type>(pd, NULL, sum, bias0, param0, param1, body);
                         }
                     }
                     else
@@ -288,7 +283,7 @@ namespace Simd
                                     }
                                 }
                             }
-                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                            Save1<term, type>(pd, NULL, sum, bias0, param0, param1, body);
                         }
                     }
                 }
@@ -301,116 +296,116 @@ namespace Simd
         //---------------------------------------------------------------------
 
         template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge2x2(const T* src0,
-            const T* src1, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+            const T* src1, size_t sX, const float* weight, size_t F, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, uint8_t* dst)
         {
             const svbool_t body = svptrue_b32();
             if (nofma)
             {
                 svfloat32_t sum = svdup_n_f32(0.0f);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                Save1<term, type>(dst, NULL, sum, bias, params, body);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                Save1<term, type>(dst, NULL, sum, bias0, param0, param1, body);
             }
             else
             {
                 svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                Save1<term, type>(dst, NULL, svadd_f32_x(body, sum0, sum1), bias, params, body);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, sum0, sum1), bias0, param0, param1, body);
             }
         }
 
         template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge2x3(const T* src0,
-            const T* src1, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+            const T* src1, size_t sX, const float* weight, size_t F, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, uint8_t* dst)
         {
             const svbool_t body = svptrue_b32();
             if (nofma)
             {
                 svfloat32_t sum = svdup_n_f32(0.0f);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 2 * sX, body), weight[2]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 2 * sX, body), weight[5]);
-                Save1<term, type>(dst, NULL, sum, bias, params, body);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 2 * sX, body), svld1_f32(body, weight + 2 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 2 * sX, body), svld1_f32(body, weight + 5 * F));
+                Save1<term, type>(dst, NULL, sum, bias0, param0, param1, body);
             }
             else
             {
                 svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f), sum2 = svdup_n_f32(0.0f);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum2 = Madd<false>(body, sum2, LoadSrc(src0 + 2 * sX, body), weight[2]);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                sum2 = Madd<false>(body, sum2, LoadSrc(src1 + 2 * sX, body), weight[5]);
-                Save1<term, type>(dst, NULL, svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), sum2), bias, params, body);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum2 = Madd<false>(body, sum2, LoadSrc(src0 + 2 * sX, body), svld1_f32(body, weight + 2 * F));
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                sum2 = Madd<false>(body, sum2, LoadSrc(src1 + 2 * sX, body), svld1_f32(body, weight + 5 * F));
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), sum2), bias0, param0, param1, body);
             }
         }
 
         template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge3x2(const T* src0,
-            const T* src1, const T* src2, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+            const T* src1, const T* src2, size_t sX, const float* weight, size_t F, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, uint8_t* dst)
         {
             const svbool_t body = svptrue_b32();
             if (nofma)
             {
                 svfloat32_t sum = svdup_n_f32(0.0f);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                sum = Madd<true>(body, sum, LoadSrc(src2 + 0 * sX, body), weight[6]);
-                sum = Madd<true>(body, sum, LoadSrc(src2 + 1 * sX, body), weight[7]);
-                Save1<term, type>(dst, NULL, sum, bias, params, body);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 0 * sX, body), svld1_f32(body, weight + 6 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 1 * sX, body), svld1_f32(body, weight + 7 * F));
+                Save1<term, type>(dst, NULL, sum, bias0, param0, param1, body);
             }
             else
             {
                 svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src2 + 0 * sX, body), weight[6]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src2 + 1 * sX, body), weight[7]);
-                Save1<term, type>(dst, NULL, svadd_f32_x(body, sum0, sum1), bias, params, body);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                sum0 = Madd<false>(body, sum0, LoadSrc(src2 + 0 * sX, body), svld1_f32(body, weight + 6 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src2 + 1 * sX, body), svld1_f32(body, weight + 7 * F));
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, sum0, sum1), bias0, param0, param1, body);
             }
         }
 
         template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Main1x1(const T* src0,
-            const T* src1, const T* src2, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+            const T* src1, const T* src2, size_t sX, const float* weight, size_t F, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, uint8_t* dst)
         {
             const svbool_t body = svptrue_b32();
             if (nofma)
             {
                 svfloat32_t sum = svdup_n_f32(0.0f);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum = Madd<true>(body, sum, LoadSrc(src0 + 2 * sX, body), weight[2]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                sum = Madd<true>(body, sum, LoadSrc(src1 + 2 * sX, body), weight[5]);
-                sum = Madd<true>(body, sum, LoadSrc(src2 + 0 * sX, body), weight[6]);
-                sum = Madd<true>(body, sum, LoadSrc(src2 + 1 * sX, body), weight[7]);
-                sum = Madd<true>(body, sum, LoadSrc(src2 + 2 * sX, body), weight[8]);
-                Save1<term, type>(dst, NULL, sum, bias, params, body);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 2 * sX, body), svld1_f32(body, weight + 2 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 2 * sX, body), svld1_f32(body, weight + 5 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 0 * sX, body), svld1_f32(body, weight + 6 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 1 * sX, body), svld1_f32(body, weight + 7 * F));
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 2 * sX, body), svld1_f32(body, weight + 8 * F));
+                Save1<term, type>(dst, NULL, sum, bias0, param0, param1, body);
             }
             else
             {
                 svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f), sum2 = svdup_n_f32(0.0f);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
-                sum2 = Madd<false>(body, sum2, LoadSrc(src0 + 2 * sX, body), weight[2]);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
-                sum2 = Madd<false>(body, sum2, LoadSrc(src1 + 2 * sX, body), weight[5]);
-                sum0 = Madd<false>(body, sum0, LoadSrc(src2 + 0 * sX, body), weight[6]);
-                sum1 = Madd<false>(body, sum1, LoadSrc(src2 + 1 * sX, body), weight[7]);
-                sum2 = Madd<false>(body, sum2, LoadSrc(src2 + 2 * sX, body), weight[8]);
-                Save1<term, type>(dst, NULL, svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), sum2), bias, params, body);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), svld1_f32(body, weight + 0 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), svld1_f32(body, weight + 1 * F));
+                sum2 = Madd<false>(body, sum2, LoadSrc(src0 + 2 * sX, body), svld1_f32(body, weight + 2 * F));
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), svld1_f32(body, weight + 3 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), svld1_f32(body, weight + 4 * F));
+                sum2 = Madd<false>(body, sum2, LoadSrc(src1 + 2 * sX, body), svld1_f32(body, weight + 5 * F));
+                sum0 = Madd<false>(body, sum0, LoadSrc(src2 + 0 * sX, body), svld1_f32(body, weight + 6 * F));
+                sum1 = Madd<false>(body, sum1, LoadSrc(src2 + 1 * sX, body), svld1_f32(body, weight + 7 * F));
+                sum2 = Madd<false>(body, sum2, LoadSrc(src2 + 2 * sX, body), svld1_f32(body, weight + 8 * F));
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), sum2), bias0, param0, param1, body);
             }
         }
 
@@ -426,21 +421,13 @@ namespace Simd
             size_t wD = p.kernelY * p.kernelX * F, ssX = p.strideX * sX, ssX0 = (p.strideX - p.padX) * sX;
             size_t xMainEnd = p.dstW - p.padW, yMainEnd = yEnd == p.dstH && p.padH ? yEnd - 1 : yEnd;
 
-            svfloat32_t _params[2], _bias[1];
-            _params[0] = svdup_n_f32(params[0]);
-            _params[1] = svdup_n_f32(params[1]);
-            if (type == SimdConvolutionActivationRestrictRange ||
-                type == SimdConvolutionActivationHswish ||
-                type == SimdConvolutionActivationHardSigmoid)
-                _params[1] = svdup_n_f32(params[1]);
+            svfloat32_t param0 = svdup_n_f32(params[0]);
+            svfloat32_t param1 = svdup_n_f32(params[1]);
             for (size_t c = 0; c < dstC; c += F)
             {
-                svfloat32_t _weight[9];
-                for (size_t i = 0; i < 9; ++i)
-                    _weight[i] = svld1_f32(body, weight + i * F);
-                _bias[0] = svld1_f32(body, bias + c);
+                svfloat32_t bias0 = svld1_f32(body, bias + c);
                 if (type == ::SimdConvolutionActivationPrelu)
-                    _params[0] = svld1_f32(body, params + c);
+                    param0 = svld1_f32(body, params + c);
 
                 size_t dy = yBeg;
                 if (yBeg == 0 && padY)
@@ -450,12 +437,12 @@ namespace Simd
                     const T* src1 = src + ((sy + 1) & sM) * sY;
                     uint8_t* pDst = dst + (dy - dy0) * dY;
                     if (padX)
-                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 4, _bias, _params, pDst),
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, weight + 4 * F, F, bias0, param0, param1, pDst),
                         pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
                     for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
-                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, _weight + 3, _bias, _params, pDst);
+                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, weight + 3 * F, F, bias0, param0, param1, pDst);
                     if (padW)
-                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 3, _bias, _params, pDst);
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, weight + 3 * F, F, bias0, param0, param1, pDst);
                     dy++;
                 }
                 for (; dy < yMainEnd; ++dy)
@@ -466,12 +453,12 @@ namespace Simd
                     const T* src2 = src + ((sy + 2) & sM) * sY;
                     uint8_t* pDst = dst + (dy - dy0) * dY;
                     if (padX)
-                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, _weight + 1, _bias, _params, pDst),
+                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, weight + 1 * F, F, bias0, param0, param1, pDst),
                         pDst += dX, dx++, src0 += ssX0, src1 += ssX0, src2 += ssX0;
                     for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX, src2 += ssX)
-                        DepthwiseConvolution3x3Main1x1<T, term, type, nofma>(src0, src1, src2, sX, _weight + 0, _bias, _params, pDst);
+                        DepthwiseConvolution3x3Main1x1<T, term, type, nofma>(src0, src1, src2, sX, weight + 0 * F, F, bias0, param0, param1, pDst);
                     if (padW)
-                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, _weight + 0, _bias, _params, pDst);
+                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, weight + 0 * F, F, bias0, param0, param1, pDst);
                 }
                 if (dy < yEnd)
                 {
@@ -480,12 +467,12 @@ namespace Simd
                     const T* src1 = src + ((sy + 1) & sM) * sY;
                     uint8_t* pDst = dst + (dy - dy0) * dY;
                     if (padX)
-                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 1, _bias, _params, pDst),
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, weight + 1 * F, F, bias0, param0, param1, pDst),
                         pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
                     for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
-                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, _weight + 0, _bias, _params, pDst);
+                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, weight + 0 * F, F, bias0, param0, param1, pDst);
                     if (padW)
-                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 0, _bias, _params, pDst);
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, weight + 0 * F, F, bias0, param0, param1, pDst);
                 }
                 src += sD;
                 dst += dD;
@@ -493,7 +480,7 @@ namespace Simd
             }
         }
 
-        //---------------------------------------------------------------------
+                //---------------------------------------------------------------------
 
         template<Term16bType term, SimdConvolutionActivationType type> static void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
         {

--- a/src/Simd/SimdSve2SynetMergedConvolution16bDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16bDepthwise.cpp
@@ -1,0 +1,558 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution32f.h"
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynetActivation.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdBFloat16.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Sve2
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+        using DepthwisePtr = Base::SynetMergedConvolution16b::DepthwiseConvolutionPtr;
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<bool nofma> SIMD_INLINE svfloat32_t Madd(const svbool_t& mask, svfloat32_t sum, svfloat32_t src, svfloat32_t weight)
+        {
+            if (nofma)
+                return svadd_f32_x(mask, svmul_f32_x(mask, src, weight), sum);
+            else
+                return svmla_f32_x(mask, sum, src, weight);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, mask);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> void DepthwiseConvolution(const uint8_t* src8, const ConvParam& p, const AlgParam& a,
+            size_t maC, size_t yBeg, size_t yEnd, const float* weight, const float* bias, const float* params, uint8_t* dst)
+        {
+            const T* src = (T*)src8;
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            size_t strideY = p.strideY, strideX = p.strideX, padY = p.padY, padX = p.padX, padH = p.padH, padW = p.padW;
+            size_t sM = (a.bufH[1] - 1), sD = a.bufH[1] ? a.bufH[1] * p.srcW * F : F, sX = a.bufH[1] ? F : p.srcC, sY = sX * p.srcW, dstC = maC;
+            size_t dX = (a.bufH[2] ? a.maC * 2 : p.dstC * a.elem[1]), dY = p.dstW * dX, dy0 = a.bufH[2] ? yBeg : 0, dD = a.bufH[2] ? F * 2 : F * a.elem[1];
+            size_t wD = p.kernelY * p.kernelX * F, ssX = strideX * sX;
+            size_t noseY = NoseH(p), bodyY = BodyH(p), noseX = NoseW(p), bodyX = BodyW(p);
+            size_t bodyS = bodyX > noseX ? bodyX - noseX : 0;
+            size_t bodyX2 = AlignLo(bodyS, 2) + noseX;
+            size_t bodyX4 = AlignLo(bodyS, 4) + noseX;
+            size_t bodyX8 = AlignLo(bodyS, 8) + noseX;
+            size_t dstCF = AlignLo(dstC, F);
+
+            svfloat32_t _params[2], _bias[1];
+            _params[0] = svdup_n_f32(params[0]);
+            _params[1] = svdup_n_f32(params[1]);
+            if (type == SimdConvolutionActivationRestrictRange ||
+                type == SimdConvolutionActivationHswish ||
+                type == SimdConvolutionActivationHardSigmoid)
+                _params[1] = svdup_n_f32(params[1]);
+            for (size_t c = 0; c < dstC; c += F)
+            {
+                _bias[0] = svld1_f32(body, bias + c);
+                if (type == ::SimdConvolutionActivationPrelu)
+                    _params[0] = svld1_f32(body, params + c);
+                if (c == dstCF)
+                {
+                    size_t tail = dstC - dstCF;
+                    svbool_t mask = svwhilelt_b32((size_t)0, tail);
+                    for (size_t dy = yBeg; dy < yEnd; ++dy)
+                    {
+                        uint8_t* pd = dst + (dy - dy0) * dY;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, pd += dX)
+                        {
+                            svfloat32_t sum = svdup_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                if (sy < p.srcH)
+                                {
+                                    for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                    {
+                                        size_t sx = dx * strideX + kx - padX;
+                                        if (sx < p.srcW)
+                                        {
+                                            const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                            const T* ps = src + (sy & sM) * sY + sx * sX;
+                                            sum = Madd<nofma>(mask, sum, LoadSrc(ps, mask), svld1_f32(mask, pw));
+                                        }
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params, mask);
+                        }
+                    }
+                    return;
+                }
+                for (size_t dy = yBeg; dy < yEnd; ++dy)
+                {
+                    uint8_t* pd = dst + (dy - dy0) * dY;
+                    if (dy >= noseY && dy < bodyY)
+                    {
+                        size_t dx = 0;
+                        for (; dx < noseX; dx += 1, pd += dX)
+                        {
+                            svfloat32_t sum = svdup_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * p.strideY + ky - padY;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                {
+                                    size_t sx = dx * p.strideX + kx - padX;
+                                    if (sx < p.srcW)
+                                    {
+                                        const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                        const T* ps = src + (sy & sM) * sY + sx * sX;
+                                        sum = Madd<nofma>(body, sum, LoadSrc(ps, body), svld1_f32(body, pw));
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                        }
+                        for (; dx < bodyX8; dx += 8, pd += 8 * dX)
+                        {
+                            svfloat32_t sum0 = svdup_n_f32(0.0f);
+                            svfloat32_t sum1 = svdup_n_f32(0.0f);
+                            svfloat32_t sum2 = svdup_n_f32(0.0f);
+                            svfloat32_t sum3 = svdup_n_f32(0.0f);
+                            svfloat32_t sum4 = svdup_n_f32(0.0f);
+                            svfloat32_t sum5 = svdup_n_f32(0.0f);
+                            svfloat32_t sum6 = svdup_n_f32(0.0f);
+                            svfloat32_t sum7 = svdup_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    svfloat32_t w0 = svld1_f32(body, pw);
+                                    sum0 = Madd<nofma>(body, sum0, LoadSrc(ps + 0 * ssX, body), w0);
+                                    sum1 = Madd<nofma>(body, sum1, LoadSrc(ps + 1 * ssX, body), w0);
+                                    sum2 = Madd<nofma>(body, sum2, LoadSrc(ps + 2 * ssX, body), w0);
+                                    sum3 = Madd<nofma>(body, sum3, LoadSrc(ps + 3 * ssX, body), w0);
+                                    sum4 = Madd<nofma>(body, sum4, LoadSrc(ps + 4 * ssX, body), w0);
+                                    sum5 = Madd<nofma>(body, sum5, LoadSrc(ps + 5 * ssX, body), w0);
+                                    sum6 = Madd<nofma>(body, sum6, LoadSrc(ps + 6 * ssX, body), w0);
+                                    sum7 = Madd<nofma>(body, sum7, LoadSrc(ps + 7 * ssX, body), w0);
+                                }
+                            }
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params, body);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params, body);
+                            Save1<term, type>(pd + 2 * dX, NULL, sum2, _bias, _params, body);
+                            Save1<term, type>(pd + 3 * dX, NULL, sum3, _bias, _params, body);
+                            Save1<term, type>(pd + 4 * dX, NULL, sum4, _bias, _params, body);
+                            Save1<term, type>(pd + 5 * dX, NULL, sum5, _bias, _params, body);
+                            Save1<term, type>(pd + 6 * dX, NULL, sum6, _bias, _params, body);
+                            Save1<term, type>(pd + 7 * dX, NULL, sum7, _bias, _params, body);
+                        }
+                        for (; dx < bodyX4; dx += 4, pd += 4 * dX)
+                        {
+                            svfloat32_t sum0 = svdup_n_f32(0.0f);
+                            svfloat32_t sum1 = svdup_n_f32(0.0f);
+                            svfloat32_t sum2 = svdup_n_f32(0.0f);
+                            svfloat32_t sum3 = svdup_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    svfloat32_t w0 = svld1_f32(body, pw);
+                                    sum0 = Madd<nofma>(body, sum0, LoadSrc(ps + 0 * ssX, body), w0);
+                                    sum1 = Madd<nofma>(body, sum1, LoadSrc(ps + 1 * ssX, body), w0);
+                                    sum2 = Madd<nofma>(body, sum2, LoadSrc(ps + 2 * ssX, body), w0);
+                                    sum3 = Madd<nofma>(body, sum3, LoadSrc(ps + 3 * ssX, body), w0);
+                                }
+                            }
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params, body);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params, body);
+                            Save1<term, type>(pd + 2 * dX, NULL, sum2, _bias, _params, body);
+                            Save1<term, type>(pd + 3 * dX, NULL, sum3, _bias, _params, body);
+                        }
+                        for (; dx < bodyX2; dx += 2, pd += 2 * dX)
+                        {
+                            svfloat32_t sum0 = svdup_n_f32(0.0f);
+                            svfloat32_t sum1 = svdup_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    svfloat32_t w0 = svld1_f32(body, pw);
+                                    sum0 = Madd<nofma>(body, sum0, LoadSrc(ps + 0 * ssX, body), w0);
+                                    sum1 = Madd<nofma>(body, sum1, LoadSrc(ps + 1 * ssX, body), w0);
+                                }
+                            }
+                            Save1<term, type>(pd + 0 * dX, NULL, sum0, _bias, _params, body);
+                            Save1<term, type>(pd + 1 * dX, NULL, sum1, _bias, _params, body);
+                        }
+                        for (; dx < bodyX; dx += 1, pd += dX)
+                        {
+                            svfloat32_t sum = svdup_n_f32(0.0f);
+                            const float* pw = weight;
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                const T* ps = src + (sy & sM) * sY + (dx * strideX - padX) * sX;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx, ps += sX, pw += F)
+                                {
+                                    svfloat32_t w0 = svld1_f32(body, pw);
+                                    sum = Madd<nofma>(body, sum, LoadSrc(ps, body), w0);
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                        }
+                        for (; dx < p.dstW; dx += 1, pd += dX)
+                        {
+                            svfloat32_t sum = svdup_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                {
+                                    size_t sx = dx * strideX + kx - padX;
+                                    if (sx < p.srcW)
+                                    {
+                                        const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                        const T* ps = src + (sy & sM) * sY + sx * sX;
+                                        sum = Madd<nofma>(body, sum, LoadSrc(ps, body), svld1_f32(body, pw));
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                        }
+                    }
+                    else
+                    {
+                        for (size_t dx = 0; dx < p.dstW; ++dx, pd += dX)
+                        {
+                            svfloat32_t sum = svdup_n_f32(0.0f);
+                            for (size_t ky = 0; ky < p.kernelY; ++ky)
+                            {
+                                size_t sy = dy * strideY + ky - padY;
+                                if (sy < p.srcH)
+                                {
+                                    for (size_t kx = 0; kx < p.kernelX; ++kx)
+                                    {
+                                        size_t sx = dx * strideX + kx - padX;
+                                        if (sx < p.srcW)
+                                        {
+                                            const float* pw = weight + (ky * p.kernelX + kx) * F;
+                                            const T* ps = src + (sy & sM) * sY + sx * sX;
+                                            sum = Madd<nofma>(body, sum, LoadSrc(ps, body), svld1_f32(body, pw));
+                                        }
+                                    }
+                                }
+                            }
+                            Save1<term, type>(pd, NULL, sum, _bias, _params, body);
+                        }
+                    }
+                }
+                src += sD;
+                dst += dD;
+                weight += wD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge2x2(const T* src0,
+            const T* src1, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+        {
+            const svbool_t body = svptrue_b32();
+            if (nofma)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                Save1<term, type>(dst, NULL, sum, bias, params, body);
+            }
+            else
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, sum0, sum1), bias, params, body);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge2x3(const T* src0,
+            const T* src1, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+        {
+            const svbool_t body = svptrue_b32();
+            if (nofma)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 2 * sX, body), weight[2]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 2 * sX, body), weight[5]);
+                Save1<term, type>(dst, NULL, sum, bias, params, body);
+            }
+            else
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f), sum2 = svdup_n_f32(0.0f);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum2 = Madd<false>(body, sum2, LoadSrc(src0 + 2 * sX, body), weight[2]);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                sum2 = Madd<false>(body, sum2, LoadSrc(src1 + 2 * sX, body), weight[5]);
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), sum2), bias, params, body);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Edge3x2(const T* src0,
+            const T* src1, const T* src2, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+        {
+            const svbool_t body = svptrue_b32();
+            if (nofma)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 0 * sX, body), weight[6]);
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 1 * sX, body), weight[7]);
+                Save1<term, type>(dst, NULL, sum, bias, params, body);
+            }
+            else
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src2 + 0 * sX, body), weight[6]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src2 + 1 * sX, body), weight[7]);
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, sum0, sum1), bias, params, body);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> SIMD_INLINE void DepthwiseConvolution3x3Main1x1(const T* src0,
+            const T* src1, const T* src2, size_t sX, const svfloat32_t* weight, const svfloat32_t* bias, const svfloat32_t* params, uint8_t* dst)
+        {
+            const svbool_t body = svptrue_b32();
+            if (nofma)
+            {
+                svfloat32_t sum = svdup_n_f32(0.0f);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum = Madd<true>(body, sum, LoadSrc(src0 + 2 * sX, body), weight[2]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                sum = Madd<true>(body, sum, LoadSrc(src1 + 2 * sX, body), weight[5]);
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 0 * sX, body), weight[6]);
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 1 * sX, body), weight[7]);
+                sum = Madd<true>(body, sum, LoadSrc(src2 + 2 * sX, body), weight[8]);
+                Save1<term, type>(dst, NULL, sum, bias, params, body);
+            }
+            else
+            {
+                svfloat32_t sum0 = svdup_n_f32(0.0f), sum1 = svdup_n_f32(0.0f), sum2 = svdup_n_f32(0.0f);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src0 + 0 * sX, body), weight[0]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src0 + 1 * sX, body), weight[1]);
+                sum2 = Madd<false>(body, sum2, LoadSrc(src0 + 2 * sX, body), weight[2]);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src1 + 0 * sX, body), weight[3]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src1 + 1 * sX, body), weight[4]);
+                sum2 = Madd<false>(body, sum2, LoadSrc(src1 + 2 * sX, body), weight[5]);
+                sum0 = Madd<false>(body, sum0, LoadSrc(src2 + 0 * sX, body), weight[6]);
+                sum1 = Madd<false>(body, sum1, LoadSrc(src2 + 1 * sX, body), weight[7]);
+                sum2 = Madd<false>(body, sum2, LoadSrc(src2 + 2 * sX, body), weight[8]);
+                Save1<term, type>(dst, NULL, svadd_f32_x(body, svadd_f32_x(body, sum0, sum1), sum2), bias, params, body);
+            }
+        }
+
+        template<typename T, Term16bType term, SimdConvolutionActivationType type, bool nofma> void DepthwiseConvolution3x3(const uint8_t* src8, const ConvParam& p, const AlgParam& a,
+            size_t maC, size_t yBeg, size_t yEnd, const float* weight, const float* bias, const float* params, uint8_t* dst)
+        {
+            const T* src = (T*)src8;
+            const size_t F = svcntw();
+            const svbool_t body = svptrue_b32();
+            size_t strideY = p.strideY, padY = p.padY, padX = p.padX, padH = p.padH, padW = p.padW, dstC = maC;
+            size_t sM = (a.bufH[1] - 1), sD = a.bufH[1] ? a.bufH[1] * p.srcW * F : F, sX = a.bufH[1] ? F : p.srcC, sY = sX * p.srcW;
+            size_t dX = (a.bufH[2] ? a.maC * 2 : p.dstC * a.elem[1]), dY = p.dstW * dX, dy0 = a.bufH[2] ? yBeg : 0, dD = a.bufH[2] ? F * 2 : F * a.elem[1];
+            size_t wD = p.kernelY * p.kernelX * F, ssX = p.strideX * sX, ssX0 = (p.strideX - p.padX) * sX;
+            size_t xMainEnd = p.dstW - p.padW, yMainEnd = yEnd == p.dstH && p.padH ? yEnd - 1 : yEnd;
+
+            svfloat32_t _params[2], _bias[1];
+            _params[0] = svdup_n_f32(params[0]);
+            _params[1] = svdup_n_f32(params[1]);
+            if (type == SimdConvolutionActivationRestrictRange ||
+                type == SimdConvolutionActivationHswish ||
+                type == SimdConvolutionActivationHardSigmoid)
+                _params[1] = svdup_n_f32(params[1]);
+            for (size_t c = 0; c < dstC; c += F)
+            {
+                svfloat32_t _weight[9];
+                for (size_t i = 0; i < 9; ++i)
+                    _weight[i] = svld1_f32(body, weight + i * F);
+                _bias[0] = svld1_f32(body, bias + c);
+                if (type == ::SimdConvolutionActivationPrelu)
+                    _params[0] = svld1_f32(body, params + c);
+
+                size_t dy = yBeg;
+                if (yBeg == 0 && padY)
+                {
+                    size_t sy = 0, dx = 0;
+                    const T* src0 = src + ((sy + 0) & sM) * sY;
+                    const T* src1 = src + ((sy + 1) & sM) * sY;
+                    uint8_t* pDst = dst + (dy - dy0) * dY;
+                    if (padX)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 4, _bias, _params, pDst),
+                        pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
+                    for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
+                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, _weight + 3, _bias, _params, pDst);
+                    if (padW)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 3, _bias, _params, pDst);
+                    dy++;
+                }
+                for (; dy < yMainEnd; ++dy)
+                {
+                    size_t sy = dy * strideY - padY, dx = 0;
+                    const T* src0 = src + ((sy + 0) & sM) * sY;
+                    const T* src1 = src + ((sy + 1) & sM) * sY;
+                    const T* src2 = src + ((sy + 2) & sM) * sY;
+                    uint8_t* pDst = dst + (dy - dy0) * dY;
+                    if (padX)
+                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, _weight + 1, _bias, _params, pDst),
+                        pDst += dX, dx++, src0 += ssX0, src1 += ssX0, src2 += ssX0;
+                    for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX, src2 += ssX)
+                        DepthwiseConvolution3x3Main1x1<T, term, type, nofma>(src0, src1, src2, sX, _weight + 0, _bias, _params, pDst);
+                    if (padW)
+                        DepthwiseConvolution3x3Edge3x2<T, term, type, nofma>(src0, src1, src2, sX, _weight + 0, _bias, _params, pDst);
+                }
+                if (dy < yEnd)
+                {
+                    size_t sy = dy * strideY - padY, dx = 0;
+                    const T* src0 = src + ((sy + 0) & sM) * sY;
+                    const T* src1 = src + ((sy + 1) & sM) * sY;
+                    uint8_t* pDst = dst + (dy - dy0) * dY;
+                    if (padX)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 1, _bias, _params, pDst),
+                        pDst += dX, dx++, src0 += ssX0, src1 += ssX0;
+                    for (; dx < xMainEnd; dx++, pDst += dX, src0 += ssX, src1 += ssX)
+                        DepthwiseConvolution3x3Edge2x3<T, term, type, nofma>(src0, src1, sX, _weight + 0, _bias, _params, pDst);
+                    if (padW)
+                        DepthwiseConvolution3x3Edge2x2<T, term, type, nofma>(src0, src1, sX, _weight + 0, _bias, _params, pDst);
+                }
+                src += sD;
+                dst += dD;
+                weight += wD;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type> static void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
+        {
+            const size_t F = svcntw();
+            if (IsKernel(p, 3) && IsDilation(p, 1) && Aligned(p.dstC, F))
+            {
+                if (Base::FmaAvoid(p.compatibility))
+                    depthwise = p.srcT == SimdTensorData16b ?
+                    DepthwiseConvolution3x3<uint16_t, term, type, true> :
+                    DepthwiseConvolution3x3<float, term, type, true>;
+                else
+                    depthwise = p.srcT == SimdTensorData16b ?
+                    DepthwiseConvolution3x3<uint16_t, term, type, false> :
+                    DepthwiseConvolution3x3<float, term, type, false>;
+            }
+            else
+            {
+                if (Base::FmaAvoid(p.compatibility))
+                {
+                    if (p.srcT == SimdTensorData16b)
+                        depthwise = DepthwiseConvolution<uint16_t, term, type, true>;
+                    else
+                        depthwise = DepthwiseConvolution<float, term, type, true>;
+                }
+                else
+                {
+                    if (p.srcT == SimdTensorData16b)
+                        depthwise = DepthwiseConvolution<uint16_t, term, type, false>;
+                    else
+                        depthwise = DepthwiseConvolution<float, term, type, false>;
+                }
+            }
+        }
+
+        template<SimdConvolutionActivationType type> static void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
+        {
+            if (p.dstT == SimdTensorData32f)
+                SetDepthwise<Term16bLast32f, type>(p, depthwise);
+            else
+                SetDepthwise<Term16bLast16b, type>(p, depthwise);
+        }
+
+        void SetDepthwise(const ConvParam& p, DepthwisePtr& depthwise)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, depthwise); break;
+            case SimdConvolutionActivationRelu: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, depthwise); break;
+            case SimdConvolutionActivationLeakyRelu: SetDepthwise<SimdConvolutionActivationPrelu>(p, depthwise); break;
+            case SimdConvolutionActivationRestrictRange: SetDepthwise<SimdConvolutionActivationRestrictRange>(p, depthwise); break;
+            case SimdConvolutionActivationPrelu: SetDepthwise<SimdConvolutionActivationPrelu>(p, depthwise); break;
+            case SimdConvolutionActivationElu: SetDepthwise<SimdConvolutionActivationElu>(p, depthwise); break;
+            case SimdConvolutionActivationHswish: SetDepthwise<SimdConvolutionActivationHswish>(p, depthwise); break;
+            case SimdConvolutionActivationMish: SetDepthwise<SimdConvolutionActivationMish>(p, depthwise); break;
+            case SimdConvolutionActivationHardSigmoid: SetDepthwise<SimdConvolutionActivationHardSigmoid>(p, depthwise); break;
+            case SimdConvolutionActivationSwish: SetDepthwise<SimdConvolutionActivationSwish>(p, depthwise); break;
+            case SimdConvolutionActivationGelu: SetDepthwise<SimdConvolutionActivationGelu>(p, depthwise); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution16bInput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16bInput.cpp
@@ -1,0 +1,273 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynetActivation.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdStore.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Sve2
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+        using InputPtr = Base::SynetMergedConvolution16b::InputConvolutionPtr;
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svbfloat16_t BroadcastBf16x2(const uint16_t* src)
+        {
+            return svreinterpret_bf16_u32(svdup_n_u32(uint32_t(src[0]) | (uint32_t(src[1]) << 16)));
+        }
+
+        SIMD_INLINE svbfloat16_t LoadBf16x2(const uint16_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_bf16_u32(svld1_u32(mask, (const uint32_t*)src));
+        }
+
+        template<SimdConvolutionActivationType type> SIMD_INLINE void SaveInput1(float* dst, svfloat32_t sum, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, size_t index, const svbool_t& mask)
+        {
+            svst1_f32(mask, dst, Activate<type>(svadd_f32_x(mask, sum, bias), param0, param1, index, mask));
+        }
+
+        template<SimdConvolutionActivationType type> SIMD_INLINE void SaveInput2(float* dst0, float* dst1, svfloat32_t sum0, svfloat32_t sum1,
+            svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask0, const svbool_t& mask1)
+        {
+            SaveInput1<type>(dst0, sum0, bias0, param0, param1, 0, mask0);
+            SaveInput1<type>(dst1, sum1, bias1, param0, param1, 1, mask1);
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type, int M> void InputConvolution1x1_2xM(const uint16_t* src0, const ConvParam& p,
+            const AlgParam& a, size_t dstC, const uint16_t* weight0, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41;
+            svbfloat16_t s0, w0, w1;
+            size_t srcC = AlignHi(p.srcC, a.miK);
+            const uint16_t* weight1 = weight0 + srcC * F;
+            const uint16_t* src1 = src0 + 1 * srcC;
+            const uint16_t* src2 = src0 + 2 * srcC;
+            const uint16_t* src3 = src0 + 3 * srcC;
+            const uint16_t* src4 = src0 + 4 * srcC;
+            if (dstC > F)
+            {
+                if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                for (size_t offs = 0, end = srcC; offs < end; offs += 2)
+                {
+                    w0 = LoadBf16x2(weight0, body);
+                    w1 = LoadBf16x2(weight1, body);
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16x2(src0 + offs);
+                        d00 = svbfdot_f32(d00, s0, w0);
+                        d01 = svbfdot_f32(d01, s0, w1);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16x2(src1 + offs);
+                        d10 = svbfdot_f32(d10, s0, w0);
+                        d11 = svbfdot_f32(d11, s0, w1);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16x2(src2 + offs);
+                        d20 = svbfdot_f32(d20, s0, w0);
+                        d21 = svbfdot_f32(d21, s0, w1);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16x2(src3 + offs);
+                        d30 = svbfdot_f32(d30, s0, w0);
+                        d31 = svbfdot_f32(d31, s0, w1);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16x2(src4 + offs);
+                        d40 = svbfdot_f32(d40, s0, w0);
+                        d41 = svbfdot_f32(d41, s0, w1);
+                    }
+                    weight0 += DF;
+                    weight1 += DF;
+                }
+                svbool_t mask1 = (dstC == DF) ? body : svwhilelt_b32((size_t)0, dstC - F);
+                if (M > 0) SaveInput2<type>(dst0 + 0 * F, dst1 + 0 * F, d00, d01, bias0, bias1, param0, param1, body, mask1);
+                if (M > 1) SaveInput2<type>(dst0 + 1 * F, dst1 + 1 * F, d10, d11, bias0, bias1, param0, param1, body, mask1);
+                if (M > 2) SaveInput2<type>(dst0 + 2 * F, dst1 + 2 * F, d20, d21, bias0, bias1, param0, param1, body, mask1);
+                if (M > 3) SaveInput2<type>(dst0 + 3 * F, dst1 + 3 * F, d30, d31, bias0, bias1, param0, param1, body, mask1);
+                if (M > 4) SaveInput2<type>(dst0 + 4 * F, dst1 + 4 * F, d40, d41, bias0, bias1, param0, param1, body, mask1);
+            }
+            else
+            {
+                if (M > 0) d00 = svdup_n_f32(0.0f);
+                if (M > 1) d10 = svdup_n_f32(0.0f);
+                if (M > 2) d20 = svdup_n_f32(0.0f);
+                if (M > 3) d30 = svdup_n_f32(0.0f);
+                if (M > 4) d40 = svdup_n_f32(0.0f);
+                for (size_t offs = 0, end = srcC; offs < end; offs += 2)
+                {
+                    w0 = LoadBf16x2(weight0, body);
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16x2(src0 + offs);
+                        d00 = svbfdot_f32(d00, s0, w0);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16x2(src1 + offs);
+                        d10 = svbfdot_f32(d10, s0, w0);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16x2(src2 + offs);
+                        d20 = svbfdot_f32(d20, s0, w0);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16x2(src3 + offs);
+                        d30 = svbfdot_f32(d30, s0, w0);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16x2(src4 + offs);
+                        d40 = svbfdot_f32(d40, s0, w0);
+                    }
+                    weight0 += DF;
+                }
+                svbool_t mask0 = (dstC == F) ? body : svwhilelt_b32((size_t)0, dstC);
+                if (M > 0) SaveInput1<type>(dst0 + 0 * F, d00, bias0, param0, param1, 0, mask0);
+                if (M > 1) SaveInput1<type>(dst0 + 1 * F, d10, bias0, param0, param1, 0, mask0);
+                if (M > 2) SaveInput1<type>(dst0 + 2 * F, d20, bias0, param0, param1, 0, mask0);
+                if (M > 3) SaveInput1<type>(dst0 + 3 * F, d30, bias0, param0, param1, 0, mask0);
+                if (M > 4) SaveInput1<type>(dst0 + 4 * F, d40, bias0, param0, param1, 0, mask0);
+            }
+        }
+
+        typedef void(*InputConvolution1x1_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a, size_t dstC,
+            const uint16_t* weight0, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* dst0, float* dst1);
+
+        template<SimdConvolutionActivationType type> InputConvolution1x1_2xM_Ptr GetInputConvolution1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return InputConvolution1x1_2xM<type, 1>;
+            case 2: return InputConvolution1x1_2xM<type, 2>;
+            case 3: return InputConvolution1x1_2xM<type, 3>;
+            case 4: return InputConvolution1x1_2xM<type, 4>;
+            case 5: return InputConvolution1x1_2xM<type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<SimdConvolutionActivationType type> void InputConvolution1x1_2(const uint16_t* src, const ConvParam& p,
+            const AlgParam& a, size_t maC, size_t yBeg, size_t yEnd, const uint16_t* weight, const float* bias, const float* params, float* sum, float* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            size_t dstM = a.bufH[1] - 1, dstS = a.bufH[1] * p.dstW * F, srcC = AlignHi(p.srcC, a.miK), y0 = a.bufH[0] ? yBeg : 0;
+            svfloat32_t param0 = svdup_n_f32(params[0]);
+            svfloat32_t param1 = svdup_n_f32(params[1]);
+            size_t yInt = Simd::Max(yBeg, AlignLo(yEnd, a.bufH[1])), n = 5;
+            size_t i1 = (yInt - yBeg) * p.dstW, in = AlignLoAny(i1, n), i = i1 - in;
+            size_t e1 = (yEnd - yInt) * p.dstW, en = AlignLoAny(e1, n), e = e1 - en;
+            InputConvolution1x1_2xM_Ptr inputConvolution1x1_2xN = GetInputConvolution1x1_2xM<type>(n);
+            InputConvolution1x1_2xM_Ptr inputConvolution1x1_2xI = GetInputConvolution1x1_2xM<type>(i);
+            InputConvolution1x1_2xM_Ptr inputConvolution1x1_2xE = GetInputConvolution1x1_2xM<type>(e);
+            for (size_t dc = 0; dc < maC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, maC - dc);
+                svfloat32_t bias0 = svld1_f32(body, bias + dc + 0);
+                svfloat32_t bias1 = svld1_f32(body, bias + dc + F);
+                if (type == ::SimdConvolutionActivationPrelu)
+                {
+                    param0 = svld1_f32(body, params + dc + 0);
+                    param1 = svld1_f32(body, params + dc + F);
+                }
+                if (yInt > yBeg)
+                {
+                    const uint16_t* src0 = src + (yBeg - y0) * p.srcW * srcC;
+                    float* dst0 = dst + (yBeg & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
+                    for (size_t j = 0; j < in; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
+                        inputConvolution1x1_2xN(src0, p, a, dC, weight, bias0, bias1, param0, param1, dst0, dst1);
+                    if (in < i1)
+                        inputConvolution1x1_2xI(src0, p, a, dC, weight, bias0, bias1, param0, param1, dst0, dst1);
+                }
+                if (yEnd > yInt)
+                {
+                    const uint16_t* src0 = src + (yInt - y0) * p.srcW * srcC;
+                    float* dst0 = dst + (yInt & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
+                    for (size_t j = 0; j < en; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
+                        inputConvolution1x1_2xN(src0, p, a, dC, weight, bias0, bias1, param0, param1, dst0, dst1);
+                    if (en < e1)
+                        inputConvolution1x1_2xE(src0, p, a, dC, weight, bias0, bias1, param0, param1, dst0, dst1);
+                }
+                dst += a.bufH[1] * p.dstW * DF;
+                weight += srcC * DF;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type> static void SetInput(const ConvParam& p, InputPtr& input)
+        {
+            if (Is1x1(p))
+                input = InputConvolution1x1_2<type>;
+            else
+                assert(0);
+        }
+
+        void SetInput(const ConvParam& p, InputPtr& input)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetInput<SimdConvolutionActivationRestrictRange>(p, input); break;
+            case SimdConvolutionActivationRelu: SetInput<SimdConvolutionActivationRestrictRange>(p, input); break;
+            case SimdConvolutionActivationLeakyRelu: SetInput<SimdConvolutionActivationPrelu>(p, input); break;
+            case SimdConvolutionActivationRestrictRange: SetInput<SimdConvolutionActivationRestrictRange>(p, input); break;
+            case SimdConvolutionActivationPrelu: SetInput<SimdConvolutionActivationPrelu>(p, input); break;
+            case SimdConvolutionActivationElu: SetInput<SimdConvolutionActivationElu>(p, input); break;
+            case SimdConvolutionActivationHswish: SetInput<SimdConvolutionActivationHswish>(p, input); break;
+            case SimdConvolutionActivationMish: SetInput<SimdConvolutionActivationMish>(p, input); break;
+            case SimdConvolutionActivationHardSigmoid: SetInput<SimdConvolutionActivationHardSigmoid>(p, input); break;
+            case SimdConvolutionActivationSwish: SetInput<SimdConvolutionActivationSwish>(p, input); break;
+            case SimdConvolutionActivationGelu: SetInput<SimdConvolutionActivationGelu>(p, input); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution16bOutput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16bOutput.cpp
@@ -1,0 +1,313 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetMergedConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynetActivation.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdSve2.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Sve2
+    {
+        using AlgParam = Base::SynetMergedConvolution16b::AlgParam;
+        using OutputPtr = Base::SynetMergedConvolution16b::OutputConvolutionPtr;
+
+        //---------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, mask);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t val1, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask0, const svbool_t& mask1)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, mask0);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, mask1);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t val1, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+        {
+            const size_t F = svcntw();
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, svptrue_b32());
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, svwhilelt_b32((size_t)0, tail));
+        }
+
+        //---------------------------------------------------------------------
+
+        SIMD_INLINE svbfloat16_t BroadcastBf16x2(const uint16_t* src)
+        {
+            return svreinterpret_bf16_u32(svdup_n_u32(uint32_t(src[0]) | (uint32_t(src[1]) << 16)));
+        }
+
+        SIMD_INLINE svbfloat16_t LoadBf16x2(const uint16_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_bf16_u32(svld1_u32(mask, (const uint32_t*)src));
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type, int M> void OutputConvolution1x1_2xM(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const svfloat32_t* bias, const svfloat32_t* params, float* buf, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41;
+            svbfloat16_t s0, w0, w1;
+            size_t dS = a.maC * p.strideX, dB = p.dstC, dD = p.dstC * a.elem[1];
+            const uint16_t* weight1 = weight0 + AlignHi(srcC, 2) * F;
+            const uint16_t* src1 = src0 + 1 * dS;
+            const uint16_t* src2 = src0 + 2 * dS;
+            const uint16_t* src3 = src0 + 3 * dS;
+            const uint16_t* src4 = src0 + 4 * dS;
+            if (dstC > F)
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f), d01 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f), d11 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f), d21 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f), d31 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f), d41 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(body, buf + 0 * dB + 0), d01 = svld1_f32(body, buf + 0 * dB + F);
+                    if (M > 1) d10 = svld1_f32(body, buf + 1 * dB + 0), d11 = svld1_f32(body, buf + 1 * dB + F);
+                    if (M > 2) d20 = svld1_f32(body, buf + 2 * dB + 0), d21 = svld1_f32(body, buf + 2 * dB + F);
+                    if (M > 3) d30 = svld1_f32(body, buf + 3 * dB + 0), d31 = svld1_f32(body, buf + 3 * dB + F);
+                    if (M > 4) d40 = svld1_f32(body, buf + 4 * dB + 0), d41 = svld1_f32(body, buf + 4 * dB + F);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 2)
+                {
+                    w0 = LoadBf16x2(weight0, body);
+                    w1 = LoadBf16x2(weight1, body);
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16x2(src0 + offs);
+                        d00 = svbfdot_f32(d00, s0, w0);
+                        d01 = svbfdot_f32(d01, s0, w1);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16x2(src1 + offs);
+                        d10 = svbfdot_f32(d10, s0, w0);
+                        d11 = svbfdot_f32(d11, s0, w1);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16x2(src2 + offs);
+                        d20 = svbfdot_f32(d20, s0, w0);
+                        d21 = svbfdot_f32(d21, s0, w1);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16x2(src3 + offs);
+                        d30 = svbfdot_f32(d30, s0, w0);
+                        d31 = svbfdot_f32(d31, s0, w1);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16x2(src4 + offs);
+                        d40 = svbfdot_f32(d40, s0, w0);
+                        d41 = svbfdot_f32(d41, s0, w1);
+                    }
+                    weight0 += DF;
+                    weight1 += DF;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, body, body), buf += dB, dst += dD;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, body, body), buf += dB, dst += dD;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, body, body), buf += dB, dst += dD;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, body, body), buf += dB, dst += dD;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, body, body), buf += dB, dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, dstC - F), buf += dB, dst += dD;
+                }
+            }
+            else
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = svdup_n_f32(0.0f);
+                    if (M > 1) d10 = svdup_n_f32(0.0f);
+                    if (M > 2) d20 = svdup_n_f32(0.0f);
+                    if (M > 3) d30 = svdup_n_f32(0.0f);
+                    if (M > 4) d40 = svdup_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = svld1_f32(body, buf + 0 * dB + 0);
+                    if (M > 1) d10 = svld1_f32(body, buf + 1 * dB + 0);
+                    if (M > 2) d20 = svld1_f32(body, buf + 2 * dB + 0);
+                    if (M > 3) d30 = svld1_f32(body, buf + 3 * dB + 0);
+                    if (M > 4) d40 = svld1_f32(body, buf + 4 * dB + 0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 2)
+                {
+                    w0 = LoadBf16x2(weight0, body);
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16x2(src0 + offs);
+                        d00 = svbfdot_f32(d00, s0, w0);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16x2(src1 + offs);
+                        d10 = svbfdot_f32(d10, s0, w0);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16x2(src2 + offs);
+                        d20 = svbfdot_f32(d20, s0, w0);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16x2(src3 + offs);
+                        d30 = svbfdot_f32(d30, s0, w0);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16x2(src4 + offs);
+                        d40 = svbfdot_f32(d40, s0, w0);
+                    }
+                    weight0 += DF;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, body), buf += dB, dst += dD;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, body), buf += dB, dst += dD;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, body), buf += dB, dst += dD;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, body), buf += dB, dst += dD;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, body), buf += dB, dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, dstC), buf += dB, dst += dD;
+                }
+            }
+        }
+
+        typedef void(*OutputConvolution1x1_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const svfloat32_t* bias, const svfloat32_t* params, float* buf, uint8_t* dst);
+
+        template<Term16bType term, SimdConvolutionActivationType type> OutputConvolution1x1_2xM_Ptr GetOutputConvolution1x1_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return OutputConvolution1x1_2xM<term, type, 1>;
+            case 2: return OutputConvolution1x1_2xM<term, type, 2>;
+            case 3: return OutputConvolution1x1_2xM<term, type, 3>;
+            case 4: return OutputConvolution1x1_2xM<term, type, 4>;
+            case 5: return OutputConvolution1x1_2xM<term, type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> void OutputConvolution1x1_2(const uint16_t* src, const ConvParam& p, const AlgParam& a,
+            size_t maC, size_t yBeg, size_t yEnd, int zero, const uint16_t* weight, const float* bias, const float* params, float* buf, float*, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            size_t n = 5, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            OutputConvolution1x1_2xM_Ptr outputConvolution1x1_2xN = GetOutputConvolution1x1_2xM<term, type>(n);
+            OutputConvolution1x1_2xM_Ptr outputConvolution1x1_2xM = GetOutputConvolution1x1_2xM<term, type>(m);
+            svfloat32_t _bias[2], _params[2];
+            _params[0] = svdup_n_f32(params[0]);
+            _params[1] = svdup_n_f32(params[1]);
+            for (size_t dc = 0; dc < p.dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, p.dstC - dc);
+                _bias[0] = svld1_f32(body, bias + dc + 0);
+                _bias[1] = svld1_f32(body, bias + dc + F);
+                if (type == ::SimdConvolutionActivationPrelu)
+                {
+                    _params[0] = svld1_f32(body, params + dc + 0);
+                    _params[1] = svld1_f32(body, params + dc + F);
+                }
+                const uint16_t* s = src;
+                float* b = buf + dc + yBeg * p.dstW * p.dstC;
+                uint8_t* d = dst + (dc + yBeg * p.dstW * p.dstC) * a.elem[1];
+                size_t i = 0;
+                for (; i < nn; i += n, s += a.maC * n, b += p.dstC * n, d += p.dstC * a.elem[1] * n)
+                    outputConvolution1x1_2xN(s, p, a, maC, dC, zero, weight, _bias, _params, b, d);
+                for (; i < n1; i += m, s += a.maC * m, b += p.dstC * m, d += p.dstC * a.elem[1] * m)
+                    outputConvolution1x1_2xM(s, p, a, maC, dC, zero, weight, _bias, _params, b, d);
+                weight += AlignHi(maC, 2) * DF;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type> static void SetOutput(const ConvParam& p, OutputPtr* output)
+        {
+            if (p.dstT == SimdTensorData16b)
+                output[0] = OutputConvolution1x1_2<Term16bLast16b, type>;
+            else
+                output[0] = OutputConvolution1x1_2<Term16bLast32f, type>;
+            output[1] = OutputConvolution1x1_2<Term16bInterim, SimdConvolutionActivationIdentity>;
+        }
+
+        void SetOutput(const ConvParam& p, OutputPtr* output)
+        {
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: SetOutput<SimdConvolutionActivationRestrictRange>(p, output); break;
+            case SimdConvolutionActivationRelu: SetOutput<SimdConvolutionActivationRestrictRange>(p, output); break;
+            case SimdConvolutionActivationLeakyRelu: SetOutput<SimdConvolutionActivationPrelu>(p, output); break;
+            case SimdConvolutionActivationRestrictRange: SetOutput<SimdConvolutionActivationRestrictRange>(p, output); break;
+            case SimdConvolutionActivationPrelu: SetOutput<SimdConvolutionActivationPrelu>(p, output); break;
+            case SimdConvolutionActivationElu: SetOutput<SimdConvolutionActivationElu>(p, output); break;
+            case SimdConvolutionActivationHswish: SetOutput<SimdConvolutionActivationHswish>(p, output); break;
+            case SimdConvolutionActivationMish: SetOutput<SimdConvolutionActivationMish>(p, output); break;
+            case SimdConvolutionActivationHardSigmoid: SetOutput<SimdConvolutionActivationHardSigmoid>(p, output); break;
+            case SimdConvolutionActivationSwish: SetOutput<SimdConvolutionActivationSwish>(p, output); break;
+            case SimdConvolutionActivationGelu: SetOutput<SimdConvolutionActivationGelu>(p, output); break;
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetMergedConvolution16bOutput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution16bOutput.cpp
@@ -42,27 +42,28 @@ namespace Simd
 
         //---------------------------------------------------------------------
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, mask);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias0, param0, param1, mask);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t bias0, svfloat32_t param0, svfloat32_t param1, size_t tail)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias0, param0, param1, tail);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t val1, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask0, const svbool_t& mask1)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t val1,
+            svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask0, const svbool_t& mask1)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, mask0);
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, mask1);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias0, param0, param1, mask0);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias1, param0, param1, mask1);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t val1, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, svfloat32_t val0, svfloat32_t val1,
+            svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, size_t tail)
         {
-            const size_t F = svcntw();
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, svptrue_b32());
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, svwhilelt_b32((size_t)0, tail));
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias0, param0, param1, svptrue_b32());
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias1, param0, param1, svwhilelt_b32((size_t)0, tail));
         }
 
         //---------------------------------------------------------------------
@@ -78,7 +79,7 @@ namespace Simd
         }
 
         template<Term16bType term, SimdConvolutionActivationType type, int M> void OutputConvolution1x1_2xM(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const svfloat32_t* bias, const svfloat32_t* params, float* buf, uint8_t* dst)
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* buf, uint8_t* dst)
         {
             const size_t F = svcntw(), DF = F * 2;
             const svbool_t body = svptrue_b32();
@@ -147,19 +148,19 @@ namespace Simd
                 }
                 if (dstC == DF)
                 {
-                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, body, body), buf += dB, dst += dD;
-                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, body, body), buf += dB, dst += dD;
-                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, body, body), buf += dB, dst += dD;
-                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, body, body), buf += dB, dst += dD;
-                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, body, body), buf += dB, dst += dD;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias0, bias1, param0, param1, body, body), buf += dB, dst += dD;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias0, bias1, param0, param1, body, body), buf += dB, dst += dD;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias0, bias1, param0, param1, body, body), buf += dB, dst += dD;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias0, bias1, param0, param1, body, body), buf += dB, dst += dD;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias0, bias1, param0, param1, body, body), buf += dB, dst += dD;
                 }
                 else
                 {
-                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, dstC - F), buf += dB, dst += dD;
-                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, dstC - F), buf += dB, dst += dD;
-                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, dstC - F), buf += dB, dst += dD;
-                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, dstC - F), buf += dB, dst += dD;
-                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, dstC - F), buf += dB, dst += dD;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias0, bias1, param0, param1, dstC - F), buf += dB, dst += dD;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias0, bias1, param0, param1, dstC - F), buf += dB, dst += dD;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias0, bias1, param0, param1, dstC - F), buf += dB, dst += dD;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias0, bias1, param0, param1, dstC - F), buf += dB, dst += dD;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias0, bias1, param0, param1, dstC - F), buf += dB, dst += dD;
                 }
             }
             else
@@ -212,25 +213,25 @@ namespace Simd
                 }
                 if (dstC == F)
                 {
-                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, body), buf += dB, dst += dD;
-                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, body), buf += dB, dst += dD;
-                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, body), buf += dB, dst += dD;
-                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, body), buf += dB, dst += dD;
-                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, body), buf += dB, dst += dD;
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias0, param0, param1, body), buf += dB, dst += dD;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias0, param0, param1, body), buf += dB, dst += dD;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias0, param0, param1, body), buf += dB, dst += dD;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias0, param0, param1, body), buf += dB, dst += dD;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias0, param0, param1, body), buf += dB, dst += dD;
                 }
                 else
                 {
-                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, dstC), buf += dB, dst += dD;
-                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, dstC), buf += dB, dst += dD;
-                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, dstC), buf += dB, dst += dD;
-                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, dstC), buf += dB, dst += dD;
-                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, dstC), buf += dB, dst += dD;
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias0, param0, param1, dstC), buf += dB, dst += dD;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias0, param0, param1, dstC), buf += dB, dst += dD;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias0, param0, param1, dstC), buf += dB, dst += dD;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias0, param0, param1, dstC), buf += dB, dst += dD;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias0, param0, param1, dstC), buf += dB, dst += dD;
                 }
             }
         }
 
         typedef void(*OutputConvolution1x1_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const svfloat32_t* bias, const svfloat32_t* params, float* buf, uint8_t* dst);
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, svfloat32_t bias0, svfloat32_t bias1, svfloat32_t param0, svfloat32_t param1, float* buf, uint8_t* dst);
 
         template<Term16bType term, SimdConvolutionActivationType type> OutputConvolution1x1_2xM_Ptr GetOutputConvolution1x1_2xM(size_t M)
         {
@@ -255,27 +256,26 @@ namespace Simd
             size_t n = 5, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
             OutputConvolution1x1_2xM_Ptr outputConvolution1x1_2xN = GetOutputConvolution1x1_2xM<term, type>(n);
             OutputConvolution1x1_2xM_Ptr outputConvolution1x1_2xM = GetOutputConvolution1x1_2xM<term, type>(m);
-            svfloat32_t _bias[2], _params[2];
-            _params[0] = svdup_n_f32(params[0]);
-            _params[1] = svdup_n_f32(params[1]);
+            svfloat32_t param0 = svdup_n_f32(params[0]);
+            svfloat32_t param1 = svdup_n_f32(params[1]);
             for (size_t dc = 0; dc < p.dstC; dc += DF)
             {
                 size_t dC = Simd::Min(DF, p.dstC - dc);
-                _bias[0] = svld1_f32(body, bias + dc + 0);
-                _bias[1] = svld1_f32(body, bias + dc + F);
+                svfloat32_t bias0 = svld1_f32(body, bias + dc + 0);
+                svfloat32_t bias1 = svld1_f32(body, bias + dc + F);
                 if (type == ::SimdConvolutionActivationPrelu)
                 {
-                    _params[0] = svld1_f32(body, params + dc + 0);
-                    _params[1] = svld1_f32(body, params + dc + F);
+                    param0 = svld1_f32(body, params + dc + 0);
+                    param1 = svld1_f32(body, params + dc + F);
                 }
                 const uint16_t* s = src;
                 float* b = buf + dc + yBeg * p.dstW * p.dstC;
                 uint8_t* d = dst + (dc + yBeg * p.dstW * p.dstC) * a.elem[1];
                 size_t i = 0;
                 for (; i < nn; i += n, s += a.maC * n, b += p.dstC * n, d += p.dstC * a.elem[1] * n)
-                    outputConvolution1x1_2xN(s, p, a, maC, dC, zero, weight, _bias, _params, b, d);
+                    outputConvolution1x1_2xN(s, p, a, maC, dC, zero, weight, bias0, bias1, param0, param1, b, d);
                 for (; i < n1; i += m, s += a.maC * m, b += p.dstC * m, d += p.dstC * a.elem[1] * m)
-                    outputConvolution1x1_2xM(s, p, a, maC, dC, zero, weight, _bias, _params, b, d);
+                    outputConvolution1x1_2xM(s, p, a, maC, dC, zero, weight, bias0, bias1, param0, param1, b, d);
                 weight += AlignHi(maC, 2) * DF;
             }
         }

--- a/src/Simd/SimdSynetConvolution16bCommon.h
+++ b/src/Simd/SimdSynetConvolution16bCommon.h
@@ -1343,5 +1343,94 @@ namespace Simd
 
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
+        {
+            svuint32_t bits = svreinterpret_u32_f32(value);
+            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+        }
+
+        template <class T> SIMD_INLINE svfloat32_t LoadSrc(const T* src, const svbool_t& mask);
+
+        template <> SIMD_INLINE svfloat32_t LoadSrc<float>(const float* src, const svbool_t& mask)
+        {
+            return svld1_f32(mask, src);
+        }
+
+        template <> SIMD_INLINE svfloat32_t LoadSrc<uint16_t>(const uint16_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_f32_u32(svlsl_n_u32_x(mask, svld1uh_u32(mask, src), Base::Bf16::SHIFT));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        template <Term16bType term> struct Term16b
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask);
+        };
+
+        template <> struct Term16b<Term16bLast16b>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+            {
+                const size_t F = svcntw();
+                svfloat32_t f32 = Activate<type>(svadd_f32_x(mask, value, bias[index]), params[0], params[1], index, mask);
+                svst1h_u32(mask, (uint16_t*)(ptr + F * sizeof(uint16_t) * index), Float32ToBFloat16(f32, mask));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+            {
+                Save<type, index>(ptr, buf, value, bias, params, svwhilelt_b32((size_t)0, tail));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params)
+            {
+                Save<type, index>(ptr, buf, value, bias, params, svptrue_b32());
+            }
+        };
+
+        template <> struct Term16b<Term16bLast32f>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+            {
+                const size_t F = svcntw();
+                svst1_f32(mask, (float*)ptr + index * F, Activate<type>(svadd_f32_x(mask, value, bias[index]), params[0], params[1], index, mask));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+            {
+                Save<type, index>(ptr, buf, value, bias, params, svwhilelt_b32((size_t)0, tail));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params)
+            {
+                Save<type, index>(ptr, buf, value, bias, params, svptrue_b32());
+            }
+        };
+
+        template <> struct Term16b<Term16bInterim>
+        {
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+            {
+                const size_t F = svcntw();
+                svst1_f32(mask, buf + index * F, value);
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+            {
+                Save<type, index>(ptr, buf, value, bias, params, svwhilelt_b32((size_t)0, tail));
+            }
+
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params)
+            {
+                Save<type, index>(ptr, buf, value, bias, params, svptrue_b32());
+            }
+        };
+    }
+#endif
 }
 #endif

--- a/src/Simd/SimdSynetConvolution16bCommon.h
+++ b/src/Simd/SimdSynetConvolution16bCommon.h
@@ -1347,13 +1347,6 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
-        {
-            svuint32_t bits = svreinterpret_u32_f32(value);
-            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
-            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
-        }
-
         template <class T> SIMD_INLINE svfloat32_t LoadSrc(const T* src, const svbool_t& mask);
 
         template <> SIMD_INLINE svfloat32_t LoadSrc<float>(const float* src, const svbool_t& mask)
@@ -1370,64 +1363,66 @@ namespace Simd
 
         template <Term16bType term> struct Term16b
         {
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask);
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
         };
 
         template <> struct Term16b<Term16bLast16b>
         {
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
             {
                 const size_t F = svcntw();
-                svfloat32_t f32 = Activate<type>(svadd_f32_x(mask, value, bias[index]), params[0], params[1], index, mask);
-                svst1h_u32(mask, (uint16_t*)(ptr + F * sizeof(uint16_t) * index), Float32ToBFloat16(f32, mask));
+                svfloat32_t f32 = Activate<type>(svadd_f32_x(mask, value, bias), param0, param1, index, mask);
+                svuint32_t bits = svreinterpret_u32_f32(f32);
+                svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
+                svst1h_u32(mask, (uint16_t*)(ptr + F * sizeof(uint16_t) * index), svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, size_t tail)
             {
-                Save<type, index>(ptr, buf, value, bias, params, svwhilelt_b32((size_t)0, tail));
+                Save<type, index>(ptr, buf, value, bias, param0, param1, svwhilelt_b32((size_t)0, tail));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1)
             {
-                Save<type, index>(ptr, buf, value, bias, params, svptrue_b32());
+                Save<type, index>(ptr, buf, value, bias, param0, param1, svptrue_b32());
             }
         };
 
         template <> struct Term16b<Term16bLast32f>
         {
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
             {
                 const size_t F = svcntw();
-                svst1_f32(mask, (float*)ptr + index * F, Activate<type>(svadd_f32_x(mask, value, bias[index]), params[0], params[1], index, mask));
+                svst1_f32(mask, (float*)ptr + index * F, Activate<type>(svadd_f32_x(mask, value, bias), param0, param1, index, mask));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, size_t tail)
             {
-                Save<type, index>(ptr, buf, value, bias, params, svwhilelt_b32((size_t)0, tail));
+                Save<type, index>(ptr, buf, value, bias, param0, param1, svwhilelt_b32((size_t)0, tail));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1)
             {
-                Save<type, index>(ptr, buf, value, bias, params, svptrue_b32());
+                Save<type, index>(ptr, buf, value, bias, param0, param1, svptrue_b32());
             }
         };
 
         template <> struct Term16b<Term16bInterim>
         {
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, const svbool_t& mask)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
             {
                 const size_t F = svcntw();
                 svst1_f32(mask, buf + index * F, value);
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params, size_t tail)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1, size_t tail)
             {
-                Save<type, index>(ptr, buf, value, bias, params, svwhilelt_b32((size_t)0, tail));
+                Save<type, index>(ptr, buf, value, bias, param0, param1, svwhilelt_b32((size_t)0, tail));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, const svfloat32_t* bias, const svfloat32_t* params)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, svfloat32_t value, svfloat32_t bias, svfloat32_t param0, svfloat32_t param1)
             {
-                Save<type, index>(ptr, buf, value, bias, params, svptrue_b32());
+                Save<type, index>(ptr, buf, value, bias, param0, param1, svptrue_b32());
             }
         };
     }

--- a/src/Simd/SimdSynetMergedConvolution16b.h
+++ b/src/Simd/SimdSynetMergedConvolution16b.h
@@ -354,5 +354,43 @@ namespace Simd
         void* SynetMergedConvolution16bInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        void SetInput(const ConvParam& p, Base::SynetMergedConvolution16b::InputConvolutionPtr& input);
+
+        void SetDepthwise(const ConvParam& p, Base::SynetMergedConvolution16b::DepthwiseConvolutionPtr& depthwise);
+
+        void SetOutput(const ConvParam& p, Base::SynetMergedConvolution16b::OutputConvolutionPtr* output);
+
+        //-------------------------------------------------------------------------------------------------
+
+        class SynetMergedConvolution16bCdc : public Base::SynetMergedConvolution16bCdc
+        {
+        public:
+            SynetMergedConvolution16bCdc(const MergConvParam& p);
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        class SynetMergedConvolution16bCd : public Base::SynetMergedConvolution16bCd
+        {
+        public:
+            SynetMergedConvolution16bCd(const MergConvParam& p);
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        class SynetMergedConvolution16bDc : public Base::SynetMergedConvolution16bDc
+        {
+        public:
+            SynetMergedConvolution16bDc(const MergConvParam& p);
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetMergedConvolution16bInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, SimdBool add);
+    }
+#endif
 }
 #endif

--- a/src/Test/TestSynetMergedConvolution16b.cpp
+++ b/src/Test/TestSynetMergedConvolution16b.cpp
@@ -381,6 +381,11 @@ namespace Test
             result = result && SynetMergedConvolution16bForwardAutoTest(EPS, FUNC_MC(Simd::Neon::SynetMergedConvolution16bInit), FUNC_MC(SimdSynetMergedConvolution16bInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetMergedConvolution16bForwardAutoTest(EPS, FUNC_MC(Simd::Sve2::SynetMergedConvolution16bInit), FUNC_MC(SimdSynetMergedConvolution16bInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add SVE2/SVE-BF16 optimizations for `SynetMergedConvolution16bCdc`, `SynetMergedConvolution16bCd`, and `SynetMergedConvolution16bDc` (Input/Depthwise/Output kernels using `svbfdot_f32` where applicable).
- Wire `SimdSynetMergedConvolution16bInit` dispatch and `Test::SynetMergedConvolution16bAutoTest` for SVE2.
- Update `prj/vs2022/Sve2.vcxproj(.filters)` and document NEON/SVE2 MergedConvolution16b entries under release 7.2.165 in `docs/2026.html`.

## Validation
- Cross-compiled `Simd` and `Test` for aarch64 with `-DSIMD_SVE2=ON` (`aarch64-linux-gnu-g++`, `-march=armv9-a+sve+sve2+i8mm+bf16`); both targets built successfully.
- Runtime SVE2 correctness/perf checks need ARM64 SVE2 hardware (`./Test "-r=.." -fi=SynetMergedConvolution16b -tt=1 -ts=1`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cb48e94-6565-4e1f-934b-5753c97770b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cb48e94-6565-4e1f-934b-5753c97770b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

