### PR TITLE
Add NEON optimizations for SynetConvolution16bNhwcGemmV0

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -55,6 +55,7 @@
  <li>NEON, SVE2 optimizations of class SynetDeconvolution16bNhwcGemm.</li>
  <li>NEON optimizations of class SynetConvolution16bNchwGemm.</li>
  <li>NEON optimizations of class SynetConvolution16bNhwcDepthwise.</li>
+ <li>NEON optimizations of class SynetConvolution16bNhwcGemmV0.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCdc.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iCd.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution8iDc.</li>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNchwGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNhwcDepthwise.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNhwcGemmV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution16b.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution16bNhwcGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetDeconvolution32f.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -292,6 +292,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNhwcDepthwise.cpp">
       <Filter>Neon\Synet\Convolution</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution16bNhwcGemmV0.cpp">
+      <Filter>Neon\Synet\Convolution</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetConvolution32f.cpp">
       <Filter>Neon\Synet\Convolution</Filter>
     </ClCompile>

--- a/src/Simd/SimdNeonSynetConvolution16b.cpp
+++ b/src/Simd/SimdNeonSynetConvolution16b.cpp
@@ -33,6 +33,8 @@ namespace Simd
             ConvParam param(batch, conv, compatibility);
             if (!param.Valid(SimdTensorData32f, SimdTensorData16b))
                 return NULL;
+            if (SynetConvolution16bNhwcGemmV0::Preferable(param))
+                return new Neon::SynetConvolution16bNhwcGemmV0(param);
             if (SynetConvolution16bNchwGemm::Preferable(param))
                 return new Neon::SynetConvolution16bNchwGemm(param);
             if (SynetConvolution16bNhwcDepthwise::Preferable(param))

--- a/src/Simd/SimdNeonSynetConvolution16bNhwcGemmV0.cpp
+++ b/src/Simd/SimdNeonSynetConvolution16bNhwcGemmV0.cpp
@@ -1,0 +1,454 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetConvolution16b.h"
+#include "Simd/SimdSynetConvolution16bCommon.h"
+#include "Simd/SimdBFloat16.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdStore.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Neon
+    {
+        typedef Base::SynetConvolution16bNhwcGemmV0::AlgParam AlgParam;
+        typedef Base::SynetConvolution16bNhwcGemmV0::ConvolutionPtr Convolution;
+
+        //-----------------------------------------------------------------------------------------
+
+        static void Convert16bNhwcGemm(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
+        {
+            const float* src = (float*)src8;
+            size_t srcC8 = Simd::AlignLo(p.srcC, 8);
+            size_t srcC4 = Simd::AlignLo(p.srcC, 4);
+            size_t gap = a.bufK - a.K;
+            for (size_t dy = yBeg, dr = 0; dy < yEnd; ++dy)
+            {
+                for (size_t dx = 0; dx < p.dstW; ++dx, ++dr)
+                {
+                    uint16_t* row = dst + dr * a.bufK;
+                    for (size_t ky = 0, k = 0; ky < p.kernelY; ky++)
+                    {
+                        size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                        if (sy < p.srcH)
+                        {
+                            for (size_t kx = 0; kx < p.kernelX; kx++)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                if (sx < p.srcW)
+                                {
+                                    const float* ps = src + (sy * p.srcW + sx) * p.srcC;
+                                    size_t sc = 0;
+                                    for (; sc < srcC8; sc += 8)
+                                    {
+                                        uint32x4_t d0 = Float32ToBFloat16(Load<false>(ps + sc + 0));
+                                        uint32x4_t d1 = Float32ToBFloat16(Load<false>(ps + sc + F));
+                                        Store<false>(row + sc, PackU32(d0, d1));
+                                    }
+                                    for (; sc < srcC4; sc += 4)
+                                    {
+                                        uint32x4_t d0 = Float32ToBFloat16(Load<false>(ps + sc));
+                                        Store<false>(row + sc, vmovn_u32(d0));
+                                    }
+                                    for (; sc < p.srcC; ++sc)
+                                        row[sc] = Base::Float32ToBFloat16(ps[sc]);
+                                    row += p.srcC;
+                                }
+                                else
+                                {
+                                    memset(row, 0, p.srcC * 2);
+                                    row += p.srcC;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            memset(row, 0, p.kernelX * p.srcC * 2);
+                            row += p.kernelX * p.srcC;
+                        }
+                    }
+                    for (size_t g = 0; g < gap; ++g)
+                        *(row++) = 0;
+                }
+            }
+        }
+
+        static void Reorder16bNhwcGemm(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint16_t* dst)
+        {
+            const uint16_t* src = (uint16_t*)src8;
+            size_t gap = a.bufK - a.K;
+            for (size_t dy = yBeg, dr = 0; dy < yEnd; ++dy)
+            {
+                for (size_t dx = 0; dx < p.dstW; ++dx, ++dr)
+                {
+                    uint16_t* row = dst + dr * a.bufK;
+                    for (size_t ky = 0, k = 0; ky < p.kernelY; ky++)
+                    {
+                        size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                        if (sy < p.srcH)
+                        {
+                            for (size_t kx = 0; kx < p.kernelX; kx++)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                if (sx < p.srcW)
+                                {
+                                    const uint16_t* ps = src + (sy * p.srcW + sx) * p.srcC;
+                                    memcpy(row, ps, p.srcC * 2);
+                                    row += p.srcC;
+                                }
+                                else
+                                {
+                                    memset(row, 0, p.srcC * 2);
+                                    row += p.srcC;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            memset(row, 0, p.kernelX * p.srcC * 2);
+                            row += p.kernelX * p.srcC;
+                        }
+                    }
+                    for (size_t g = 0; g < gap; ++g)
+                        *(row++) = 0;
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE float32x4_t BroadcastBf16(uint16_t value)
+        {
+            return vreinterpretq_f32_u32(vdupq_n_u32(uint32_t(value) << Base::Bf16::SHIFT));
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, float32x4_t val0, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, tail);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params);
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, float32x4_t val0, float32x4_t val1, const float32x4_t* bias, const float32x4_t* params, size_t tail)
+        {
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, tail);
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<Term16bType term, SimdConvolutionActivationType type, int M> void Convolution16bNhwcGemm_2xM(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight0, const float32x4_t* bias, const float32x4_t* params, float* buf, uint8_t* dst)
+        {
+            float32x4_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, s0, w00, w01, w10, w11;
+            size_t dB = a.dB, dD = p.dstC * a.elem, dS = a.bufK;
+            const uint16_t* weight1 = weight0 + a.bufK * F;
+            const uint16_t* src1 = src0 + 1 * dS;
+            const uint16_t* src2 = src0 + 2 * dS;
+            const uint16_t* src3 = src0 + 3 * dS;
+            const uint16_t* src4 = src0 + 4 * dS;
+            if (dstC > F)
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = vdupq_n_f32(0.0f), d01 = vdupq_n_f32(0.0f);
+                    if (M > 1) d10 = vdupq_n_f32(0.0f), d11 = vdupq_n_f32(0.0f);
+                    if (M > 2) d20 = vdupq_n_f32(0.0f), d21 = vdupq_n_f32(0.0f);
+                    if (M > 3) d30 = vdupq_n_f32(0.0f), d31 = vdupq_n_f32(0.0f);
+                    if (M > 4) d40 = vdupq_n_f32(0.0f), d41 = vdupq_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = Load<false>(buf + 0 * dB + 0), d01 = Load<false>(buf + 0 * dB + F);
+                    if (M > 1) d10 = Load<false>(buf + 1 * dB + 0), d11 = Load<false>(buf + 1 * dB + F);
+                    if (M > 2) d20 = Load<false>(buf + 2 * dB + 0), d21 = Load<false>(buf + 2 * dB + F);
+                    if (M > 3) d30 = Load<false>(buf + 3 * dB + 0), d31 = Load<false>(buf + 3 * dB + F);
+                    if (M > 4) d40 = Load<false>(buf + 4 * dB + 0), d41 = Load<false>(buf + 4 * dB + F);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 2)
+                {
+                    w01 = Load<false>((float*)weight0);
+                    w00 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w01), Base::Bf16::SHIFT));
+                    w01 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w01), Bf16::MASK));
+                    w11 = Load<false>((float*)weight1);
+                    w10 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w11), Base::Bf16::SHIFT));
+                    w11 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w11), Bf16::MASK));
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16(src0[offs + 0]);
+                        d00 = vaddq_f32(vmulq_f32(s0, w00), d00);
+                        d01 = vaddq_f32(vmulq_f32(s0, w10), d01);
+                        s0 = BroadcastBf16(src0[offs + 1]);
+                        d00 = vaddq_f32(vmulq_f32(s0, w01), d00);
+                        d01 = vaddq_f32(vmulq_f32(s0, w11), d01);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16(src1[offs + 0]);
+                        d10 = vaddq_f32(vmulq_f32(s0, w00), d10);
+                        d11 = vaddq_f32(vmulq_f32(s0, w10), d11);
+                        s0 = BroadcastBf16(src1[offs + 1]);
+                        d10 = vaddq_f32(vmulq_f32(s0, w01), d10);
+                        d11 = vaddq_f32(vmulq_f32(s0, w11), d11);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16(src2[offs + 0]);
+                        d20 = vaddq_f32(vmulq_f32(s0, w00), d20);
+                        d21 = vaddq_f32(vmulq_f32(s0, w10), d21);
+                        s0 = BroadcastBf16(src2[offs + 1]);
+                        d20 = vaddq_f32(vmulq_f32(s0, w01), d20);
+                        d21 = vaddq_f32(vmulq_f32(s0, w11), d21);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16(src3[offs + 0]);
+                        d30 = vaddq_f32(vmulq_f32(s0, w00), d30);
+                        d31 = vaddq_f32(vmulq_f32(s0, w10), d31);
+                        s0 = BroadcastBf16(src3[offs + 1]);
+                        d30 = vaddq_f32(vmulq_f32(s0, w01), d30);
+                        d31 = vaddq_f32(vmulq_f32(s0, w11), d31);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16(src4[offs + 0]);
+                        d40 = vaddq_f32(vmulq_f32(s0, w00), d40);
+                        d41 = vaddq_f32(vmulq_f32(s0, w10), d41);
+                        s0 = BroadcastBf16(src4[offs + 1]);
+                        d40 = vaddq_f32(vmulq_f32(s0, w01), d40);
+                        d41 = vaddq_f32(vmulq_f32(s0, w11), d41);
+                    }
+                    weight0 += DF;
+                    weight1 += DF;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params), dst += dD, buf += dB;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, dstC), dst += dD, buf += dB;
+                }
+            }
+            else
+            {
+                if (zero)
+                {
+                    if (M > 0) d00 = vdupq_n_f32(0.0f);
+                    if (M > 1) d10 = vdupq_n_f32(0.0f);
+                    if (M > 2) d20 = vdupq_n_f32(0.0f);
+                    if (M > 3) d30 = vdupq_n_f32(0.0f);
+                    if (M > 4) d40 = vdupq_n_f32(0.0f);
+                }
+                else
+                {
+                    if (M > 0) d00 = Load<false>(buf + 0 * dB + 0);
+                    if (M > 1) d10 = Load<false>(buf + 1 * dB + 0);
+                    if (M > 2) d20 = Load<false>(buf + 2 * dB + 0);
+                    if (M > 3) d30 = Load<false>(buf + 3 * dB + 0);
+                    if (M > 4) d40 = Load<false>(buf + 4 * dB + 0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 2)
+                {
+                    w01 = Load<false>((float*)weight0);
+                    w00 = vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(w01), Base::Bf16::SHIFT));
+                    w01 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(w01), Bf16::MASK));
+                    if (M > 0)
+                    {
+                        s0 = BroadcastBf16(src0[offs + 0]);
+                        d00 = vaddq_f32(vmulq_f32(s0, w00), d00);
+                        s0 = BroadcastBf16(src0[offs + 1]);
+                        d00 = vaddq_f32(vmulq_f32(s0, w01), d00);
+                    }
+                    if (M > 1)
+                    {
+                        s0 = BroadcastBf16(src1[offs + 0]);
+                        d10 = vaddq_f32(vmulq_f32(s0, w00), d10);
+                        s0 = BroadcastBf16(src1[offs + 1]);
+                        d10 = vaddq_f32(vmulq_f32(s0, w01), d10);
+                    }
+                    if (M > 2)
+                    {
+                        s0 = BroadcastBf16(src2[offs + 0]);
+                        d20 = vaddq_f32(vmulq_f32(s0, w00), d20);
+                        s0 = BroadcastBf16(src2[offs + 1]);
+                        d20 = vaddq_f32(vmulq_f32(s0, w01), d20);
+                    }
+                    if (M > 3)
+                    {
+                        s0 = BroadcastBf16(src3[offs + 0]);
+                        d30 = vaddq_f32(vmulq_f32(s0, w00), d30);
+                        s0 = BroadcastBf16(src3[offs + 1]);
+                        d30 = vaddq_f32(vmulq_f32(s0, w01), d30);
+                    }
+                    if (M > 4)
+                    {
+                        s0 = BroadcastBf16(src4[offs + 0]);
+                        d40 = vaddq_f32(vmulq_f32(s0, w00), d40);
+                        s0 = BroadcastBf16(src4[offs + 1]);
+                        d40 = vaddq_f32(vmulq_f32(s0, w01), d40);
+                    }
+                    weight0 += DF;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params), dst += dD, buf += dB;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, dstC), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, dstC), dst += dD, buf += dB;
+                }
+            }
+        }
+
+        typedef void(*Convolution16bNhwcGemm_2xM_Ptr)(const uint16_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int zero, const uint16_t* weight, const float32x4_t* bias, const float32x4_t* params, float* buf, uint8_t* dst);
+
+        template<Term16bType term, SimdConvolutionActivationType type> Convolution16bNhwcGemm_2xM_Ptr GetConvolution16bNhwcGemm_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return Convolution16bNhwcGemm_2xM<term, type, 1>;
+            case 2: return Convolution16bNhwcGemm_2xM<term, type, 2>;
+            case 3: return Convolution16bNhwcGemm_2xM<term, type, 3>;
+            case 4: return Convolution16bNhwcGemm_2xM<term, type, 4>;
+            case 5: return Convolution16bNhwcGemm_2xM<term, type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<Term16bType term, SimdConvolutionActivationType type> void Convolution16bNhwcGemm_2(const uint16_t* src, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t dstH, size_t srcC, int zero, const uint16_t* weight, const float* bias, const float* params, float* buf, uint8_t* dst)
+        {
+            size_t n1 = dstH * p.dstW, n = 5;
+            size_t nn = AlignLoAny(n1, n), m = n1 - nn, dW = a.bufK * DF;
+            size_t dB = a.dB, dD = p.dstC * a.elem, dS = a.bufK;
+            Convolution16bNhwcGemm_2xM_Ptr convolution_2xN = GetConvolution16bNhwcGemm_2xM<term, type>(n);
+            Convolution16bNhwcGemm_2xM_Ptr convolution_2xM = GetConvolution16bNhwcGemm_2xM<term, type>(m);
+
+            float32x4_t _params[2], _bias[2];
+            _params[0] = vdupq_n_f32(params[0]);
+            if (type == SimdConvolutionActivationRestrictRange ||
+                type == SimdConvolutionActivationHswish ||
+                type == SimdConvolutionActivationHardSigmoid)
+                _params[1] = vdupq_n_f32(params[1]);
+
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                _bias[0] = Load<false>(bias + dc + 0);
+                _bias[1] = Load<false>(bias + dc + F);
+                if (type == ::SimdConvolutionActivationPrelu)
+                {
+                    _params[0] = Load<false>(params + dc + 0);
+                    _params[1] = Load<false>(params + dc + F);
+                }
+                const uint16_t* s = src;
+                float* b = buf + dc;
+                uint8_t* d = dst + dc * a.elem;
+                size_t i = 0;
+                for (; i < nn; i += n, s += n * dS, b += n * dB, d += n * dD)
+                    convolution_2xN(s, p, a, srcC, dC, zero, weight, _bias, _params, b, d);
+                for (; i < n1; i += m, s += m * dS, b += m * dB, d += m * dD)
+                    convolution_2xM(s, p, a, srcC, dC, zero, weight, _bias, _params, b, d);
+                weight += dW;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template <SimdConvolutionActivationType type> SIMD_INLINE void Set(const ConvParam& p, const AlgParam& a, Convolution* convolutions)
+        {
+            convolutions[0] = Convolution16bNhwcGemm_2<Term16bInterim, SimdConvolutionActivationIdentity>;
+            if (p.dstT == SimdTensorData16b)
+                convolutions[1] = Convolution16bNhwcGemm_2<Term16bLast16b, type>;
+            else
+                convolutions[1] = Convolution16bNhwcGemm_2<Term16bLast32f, type>;
+        }
+
+        SynetConvolution16bNhwcGemmV0::SynetConvolution16bNhwcGemmV0(const ConvParam& p)
+            : Base::SynetConvolution16bNhwcGemmV0(p)
+        {
+            SetAlgParam(F, F * 2, 5, 2, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3());
+            if (_src16b)
+            {
+                AlgParam& a = _alg;
+                if (_is1x1 && a.K == a.bufK)
+                    _convert = NULL;
+                else
+                    _convert = Reorder16bNhwcGemm;
+            }
+            else
+                _convert = Convert16bNhwcGemm;
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: Set<SimdConvolutionActivationRestrictRange>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationRelu: Set<SimdConvolutionActivationRestrictRange>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationLeakyRelu: Set<SimdConvolutionActivationPrelu>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationRestrictRange: Set<SimdConvolutionActivationRestrictRange>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationPrelu: Set<SimdConvolutionActivationPrelu>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationElu: Set<SimdConvolutionActivationElu>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationHswish: Set<SimdConvolutionActivationHswish>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationMish: Set<SimdConvolutionActivationMish>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationHardSigmoid: Set<SimdConvolutionActivationHardSigmoid>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationSwish: Set<SimdConvolutionActivationSwish>(p, _alg, _convolutions); break;
+            case SimdConvolutionActivationGelu: Set<SimdConvolutionActivationGelu>(p, _alg, _convolutions); break;
+            default: assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetConvolution16b.h
+++ b/src/Simd/SimdSynetConvolution16b.h
@@ -717,6 +717,14 @@ namespace Simd
 #ifdef SIMD_NEON_ENABLE
     namespace Neon
     {
+        class SynetConvolution16bNhwcGemmV0 : public Base::SynetConvolution16bNhwcGemmV0
+        {
+        public:
+            SynetConvolution16bNhwcGemmV0(const ConvParam& p);
+
+            virtual String Ext() const { return "Neon"; }
+        };
+
         class SynetConvolution16bNhwcDepthwise : public Base::SynetConvolution16bNhwcDepthwise
         {
         public:

--- a/src/Test/TestSynetConvolution16b.cpp
+++ b/src/Test/TestSynetConvolution16b.cpp
@@ -482,6 +482,9 @@ namespace Test
         result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 512, 32, 32, 512, _1, _1, _1, _0, _0, 1, aId, tT, b16, b16), c, f1, f2);
         result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 768, 32, 32, 384, _1, _1, _1, _0, _0, 1, aId, tT, b16, b16), c, f1, f2);
         result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 1024, 32, 32, 256, _1, _1, _1, _0, _0, 1, aId, tT, b16, b16), c, f1, f2);
+        result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 256, 32, 32, 256, _3, _1, _1, _1, _1, 1, aRe, tT, f32, f32), c, f1, f2);
+        result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 99, 31, 33, 128, _1, _1, _1, _0, _0, 1, aId, tT, f32, b16), c, f1, f2);
+        result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 128, 32, 32, 127, _3, _1, _1, _1, _1, 1, aPr, tT, b16, f32), c, f1, f2);
 #endif
 #if 0
         result = result && SynetConvolution16bForwardAutoTest(eps, Param(1, 512, 2, 8, 128, _1, _1, _1, _0, _0, 1, aId, tT, b16, b16), c, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Port `Base::SynetConvolution16bNhwcGemmV0` to ARM NEON (Convert/Reorder + 2xM GEMM kernels), following the existing SSE4.1 implementation and Neon MergedConvolution16b Output patterns.
- Wire the Neon path into `Neon::SynetConvolution16bInit`, declare the class in `SimdSynetConvolution16b.h`, and add the new source to VS2022 Neon project files.
- Extend NhwcGemmV0 AutoTests (f32 convert, unaligned channels, 3x3 + PReLU) and document the change under release 7.2.165 in `docs/2026.html`.

## Validation
- AArch64 cross-compile of `libSimd.so` succeeded (`SimdNeonSynetConvolution16bNhwcGemmV0.cpp` built cleanly).
- Native x86 Release build succeeded; `./Test "-r=.." -fi=SynetConvolution16b -tt=1 -ts=1` finished successfully (NhwcGemmV0 cases included).

## Test plan
- [x] Cross-compile Neon sources for aarch64 and confirm the new file builds.
- [x] Native x86 Release build + SynetConvolution16b AutoTest.
- [ ] On ARM/ARM64 hardware, confirm Neon NhwcGemmV0 correctness/perf vs Base.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-074d7bad-9397-45de-9833-e278f847be68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-074d7bad-9397-45de-9833-e278f847be68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

