### PR TITLE
Add NEON optimizations for SynetConvolution16bNchwGemm

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -53,6 +53,7 @@
  <li>SVE2 optimizations of class SynetInnerProduct32fProd.</li>
  <li>NEON, SVE2 optimizations of class SynetInnerProduct16bGemmNN.</li>
  <li>NEON, SVE2 optimizations of class SynetDeconvolution16bNhwcGemm.</li>
+ <li>NEON optimizations of class SynetConvolution16bNchwGemm.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCdc.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCd.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iDc.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -121,6 +121,8 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32fNhwcDirect3r.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32fNhwcDirect4r.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution8i.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16b.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNchwGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution16bNhwcGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution32f.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -283,6 +283,12 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution8i.cpp">
       <Filter>Neon\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16b.cpp">
+      <Filter>Neon\Synet\Convolution</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNchwGemm.cpp">
+      <Filter>Neon\Synet\Convolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32f.cpp">
       <Filter>Neon\Synet\Convolution</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -6266,7 +6266,7 @@ SIMD_API void* SimdSynetConvolution16bInit(size_t batch, const SimdConvolutionPa
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetConvolution6bInitPtr) (size_t batch, const SimdConvolutionParameters* conv, SimdSynetCompatibilityType compatibility);
-    const static SimdSynetConvolution6bInitPtr simdSynetConvolution6bInit = SIMD_FUNC4(SynetConvolution16bInit, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC);
+    const static SimdSynetConvolution6bInitPtr simdSynetConvolution6bInit = SIMD_FUNC5(SynetConvolution16bInit, SIMD_AMXBF16_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetConvolution6bInit(batch, conv, compatibility);
 #else

--- a/src/Simd/SimdNeonSynetConvolution16b.cpp
+++ b/src/Simd/SimdNeonSynetConvolution16b.cpp
@@ -1,0 +1,42 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution16b.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Neon
+    {
+        void* SynetConvolution16bInit(size_t batch, const SimdConvolutionParameters* conv, SimdSynetCompatibilityType compatibility)
+        {
+            ConvParam param(batch, conv, compatibility);
+            if (!param.Valid(SimdTensorData32f, SimdTensorData16b))
+                return NULL;
+            if (SynetConvolution16bNchwGemm::Preferable(param))
+                return new Neon::SynetConvolution16bNchwGemm(param);
+            return new Base::SynetConvolution16bGemm(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdNeonSynetConvolution16bNchwGemm.cpp
+++ b/src/Simd/SimdNeonSynetConvolution16bNchwGemm.cpp
@@ -1,0 +1,567 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdSynetConvolution32fCommon.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Neon
+    {
+        typedef Base::SynetConvolution16bNchwGemm::AlgParam AlgParam;
+        typedef Base::SynetConvolution16bNchwGemm::ConvolutionPtr Convolution;
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE float32x4_t BroadcastBf16(uint16_t value)
+        {
+            return vreinterpretq_f32_u32(vdupq_n_u32(uint32_t(value) << Base::Bf16::SHIFT));
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE void ConvertF(const float* src, size_t stride, uint16_t*& dst)
+        {
+            uint32x4_t even = Float32ToBFloat16(Load<false>(src));
+            uint32x4_t odd = vshlq_n_u32(Float32ToBFloat16(Load<false>(src + stride)), Base::Bf16::SHIFT);
+            Store<false>((uint32_t*)dst, vorrq_u32(even, odd));
+            dst += DF;
+        }
+
+        static void Convert16bNchwGemm1x1(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, size_t cBeg, size_t cEnd, uint16_t* dst)
+        {
+            const float* src = ((float*)src8) + (cBeg * p.srcH + yBeg) * p.srcW;
+            size_t N = (yEnd - yBeg) * p.srcW, NF = AlignLo(N, a.F), j, dS = p.srcH * p.srcW;
+            size_t K = Min(cEnd, a.K) - cBeg, K2 = AlignLo(K, 2), KH = AlignHi(K, a.microK), k;
+            for (j = 0; j < NF; j += a.F)
+            {
+                for (k = 0; k < K2; k += 2)
+                {
+                    const float* src0 = src + k * dS;
+                    for (size_t f = 0; f < a.F; f += F)
+                        ConvertF(src0 + f, dS, dst);
+                }
+                for (; k < K; k += 2)
+                {
+                    const float* src0 = src + k * dS;
+                    for (size_t f = 0; f < a.F; ++f)
+                    {
+                        *dst++ = Base::Float32ToBFloat16(src0[f]);
+                        *dst++ = 0;
+                    }
+                }
+                for (; k < KH; k += 2)
+                {
+                    for (size_t f = 0; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+                src += a.F;
+            }
+            if (j < N)
+            {
+                size_t tail = N - j, f;
+                for (k = 0; k < K2; k += 2)
+                {
+                    const float* src0 = src + k * dS, * src1 = src0 + dS;
+                    for (f = 0; f < tail; ++f)
+                    {
+                        *dst++ = Base::Float32ToBFloat16(src0[f]);
+                        *dst++ = Base::Float32ToBFloat16(src1[f]);
+                    }
+                    for (; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+                for (; k < K; k += 2)
+                {
+                    const float* src0 = src + k * dS;
+                    for (f = 0; f < tail; ++f)
+                    {
+                        *dst++ = Base::Float32ToBFloat16(src0[f]);
+                        *dst++ = 0;
+                    }
+                    for (; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+                for (; k < KH; k += 2)
+                {
+                    for (size_t f = 0; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+            }
+        }
+
+        SIMD_INLINE void ReorderF(const uint16_t* src, size_t stride, uint16_t*& dst)
+        {
+            uint16x4x2_t zipped = vzip_u16(vld1_u16(src), vld1_u16(src + stride));
+            Store<false>(dst, vcombine_u16(zipped.val[0], zipped.val[1]));
+            dst += DF;
+        }
+
+        static void Reorder16bNchwGemm1x1(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, size_t cBeg, size_t cEnd, uint16_t* dst)
+        {
+            const uint16_t* src = ((uint16_t*)src8) + (cBeg * p.srcH + yBeg) * p.srcW;
+            size_t N = (yEnd - yBeg) * p.srcW, NF = AlignLo(N, a.F), j = 0, dS = p.srcH * p.srcW;
+            size_t K = Min(cEnd, a.K) - cBeg, K2 = AlignLo(K, 2), KH = AlignHi(K, a.microK), k;
+            for (; j < NF; j += a.F)
+            {
+                for (k = 0; k < K2; k += 2)
+                {
+                    const uint16_t* src0 = src + k * dS;
+                    for (size_t f = 0; f < a.F; f += F)
+                        ReorderF(src0 + f, dS, dst);
+                }
+                for (; k < K; k += 2)
+                {
+                    const uint16_t* src0 = src + k * dS;
+                    for (size_t f = 0; f < a.F; ++f)
+                    {
+                        *dst++ = src0[f];
+                        *dst++ = 0;
+                    }
+                }
+                for (; k < KH; k += 2)
+                {
+                    for (size_t f = 0; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+                src += a.F;
+            }
+            if (j < N)
+            {
+                size_t tail = N - j, f;
+                for (k = 0; k < K2; k += 2)
+                {
+                    const uint16_t* src0 = src + k * dS, * src1 = src0 + dS;
+                    for (f = 0; f < tail; ++f)
+                    {
+                        *dst++ = src0[f];
+                        *dst++ = src1[f];
+                    }
+                    for (; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+                for (; k < K; k += 2)
+                {
+                    const uint16_t* src0 = src + k * dS;
+                    for (f = 0; f < tail; ++f)
+                    {
+                        *dst++ = src0[f];
+                        *dst++ = 0;
+                    }
+                    for (; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+                for (; k < KH; k += 2)
+                {
+                    for (size_t f = 0; f < a.F; ++f)
+                    {
+                        *dst++ = 0;
+                        *dst++ = 0;
+                    }
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(
+            uint8_t* ptr, float* buf, float32x4_t val, const float* bias, const float* params, size_t offset)
+        {
+            if (term == Term16bInterim)
+            {
+                Store<false>(buf, val);
+            }
+            else
+            {
+                float32x4_t f32 = ActivateNchw<type>(vaddq_f32(val, vdupq_n_f32(bias[offset])), params, offset);
+                if (term == Term16bLast16b)
+                    Store<false>((uint16_t*)ptr, vmovn_u32(Float32ToBFloat16(f32)));
+                else
+                    Store<false>((float*)ptr, f32);
+            }
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(
+            uint8_t* ptr, float* buf, float32x4_t val, const float* bias, const float* params, size_t offset, size_t tail)
+        {
+            if (term == Term16bInterim)
+            {
+                float tmp[F];
+                Store<false>(tmp, val);
+                for (size_t i = 0; i < tail; ++i)
+                    buf[i] = tmp[i];
+            }
+            else
+            {
+                float32x4_t f32 = ActivateNchw<type>(vaddq_f32(val, vdupq_n_f32(bias[offset])), params, offset);
+                if (term == Term16bLast16b)
+                {
+                    uint16_t tmp[F];
+                    Store<false>(tmp, vmovn_u32(Float32ToBFloat16(f32)));
+                    for (size_t i = 0; i < tail; ++i)
+                        ((uint16_t*)ptr)[i] = tmp[i];
+                }
+                else
+                {
+                    float tmp[F];
+                    Store<false>(tmp, f32);
+                    for (size_t i = 0; i < tail; ++i)
+                        ((float*)ptr)[i] = tmp[i];
+                }
+            }
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(
+            uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float* bias, const float* params, size_t offset)
+        {
+            if (term == Term16bInterim)
+            {
+                Store<false>(buf + 0, val0);
+                Store<false>(buf + F, val1);
+            }
+            else
+            {
+                float32x4_t f32 = ActivateNchw<type>(vaddq_f32(val0, vdupq_n_f32(bias[offset])), params, offset);
+                if (term == Term16bLast16b)
+                    Store<false>((uint16_t*)ptr, vmovn_u32(Float32ToBFloat16(f32)));
+                else
+                    Store<false>((float*)ptr, f32);
+                f32 = ActivateNchw<type>(vaddq_f32(val1, vdupq_n_f32(bias[offset])), params, offset);
+                if (term == Term16bLast16b)
+                    Store<false>((uint16_t*)ptr + F, vmovn_u32(Float32ToBFloat16(f32)));
+                else
+                    Store<false>((float*)ptr + F, f32);
+            }
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(
+            uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float* bias, const float* params, size_t offset, size_t tail)
+        {
+            Save1<term, type>(ptr, buf, val0, bias, params, offset);
+            if (term == Term16bInterim)
+                Save1<term, type>(ptr, buf + F, val1, bias, params, offset, tail);
+            else if (term == Term16bLast16b)
+                Save1<term, type>(ptr + F * sizeof(uint16_t), buf, val1, bias, params, offset, tail);
+            else
+                Save1<term, type>(ptr + F * sizeof(float), buf, val1, bias, params, offset, tail);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type, int M> void Convolution16bNchwGemm_2xM(const uint16_t* weight0, const ConvParam& p, const AlgParam& a,
+            size_t K, size_t dstS, int zero, const uint16_t* src0, const float* bias, const float* params, float* buf, uint8_t* dst)
+        {
+            float32x4_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, w0, s00, s01, s10, s11;
+            size_t dB = a.sumBuf ? a.bufN : a.N, dD = a.N * a.elem;
+            const uint16_t* src1 = src0 + K * F;
+            const uint16_t* weight1 = weight0 + 1 * K;
+            const uint16_t* weight2 = weight0 + 2 * K;
+            const uint16_t* weight3 = weight0 + 3 * K;
+            const uint16_t* weight4 = weight0 + 4 * K;
+            if (dstS > F)
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = vdupq_n_f32(0.0f), d01 = vdupq_n_f32(0.0f);
+                    if (M > 1) d10 = vdupq_n_f32(0.0f), d11 = vdupq_n_f32(0.0f);
+                    if (M > 2) d20 = vdupq_n_f32(0.0f), d21 = vdupq_n_f32(0.0f);
+                    if (M > 3) d30 = vdupq_n_f32(0.0f), d31 = vdupq_n_f32(0.0f);
+                    if (M > 4) d40 = vdupq_n_f32(0.0f), d41 = vdupq_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = Load<false>(buf + 0 * dB + 0), d01 = Load<false>(buf + 0 * dB + F);
+                    if (M > 1) d10 = Load<false>(buf + 1 * dB + 0), d11 = Load<false>(buf + 1 * dB + F);
+                    if (M > 2) d20 = Load<false>(buf + 2 * dB + 0), d21 = Load<false>(buf + 2 * dB + F);
+                    if (M > 3) d30 = Load<false>(buf + 3 * dB + 0), d31 = Load<false>(buf + 3 * dB + F);
+                    if (M > 4) d40 = Load<false>(buf + 4 * dB + 0), d41 = Load<false>(buf + 4 * dB + F);
+                }
+                for (size_t k = 0; k < K; k += 2)
+                {
+                    uint32x4_t s0u = Load<false>((uint32_t*)src0);
+                    s00 = vreinterpretq_f32_u32(vshlq_n_u32(s0u, Base::Bf16::SHIFT));
+                    s01 = vreinterpretq_f32_u32(vandq_u32(s0u, Bf16::MASK));
+                    uint32x4_t s1u = Load<false>((uint32_t*)src1);
+                    s10 = vreinterpretq_f32_u32(vshlq_n_u32(s1u, Base::Bf16::SHIFT));
+                    s11 = vreinterpretq_f32_u32(vandq_u32(s1u, Bf16::MASK));
+                    if (M > 0)
+                    {
+                        w0 = BroadcastBf16(weight0[k + 0]);
+                        d00 = vmlaq_f32(d00, w0, s00);
+                        d01 = vmlaq_f32(d01, w0, s10);
+                        w0 = BroadcastBf16(weight0[k + 1]);
+                        d00 = vmlaq_f32(d00, w0, s01);
+                        d01 = vmlaq_f32(d01, w0, s11);
+                    }
+                    if (M > 1)
+                    {
+                        w0 = BroadcastBf16(weight1[k + 0]);
+                        d10 = vmlaq_f32(d10, w0, s00);
+                        d11 = vmlaq_f32(d11, w0, s10);
+                        w0 = BroadcastBf16(weight1[k + 1]);
+                        d10 = vmlaq_f32(d10, w0, s01);
+                        d11 = vmlaq_f32(d11, w0, s11);
+                    }
+                    if (M > 2)
+                    {
+                        w0 = BroadcastBf16(weight2[k + 0]);
+                        d20 = vmlaq_f32(d20, w0, s00);
+                        d21 = vmlaq_f32(d21, w0, s10);
+                        w0 = BroadcastBf16(weight2[k + 1]);
+                        d20 = vmlaq_f32(d20, w0, s01);
+                        d21 = vmlaq_f32(d21, w0, s11);
+                    }
+                    if (M > 3)
+                    {
+                        w0 = BroadcastBf16(weight3[k + 0]);
+                        d30 = vmlaq_f32(d30, w0, s00);
+                        d31 = vmlaq_f32(d31, w0, s10);
+                        w0 = BroadcastBf16(weight3[k + 1]);
+                        d30 = vmlaq_f32(d30, w0, s01);
+                        d31 = vmlaq_f32(d31, w0, s11);
+                    }
+                    if (M > 4)
+                    {
+                        w0 = BroadcastBf16(weight4[k + 0]);
+                        d40 = vmlaq_f32(d40, w0, s00);
+                        d41 = vmlaq_f32(d41, w0, s10);
+                        w0 = BroadcastBf16(weight4[k + 1]);
+                        d40 = vmlaq_f32(d40, w0, s01);
+                        d41 = vmlaq_f32(d41, w0, s11);
+                    }
+                    src0 += DF;
+                    src1 += DF;
+                }
+                if (dstS == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, 0), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, 1), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, 2), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, 3), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, 4), dst += dD, buf += dB;
+                }
+                else
+                {
+                    dstS -= F;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, 0, dstS), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, 1, dstS), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, 2, dstS), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, 3, dstS), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, 4, dstS), dst += dD, buf += dB;
+                }
+            }
+            else
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = vdupq_n_f32(0.0f);
+                    if (M > 1) d10 = vdupq_n_f32(0.0f);
+                    if (M > 2) d20 = vdupq_n_f32(0.0f);
+                    if (M > 3) d30 = vdupq_n_f32(0.0f);
+                    if (M > 4) d40 = vdupq_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = Load<false>(buf + 0 * dB + 0);
+                    if (M > 1) d10 = Load<false>(buf + 1 * dB + 0);
+                    if (M > 2) d20 = Load<false>(buf + 2 * dB + 0);
+                    if (M > 3) d30 = Load<false>(buf + 3 * dB + 0);
+                    if (M > 4) d40 = Load<false>(buf + 4 * dB + 0);
+                }
+                for (size_t k = 0; k < K; k += 2)
+                {
+                    uint32x4_t s0u = Load<false>((uint32_t*)src0);
+                    s00 = vreinterpretq_f32_u32(vshlq_n_u32(s0u, Base::Bf16::SHIFT));
+                    s01 = vreinterpretq_f32_u32(vandq_u32(s0u, Bf16::MASK));
+                    if (M > 0)
+                    {
+                        w0 = BroadcastBf16(weight0[k + 0]);
+                        d00 = vmlaq_f32(d00, w0, s00);
+                        w0 = BroadcastBf16(weight0[k + 1]);
+                        d00 = vmlaq_f32(d00, w0, s01);
+                    }
+                    if (M > 1)
+                    {
+                        w0 = BroadcastBf16(weight1[k + 0]);
+                        d10 = vmlaq_f32(d10, w0, s00);
+                        w0 = BroadcastBf16(weight1[k + 1]);
+                        d10 = vmlaq_f32(d10, w0, s01);
+                    }
+                    if (M > 2)
+                    {
+                        w0 = BroadcastBf16(weight2[k + 0]);
+                        d20 = vmlaq_f32(d20, w0, s00);
+                        w0 = BroadcastBf16(weight2[k + 1]);
+                        d20 = vmlaq_f32(d20, w0, s01);
+                    }
+                    if (M > 3)
+                    {
+                        w0 = BroadcastBf16(weight3[k + 0]);
+                        d30 = vmlaq_f32(d30, w0, s00);
+                        w0 = BroadcastBf16(weight3[k + 1]);
+                        d30 = vmlaq_f32(d30, w0, s01);
+                    }
+                    if (M > 4)
+                    {
+                        w0 = BroadcastBf16(weight4[k + 0]);
+                        d40 = vmlaq_f32(d40, w0, s00);
+                        w0 = BroadcastBf16(weight4[k + 1]);
+                        d40 = vmlaq_f32(d40, w0, s01);
+                    }
+                    src0 += DF;
+                }
+                if (dstS == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, 0), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, 1), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, 2), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, 3), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, 4), dst += dD, buf += dB;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, 0, dstS), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, 1, dstS), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, 2, dstS), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, 3, dstS), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, 4, dstS), dst += dD, buf += dB;
+                }
+            }
+        }
+
+        typedef void(*Convolution16bNchwGemm_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const float* bias, const float* params, float* buf, uint8_t* dst);
+
+        template<Term16bType term, SimdConvolutionActivationType type> Convolution16bNchwGemm_2xM_Ptr GetConvolution16bNchwGemm_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return Convolution16bNchwGemm_2xM<term, type, 1>;
+            case 2: return Convolution16bNchwGemm_2xM<term, type, 2>;
+            case 3: return Convolution16bNchwGemm_2xM<term, type, 3>;
+            case 4: return Convolution16bNchwGemm_2xM<term, type, 4>;
+            case 5: return Convolution16bNchwGemm_2xM<term, type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> void Convolution16bNchwGemm_2(const uint16_t* weight, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t dstH, size_t K, int zero, const uint16_t* src, const float* bias, const float* params, float* buf, uint8_t* dst)
+        {
+            size_t dstS = dstH * p.dstW, n1 = dstC, n = 5;
+            size_t nn = AlignLoAny(n1, n), m = n1 - nn;
+            size_t dB = a.sumBuf ? a.bufN : a.N, dD = a.N * a.elem, dW = K, dp = type == ::SimdConvolutionActivationPrelu ? 1 : 0;
+            Convolution16bNchwGemm_2xM_Ptr convolution_2xN = GetConvolution16bNchwGemm_2xM<term, type>(n);
+            Convolution16bNchwGemm_2xM_Ptr convolution_2xM = GetConvolution16bNchwGemm_2xM<term, type>(m);
+
+            for (size_t ds = 0; ds < dstS; ds += DF)
+            {
+                size_t dS = Simd::Min(DF, dstS - ds);
+                const uint16_t* w = weight;
+                float* b = buf + ds;
+                uint8_t* d = dst + ds * a.elem;
+                size_t i = 0;
+                for (; i < nn; i += n, w += n * dW, b += n * dB, d += n * dD)
+                    convolution_2xN(w, p, a, K, dS, zero, src, bias + i, params + i * dp, b, d);
+                for (; i < n1; i += m, w += m * dW, b += m * dB, d += m * dD)
+                    convolution_2xM(w, p, a, K, dS, zero, src, bias + i, params + i * dp, b, d);
+                src += K * DF;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template <SimdConvolutionActivationType type> SIMD_INLINE void Set(const ConvParam& p, const AlgParam& a, Convolution* convolutions)
+        {
+            convolutions[0] = Convolution16bNchwGemm_2<Term16bInterim, SimdConvolutionActivationIdentity>;
+            if (p.dstT == SimdTensorData16b)
+                convolutions[1] = Convolution16bNchwGemm_2<Term16bLast16b, type>;
+            else
+                convolutions[1] = Convolution16bNchwGemm_2<Term16bLast32f, type>;
+        }
+
+        SynetConvolution16bNchwGemm::SynetConvolution16bNchwGemm(const ConvParam& p)
+            : Base::SynetConvolution16bNchwGemm(p)
+        {
+            SetAlgParam(F, F * 2, 5, 2, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3());
+            if (_src16b)
+            {
+                if (_is1x1)
+                    _convert = Reorder16bNchwGemm1x1;
+            }
+            else
+            {
+                if (_is1x1)
+                    _convert = Convert16bNchwGemm1x1;
+            }
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, _alg, _convolutions); break;
+            default: assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetConvolution16b.h
+++ b/src/Simd/SimdSynetConvolution16b.h
@@ -713,6 +713,23 @@ namespace Simd
         void* SynetConvolution16bInit(size_t batch, const SimdConvolutionParameters* conv, SimdSynetCompatibilityType compatibility);
     }
 #endif
+
+#ifdef SIMD_NEON_ENABLE
+    namespace Neon
+    {
+        class SynetConvolution16bNchwGemm : public Base::SynetConvolution16bNchwGemm
+        {
+        public:
+            SynetConvolution16bNchwGemm(const ConvParam& p);
+
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        void* SynetConvolution16bInit(size_t batch, const SimdConvolutionParameters* conv, SimdSynetCompatibilityType compatibility);
+    }
+#endif
 }
 
 #endif

--- a/src/Simd/SimdSynetConvolution32fCommon.h
+++ b/src/Simd/SimdSynetConvolution32fCommon.h
@@ -346,6 +346,18 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        template<::SimdConvolutionActivationType type> SIMD_INLINE float32x4_t ActivateNchw(float32x4_t value, const float* params, size_t offset)
+        {
+            return Activate<type>(value, params, offset);
+        }
+
+        template<> SIMD_INLINE float32x4_t ActivateNchw<::SimdConvolutionActivationPrelu>(float32x4_t value, const float* params, size_t offset)
+        {
+            return vmlaq_f32(vmaxq_f32(vdupq_n_f32(0.0f), value), vld1q_dup_f32(params + offset), vminq_f32(vdupq_n_f32(0.0f), value));
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         template <TermType term> struct Term
         {
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(float * ptr, float32x4_t value, const float32x4_t * bias, const float32x4_t * params);

--- a/src/Test/TestSynetConvolution16b.cpp
+++ b/src/Test/TestSynetConvolution16b.cpp
@@ -662,6 +662,11 @@ namespace Test
             result = result && SynetConvolution16bForwardAutoTest(EPS, FUNC_C(Simd::AmxBf16::SynetConvolution16bInit), FUNC_C(SimdSynetConvolution16bInit));
 #endif
 
+#ifdef SIMD_NEON_ENABLE
+        if (Simd::Neon::Enable && TestNeon(options))
+            result = result && SynetConvolution16bForwardAutoTest(EPS, FUNC_C(Simd::Neon::SynetConvolution16bInit), FUNC_C(SimdSynetConvolution16bInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds ARM/ARM64 NEON optimizations for `Base::SynetConvolution16bNchwGemm` (NCHW 1×1 bf16 convolution via GEMM), following the existing SSE4.1 algorithm and Neon 16b GEMM patterns used by `SynetDeconvolution16bNhwcGemm` / `SynetInnerProduct16bGemmNN`.

### Changes
- **New:** `SimdNeonSynetConvolution16bNchwGemm.cpp` — convert/reorder, 2×M microkernels (`F=4`, `microN=5`, `microK=2`), NCHW `ActivateNchw` / Save helpers
- **New:** `SimdNeonSynetConvolution16b.cpp` — `Neon::SynetConvolution16bInit` dispatch
- **Header:** Neon class declaration in `SimdSynetConvolution16b.h`
- **Helpers:** `Neon::ActivateNchw` (PReLU scalar broadcast) in `SimdSynetConvolution32fCommon.h`
- **API:** `SimdSynetConvolution16bInit` includes `SIMD_NEON_FUNC`
- **Tests:** Neon AutoTest path in `TestSynetConvolution16b.cpp`
- **VS2022:** `Neon.vcxproj` / `.filters`
- **Docs:** release **7.2.165** note in `docs/2026.html`

### Validation
- Cross-compiled `libSimd.so` + `Test` for `aarch64` with `aarch64-linux-gnu-g++`
- Ran under `qemu-aarch64-static`:
  ```
  ./Test "-r=.." -fi=SynetConvolution16b -tt=1 -ts=1
  ```
  Result: **ALL TESTS ARE FINISHED SUCCESSFULLY** (includes enabled NCHW Gemm cases `1x1024x14x14→120`)

### Notes
- Preferable path remains Base’s: NCHW (`trans==0`), `group==1`, 1×1 kernels
- Non-NchwGemm cases continue to fall back to `Base::SynetConvolution16bGemm` on Neon
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2439c8e3-42ca-4eb9-837f-fecd2d2fcbf7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2439c8e3-42ca-4eb9-837f-fecd2d2fcbf7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

