### PR TITLE
Fix Base::CpuCurrentFrequency on ARM/ARM64 Neoverse-N2 (Linux)

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,10 @@
 <ul>
  <li>Separate support of SVE extension (ARM/ARM64 platform).</li>
 </ul>
+<h5>Bug fixing</h5>
+<ul>
+ <li>Error in function Base::CpuCurrentFrequency on ARM/ARM64 Neoverse-N2 (Linux).</li>
+</ul>
 
 <h4>Documentation</h4>
 <h5>Improving</h5>

--- a/src/Simd/SimdBaseCpu.cpp
+++ b/src/Simd/SimdBaseCpu.cpp
@@ -45,9 +45,13 @@
 #include <intrin.h>
 
 #elif defined(__GNUC__)
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <unistd.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sched.h>
 
 #if defined(SIMD_X86_ENABLE) || defined(SIMD_X64_ENABLE)
 #include <cpuid.h>
@@ -451,23 +455,118 @@ namespace Simd
         uint64_t CpuFrequencyFromFile(const std::string & path, uint64_t valueScale)
         {
             uint64_t freq = 0;
-            if (::access(path.c_str(), R_OK) != -1)
+            std::ifstream file(path.c_str());
+            if (file.is_open())
             {
-                std::stringstream args;
-                args << "cat " << path << " 2>/dev/null";
-                ::FILE* p = ::popen(args.str().c_str(), "r");
-                if (p)
-                {
-                    char buffer[PATH_MAX];
-                    buffer[0] = 0;
-                    while (::fgets(buffer, PATH_MAX, p));
-                    ::pclose(p);
-                    int value = ::atoi(buffer);
-                    if (value > 0)
-                        freq = uint64_t(value) * valueScale;
-                }
+                double value = 0;
+                file >> value;
+                if (value > 0)
+                    freq = (uint64_t)Round(value * double(valueScale));
             }
             return freq;
+        }
+
+        uint64_t CpuFrequencyFromSysfs(int core)
+        {
+            if (core < 0)
+                core = 0;
+            std::string cpu = "/sys/devices/system/cpu/cpu" + std::to_string(core);
+            std::string cpufreq = cpu + "/cpufreq/";
+            std::string policy = "/sys/devices/system/cpu/cpufreq/policy" + std::to_string(core) + "/";
+            const char* names[5] = { "scaling_cur_freq", "cpuinfo_cur_freq", "cpuinfo_avg_freq", "cpuinfo_max_freq", "scaling_max_freq" };
+            for (int i = 0; i < 5; ++i)
+            {
+                uint64_t freq = CpuFrequencyFromFile(cpufreq + names[i], 1000);
+                if (freq == 0)
+                    freq = CpuFrequencyFromFile(policy + names[i], 1000);
+                if (freq > 0)
+                    return freq;
+            }
+            // ACPI CPPC (common on ARM/ARM64 servers, including Neoverse): values are in MHz.
+            uint64_t freq = CpuFrequencyFromFile(cpu + "/acpi_cppc/nominal_freq", 1000000);
+            if (freq == 0)
+                freq = CpuFrequencyFromFile(cpu + "/acpi_cppc/lowest_freq", 1000000);
+            return freq;
+        }
+
+        uint64_t CpuFrequencyFromSmbios()
+        {
+            // Prefer per-structure sysfs nodes when present.
+            for (int i = 0; i < 8; ++i)
+            {
+                std::string path = "/sys/firmware/dmi/entries/4-" + std::to_string(i) + "/raw";
+                std::ifstream file(path.c_str(), std::ios::binary);
+                if (!file.is_open())
+                    continue;
+                unsigned char buf[0x18];
+                file.read((char*)buf, 0x18);
+                if (file.gcount() < 0x18 || buf[0] != 4 || buf[1] < 0x18)
+                    continue;
+                unsigned int current = unsigned(buf[0x16]) | (unsigned(buf[0x17]) << 8);
+                unsigned int maxSpeed = unsigned(buf[0x14]) | (unsigned(buf[0x15]) << 8);
+                unsigned int mhz = current ? current : maxSpeed;
+                if (mhz > 0 && mhz < 100000)
+                    return uint64_t(mhz) * 1000000;
+            }
+
+            // Fallback: scan raw SMBIOS table (usually world-readable; no root dmidecode needed).
+            std::ifstream table("/sys/firmware/dmi/tables/DMI", std::ios::binary);
+            if (!table.is_open())
+                return 0;
+            std::vector<unsigned char> data((std::istreambuf_iterator<char>(table)), std::istreambuf_iterator<char>());
+            size_t off = 0;
+            while (off + 4 < data.size())
+            {
+                unsigned char type = data[off];
+                unsigned char length = data[off + 1];
+                if (length < 4 || off + length > data.size())
+                    break;
+                if (type == 4 && length >= 0x18)
+                {
+                    unsigned int current = unsigned(data[off + 0x16]) | (unsigned(data[off + 0x17]) << 8);
+                    unsigned int maxSpeed = unsigned(data[off + 0x14]) | (unsigned(data[off + 0x15]) << 8);
+                    unsigned int mhz = current ? current : maxSpeed;
+                    if (mhz > 0 && mhz < 100000)
+                        return uint64_t(mhz) * 1000000;
+                }
+                size_t next = off + length;
+                while (next + 1 < data.size() && !(data[next] == 0 && data[next + 1] == 0))
+                    ++next;
+                if (next + 1 >= data.size())
+                    break;
+                off = next + 2;
+                if (type == 127)
+                    break;
+            }
+            return 0;
+        }
+
+        uint64_t CpuFrequencyFromDeviceTree()
+        {
+            ::FILE* p = ::popen("find /sys/firmware/devicetree/base/cpus -name clock-frequency 2>/dev/null | head -n1", "r");
+            if (!p)
+                return 0;
+            char path[PATH_MAX];
+            path[0] = 0;
+            if (!::fgets(path, PATH_MAX, p))
+            {
+                ::pclose(p);
+                return 0;
+            }
+            ::pclose(p);
+            std::string filePath = path;
+            filePath = filePath.substr(0, filePath.find('\n'));
+            if (filePath.empty())
+                return 0;
+            std::ifstream file(filePath.c_str(), std::ios::binary);
+            if (!file.is_open())
+                return 0;
+            unsigned char b[4] = { 0, 0, 0, 0 };
+            file.read((char*)b, 4);
+            if (file.gcount() < 4)
+                return 0;
+            uint64_t hz = (uint64_t(b[0]) << 24) | (uint64_t(b[1]) << 16) | (uint64_t(b[2]) << 8) | uint64_t(b[3]);
+            return hz > 0 ? hz : 0;
         }
 
         uint64_t CpuCurrentFrequency()
@@ -476,14 +575,19 @@ namespace Simd
 #elif defined(__ANDROID__)
 #else
             int core = sched_getcpu();
-            std::string cpufreq = "/sys/devices/system/cpu/cpu" + std::to_string(core) + "/cpufreq/";
-            uint64_t freq = CpuFrequencyFromFile(cpufreq + "scaling_cur_freq", 1000);
-            if (freq == 0)
-                freq = CpuFrequencyFromFile(cpufreq + "cpuinfo_cur_freq", 1000);
+            if (core < 0)
+                core = 0;
+
+            uint64_t freq = CpuFrequencyFromSysfs(core);
+            // AMU-based scaling_cur_freq can be 0 on an idle core; try cpu0 and a few neighbors.
+            for (int i = 0; freq == 0 && i < 8; ++i)
+                if (i != core)
+                    freq = CpuFrequencyFromSysfs(i);
+
             if (freq == 0)
             {
                 std::stringstream args;
-                args << "cat /proc/cpuinfo | grep \"MHz\" | head -n" << core + 1 << " | tail -1";
+                args << "cat /proc/cpuinfo 2>/dev/null | grep -i \"MHz\" | head -n" << core + 1 << " | tail -1";
                 ::FILE* p = ::popen(args.str().c_str(), "r");
                 if (p)
                 {
@@ -501,15 +605,16 @@ namespace Simd
                     }
                 }
             }
-            // Fallbacks for platforms without a readable current frequency
-            // (typical for ARM/ARM64 Neoverse-N2: no cpufreq, no MHz in /proc/cpuinfo).
+
+            // ARM/ARM64 Neoverse-N2 and similar: often no cpufreq and no MHz in /proc/cpuinfo.
             if (freq == 0)
-                freq = CpuFrequencyFromFile(cpufreq + "cpuinfo_max_freq", 1000);
+                freq = CpuFrequencyFromSmbios();
             if (freq == 0)
-                freq = CpuFrequencyFromFile(cpufreq + "scaling_max_freq", 1000);
+                freq = CpuFrequencyFromDeviceTree();
             if (freq == 0)
             {
-                ::FILE* p = ::popen("dmidecode -t processor 2>/dev/null | grep -E 'Current Speed|Max Speed' | grep -oE '[0-9]+' | head -n1", "r");
+                // Non-zero speeds only (skip "Current Speed: 0" / "Unknown").
+                ::FILE* p = ::popen("dmidecode -t processor 2>/dev/null | grep -E 'Current Speed|Max Speed' | grep -oE '[1-9][0-9]*' | head -n1", "r");
                 if (p)
                 {
                     char buffer[PATH_MAX];
@@ -523,7 +628,35 @@ namespace Simd
             }
             if (freq == 0)
             {
-                ::FILE* p = ::popen("lscpu 2>/dev/null | grep -oE '@ [0-9]+(\\.[0-9]+)?GHz' | head -n1 | grep -oE '[0-9]+(\\.[0-9]+)?'", "r");
+                ::FILE* p = ::popen("dmidecode -s processor-frequency 2>/dev/null | grep -oE '[1-9][0-9]*' | head -n1", "r");
+                if (p)
+                {
+                    char buffer[PATH_MAX];
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
+                    ::pclose(p);
+                    int mhz = ::atoi(buffer);
+                    if (mhz > 0)
+                        freq = uint64_t(mhz) * 1000000;
+                }
+            }
+            if (freq == 0)
+            {
+                ::FILE* p = ::popen("lscpu 2>/dev/null | grep -E 'CPU max MHz|CPU MHz' | head -n1 | grep -oE '[0-9]+(\\.[0-9]+)?' | head -n1", "r");
+                if (p)
+                {
+                    char buffer[PATH_MAX];
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
+                    ::pclose(p);
+                    double mhz = ::atof(buffer);
+                    if (mhz > 0)
+                        freq = (uint64_t)Round(mhz * 1000000.0);
+                }
+            }
+            if (freq == 0)
+            {
+                ::FILE* p = ::popen("lscpu 2>/dev/null | grep -oE '@[ ]*[0-9]+(\\.[0-9]+)?[ ]*GHz' | head -n1 | grep -oE '[0-9]+(\\.[0-9]+)?'", "r");
                 if (p)
                 {
                     char buffer[PATH_MAX];

--- a/src/Simd/SimdBaseCpu.cpp
+++ b/src/Simd/SimdBaseCpu.cpp
@@ -448,42 +448,94 @@ namespace Simd
             return model;
         }
 
+        uint64_t CpuFrequencyFromFile(const std::string & path, uint64_t valueScale)
+        {
+            uint64_t freq = 0;
+            if (::access(path.c_str(), R_OK) != -1)
+            {
+                std::stringstream args;
+                args << "cat " << path << " 2>/dev/null";
+                ::FILE* p = ::popen(args.str().c_str(), "r");
+                if (p)
+                {
+                    char buffer[PATH_MAX];
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
+                    ::pclose(p);
+                    int value = ::atoi(buffer);
+                    if (value > 0)
+                        freq = uint64_t(value) * valueScale;
+                }
+            }
+            return freq;
+        }
+
         uint64_t CpuCurrentFrequency()
         {
 #if defined(__APPLE__)
 #elif defined(__ANDROID__)
 #else
             int core = sched_getcpu();
-            std::string scaling_cur_freq = "/sys/devices/system/cpu/cpu" + std::to_string(core) + "/cpufreq/scaling_cur_freq";
-            if (::access(scaling_cur_freq.c_str(), F_OK) != -1)
-            {
-                std::stringstream args;
-                args << "cat " << scaling_cur_freq;
-                ::FILE* p = ::popen(args.str().c_str(), "r");
-                if (p)
-                {
-                    char buffer[1024];
-                    while (::fgets(buffer, 1024, p));
-                    ::pclose(p);
-                    return ::atoi(buffer) * uint64_t(1000);
-                }
-            }
-            else
+            std::string cpufreq = "/sys/devices/system/cpu/cpu" + std::to_string(core) + "/cpufreq/";
+            uint64_t freq = CpuFrequencyFromFile(cpufreq + "scaling_cur_freq", 1000);
+            if (freq == 0)
+                freq = CpuFrequencyFromFile(cpufreq + "cpuinfo_cur_freq", 1000);
+            if (freq == 0)
             {
                 std::stringstream args;
                 args << "cat /proc/cpuinfo | grep \"MHz\" | head -n" << core + 1 << " | tail -1";
                 ::FILE* p = ::popen(args.str().c_str(), "r");
                 if (p)
                 {
-                    char buffer[1024];
-                    while (::fgets(buffer, 1024, p));
+                    char buffer[PATH_MAX];
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
                     ::pclose(p);
                     std::string output = buffer;
                     std::size_t beg = output.find(":");
                     if (beg != std::string::npos)
-                        return Round(::atof(output.substr(beg + 1).c_str())) * uint64_t(1000000);
+                    {
+                        int mhz = Round(::atof(output.substr(beg + 1).c_str()));
+                        if (mhz > 0)
+                            freq = uint64_t(mhz) * 1000000;
+                    }
                 }
             }
+            // Fallbacks for platforms without a readable current frequency
+            // (typical for ARM/ARM64 Neoverse-N2: no cpufreq, no MHz in /proc/cpuinfo).
+            if (freq == 0)
+                freq = CpuFrequencyFromFile(cpufreq + "cpuinfo_max_freq", 1000);
+            if (freq == 0)
+                freq = CpuFrequencyFromFile(cpufreq + "scaling_max_freq", 1000);
+            if (freq == 0)
+            {
+                ::FILE* p = ::popen("dmidecode -t processor 2>/dev/null | grep -E 'Current Speed|Max Speed' | grep -oE '[0-9]+' | head -n1", "r");
+                if (p)
+                {
+                    char buffer[PATH_MAX];
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
+                    ::pclose(p);
+                    int mhz = ::atoi(buffer);
+                    if (mhz > 0)
+                        freq = uint64_t(mhz) * 1000000;
+                }
+            }
+            if (freq == 0)
+            {
+                ::FILE* p = ::popen("lscpu 2>/dev/null | grep -oE '@ [0-9]+(\\.[0-9]+)?GHz' | head -n1 | grep -oE '[0-9]+(\\.[0-9]+)?'", "r");
+                if (p)
+                {
+                    char buffer[PATH_MAX];
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
+                    ::pclose(p);
+                    double ghz = ::atof(buffer);
+                    if (ghz > 0)
+                        freq = (uint64_t)Round(ghz * 1000000000.0);
+                }
+            }
+            return freq;
 #endif
             return 0;
         }

--- a/src/Simd/SimdBaseCpu.cpp
+++ b/src/Simd/SimdBaseCpu.cpp
@@ -51,7 +51,14 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sched.h>
+#if defined(__linux__)
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <time.h>
+#endif
 
 #if defined(SIMD_X86_ENABLE) || defined(SIMD_X64_ENABLE)
 #include <cpuid.h>
@@ -452,46 +459,26 @@ namespace Simd
             return model;
         }
 
-        uint64_t CpuFrequencyFromFile(const std::string & path, uint64_t valueScale)
+        uint64_t CpuFrequencyFromPopen(const char * command, uint64_t valueScale)
         {
             uint64_t freq = 0;
-            std::ifstream file(path.c_str());
-            if (file.is_open())
+            ::FILE* p = ::popen(command, "r");
+            if (p)
             {
-                double value = 0;
-                file >> value;
+                char buffer[PATH_MAX];
+                buffer[0] = 0;
+                while (::fgets(buffer, PATH_MAX, p));
+                ::pclose(p);
+                // Use 64-bit multiply; Round()/int overflow for GHz-scale values.
+                double value = ::atof(buffer);
                 if (value > 0)
-                    freq = (uint64_t)Round(value * double(valueScale));
+                    freq = (uint64_t)(value + 0.5) * valueScale;
             }
-            return freq;
-        }
-
-        uint64_t CpuFrequencyFromSysfs(int core)
-        {
-            if (core < 0)
-                core = 0;
-            std::string cpu = "/sys/devices/system/cpu/cpu" + std::to_string(core);
-            std::string cpufreq = cpu + "/cpufreq/";
-            std::string policy = "/sys/devices/system/cpu/cpufreq/policy" + std::to_string(core) + "/";
-            const char* names[5] = { "scaling_cur_freq", "cpuinfo_cur_freq", "cpuinfo_avg_freq", "cpuinfo_max_freq", "scaling_max_freq" };
-            for (int i = 0; i < 5; ++i)
-            {
-                uint64_t freq = CpuFrequencyFromFile(cpufreq + names[i], 1000);
-                if (freq == 0)
-                    freq = CpuFrequencyFromFile(policy + names[i], 1000);
-                if (freq > 0)
-                    return freq;
-            }
-            // ACPI CPPC (common on ARM/ARM64 servers, including Neoverse): values are in MHz.
-            uint64_t freq = CpuFrequencyFromFile(cpu + "/acpi_cppc/nominal_freq", 1000000);
-            if (freq == 0)
-                freq = CpuFrequencyFromFile(cpu + "/acpi_cppc/lowest_freq", 1000000);
             return freq;
         }
 
         uint64_t CpuFrequencyFromSmbios()
         {
-            // Prefer per-structure sysfs nodes when present.
             for (int i = 0; i < 8; ++i)
             {
                 std::string path = "/sys/firmware/dmi/entries/4-" + std::to_string(i) + "/raw";
@@ -509,7 +496,6 @@ namespace Simd
                     return uint64_t(mhz) * 1000000;
             }
 
-            // Fallback: scan raw SMBIOS table (usually world-readable; no root dmidecode needed).
             std::ifstream table("/sys/firmware/dmi/tables/DMI", std::ios::binary);
             if (!table.is_open())
                 return 0;
@@ -541,33 +527,46 @@ namespace Simd
             return 0;
         }
 
-        uint64_t CpuFrequencyFromDeviceTree()
+#if defined(__linux__)
+        uint64_t CpuFrequencyByMeasurement()
         {
-            ::FILE* p = ::popen("find /sys/firmware/devicetree/base/cpus -name clock-frequency 2>/dev/null | head -n1", "r");
-            if (!p)
+            struct perf_event_attr pe;
+            memset(&pe, 0, sizeof(pe));
+            pe.type = PERF_TYPE_HARDWARE;
+            pe.size = sizeof(struct perf_event_attr);
+            pe.config = PERF_COUNT_HW_CPU_CYCLES;
+            pe.disabled = 1;
+
+            long fd = ::syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
+            if (fd < 0)
                 return 0;
-            char path[PATH_MAX];
-            path[0] = 0;
-            if (!::fgets(path, PATH_MAX, p))
-            {
-                ::pclose(p);
+
+            ::ioctl((int)fd, PERF_EVENT_IOC_RESET, 0);
+            ::ioctl((int)fd, PERF_EVENT_IOC_ENABLE, 0);
+
+            struct timespec t0, t1;
+            ::clock_gettime(CLOCK_MONOTONIC_RAW, &t0);
+            volatile uint64_t sink = 0;
+            for (uint64_t i = 0; i < 20000000ull; ++i)
+                sink += i;
+            ::clock_gettime(CLOCK_MONOTONIC_RAW, &t1);
+
+            ::ioctl((int)fd, PERF_EVENT_IOC_DISABLE, 0);
+            uint64_t cycles = 0;
+            if (::read((int)fd, &cycles, sizeof(cycles)) != (ssize_t)sizeof(cycles))
+                cycles = 0;
+            ::close((int)fd);
+            (void)sink;
+
+            double seconds = double(t1.tv_sec - t0.tv_sec) + double(t1.tv_nsec - t0.tv_nsec) * 1e-9;
+            if (seconds <= 0 || cycles == 0)
                 return 0;
-            }
-            ::pclose(p);
-            std::string filePath = path;
-            filePath = filePath.substr(0, filePath.find('\n'));
-            if (filePath.empty())
+            uint64_t hz = (uint64_t)(double(cycles) / seconds + 0.5);
+            if (hz < 100000000ull || hz > 10000000000ull)
                 return 0;
-            std::ifstream file(filePath.c_str(), std::ios::binary);
-            if (!file.is_open())
-                return 0;
-            unsigned char b[4] = { 0, 0, 0, 0 };
-            file.read((char*)b, 4);
-            if (file.gcount() < 4)
-                return 0;
-            uint64_t hz = (uint64_t(b[0]) << 24) | (uint64_t(b[1]) << 16) | (uint64_t(b[2]) << 8) | uint64_t(b[3]);
-            return hz > 0 ? hz : 0;
+            return hz;
         }
+#endif
 
         uint64_t CpuCurrentFrequency()
         {
@@ -577,13 +576,28 @@ namespace Simd
             int core = sched_getcpu();
             if (core < 0)
                 core = 0;
+            uint64_t freq = 0;
+            char buffer[PATH_MAX];
 
-            uint64_t freq = CpuFrequencyFromSysfs(core);
-            // AMU-based scaling_cur_freq can be 0 on an idle core; try cpu0 and a few neighbors.
-            for (int i = 0; freq == 0 && i < 8; ++i)
-                if (i != core)
-                    freq = CpuFrequencyFromSysfs(i);
+            // 1) cpufreq sysfs (kHz). Scan all CPUs/policies: AMU scaling_cur_freq can be 0 on an idle core.
+            freq = CpuFrequencyFromPopen(
+                "cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq "
+                "/sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq "
+                "/sys/devices/system/cpu/cpu*/cpufreq/cpuinfo_cur_freq "
+                "/sys/devices/system/cpu/cpu*/cpufreq/cpuinfo_avg_freq "
+                "/sys/devices/system/cpu/cpu*/cpufreq/cpuinfo_max_freq "
+                "/sys/devices/system/cpu/cpu*/cpufreq/scaling_max_freq "
+                "/sys/devices/system/cpu/cpufreq/policy*/cpuinfo_max_freq "
+                "2>/dev/null | awk '$1 > 0 { print $1; exit }'", 1000);
 
+            // 2) ACPI CPPC nominal frequency (MHz), typical on ARM/ARM64 Neoverse.
+            if (freq == 0)
+                freq = CpuFrequencyFromPopen(
+                    "cat /sys/devices/system/cpu/cpu*/acpi_cppc/nominal_freq "
+                    "/sys/devices/system/cpu/cpu*/acpi_cppc/lowest_freq "
+                    "2>/dev/null | awk '$1 > 0 { print $1; exit }'", 1000000);
+
+            // 3) /proc/cpuinfo (x86 and some ARM kernels).
             if (freq == 0)
             {
                 std::stringstream args;
@@ -591,7 +605,6 @@ namespace Simd
                 ::FILE* p = ::popen(args.str().c_str(), "r");
                 if (p)
                 {
-                    char buffer[PATH_MAX];
                     buffer[0] = 0;
                     while (::fgets(buffer, PATH_MAX, p));
                     ::pclose(p);
@@ -599,75 +612,62 @@ namespace Simd
                     std::size_t beg = output.find(":");
                     if (beg != std::string::npos)
                     {
-                        int mhz = Round(::atof(output.substr(beg + 1).c_str()));
+                        double mhz = ::atof(output.substr(beg + 1).c_str());
                         if (mhz > 0)
-                            freq = uint64_t(mhz) * 1000000;
+                            freq = (uint64_t)(mhz + 0.5) * 1000000;
                     }
                 }
             }
 
-            // ARM/ARM64 Neoverse-N2 and similar: often no cpufreq and no MHz in /proc/cpuinfo.
+            // 4) SMBIOS Type 4 via sysfs (no root), then dmidecode / lscpu.
             if (freq == 0)
                 freq = CpuFrequencyFromSmbios();
             if (freq == 0)
-                freq = CpuFrequencyFromDeviceTree();
+                freq = CpuFrequencyFromPopen(
+                    "dmidecode -t processor 2>/dev/null | grep -E 'Current Speed|Max Speed' | "
+                    "grep -oE '[1-9][0-9]*' | head -n1", 1000000);
+            if (freq == 0)
+                freq = CpuFrequencyFromPopen(
+                    "dmidecode -s processor-frequency 2>/dev/null | grep -oE '[1-9][0-9]*' | head -n1", 1000000);
+            if (freq == 0)
+                freq = CpuFrequencyFromPopen(
+                    "lscpu 2>/dev/null | grep -E 'CPU max MHz|CPU MHz' | head -n1 | "
+                    "grep -oE '[0-9]+(\\.[0-9]+)?' | head -n1", 1000000);
             if (freq == 0)
             {
-                // Non-zero speeds only (skip "Current Speed: 0" / "Unknown").
-                ::FILE* p = ::popen("dmidecode -t processor 2>/dev/null | grep -E 'Current Speed|Max Speed' | grep -oE '[1-9][0-9]*' | head -n1", "r");
+                ::FILE* p = ::popen(
+                    "lscpu 2>/dev/null | grep -oE '@[ ]*[0-9]+(\\.[0-9]+)?[ ]*GHz' | head -n1 | "
+                    "grep -oE '[0-9]+(\\.[0-9]+)?'", "r");
                 if (p)
                 {
-                    char buffer[PATH_MAX];
-                    buffer[0] = 0;
-                    while (::fgets(buffer, PATH_MAX, p));
-                    ::pclose(p);
-                    int mhz = ::atoi(buffer);
-                    if (mhz > 0)
-                        freq = uint64_t(mhz) * 1000000;
-                }
-            }
-            if (freq == 0)
-            {
-                ::FILE* p = ::popen("dmidecode -s processor-frequency 2>/dev/null | grep -oE '[1-9][0-9]*' | head -n1", "r");
-                if (p)
-                {
-                    char buffer[PATH_MAX];
-                    buffer[0] = 0;
-                    while (::fgets(buffer, PATH_MAX, p));
-                    ::pclose(p);
-                    int mhz = ::atoi(buffer);
-                    if (mhz > 0)
-                        freq = uint64_t(mhz) * 1000000;
-                }
-            }
-            if (freq == 0)
-            {
-                ::FILE* p = ::popen("lscpu 2>/dev/null | grep -E 'CPU max MHz|CPU MHz' | head -n1 | grep -oE '[0-9]+(\\.[0-9]+)?' | head -n1", "r");
-                if (p)
-                {
-                    char buffer[PATH_MAX];
-                    buffer[0] = 0;
-                    while (::fgets(buffer, PATH_MAX, p));
-                    ::pclose(p);
-                    double mhz = ::atof(buffer);
-                    if (mhz > 0)
-                        freq = (uint64_t)Round(mhz * 1000000.0);
-                }
-            }
-            if (freq == 0)
-            {
-                ::FILE* p = ::popen("lscpu 2>/dev/null | grep -oE '@[ ]*[0-9]+(\\.[0-9]+)?[ ]*GHz' | head -n1 | grep -oE '[0-9]+(\\.[0-9]+)?'", "r");
-                if (p)
-                {
-                    char buffer[PATH_MAX];
                     buffer[0] = 0;
                     while (::fgets(buffer, PATH_MAX, p));
                     ::pclose(p);
                     double ghz = ::atof(buffer);
                     if (ghz > 0)
-                        freq = (uint64_t)Round(ghz * 1000000000.0);
+                        freq = (uint64_t)(ghz * 1000000000.0 + 0.5);
                 }
             }
+            if (freq == 0)
+            {
+                // Device-tree clock-frequency (Hz, big-endian u32).
+                ::FILE* p = ::popen(
+                    "path=$(find /sys/firmware/devicetree/base/cpus -name clock-frequency 2>/dev/null | head -n1); "
+                    "if [ -n \"$path\" ]; then od -An -t u4 -N 4 --endian=big \"$path\" 2>/dev/null | tr -d ' '; fi", "r");
+                if (p)
+                {
+                    buffer[0] = 0;
+                    while (::fgets(buffer, PATH_MAX, p));
+                    ::pclose(p);
+                    double hz = ::atof(buffer);
+                    if (hz > 0)
+                        freq = (uint64_t)(hz + 0.5);
+                }
+            }
+#if defined(__linux__)
+            if (freq == 0)
+                freq = CpuFrequencyByMeasurement();
+#endif
             return freq;
 #endif
             return 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Base::CpuCurrentFrequency()` returned **0 Hz** on ARM/ARM64 Neoverse-N2 Linux.

### Root causes addressed

1. **Idle-core AMU zero**: `scaling_cur_freq` can be `0` on the current core; old code returned immediately without trying other CPUs / max freq.
2. **`Round()` overflow** (prior revision): `Round()` returns `int`, so `kHz * 1000` / `MHz * 1e6` overflows around 2.1 GHz.
3. **Missing ARM sources**: no `MHz` in `/proc/cpuinfo`; need CPPC / SMBIOS / other fallbacks.

### Fix (`SimdBaseCpu.cpp`)

1. Scan **all** `cpu*/cpufreq` + `policy*` files; take first value `&gt; 0` (kHz → Hz via 64-bit multiply)
2. ACPI CPPC `nominal_freq` / `lowest_freq` (MHz)
3. `/proc/cpuinfo` `MHz`
4. SMBIOS Type 4 from `/sys/firmware/dmi/...` (no root)
5. `dmidecode` / `lscpu`
6. Device-tree `clock-frequency`
7. `perf_event_open` cycle measurement (when permitted)

Also documents the fix in `docs/2026.html` release **7.2.165**.

## Test plan

- [x] Build `libSimd.so` (g++)
- [x] Frequency non-zero on this host (2400 MHz via `/proc/cpuinfo`)
- [x] `awk '$1 > 0'` skips leading idle `0` readings and selects `2600000`
- [x] aarch64 cross-compile of `SimdBaseCpu.cpp` succeeds
- [ ] Retest on Neoverse-N2 with commit `97aff938f`

If still 0 on Neoverse-N2, please share:

```bash
ls /sys/devices/system/cpu/cpu0/cpufreq /sys/devices/system/cpu/cpu0/acpi_cppc 2>&1
cat /sys/devices/system/cpu/cpu*/cpufreq/*cur* /sys/devices/system/cpu/cpu*/cpufreq/*max* 2>/dev/null | head
cat /sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq 2>&1
ls /sys/firmware/dmi/tables 2>&1
dmidecode -t processor 2>&1 | head -40
lscpu | head -40
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c01f076-703e-4d69-a1bb-f2b1f7662de4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c01f076-703e-4d69-a1bb-f2b1f7662de4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

