### PR TITLE
Add SVE2 optimizations for SynetQuantizedMergedConvolution Cdc/Cd/Dc

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -63,9 +63,9 @@
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution16bCdc.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution16bCd.</li>
  <li>NEON, SVE2 optimizations of classes SynetMergedConvolution16bDc.</li>
- <li>NEON optimizations of classes SynetQuantizedMergedConvolutionCdc.</li>
- <li>NEON optimizations of classes SynetQuantizedMergedConvolutionCd.</li>
- <li>NEON optimizations of classes SynetQuantizedMergedConvolutionDc.</li>
+ <li>NEON, SVE2 optimizations of classes SynetQuantizedMergedConvolutionCdc.</li>
+ <li>NEON, SVE2 optimizations of classes SynetQuantizedMergedConvolutionCd.</li>
+ <li>NEON, SVE2 optimizations of classes SynetQuantizedMergedConvolutionDc.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -153,6 +153,10 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConcat.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolutionDepthwise.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolutionInput.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolutionOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedPoolingAverage.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedScale.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -470,6 +470,18 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConcat.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolution.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolutionDepthwise.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolutionInput.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolutionOutput.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMul.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7480,7 +7480,7 @@ SIMD_API void* SimdSynetQuantizedMergedConvolutionInit(size_t batch, const SimdC
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetQuantizedMergedConvolutionInitPtr) (size_t batch, const SimdConvolutionParameters* convs, size_t count, int add);
-    const static SimdSynetQuantizedMergedConvolutionInitPtr simdSynetQuantizedMergedConvolutionInit = SIMD_FUNC6(SynetQuantizedMergedConvolutionInit, SIMD_AMXBF16_FUNC, SIMD_AVX512VNNI_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedMergedConvolutionInitPtr simdSynetQuantizedMergedConvolutionInit = SIMD_FUNC7(SynetQuantizedMergedConvolutionInit, SIMD_AMXBF16_FUNC, SIMD_AVX512VNNI_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetQuantizedMergedConvolutionInit(batch, convs, count, add);
 #else

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolution.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolution.cpp
@@ -1,0 +1,94 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedMergedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        typedef Base::SynetQuantizedMergedConvolution::AlgParam AlgParam;
+
+        //------------------------------------------------------------------------------------------------
+
+        SynetQuantizedMergedConvolutionCdc::SynetQuantizedMergedConvolutionCdc(const MergConvParam& p)
+            : Base::SynetQuantizedMergedConvolutionCdc(p)
+        {
+            SetSize(svcntw(), 4, 2);
+            SetInputConvolution(p.conv[0], _alg, _inputConvolution);
+            SetDepthwisePreprocess(p.conv[1], _alg, _depthwisePreprocess);
+            SetDepthwiseConvolution(p.conv[1], _alg, _depthwiseConvolution);
+            SetOutputConvolution(p.conv[2], _alg, _outputConvolution);
+            SetAddInputToOutput(p.conv[2], _alg, _addInputToOutput);
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        SynetQuantizedMergedConvolutionCd::SynetQuantizedMergedConvolutionCd(const MergConvParam& p)
+            : Base::SynetQuantizedMergedConvolutionCd(p)
+        {
+            SetSize(svcntw(), 4, 2);
+            SetInputConvolution(p.conv[0], _alg, _inputConvolution);
+            SetDepthwisePreprocess(p.conv[1], _alg, _depthwisePreprocess);
+            SetDepthwiseConvolution(p.conv[1], _alg, _depthwiseConvolution);
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        SynetQuantizedMergedConvolutionDc::SynetQuantizedMergedConvolutionDc(const MergConvParam& p)
+            : Base::SynetQuantizedMergedConvolutionDc(p)
+        {
+            SetSize(svcntw(), 4, 2);
+            SetDepthwisePreprocess(p.conv[0], _alg, _depthwisePreprocess);
+            SetDepthwiseConvolution(p.conv[0], _alg, _depthwiseConvolution);
+            SetOutputConvolution(p.conv[1], _alg, _outputConvolution);
+            SetAddInputToOutput(p.conv[1], _alg, _addInputToOutput);
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        void* SynetQuantizedMergedConvolutionInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, int add)
+        {
+            MergConvParam param(batch, convs, count, add);
+            if (!param.Valid(SimdTensorData8u, SimdTensorData8u))
+                return NULL;
+            else if (SynetQuantizedMergedConvolutionCdc::Preferable(param))
+                return new SynetQuantizedMergedConvolutionCdc(param);
+            else if (SynetQuantizedMergedConvolutionCd::Preferable(param))
+                return new SynetQuantizedMergedConvolutionCd(param);
+            else if (SynetQuantizedMergedConvolutionDc::Preferable(param))
+                return new SynetQuantizedMergedConvolutionDc(param);
+            return new Base::SynetQuantizedMergedConvolutionRef(param);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionDepthwise.cpp
@@ -1,0 +1,647 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedMergedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        typedef Base::SynetQuantizedMergedConvolution::AlgParam AlgParam;
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svint32_t UnpackU8(const uint8_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE svint32_t PackRows(const svint32_t& s0, const svint32_t& s1, const svbool_t& mask)
+        {
+            return svorr_s32_x(mask, s0, svlsl_n_s32_x(mask, s1, 16));
+        }
+
+        SIMD_INLINE svint32_t ShiftLeft16(const svint32_t& value, const svbool_t& mask)
+        {
+            return svlsl_n_s32_x(mask, value, 16);
+        }
+
+        SIMD_INLINE svint32_t ShiftRight16(const svint32_t& value, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svlsr_n_u32_x(mask, svreinterpret_u32_s32(value), 16));
+        }
+
+        void QuantizedMergedConvolutionDepthwisePreprocess(const uint8_t* src, const uint8_t* zero, const ConvParam& p, const AlgParam& a, size_t maC, size_t dyBeg, size_t dyEnd, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body32 = svptrue_b32();
+            const svbool_t body16 = svptrue_b16();
+            svint16_t _zero = svdup_n_s16(zero[0]);
+            size_t byMask = a.dbH - 1, byPad = p.kernelY - 1, byBeg = dyBeg ? dyBeg * p.strideY + byPad : 0, byEnd = dyEnd * p.strideY + byPad;
+            if (a.dsB)
+            {
+                size_t syMask = a.dsH - 1, sC = a.dsH * p.srcW, sR = p.srcW * F;
+                size_t bW = a.dbW * 2, bR = a.dbW * a.maC, xPad = p.padX * 2, wPad = p.padW * 2;
+                for (size_t c = 0; c < maC; c += F)
+                {
+                    for (size_t by = byBeg; by < byEnd; by += 2)
+                    {
+                        int16_t* pd = (int16_t*)dst + (by & byMask) * bR;
+                        size_t sy = by - p.padY;
+                        const uint8_t* ps0 = (sy + 0) < p.srcH ? src + ((sy + 0) & syMask) * sR : zero;
+                        const uint8_t* ps1 = (sy + 1) < p.srcH ? src + ((sy + 1) & syMask) * sR : zero;
+                        if (xPad)
+                        {
+                            for (size_t x = 0; x < xPad; x += 2, pd += DF)
+                                svst1_s16(body16, pd, _zero);
+                        }
+                        for (size_t sx = 0; sx < sR; sx += F, pd += DF)
+                        {
+                            svint32_t s0 = UnpackU8(ps0 + sx, body32);
+                            svint32_t s1 = UnpackU8(ps1 + sx, body32);
+                            svst1_s32(body32, (int32_t*)pd, PackRows(s0, s1, body32));
+                        }
+                        if (wPad)
+                        {
+                            for (size_t x = 0; x < wPad; x += 2, pd += DF)
+                                svst1_s16(body16, pd, _zero);
+                        }
+                    }
+                    src += sC * F;
+                    dst += bW * DF;
+                }
+            }
+            else
+            {
+                size_t sR = p.srcW * p.srcC, sC = p.srcC;
+                size_t bW = a.dbW * 2, bC = a.maC, xPad = p.padX * 2, wPad = p.padW * 2, bR = a.dbW * a.maC;
+                for (size_t by = byBeg; by < byEnd; by += 2)
+                {
+                    int16_t* pd = (int16_t*)dst + (by & byMask) * bR;
+                    size_t sy = by - p.padY;
+                    const uint8_t* ps0 = (sy + 0) < p.srcH ? src + (sy + 0) * sR : zero;
+                    const uint8_t* ps1 = (sy + 1) < p.srcH ? src + (sy + 1) * sR : zero;
+                    if (xPad)
+                    {
+                        for (size_t x = 0; x < xPad; x += 2, pd += DF)
+                            for (size_t c = 0; c < bC; c += F)
+                                svst1_s16(body16, pd + c * bW, _zero);
+                    }
+                    for (size_t sx = 0; sx < p.srcW; sx++, pd += DF)
+                    {
+                        for (size_t sc = 0; sc < maC; sc += F)
+                        {
+                            svint32_t s0 = UnpackU8(ps0 + sc, body32);
+                            svint32_t s1 = UnpackU8(ps1 + sc, body32);
+                            svst1_s32(body32, (int32_t*)(pd + sc * bW), PackRows(s0, s1, body32));
+                        }
+                        ps0 += sC;
+                        ps1 += sC;
+                    }
+                    if (wPad)
+                    {
+                        for (size_t x = 0; x < wPad; x += 2, pd += DF)
+                            for (size_t c = 0; c < bC; c += F)
+                                svst1_s16(body16, pd + c * bW, _zero);
+                    }
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void Madd2(svint32_t& i32, const svint32_t& u8, const svint32_t& i8)
+        {
+            const svbool_t mask = svptrue_b32();
+            svint16_t a = svreinterpret_s16_s32(u8);
+            svint16_t b = svreinterpret_s16_s32(i8);
+            svint32_t even = svmullb_s32(a, b);
+            svint32_t odd = svmullt_s32(a, b);
+            i32 = svadd_s32_x(mask, i32, svadd_s32_x(mask, even, odd));
+        }
+
+        SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero)
+        {
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, (int32_t*)NULL, sum, &bias, &norm, zero, svptrue_b32());
+        }
+
+        SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero, size_t tail)
+        {
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, (int32_t*)NULL, sum, &bias, &norm, zero, svwhilelt_b32((size_t)0, tail));
+        }
+
+        SIMD_INLINE svint32_t LoadI16(const int16_t* src)
+        {
+            return svld1_s32(svptrue_b32(), (const int32_t*)src);
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        void QuantizedMergedConvolutionDepthwiseConvolutionAny(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t maC, size_t dyBeg, size_t dyEnd,
+            const int8_t* weight8, const int32_t* bias, const float* norm, int32_t zero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            const int16_t* src = (int16_t*)src8, *weight = (int16_t*)weight8;
+            svfloat32_t _norm;
+            svint32_t _zero = svdup_n_s32(zero), _bias;
+            svint32_t d00, d10, d20, d30, d01, d11, d21, d31, w0, w1, s0;
+            size_t sC = maC, sCF = AlignLo(sC, F), kY = p.kernelY, kX = p.kernelX, sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.dwStep;
+            size_t byMask = a.dbH - 1, bW = a.dbW * 2, bR = a.dbW * a.maC, dstW2 = AlignLo(p.dstW, 2), dstW4 = AlignLo(p.dstW, 4), dD = a.ddB ? a.maC : p.dstC;
+            size_t dyEnd2 = dyBeg + (sY == 1 ? AlignLo(dyEnd - dyBeg, 2) : 0), sizeW = a.dwSize, dyD = p.dstW * dD;
+            if(a.ddB)
+                dst += (dyBeg % a.ddStep) * p.dstW * dD;
+            else
+                dst += dyBeg * p.dstW * dD;
+            size_t dy = dyBeg;
+            for (; dy < dyEnd2; dy += 2)
+            {
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < sCF; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + sc * bW;
+                    _bias = svld1_s32(body, bias + sc);
+                    _norm = svld1_f32(body, norm + sc);
+                    size_t dx = 0;
+                    for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        d20 = svdup_n_s32(0);
+                        d30 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        d11 = svdup_n_s32(0);
+                        d21 = svdup_n_s32(0);
+                        d31 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                                s0 = LoadI16(ps + 1 * dX);
+                                Madd2(d10, s0, w0);
+                                Madd2(d11, s0, w1);
+                                s0 = LoadI16(ps + 2 * dX);
+                                Madd2(d20, s0, w0);
+                                Madd2(d21, s0, w1);
+                                s0 = LoadI16(ps + 3 * dX);
+                                Madd2(d30, s0, w0);
+                                Madd2(d31, s0, w1);
+                            }
+                        }
+                        Save1(pd0 + 0 * dD, d00, _bias, _norm, _zero);
+                        Save1(pd0 + 1 * dD, d10, _bias, _norm, _zero);
+                        Save1(pd0 + 2 * dD, d20, _bias, _norm, _zero);
+                        Save1(pd0 + 3 * dD, d30, _bias, _norm, _zero);
+                        Save1(pd1 + 0 * dD, d01, _bias, _norm, _zero);
+                        Save1(pd1 + 1 * dD, d11, _bias, _norm, _zero);
+                        Save1(pd1 + 2 * dD, d21, _bias, _norm, _zero);
+                        Save1(pd1 + 3 * dD, d31, _bias, _norm, _zero);
+                        pd0 += 4 * dD;
+                        pd1 += 4 * dD;
+                    }
+                    for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        d11 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                                s0 = LoadI16(ps + 1 * dX);
+                                Madd2(d10, s0, w0);
+                                Madd2(d11, s0, w1);
+                            }
+                        }
+                        Save1(pd0 + 0 * dD, d00, _bias, _norm, _zero);
+                        Save1(pd0 + 1 * dD, d10, _bias, _norm, _zero);
+                        Save1(pd1 + 0 * dD, d01, _bias, _norm, _zero);
+                        Save1(pd1 + 1 * dD, d11, _bias, _norm, _zero);
+                        pd0 += 2 * dD;
+                        pd1 += 2 * dD;
+                    }
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                            }
+                        }
+                        Save1(pd0 + 0 * dD, d00, _bias, _norm, _zero);
+                        Save1(pd1 + 0 * dD, d01, _bias, _norm, _zero);
+                        pd0 += dD;
+                        pd1 += dD;
+                    }
+                }
+                for (; sc < sC; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + sc * bW;
+                    _bias = svld1_s32(body, bias + sc);
+                    _norm = svld1_f32(body, norm + sc);
+                    size_t dx = 0, tail = sC - sCF;
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                            }
+                        }
+                        Save1(pd0 + 0 * dD, d00, _bias, _norm, _zero, tail);
+                        Save1(pd1 + 0 * dD, d01, _bias, _norm, _zero, tail);
+                        pd0 += dD;
+                        pd1 += dD;
+                    }
+                }
+                dst += p.dstW * 2 * dD;
+            }
+            for (; dy < dyEnd; ++dy)
+            {
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < sCF; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + sc * bW;
+                    _bias = svld1_s32(body, bias + sc);
+                    _norm = svld1_f32(body, norm + sc);
+                    size_t dx = 0;
+                    for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        d20 = svdup_n_s32(0);
+                        d30 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps + 0 * dX), w0);
+                                Madd2(d10, LoadI16(ps + 1 * dX), w0);
+                                Madd2(d20, LoadI16(ps + 2 * dX), w0);
+                                Madd2(d30, LoadI16(ps + 3 * dX), w0);
+                            }
+                        }
+                        Save1(pd + 0 * dD, d00, _bias, _norm, _zero);
+                        Save1(pd + 1 * dD, d10, _bias, _norm, _zero);
+                        Save1(pd + 2 * dD, d20, _bias, _norm, _zero);
+                        Save1(pd + 3 * dD, d30, _bias, _norm, _zero);
+                        pd += 4 * dD;
+                    }
+                    for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps + 0 * dX), w0);
+                                Madd2(d10, LoadI16(ps + 1 * dX), w0);
+                            }
+                        }
+                        Save1(pd + 0 * dD, d00, _bias, _norm, _zero);
+                        Save1(pd + 1 * dD, d10, _bias, _norm, _zero);
+                        pd += 2 * dD;
+                    }
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps), w0);
+                            }
+                        }
+                        Save1(pd, d00, _bias, _norm, _zero);
+                        pd += dD;
+                    }
+                }
+                for (; sc < sC; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + sc * bW;
+                    _bias = svld1_s32(body, bias + sc);
+                    _norm = svld1_f32(body, norm + sc);
+                    size_t dx = 0, tail = sC - sCF;
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps), w0);
+                            }
+                        }
+                        Save1(pd, d00, _bias, _norm, _zero, tail);
+                        pd += dD;
+                    }
+                }
+                dst += p.dstW * dD;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void QuantizedMergedConvolutionDepthwiseConvolution3x3(const uint8_t* src8, const ConvParam& p, const AlgParam& a, size_t maC, size_t dyBeg, size_t dyEnd,
+            const int8_t* weight8, const int32_t* bias, const float* norm, int32_t zero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2, QF = F * 4;
+            const svbool_t body = svptrue_b32();
+            const int16_t* src = (int16_t*)src8, * weight = (int16_t*)weight8;
+            svfloat32_t _norm;
+            svint32_t _zero = svdup_n_s32(zero), _bias;
+            svint32_t d00, d10, w03, w14, w25, s0;
+            size_t sC = maC, sCF = AlignLo(sC, F), kY = p.kernelY, kX = p.kernelX, sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.dwStep;
+            size_t byMask = a.dbH - 1, bW = a.dbW * 2, bR = a.dbW * a.maC, dstW2 = (sX == 1 ? AlignLo(p.dstW, 2) : 0), dD = a.ddB ? a.maC : p.dstC;
+            size_t dyEnd2 = dyBeg + (sY == 1 ? AlignLo(dyEnd - dyBeg, 2) : 0), sizeW = a.dwSize, dyD = p.dstW * dD;
+            if (a.ddB)
+                dst += (dyBeg % a.ddStep) * p.dstW * dD;
+            else
+                dst += dyBeg * p.dstW * dD;
+            size_t dy = dyBeg;
+            for (; dy < dyEnd2; dy += 2)
+            {
+                svint32_t d01, w36, w47, w58;
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < sC; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + ((sy + 0) & byMask) * bR + sc * bW;
+                    const int16_t* ps2 = src + ((sy + 2) & byMask) * bR + sc * bW;
+                    const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                    _bias = svld1_s32(body, bias + sc);
+                    _norm = svld1_f32(body, norm + sc);
+                    w03 = LoadI16(pw0 + 0 * DF);
+                    w14 = LoadI16(pw0 + 1 * DF);
+                    w25 = LoadI16(pw0 + 2 * DF);
+                    w36 = LoadI16(pw1 + 3 * DF);
+                    w47 = LoadI16(pw1 + 4 * DF);
+                    w58 = LoadI16(pw1 + 5 * DF);
+                    if (sc < sCF)
+                    {
+                        size_t dx = 0;
+                        for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+                            d01 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF);
+                            Madd2(d00, s0, w03);
+                            Madd2(d01, s0, ShiftLeft16(w03, body));
+                            s0 = LoadI16(ps0 + 1 * DF);
+                            Madd2(d00, s0, w14);
+                            Madd2(d01, s0, ShiftLeft16(w14, body));
+                            s0 = LoadI16(ps0 + 2 * DF);
+                            Madd2(d00, s0, w25);
+                            Madd2(d01, s0, ShiftLeft16(w25, body));
+                            s0 = LoadI16(ps2 + 0 * DF);
+                            Madd2(d00, s0, ShiftRight16(w36, body));
+                            Madd2(d01, s0, w36);
+                            s0 = LoadI16(ps2 + 1 * DF);
+                            Madd2(d00, s0, ShiftRight16(w47, body));
+                            Madd2(d01, s0, w47);
+                            s0 = LoadI16(ps2 + 2 * DF);
+                            Madd2(d00, s0, ShiftRight16(w58, body));
+                            Madd2(d01, s0, w58);
+
+                            Save1(pd0, d00, _bias, _norm, _zero);
+                            Save1(pd1, d01, _bias, _norm, _zero);
+                            pd0 += dD;
+                            pd1 += dD;
+                        }
+                    }
+                    else
+                    {
+                        size_t tail = sC - sCF;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+                            d01 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF);
+                            Madd2(d00, s0, w03);
+                            Madd2(d01, s0, ShiftLeft16(w03, body));
+                            s0 = LoadI16(ps0 + 1 * DF);
+                            Madd2(d00, s0, w14);
+                            Madd2(d01, s0, ShiftLeft16(w14, body));
+                            s0 = LoadI16(ps0 + 2 * DF);
+                            Madd2(d00, s0, w25);
+                            Madd2(d01, s0, ShiftLeft16(w25, body));
+                            s0 = LoadI16(ps2 + 0 * DF);
+                            Madd2(d00, s0, ShiftRight16(w36, body));
+                            Madd2(d01, s0, w36);
+                            s0 = LoadI16(ps2 + 1 * DF);
+                            Madd2(d00, s0, ShiftRight16(w47, body));
+                            Madd2(d01, s0, w47);
+                            s0 = LoadI16(ps2 + 2 * DF);
+                            Madd2(d00, s0, ShiftRight16(w58, body));
+                            Madd2(d01, s0, w58);
+
+                            Save1(pd0, d00, _bias, _norm, _zero, tail);
+                            Save1(pd1, d01, _bias, _norm, _zero, tail);
+                            pd0 += dD;
+                            pd1 += dD;
+                        }
+                    }
+                }
+                dst += p.dstW * dD * 2;
+            }
+            for (; dy < dyEnd; ++dy)
+            {
+                svint32_t w6, w7, w8;
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < sC; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + ((sy + 0) & byMask) * bR + sc * bW;
+                    const int16_t* ps2 = src + ((sy + 2) & byMask) * bR + sc * bW;
+                    const int16_t* pw = weight + sc * dW;
+                    _bias = svld1_s32(body, bias + sc);
+                    _norm = svld1_f32(body, norm + sc);
+                    w03 = LoadI16(pw + 0 * DF);
+                    w14 = LoadI16(pw + 1 * DF);
+                    w25 = LoadI16(pw + 2 * DF);
+                    w6 = LoadI16(pw + 3 * DF);
+                    w7 = LoadI16(pw + 4 * DF);
+                    w8 = LoadI16(pw + 5 * DF);
+                    if (sc < sCF)
+                    {
+                        size_t dx = 0;
+                        for (; dx < dstW2; dx += 2, ps0 += QF, ps2 += QF)
+                        {
+                            d00 = svdup_n_s32(0);
+                            d10 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * DF);
+                            Madd2(d00, s0, w14);
+                            Madd2(d10, s0, w03);
+                            s0 = LoadI16(ps0 + 2 * DF);
+                            Madd2(d00, s0, w25);
+                            Madd2(d10, s0, w14);
+                            s0 = LoadI16(ps0 + 3 * DF);
+                            Madd2(d10, s0, w25);
+
+                            s0 = LoadI16(ps2 + 0 * DF);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * DF);
+                            Madd2(d00, s0, w7);
+                            Madd2(d10, s0, w6);
+                            s0 = LoadI16(ps2 + 2 * DF);
+                            Madd2(d00, s0, w8);
+                            Madd2(d10, s0, w7);
+                            s0 = LoadI16(ps2 + 3 * DF);
+                            Madd2(d10, s0, w8);
+
+                            Save1(pd + 0 * dD, d00, _bias, _norm, _zero);
+                            Save1(pd + 1 * dD, d10, _bias, _norm, _zero);
+                            pd += 2 * dD;
+                        }
+                        for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * DF);
+                            Madd2(d00, s0, w14);
+                            s0 = LoadI16(ps0 + 2 * DF);
+                            Madd2(d00, s0, w25);
+                            s0 = LoadI16(ps2 + 0 * DF);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * DF);
+                            Madd2(d00, s0, w7);
+                            s0 = LoadI16(ps2 + 2 * DF);
+                            Madd2(d00, s0, w8);
+
+                            Save1(pd, d00, _bias, _norm, _zero);
+                            pd += dD;
+                        }
+                    }
+                    else
+                    {
+                        size_t tail = sC - sCF;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * DF);
+                            Madd2(d00, s0, w14);
+                            s0 = LoadI16(ps0 + 2 * DF);
+                            Madd2(d00, s0, w25);
+                            s0 = LoadI16(ps2 + 0 * DF);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * DF);
+                            Madd2(d00, s0, w7);
+                            s0 = LoadI16(ps2 + 2 * DF);
+                            Madd2(d00, s0, w8);
+
+                            Save1(pd, d00, _bias, _norm, _zero, tail);
+                            pd += dD;
+                        }
+                    }
+                }
+                dst += p.dstW * dD;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        void SetDepthwisePreprocess(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::DepthwisePreprocessPtr& func)
+        {
+            func = QuantizedMergedConvolutionDepthwisePreprocess;
+        }
+
+        void SetDepthwiseConvolution(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::DepthwiseConvolutionPtr& func)
+        {
+            if(p.IsKernel(3))
+                func = QuantizedMergedConvolutionDepthwiseConvolution3x3;
+            else
+                func = QuantizedMergedConvolutionDepthwiseConvolutionAny;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionDepthwise.cpp
@@ -152,12 +152,12 @@ namespace Simd
 
         SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero)
         {
-            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, (int32_t*)NULL, sum, &bias, &norm, zero, svptrue_b32());
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, (int32_t*)NULL, sum, bias, bias, norm, norm, zero, svptrue_b32());
         }
 
         SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero, size_t tail)
         {
-            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, (int32_t*)NULL, sum, &bias, &norm, zero, svwhilelt_b32((size_t)0, tail));
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, (int32_t*)NULL, sum, bias, bias, norm, norm, zero, svwhilelt_b32((size_t)0, tail));
         }
 
         SIMD_INLINE svint32_t LoadI16(const int16_t* src)

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionInput.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionInput.cpp
@@ -41,22 +41,22 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        SIMD_INLINE void SaveInput1(uint8_t* dst, const svint32_t& sum, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+        SIMD_INLINE void SaveInput1(uint8_t* dst, const svint32_t& sum, const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero)
         {
-            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, NULL, sum, bias, norm, zero, svptrue_b32());
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, NULL, sum, bias, bias, norm, norm, zero, svptrue_b32());
         }
 
         SIMD_INLINE void SaveInput2(uint8_t* dst0, uint8_t* dst1, const svint32_t& sum0, const svint32_t& sum1,
-            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+            const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero)
         {
-            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst0, NULL, sum0, bias + 0, norm + 0, zero, svptrue_b32());
-            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst1, NULL, sum1, bias + 1, norm + 1, zero, svptrue_b32());
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst0, NULL, sum0, bias0, bias0, norm0, norm0, zero, svptrue_b32());
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst1, NULL, sum1, bias1, bias1, norm1, norm1, zero, svptrue_b32());
         }
 
         //------------------------------------------------------------------------------------------------
 
         template<int M> void QuantizedMergedConvolutionInput_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t dstC, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, uint8_t* dst0, uint8_t* dst1)
+            size_t dstC, const int8_t* weight0, const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero, uint8_t* dst0, uint8_t* dst1)
         {
             const size_t F = svcntw(), A = F * 4;
             const svbool_t body8 = svptrue_b8();
@@ -87,11 +87,11 @@ namespace Simd
                     if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0), Madd4<true>(d41, s0, w1);
                     weight0 += A, weight1 += A;
                 }
-                if (M > 0) SaveInput2(dst0 + 0 * F, dst1 + 0 * F, d00, d01, bias, norm, zero);
-                if (M > 1) SaveInput2(dst0 + 1 * F, dst1 + 1 * F, d10, d11, bias, norm, zero);
-                if (M > 2) SaveInput2(dst0 + 2 * F, dst1 + 2 * F, d20, d21, bias, norm, zero);
-                if (M > 3) SaveInput2(dst0 + 3 * F, dst1 + 3 * F, d30, d31, bias, norm, zero);
-                if (M > 4) SaveInput2(dst0 + 4 * F, dst1 + 4 * F, d40, d41, bias, norm, zero);
+                if (M > 0) SaveInput2(dst0 + 0 * F, dst1 + 0 * F, d00, d01, bias0, bias1, norm0, norm1, zero);
+                if (M > 1) SaveInput2(dst0 + 1 * F, dst1 + 1 * F, d10, d11, bias0, bias1, norm0, norm1, zero);
+                if (M > 2) SaveInput2(dst0 + 2 * F, dst1 + 2 * F, d20, d21, bias0, bias1, norm0, norm1, zero);
+                if (M > 3) SaveInput2(dst0 + 3 * F, dst1 + 3 * F, d30, d31, bias0, bias1, norm0, norm1, zero);
+                if (M > 4) SaveInput2(dst0 + 4 * F, dst1 + 4 * F, d40, d41, bias0, bias1, norm0, norm1, zero);
             }
             else
             {
@@ -110,16 +110,16 @@ namespace Simd
                     if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0);
                     weight0 += A;
                 }
-                if (M > 0) SaveInput1(dst0 + 0 * F, d00, bias, norm, zero);
-                if (M > 1) SaveInput1(dst0 + 1 * F, d10, bias, norm, zero);
-                if (M > 2) SaveInput1(dst0 + 2 * F, d20, bias, norm, zero);
-                if (M > 3) SaveInput1(dst0 + 3 * F, d30, bias, norm, zero);
-                if (M > 4) SaveInput1(dst0 + 4 * F, d40, bias, norm, zero);
+                if (M > 0) SaveInput1(dst0 + 0 * F, d00, bias0, norm0, zero);
+                if (M > 1) SaveInput1(dst0 + 1 * F, d10, bias0, norm0, zero);
+                if (M > 2) SaveInput1(dst0 + 2 * F, d20, bias0, norm0, zero);
+                if (M > 3) SaveInput1(dst0 + 3 * F, d30, bias0, norm0, zero);
+                if (M > 4) SaveInput1(dst0 + 4 * F, d40, bias0, norm0, zero);
             }
         }
 
         typedef void(*QuantizedMergedConvolutionInput_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t dstC, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, uint8_t* dst0, uint8_t* dst1);
+            size_t dstC, const int8_t* weight0, const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero, uint8_t* dst0, uint8_t* dst1);
 
         QuantizedMergedConvolutionInput_2xM_Ptr GetQuantizedMergedConvolutionInput_2xM(size_t M)
         {
@@ -142,8 +142,7 @@ namespace Simd
             const size_t F = svcntw(), DF = F * 2;
             const svbool_t body = svptrue_b32();
             size_t dstM = a.dsH - 1, dstS = a.dsH * p.dstW * F, srcC = a.isB ? a.iwStep : p.srcC, y0 = a.isB ? yBeg : 0;
-            svfloat32_t _norm[2];
-            svint32_t _bias[2], _zero = svdup_n_s32(zero);
+            svint32_t _zero = svdup_n_s32(zero);
             size_t yInt = Simd::Max(yBeg, AlignLo(yEnd, a.dsH)), n = 5;
             size_t i1 = (yInt - yBeg) * p.dstW, in = AlignLoAny(i1, n), i = i1 - in;
             size_t e1 = (yEnd - yInt) * p.dstW, en = AlignLoAny(e1, n), e = e1 - en;
@@ -153,27 +152,27 @@ namespace Simd
             for (size_t dc = 0; dc < maC; dc += DF)
             {
                 size_t dC = Simd::Min(DF, maC - dc);
-                _bias[0] = svld1_s32(body, bias + dc + 0);
-                _bias[1] = svld1_s32(body, bias + dc + F);
-                _norm[0] = svld1_f32(body, norm + dc + 0);
-                _norm[1] = svld1_f32(body, norm + dc + F);
+                svint32_t _bias0 = svld1_s32(body, bias + dc + 0);
+                svint32_t _bias1 = svld1_s32(body, bias + dc + F);
+                svfloat32_t _norm0 = svld1_f32(body, norm + dc + 0);
+                svfloat32_t _norm1 = svld1_f32(body, norm + dc + F);
                 if (yInt > yBeg)
                 {
                     const uint8_t* src0 = src + (yBeg - y0) * p.srcW * srcC;
                     uint8_t* dst0 = dst + (yBeg & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
                     for (size_t j = 0; j < in; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
-                        quantizedMergedConvolutionInput_2xN(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                        quantizedMergedConvolutionInput_2xN(src0, p, a, dC, weight, _bias0, _bias1, _norm0, _norm1, _zero, dst0, dst1);
                     if (in < i1)
-                        quantizedMergedConvolutionInput_2xI(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                        quantizedMergedConvolutionInput_2xI(src0, p, a, dC, weight, _bias0, _bias1, _norm0, _norm1, _zero, dst0, dst1);
                 }
                 if (yEnd > yInt)
                 {
                     const uint8_t* src0 = src + (yInt - y0) * p.srcW * srcC;
                     uint8_t* dst0 = dst + (yInt & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
                     for (size_t j = 0; j < en; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
-                        quantizedMergedConvolutionInput_2xN(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                        quantizedMergedConvolutionInput_2xN(src0, p, a, dC, weight, _bias0, _bias1, _norm0, _norm1, _zero, dst0, dst1);
                     if (en < e1)
-                        quantizedMergedConvolutionInput_2xE(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                        quantizedMergedConvolutionInput_2xE(src0, p, a, dC, weight, _bias0, _bias1, _norm0, _norm1, _zero, dst0, dst1);
                 }
                 dst += a.dsH * p.dstW * DF;
                 weight += a.iwStep * DF;

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionInput.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionInput.cpp
@@ -1,0 +1,191 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedMergedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        typedef Base::SynetQuantizedMergedConvolution::AlgParam AlgParam;
+
+        //-------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE void SaveInput1(uint8_t* dst, const svint32_t& sum, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+        {
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst, NULL, sum, bias, norm, zero, svptrue_b32());
+        }
+
+        SIMD_INLINE void SaveInput2(uint8_t* dst0, uint8_t* dst1, const svint32_t& sum0, const svint32_t& sum1,
+            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+        {
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst0, NULL, sum0, bias + 0, norm + 0, zero, svptrue_b32());
+            QuntizedTerm8i<Term8iLast8u>::template Save<0>(dst1, NULL, sum1, bias + 1, norm + 1, zero, svptrue_b32());
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template<int M> void QuantizedMergedConvolutionInput_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t dstC, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, uint8_t* dst0, uint8_t* dst1)
+        {
+            const size_t F = svcntw(), A = F * 4;
+            const svbool_t body8 = svptrue_b8();
+            svint32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41;
+            svuint8_t s0;
+            svint8_t w0, w1;
+            size_t srcC = a.isB ? a.iwStep : p.srcC;
+            const int8_t* weight1 = weight0 + a.iwStep * F;
+            const uint8_t* src1 = src0 + 1 * srcC;
+            const uint8_t* src2 = src0 + 2 * srcC;
+            const uint8_t* src3 = src0 + 3 * srcC;
+            const uint8_t* src4 = src0 + 4 * srcC;
+            if (dstC > F)
+            {
+                if (M > 0) d00 = svdup_n_s32(0), d01 = svdup_n_s32(0);
+                if (M > 1) d10 = svdup_n_s32(0), d11 = svdup_n_s32(0);
+                if (M > 2) d20 = svdup_n_s32(0), d21 = svdup_n_s32(0);
+                if (M > 3) d30 = svdup_n_s32(0), d31 = svdup_n_s32(0);
+                if (M > 4) d40 = svdup_n_s32(0), d41 = svdup_n_s32(0);
+                for (size_t offs = 0; offs < srcC; offs += 4)
+                {
+                    w0 = svld1_s8(body8, weight0);
+                    w1 = svld1_s8(body8, weight1);
+                    if (M > 0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0), Madd4<true>(d01, s0, w1);
+                    if (M > 1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0), Madd4<true>(d11, s0, w1);
+                    if (M > 2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0), Madd4<true>(d21, s0, w1);
+                    if (M > 3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0), Madd4<true>(d31, s0, w1);
+                    if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0), Madd4<true>(d41, s0, w1);
+                    weight0 += A, weight1 += A;
+                }
+                if (M > 0) SaveInput2(dst0 + 0 * F, dst1 + 0 * F, d00, d01, bias, norm, zero);
+                if (M > 1) SaveInput2(dst0 + 1 * F, dst1 + 1 * F, d10, d11, bias, norm, zero);
+                if (M > 2) SaveInput2(dst0 + 2 * F, dst1 + 2 * F, d20, d21, bias, norm, zero);
+                if (M > 3) SaveInput2(dst0 + 3 * F, dst1 + 3 * F, d30, d31, bias, norm, zero);
+                if (M > 4) SaveInput2(dst0 + 4 * F, dst1 + 4 * F, d40, d41, bias, norm, zero);
+            }
+            else
+            {
+                if (M > 0) d00 = svdup_n_s32(0);
+                if (M > 1) d10 = svdup_n_s32(0);
+                if (M > 2) d20 = svdup_n_s32(0);
+                if (M > 3) d30 = svdup_n_s32(0);
+                if (M > 4) d40 = svdup_n_s32(0);
+                for (size_t offs = 0; offs < srcC; offs += 4)
+                {
+                    w0 = svld1_s8(body8, weight0);
+                    if (M > 0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0);
+                    if (M > 1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0);
+                    if (M > 2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0);
+                    if (M > 3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0);
+                    if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0);
+                    weight0 += A;
+                }
+                if (M > 0) SaveInput1(dst0 + 0 * F, d00, bias, norm, zero);
+                if (M > 1) SaveInput1(dst0 + 1 * F, d10, bias, norm, zero);
+                if (M > 2) SaveInput1(dst0 + 2 * F, d20, bias, norm, zero);
+                if (M > 3) SaveInput1(dst0 + 3 * F, d30, bias, norm, zero);
+                if (M > 4) SaveInput1(dst0 + 4 * F, d40, bias, norm, zero);
+            }
+        }
+
+        typedef void(*QuantizedMergedConvolutionInput_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t dstC, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, uint8_t* dst0, uint8_t* dst1);
+
+        QuantizedMergedConvolutionInput_2xM_Ptr GetQuantizedMergedConvolutionInput_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return QuantizedMergedConvolutionInput_2xM<1>;
+            case 2: return QuantizedMergedConvolutionInput_2xM<2>;
+            case 3: return QuantizedMergedConvolutionInput_2xM<3>;
+            case 4: return QuantizedMergedConvolutionInput_2xM<4>;
+            case 5: return QuantizedMergedConvolutionInput_2xM<5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        void QuantizedMergedConvolutionInput_2(const uint8_t* src, const ConvParam& p, const AlgParam& a, size_t maC, size_t yBeg, size_t yEnd,
+            const int8_t* weight, const int32_t* bias, const float* norm, int32_t zero, int32_t* sum, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            size_t dstM = a.dsH - 1, dstS = a.dsH * p.dstW * F, srcC = a.isB ? a.iwStep : p.srcC, y0 = a.isB ? yBeg : 0;
+            svfloat32_t _norm[2];
+            svint32_t _bias[2], _zero = svdup_n_s32(zero);
+            size_t yInt = Simd::Max(yBeg, AlignLo(yEnd, a.dsH)), n = 5;
+            size_t i1 = (yInt - yBeg) * p.dstW, in = AlignLoAny(i1, n), i = i1 - in;
+            size_t e1 = (yEnd - yInt) * p.dstW, en = AlignLoAny(e1, n), e = e1 - en;
+            QuantizedMergedConvolutionInput_2xM_Ptr quantizedMergedConvolutionInput_2xN = GetQuantizedMergedConvolutionInput_2xM(n);
+            QuantizedMergedConvolutionInput_2xM_Ptr quantizedMergedConvolutionInput_2xI = GetQuantizedMergedConvolutionInput_2xM(i);
+            QuantizedMergedConvolutionInput_2xM_Ptr quantizedMergedConvolutionInput_2xE = GetQuantizedMergedConvolutionInput_2xM(e);
+            for (size_t dc = 0; dc < maC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, maC - dc);
+                _bias[0] = svld1_s32(body, bias + dc + 0);
+                _bias[1] = svld1_s32(body, bias + dc + F);
+                _norm[0] = svld1_f32(body, norm + dc + 0);
+                _norm[1] = svld1_f32(body, norm + dc + F);
+                if (yInt > yBeg)
+                {
+                    const uint8_t* src0 = src + (yBeg - y0) * p.srcW * srcC;
+                    uint8_t* dst0 = dst + (yBeg & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
+                    for (size_t j = 0; j < in; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
+                        quantizedMergedConvolutionInput_2xN(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                    if (in < i1)
+                        quantizedMergedConvolutionInput_2xI(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                }
+                if (yEnd > yInt)
+                {
+                    const uint8_t* src0 = src + (yInt - y0) * p.srcW * srcC;
+                    uint8_t* dst0 = dst + (yInt & dstM) * p.dstW * F, * dst1 = dst0 + dstS;
+                    for (size_t j = 0; j < en; j += n, src0 += srcC * n, dst0 += F * n, dst1 += F * n)
+                        quantizedMergedConvolutionInput_2xN(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                    if (en < e1)
+                        quantizedMergedConvolutionInput_2xE(src0, p, a, dC, weight, _bias, _norm, _zero, dst0, dst1);
+                }
+                dst += a.dsH * p.dstW * DF;
+                weight += a.iwStep * DF;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        void SetInputConvolution(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::InputConvolutionPtr& func)
+        {
+            func = QuantizedMergedConvolutionInput_2;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionOutput.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionOutput.cpp
@@ -43,7 +43,7 @@ namespace Simd
         //------------------------------------------------------------------------------------------------
 
         template<Term8iType term, int M> void QuantizedMergedConvolutionOutputConvolution_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t srcC, size_t dstC, int update, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, int32_t* buf, uint8_t* dst)
+            size_t srcC, size_t dstC, int update, const int8_t* weight0, const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero, int32_t* buf, uint8_t* dst)
         {
             const size_t F = svcntw(), A = F * 4, DF = F * 2;
             const svbool_t body8 = svptrue_b8();
@@ -89,19 +89,19 @@ namespace Simd
                 }
                 if (dstC == DF)
                 {
-                    if (M > 0) Save2<term>(dst, buf, d00, d01, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 1) Save2<term>(dst, buf, d10, d11, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 2) Save2<term>(dst, buf, d20, d21, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 3) Save2<term>(dst, buf, d30, d31, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 4) Save2<term>(dst, buf, d40, d41, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 0) Save2<term>(dst, buf, d00, d01, bias0, bias1, norm0, norm1, zero), buf += dB, dst += dD;
+                    if (M > 1) Save2<term>(dst, buf, d10, d11, bias0, bias1, norm0, norm1, zero), buf += dB, dst += dD;
+                    if (M > 2) Save2<term>(dst, buf, d20, d21, bias0, bias1, norm0, norm1, zero), buf += dB, dst += dD;
+                    if (M > 3) Save2<term>(dst, buf, d30, d31, bias0, bias1, norm0, norm1, zero), buf += dB, dst += dD;
+                    if (M > 4) Save2<term>(dst, buf, d40, d41, bias0, bias1, norm0, norm1, zero), buf += dB, dst += dD;
                 }
                 else
                 {
-                    if (M > 0) Save2<term>(dst, buf, d00, d01, bias, norm, zero, dstC - F), buf += dB, dst += dD;
-                    if (M > 1) Save2<term>(dst, buf, d10, d11, bias, norm, zero, dstC - F), buf += dB, dst += dD;
-                    if (M > 2) Save2<term>(dst, buf, d20, d21, bias, norm, zero, dstC - F), buf += dB, dst += dD;
-                    if (M > 3) Save2<term>(dst, buf, d30, d31, bias, norm, zero, dstC - F), buf += dB, dst += dD;
-                    if (M > 4) Save2<term>(dst, buf, d40, d41, bias, norm, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 0) Save2<term>(dst, buf, d00, d01, bias0, bias1, norm0, norm1, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 1) Save2<term>(dst, buf, d10, d11, bias0, bias1, norm0, norm1, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 2) Save2<term>(dst, buf, d20, d21, bias0, bias1, norm0, norm1, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 3) Save2<term>(dst, buf, d30, d31, bias0, bias1, norm0, norm1, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 4) Save2<term>(dst, buf, d40, d41, bias0, bias1, norm0, norm1, zero, dstC - F), buf += dB, dst += dD;
                 }
             }
             else
@@ -134,25 +134,25 @@ namespace Simd
                 }
                 if (dstC == F)
                 {
-                    if (M > 0) Save1<term>(dst, buf, d00, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 1) Save1<term>(dst, buf, d10, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 2) Save1<term>(dst, buf, d20, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 3) Save1<term>(dst, buf, d30, bias, norm, zero), buf += dB, dst += dD;
-                    if (M > 4) Save1<term>(dst, buf, d40, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 0) Save1<term>(dst, buf, d00, bias0, norm0, zero), buf += dB, dst += dD;
+                    if (M > 1) Save1<term>(dst, buf, d10, bias0, norm0, zero), buf += dB, dst += dD;
+                    if (M > 2) Save1<term>(dst, buf, d20, bias0, norm0, zero), buf += dB, dst += dD;
+                    if (M > 3) Save1<term>(dst, buf, d30, bias0, norm0, zero), buf += dB, dst += dD;
+                    if (M > 4) Save1<term>(dst, buf, d40, bias0, norm0, zero), buf += dB, dst += dD;
                 }
                 else
                 {
-                    if (M > 0) Save1<term>(dst, buf, d00, bias, norm, zero, dstC), buf += dB, dst += dD;
-                    if (M > 1) Save1<term>(dst, buf, d10, bias, norm, zero, dstC), buf += dB, dst += dD;
-                    if (M > 2) Save1<term>(dst, buf, d20, bias, norm, zero, dstC), buf += dB, dst += dD;
-                    if (M > 3) Save1<term>(dst, buf, d30, bias, norm, zero, dstC), buf += dB, dst += dD;
-                    if (M > 4) Save1<term>(dst, buf, d40, bias, norm, zero, dstC), buf += dB, dst += dD;
+                    if (M > 0) Save1<term>(dst, buf, d00, bias0, norm0, zero, dstC), buf += dB, dst += dD;
+                    if (M > 1) Save1<term>(dst, buf, d10, bias0, norm0, zero, dstC), buf += dB, dst += dD;
+                    if (M > 2) Save1<term>(dst, buf, d20, bias0, norm0, zero, dstC), buf += dB, dst += dD;
+                    if (M > 3) Save1<term>(dst, buf, d30, bias0, norm0, zero, dstC), buf += dB, dst += dD;
+                    if (M > 4) Save1<term>(dst, buf, d40, bias0, norm0, zero, dstC), buf += dB, dst += dD;
                 }
             }
         }
 
         typedef void(*QuantizedMergedConvolutionOutputConvolution_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
-            size_t srcC, size_t dstC, int update, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, int32_t* buf, uint8_t* dst);
+            size_t srcC, size_t dstC, int update, const int8_t* weight0, const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero, int32_t* buf, uint8_t* dst);
 
         template<Term8iType term> QuantizedMergedConvolutionOutputConvolution_2xM_Ptr GetQuantizedMergedConvolutionOutputConvolution_2xM(size_t M)
         {
@@ -177,23 +177,22 @@ namespace Simd
             size_t n = 5, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
             QuantizedMergedConvolutionOutputConvolution_2xM_Ptr outputConvolution1x1_2xN = GetQuantizedMergedConvolutionOutputConvolution_2xM<term>(n);
             QuantizedMergedConvolutionOutputConvolution_2xM_Ptr outputConvolution1x1_2xM = GetQuantizedMergedConvolutionOutputConvolution_2xM<term>(m);
-            svfloat32_t _norm[2];
-            svint32_t _bias[2], _zero = svdup_n_s32(zero);
+            svint32_t _zero = svdup_n_s32(zero);
             for (size_t dc = 0; dc < p.dstC; dc += DF)
             {
                 size_t dC = Simd::Min(DF, p.dstC - dc);
-                _bias[0] = svld1_s32(body, bias + dc + 0);
-                _bias[1] = svld1_s32(body, bias + dc + F);
-                _norm[0] = svld1_f32(body, norm + dc + 0);
-                _norm[1] = svld1_f32(body, norm + dc + F);
+                svint32_t _bias0 = svld1_s32(body, bias + dc + 0);
+                svint32_t _bias1 = svld1_s32(body, bias + dc + F);
+                svfloat32_t _norm0 = svld1_f32(body, norm + dc + 0);
+                svfloat32_t _norm1 = svld1_f32(body, norm + dc + F);
                 const uint8_t* s = src;
                 int32_t* b = buf + dc + yBeg * p.dstW * a.owStep;
                 uint8_t* d = dst + dc + yBeg * p.dstW * p.dstC;
                 size_t i = 0;
                 for (; i < nn; i += n, s += a.maC * n, b += a.owStep * n, d += p.dstC * n)
-                    outputConvolution1x1_2xN(s, p, a, maC, dC, update, weight, _bias, _norm, _zero, b, d);
+                    outputConvolution1x1_2xN(s, p, a, maC, dC, update, weight, _bias0, _bias1, _norm0, _norm1, _zero, b, d);
                 for (; i < n1; i += m, s += a.maC * m, b += a.owStep * m, d += p.dstC * m)
-                    outputConvolution1x1_2xM(s, p, a, maC, dC, update, weight, _bias, _norm, _zero, b, d);
+                    outputConvolution1x1_2xM(s, p, a, maC, dC, update, weight, _bias0, _bias1, _norm0, _norm1, _zero, b, d);
                 weight += AlignHi(maC, 4) * DF;
             }
         }

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionOutput.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionOutput.cpp
@@ -215,7 +215,7 @@ namespace Simd
         {
             svfloat32_t value = svmla_f32_x(mask, term, svcvt_f32_s32_x(mask, Load8u(a, mask)), aNorm);
             value = svmla_f32_x(mask, value, svcvt_f32_s32_x(mask, Load8u(b, mask)), bNorm);
-            Store8u(Round(value, mask), dst, mask);
+            Store8u(NearbyInt(value, mask), dst, mask);
         }
 
         void QuantizedMergedConvolutionAddInputToOutput(const uint8_t* a, float aNorm, const uint8_t* b, float bNorm, const ConvParam& p, size_t yBeg, size_t yEnd, float dBias, uint8_t* dst)

--- a/src/Simd/SimdSve2SynetQuantizedMergedConvolutionOutput.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedMergedConvolutionOutput.cpp
@@ -1,0 +1,254 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedMergedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynetQuantizedAddCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        typedef Base::SynetQuantizedMergedConvolution::AlgParam AlgParam;
+
+        //------------------------------------------------------------------------------------------------
+
+        template<Term8iType term, int M> void QuantizedMergedConvolutionOutputConvolution_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int update, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, int32_t* buf, uint8_t* dst)
+        {
+            const size_t F = svcntw(), A = F * 4, DF = F * 2;
+            const svbool_t body8 = svptrue_b8();
+            const svbool_t body = svptrue_b32();
+            svint32_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41;
+            svuint8_t s0;
+            svint8_t w0, w1;
+            size_t dS = a.maC * p.strideX, dB = a.owStep, dD = p.dstC;
+            const int8_t* weight1 = weight0 + AlignHi(srcC, 4) * F;
+            const uint8_t* src1 = src0 + 1 * dS;
+            const uint8_t* src2 = src0 + 2 * dS;
+            const uint8_t* src3 = src0 + 3 * dS;
+            const uint8_t* src4 = src0 + 4 * dS;
+            if (dstC > F)
+            {
+                if (update)
+                {
+                    if (M > 0) d00 = svld1_s32(body, buf + 0 * dB + 0), d01 = svld1_s32(body, buf + 0 * dB + F);
+                    if (M > 1) d10 = svld1_s32(body, buf + 1 * dB + 0), d11 = svld1_s32(body, buf + 1 * dB + F);
+                    if (M > 2) d20 = svld1_s32(body, buf + 2 * dB + 0), d21 = svld1_s32(body, buf + 2 * dB + F);
+                    if (M > 3) d30 = svld1_s32(body, buf + 3 * dB + 0), d31 = svld1_s32(body, buf + 3 * dB + F);
+                    if (M > 4) d40 = svld1_s32(body, buf + 4 * dB + 0), d41 = svld1_s32(body, buf + 4 * dB + F);
+                }
+                else
+                {
+                    if (M > 0) d00 = svdup_n_s32(0), d01 = svdup_n_s32(0);
+                    if (M > 1) d10 = svdup_n_s32(0), d11 = svdup_n_s32(0);
+                    if (M > 2) d20 = svdup_n_s32(0), d21 = svdup_n_s32(0);
+                    if (M > 3) d30 = svdup_n_s32(0), d31 = svdup_n_s32(0);
+                    if (M > 4) d40 = svdup_n_s32(0), d41 = svdup_n_s32(0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 4)
+                {
+                    w0 = svld1_s8(body8, weight0);
+                    w1 = svld1_s8(body8, weight1);
+                    if (M > 0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0), Madd4<true>(d01, s0, w1);
+                    if (M > 1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0), Madd4<true>(d11, s0, w1);
+                    if (M > 2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0), Madd4<true>(d21, s0, w1);
+                    if (M > 3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0), Madd4<true>(d31, s0, w1);
+                    if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0), Madd4<true>(d41, s0, w1);
+                    weight0 += A;
+                    weight1 += A;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term>(dst, buf, d00, d01, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 1) Save2<term>(dst, buf, d10, d11, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 2) Save2<term>(dst, buf, d20, d21, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 3) Save2<term>(dst, buf, d30, d31, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 4) Save2<term>(dst, buf, d40, d41, bias, norm, zero), buf += dB, dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save2<term>(dst, buf, d00, d01, bias, norm, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 1) Save2<term>(dst, buf, d10, d11, bias, norm, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 2) Save2<term>(dst, buf, d20, d21, bias, norm, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 3) Save2<term>(dst, buf, d30, d31, bias, norm, zero, dstC - F), buf += dB, dst += dD;
+                    if (M > 4) Save2<term>(dst, buf, d40, d41, bias, norm, zero, dstC - F), buf += dB, dst += dD;
+                }
+            }
+            else
+            {
+                if (update)
+                {
+                    if (M > 0) d00 = svld1_s32(body, buf + 0 * dB);
+                    if (M > 1) d10 = svld1_s32(body, buf + 1 * dB);
+                    if (M > 2) d20 = svld1_s32(body, buf + 2 * dB);
+                    if (M > 3) d30 = svld1_s32(body, buf + 3 * dB);
+                    if (M > 4) d40 = svld1_s32(body, buf + 4 * dB);
+                }
+                else
+                {
+                    if (M > 0) d00 = svdup_n_s32(0);
+                    if (M > 1) d10 = svdup_n_s32(0);
+                    if (M > 2) d20 = svdup_n_s32(0);
+                    if (M > 3) d30 = svdup_n_s32(0);
+                    if (M > 4) d40 = svdup_n_s32(0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 4)
+                {
+                    w0 = svld1_s8(body8, weight0);
+                    if (M > 0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0);
+                    if (M > 1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0);
+                    if (M > 2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0);
+                    if (M > 3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0);
+                    if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0);
+                    weight0 += A;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term>(dst, buf, d00, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 1) Save1<term>(dst, buf, d10, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 2) Save1<term>(dst, buf, d20, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 3) Save1<term>(dst, buf, d30, bias, norm, zero), buf += dB, dst += dD;
+                    if (M > 4) Save1<term>(dst, buf, d40, bias, norm, zero), buf += dB, dst += dD;
+                }
+                else
+                {
+                    if (M > 0) Save1<term>(dst, buf, d00, bias, norm, zero, dstC), buf += dB, dst += dD;
+                    if (M > 1) Save1<term>(dst, buf, d10, bias, norm, zero, dstC), buf += dB, dst += dD;
+                    if (M > 2) Save1<term>(dst, buf, d20, bias, norm, zero, dstC), buf += dB, dst += dD;
+                    if (M > 3) Save1<term>(dst, buf, d30, bias, norm, zero, dstC), buf += dB, dst += dD;
+                    if (M > 4) Save1<term>(dst, buf, d40, bias, norm, zero, dstC), buf += dB, dst += dD;
+                }
+            }
+        }
+
+        typedef void(*QuantizedMergedConvolutionOutputConvolution_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a,
+            size_t srcC, size_t dstC, int update, const int8_t* weight0, const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, int32_t* buf, uint8_t* dst);
+
+        template<Term8iType term> QuantizedMergedConvolutionOutputConvolution_2xM_Ptr GetQuantizedMergedConvolutionOutputConvolution_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return QuantizedMergedConvolutionOutputConvolution_2xM<term, 1>;
+            case 2: return QuantizedMergedConvolutionOutputConvolution_2xM<term, 2>;
+            case 3: return QuantizedMergedConvolutionOutputConvolution_2xM<term, 3>;
+            case 4: return QuantizedMergedConvolutionOutputConvolution_2xM<term, 4>;
+            case 5: return QuantizedMergedConvolutionOutputConvolution_2xM<term, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<Term8iType term> void QuantizedMergedConvolutionOutputConvolution_2(const uint8_t* src, const ConvParam& p, const AlgParam& a, size_t maC, size_t yBeg, size_t yEnd,
+            int update, const int8_t* weight, const int32_t* bias, const float* norm, int32_t zero, int32_t* buf, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            size_t n = 5, n1 = (yEnd - yBeg) * p.dstW, nn = AlignLoAny(n1, n), m = n1 - nn;
+            QuantizedMergedConvolutionOutputConvolution_2xM_Ptr outputConvolution1x1_2xN = GetQuantizedMergedConvolutionOutputConvolution_2xM<term>(n);
+            QuantizedMergedConvolutionOutputConvolution_2xM_Ptr outputConvolution1x1_2xM = GetQuantizedMergedConvolutionOutputConvolution_2xM<term>(m);
+            svfloat32_t _norm[2];
+            svint32_t _bias[2], _zero = svdup_n_s32(zero);
+            for (size_t dc = 0; dc < p.dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, p.dstC - dc);
+                _bias[0] = svld1_s32(body, bias + dc + 0);
+                _bias[1] = svld1_s32(body, bias + dc + F);
+                _norm[0] = svld1_f32(body, norm + dc + 0);
+                _norm[1] = svld1_f32(body, norm + dc + F);
+                const uint8_t* s = src;
+                int32_t* b = buf + dc + yBeg * p.dstW * a.owStep;
+                uint8_t* d = dst + dc + yBeg * p.dstW * p.dstC;
+                size_t i = 0;
+                for (; i < nn; i += n, s += a.maC * n, b += a.owStep * n, d += p.dstC * n)
+                    outputConvolution1x1_2xN(s, p, a, maC, dC, update, weight, _bias, _norm, _zero, b, d);
+                for (; i < n1; i += m, s += a.maC * m, b += a.owStep * m, d += p.dstC * m)
+                    outputConvolution1x1_2xM(s, p, a, maC, dC, update, weight, _bias, _norm, _zero, b, d);
+                weight += AlignHi(maC, 4) * DF;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svint32_t Load8u(const uint8_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE void Store8u(const svint32_t& value, uint8_t* dst, const svbool_t& mask)
+        {
+            svint32_t lo = svmax_n_s32_x(mask, value, 0);
+            svuint32_t u32 = svreinterpret_u32_s32(svmin_n_s32_x(mask, lo, 255));
+            svst1b_u32(mask, dst, u32);
+        }
+
+        SIMD_INLINE void QuantizedAdd8u8u8u(const uint8_t* a, const svfloat32_t& aNorm, const uint8_t* b, const svfloat32_t& bNorm, const svfloat32_t& term, uint8_t* dst, const svbool_t& mask)
+        {
+            svfloat32_t value = svmla_f32_x(mask, term, svcvt_f32_s32_x(mask, Load8u(a, mask)), aNorm);
+            value = svmla_f32_x(mask, value, svcvt_f32_s32_x(mask, Load8u(b, mask)), bNorm);
+            Store8u(Round(value, mask), dst, mask);
+        }
+
+        void QuantizedMergedConvolutionAddInputToOutput(const uint8_t* a, float aNorm, const uint8_t* b, float bNorm, const ConvParam& p, size_t yBeg, size_t yEnd, float dBias, uint8_t* dst)
+        {
+            const size_t F = svcntw(), QF = 4 * F;
+            const svbool_t full = svptrue_b32();
+            svfloat32_t _aNorm = svdup_n_f32(aNorm), _bNorm = svdup_n_f32(bNorm), _dBias = svdup_n_f32(dBias);
+            size_t beg = yBeg * p.dstW * p.dstC, end = yEnd * p.dstW * p.dstC;
+            size_t i = beg, endQF = beg + AlignLo(end - beg, QF);
+            for (; i < endQF; i += QF)
+            {
+                QuantizedAdd8u8u8u(a + i + 0 * F, _aNorm, b + i + 0 * F, _bNorm, _dBias, dst + i + 0 * F, full);
+                QuantizedAdd8u8u8u(a + i + 1 * F, _aNorm, b + i + 1 * F, _bNorm, _dBias, dst + i + 1 * F, full);
+                QuantizedAdd8u8u8u(a + i + 2 * F, _aNorm, b + i + 2 * F, _bNorm, _dBias, dst + i + 2 * F, full);
+                QuantizedAdd8u8u8u(a + i + 3 * F, _aNorm, b + i + 3 * F, _bNorm, _dBias, dst + i + 3 * F, full);
+            }
+            for (; i < end; i += F)
+                QuantizedAdd8u8u8u(a + i, _aNorm, b + i, _bNorm, _dBias, dst + i, svwhilelt_b32(i, end));
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        void SetOutputConvolution(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::OutputConvolutionPtr* funcs)
+        {
+            funcs[0] = QuantizedMergedConvolutionOutputConvolution_2<Term8iInterim>;
+            funcs[1] = QuantizedMergedConvolutionOutputConvolution_2<Term8iLast8u>;
+        }
+
+        void SetAddInputToOutput(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::AddInputToOutputPtr& func)
+        {
+            func = QuantizedMergedConvolutionAddInputToOutput;
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetActivation.h
+++ b/src/Simd/SimdSynetActivation.h
@@ -613,6 +613,11 @@ namespace Simd
             return svcvt_s32_f32_x(mask, svadd_f32_x(mask, value, round));
         }
 
+        SIMD_INLINE svint32_t NearbyInt(const svfloat32_t& value, const svbool_t& mask)
+        {
+            return svcvt_s32_f32_x(mask, svrintn_f32_x(mask, value));
+        }
+
         SIMD_INLINE svfloat32_t SynetHardSigmoid32f(const svbool_t& mask, svfloat32_t value, svfloat32_t scale, svfloat32_t shift)
         {
             return svmax_f32_x(mask, svmin_f32_x(mask, svmla_f32_x(mask, shift, value, scale), svdup_n_f32(1.0f)), svdup_n_f32(0.0f));

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -790,16 +790,20 @@ namespace Simd
         template <Term8iType term> struct QuntizedTerm8i
         {
             template<int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-                const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, const svbool_t& mask);
+                const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1,
+                const svint32_t& zero, const svbool_t& mask);
         };
 
         template <> struct QuntizedTerm8i<Term8iLast8u>
         {
             template<int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-                const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, const svbool_t& mask)
+                const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1,
+                const svint32_t& zero, const svbool_t& mask)
             {
                 const size_t F = svcntw();
-                svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, bias[index])), norm[index]);
+                const svint32_t& bias = index ? bias1 : bias0;
+                const svfloat32_t& nrm = index ? norm1 : norm0;
+                svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, bias)), nrm);
                 svint32_t i32 = svadd_s32_x(mask, Round(f32, mask), zero);
                 i32 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, i32, 0), 255);
                 svst1b_u32(mask, dst + index * F, svreinterpret_u32_s32(i32));
@@ -809,7 +813,8 @@ namespace Simd
         template <> struct QuntizedTerm8i<Term8iInterim>
         {
             template<int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-                const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, const svbool_t& mask)
+                const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1,
+                const svint32_t& zero, const svbool_t& mask)
             {
                 const size_t F = svcntw();
                 svst1_s32(mask, buf + index * F, sum);
@@ -818,32 +823,32 @@ namespace Simd
 
         template<Term8iType term>
         SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+            const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero)
         {
-            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum, bias, norm, zero, svptrue_b32());
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum, bias, bias, norm, norm, zero, svptrue_b32());
         }
 
         template<Term8iType term>
         SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, size_t tail)
+            const svint32_t& bias, const svfloat32_t& norm, const svint32_t& zero, size_t tail)
         {
-            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum, bias, norm, zero, svwhilelt_b32((size_t)0, tail));
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum, bias, bias, norm, norm, zero, svwhilelt_b32((size_t)0, tail));
         }
 
         template<Term8iType term>
         SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, const svint32_t& sum0, const svint32_t& sum1,
-            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+            const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero)
         {
-            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias, norm, zero, svptrue_b32());
-            QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias, norm, zero, svptrue_b32());
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias0, bias1, norm0, norm1, zero, svptrue_b32());
+            QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias0, bias1, norm0, norm1, zero, svptrue_b32());
         }
 
         template<Term8iType term>
         SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, const svint32_t& sum0, const svint32_t& sum1,
-            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, size_t tail)
+            const svint32_t& bias0, const svint32_t& bias1, const svfloat32_t& norm0, const svfloat32_t& norm1, const svint32_t& zero, size_t tail)
         {
-            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias, norm, zero, svptrue_b32());
-            QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias, norm, zero, svwhilelt_b32((size_t)0, tail));
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias0, bias1, norm0, norm1, zero, svptrue_b32());
+            QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias0, bias1, norm0, norm1, zero, svwhilelt_b32((size_t)0, tail));
         }
     }
 #endif

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -783,6 +783,70 @@ namespace Simd
         }
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template <Term8iType term> struct QuntizedTerm8i
+        {
+            template<int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+                const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, const svbool_t& mask);
+        };
+
+        template <> struct QuntizedTerm8i<Term8iLast8u>
+        {
+            template<int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+                const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, const svbool_t& mask)
+            {
+                const size_t F = svcntw();
+                svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, bias[index])), norm[index]);
+                svint32_t i32 = svadd_s32_x(mask, Round(f32, mask), zero);
+                i32 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, i32, 0), 255);
+                svst1b_u32(mask, dst + index * F, svreinterpret_u32_s32(i32));
+            }
+        };
+
+        template <> struct QuntizedTerm8i<Term8iInterim>
+        {
+            template<int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+                const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, const svbool_t& mask)
+            {
+                const size_t F = svcntw();
+                svst1_s32(mask, buf + index * F, sum);
+            }
+        };
+
+        template<Term8iType term>
+        SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+        {
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum, bias, norm, zero, svptrue_b32());
+        }
+
+        template<Term8iType term>
+        SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, size_t tail)
+        {
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum, bias, norm, zero, svwhilelt_b32((size_t)0, tail));
+        }
+
+        template<Term8iType term>
+        SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, const svint32_t& sum0, const svint32_t& sum1,
+            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero)
+        {
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias, norm, zero, svptrue_b32());
+            QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias, norm, zero, svptrue_b32());
+        }
+
+        template<Term8iType term>
+        SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, const svint32_t& sum0, const svint32_t& sum1,
+            const svint32_t* bias, const svfloat32_t* norm, const svint32_t& zero, size_t tail)
+        {
+            QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias, norm, zero, svptrue_b32());
+            QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias, norm, zero, svwhilelt_b32((size_t)0, tail));
+        }
+    }
+#endif
 }
 
 #endif

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -804,7 +804,7 @@ namespace Simd
                 const svint32_t& bias = index ? bias1 : bias0;
                 const svfloat32_t& nrm = index ? norm1 : norm0;
                 svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, bias)), nrm);
-                svint32_t i32 = svadd_s32_x(mask, Round(f32, mask), zero);
+                svint32_t i32 = svadd_s32_x(mask, NearbyInt(f32, mask), zero);
                 i32 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, i32, 0), 255);
                 svst1b_u32(mask, dst + index * F, svreinterpret_u32_s32(i32));
             }

--- a/src/Simd/SimdSynetQuantizedMergedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedMergedConvolution.h
@@ -490,6 +490,55 @@ namespace Simd
         void* SynetQuantizedMergedConvolutionInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, int add);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        void SetInputConvolution(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::InputConvolutionPtr& func);
+
+        void SetDepthwisePreprocess(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::DepthwisePreprocessPtr& func);
+
+        void SetDepthwiseConvolution(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::DepthwiseConvolutionPtr& func);
+
+        void SetOutputConvolution(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::OutputConvolutionPtr* funcs);
+
+        void SetAddInputToOutput(const ConvParam& p, const Base::SynetQuantizedMergedConvolution::AlgParam& a, Base::SynetQuantizedMergedConvolution::AddInputToOutputPtr& func);
+
+        //------------------------------------------------------------------------------------------------
+
+        class SynetQuantizedMergedConvolutionCdc : public Base::SynetQuantizedMergedConvolutionCdc
+        {
+        public:
+            SynetQuantizedMergedConvolutionCdc(const MergConvParam& p);
+
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
+        class SynetQuantizedMergedConvolutionCd : public Base::SynetQuantizedMergedConvolutionCd
+        {
+        public:
+            SynetQuantizedMergedConvolutionCd(const MergConvParam& p);
+
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
+        class SynetQuantizedMergedConvolutionDc : public Base::SynetQuantizedMergedConvolutionDc
+        {
+        public:
+            SynetQuantizedMergedConvolutionDc(const MergConvParam& p);
+
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
+        void* SynetQuantizedMergedConvolutionInit(size_t batch, const SimdConvolutionParameters* convs, size_t count, int add);
+    }
+#endif
 }
 
 #endif

--- a/src/Test/TestSynetQuantizedMergedConvolution.cpp
+++ b/src/Test/TestSynetQuantizedMergedConvolution.cpp
@@ -389,6 +389,11 @@ namespace Test
             result = result && SynetQuantizedMergedConvolutionForwardAutoTest(t, FUNC_QMC(Simd::Neon::SynetQuantizedMergedConvolutionInit), FUNC_QMC(SimdSynetQuantizedMergedConvolutionInit));
 #endif
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedMergedConvolutionForwardAutoTest(t, FUNC_QMC(Simd::Sve2::SynetQuantizedMergedConvolutionInit), FUNC_QMC(SimdSynetQuantizedMergedConvolutionInit));
+#endif
+
         return result;
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add SVE/SVE2 kernels for quantized merged convolution on ARM/ARM64, covering `SynetQuantizedMergedConvolutionCdc`, `SynetQuantizedMergedConvolutionCd`, and `SynetQuantizedMergedConvolutionDc`.

## Changes
- SVE2 input 1x1 GEMM (`Set4` + `Madd4`), depthwise preprocess/any/3x3 (`Madd2` on packed int16 rows), output 1x1 GEMM, and residual `AddInputToOutput`.
- Dispatch via `SimdSynetQuantizedMergedConvolutionInit` (`SIMD_SVE2_FUNC` before NEON).
- Tests compare `Simd::Sve2::SynetQuantizedMergedConvolutionInit` with the public Init.
- VS2022 `Sve2.vcxproj` / `.filters` entries and release 7.2.165 notes in `docs/2026.html`.
- Bias/norm are passed as individual SVE vectors (sizeless types cannot be used in arrays).
- Quantized store/add now use `NearbyInt` (`svrintn` + convert, ties to even) to match `Base::NearByInt` and NEON `NearbyInt`. The previous `Round` (half away from zero) caused off-by-one errors such as `1x32x56x56-192x1x1-5x2-56x1x1`.

Based on `dev` (including NEON quantized merged convolution). Vector-length agnostic (`svcntw()` as `miC`).

AArch64 cross-compile of the new SVE2 sources and the corresponding test translation unit succeeds with `-march=armv9-a+sve+sve2+i8mm+bf16`. This environment is x86_64, so native SVE2 `Test` was not run. Please re-run `./Test "-r=.." -fi=SynetQuantizedMergedConvolution` on ARM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17660cec-6203-4490-a36f-e03e2c43b772?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17660cec-6203-4490-a36f-e03e2c43b772&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

