### PR TITLE
Fix Sve2 SynetConvolution16bInit fallback for depthwise cases

### DIFF
--- a/src/Simd/SimdSve2SynetConvolution16b.cpp
+++ b/src/Simd/SimdSve2SynetConvolution16b.cpp
@@ -35,7 +35,12 @@ namespace Simd
                 return NULL;
             if (SynetConvolution16bNchwGemm::Preferable(param))
                 return new Sve2::SynetConvolution16bNchwGemm(param);
+            // Keep Neon algorithm selection (Depthwise / NhwcGemmV0 / SpecV0, ...) for other shapes.
+#if defined(SIMD_NEON_ENABLE)
+            return Neon::SynetConvolution16bInit(batch, conv, compatibility);
+#else
             return Base::SynetConvolution16bInit(batch, conv, compatibility);
+#endif
         }
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #849. `Sve2::SynetConvolution16bInit` currently falls back to `Base::SynetConvolution16bInit` for non-`NchwGemm` shapes. That avoids the original Gemm mismatch, but it also bypasses Neon Depthwise / NhwcGemmV0 / SpecV0 selection once SVE2 is preferred in the API dispatch chain.

### Change
In `SimdSve2SynetConvolution16b.cpp`, for non-NchwGemm params:
- prefer `Neon::SynetConvolution16bInit` when Neon is built
- otherwise keep `Base::SynetConvolution16bInit`

### Why this matters
The failure:
```
Base::SynetConvolution16bInit[1x76x64x64-76x7x7-...] vs SimdSynetConvolution16bInit[...]
```
happens when API selects a different algorithm than Base Depthwise (e.g. early Gemm fallback). Delegating to Neon keeps the same algorithm family Neon already validates for grouped depthwise / NHWC cases, and restores Neon opts under SVE2.

### Validation
`aarch64` cross-build + `qemu-aarch64-static -cpu max`:
```bash
./Test "-r=.." -fi=SynetConvolution16b -tt=1 -ts=1
```
**ALL TESTS ARE FINISHED SUCCESSFULLY** (includes `1x76x64x64-76x7x7` and NCHW Gemm `1x1024x14x14`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddf7d8e4-e6bf-4595-b9e9-ee983a3e82e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddf7d8e4-e6bf-4595-b9e9-ee983a3e82e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

