### PR TITLE
Add C++ wrapper Simd::SynetQuantizedAdd

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -68,6 +68,7 @@
  <li>NEON, SVE2 optimizations of classes SynetQuantizedMergedConvolutionDc.</li>
  <li>NEON, SVE2 optimizations of class SynetQuantizedInnerProductGemmV0.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
+ <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/txt/DoxygenGroups.txt
+++ b/prj/txt/DoxygenGroups.txt
@@ -93,7 +93,7 @@
 
 /*! @ingroup cpp_types
     @defgroup cpp_synet Synet Wrappers
-    \short C++ Synet Wrappers.
+    \short Simd::SynetAdd16b and Simd::SynetQuantizedAdd classes (C++ wrappers of Synet addition).
 */
 
 /*! @ingroup cpp_types

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -9756,6 +9756,8 @@ extern "C"
         as (value - zero)*scale, adds the two values, applies activation if it is specified and converts the
         result to FP32 or UINT8 output. FP32 inputs and outputs ignore the corresponding quantization zero.
 
+        \note This function has a C++ wrapper: Simd::SynetQuantizedAdd.
+
         \param [in] aShape - a pointer to shape of input A tensor.
         \param [in] aCount - a count of dimensions of input A tensor.
         \param [in] aType - a type of input A tensor. It can be ::SimdTensorData32f or ::SimdTensorData8u.
@@ -9793,6 +9795,8 @@ extern "C"
             dst[i] = RestrictRange(Round(value/dstScale) + dstZero, 0, 255);
         }
         \endverbatim
+
+        \note This function has a C++ wrapper: Simd::SynetQuantizedAdd.
 
         \param [in] context - a pointer to quantized addition context. It must be created by function ::SimdSynetQuantizedAddInit and released by function ::SimdRelease.
         \param [in] a - a pointer to input A tensor data. Its type is defined by parameter aType of ::SimdSynetQuantizedAddInit.

--- a/src/Simd/SimdSynet.hpp
+++ b/src/Simd/SimdSynet.hpp
@@ -167,6 +167,153 @@ namespace Simd
         void * _context;
         Shape _aShape, _bShape;
     };
+
+    //-------------------------------------------------------------------------------------------------
+
+    /*! @ingroup cpp_synet
+
+        \short The SynetQuantizedAdd class is a C++ wrapper of quantized (UINT8/FP32) element-wise addition.
+
+        The class wraps C API functions ::SimdSynetQuantizedAddInit and ::SimdSynetQuantizedAddForward.
+        It dequantizes UINT8 inputs as (value - zero)*scale, adds the two values, applies activation
+        if it is specified and converts the result to FP32 or UINT8 output. FP32 inputs and outputs
+        ignore the corresponding quantization zero. Algorithm's details for UINT8 output:
+        \verbatim
+        for(i = 0; i < size; ++i)
+        {
+            value = Activate((a[i] - aZero)*aScale + (b[i] - bZero)*bScale, actType, actParams);
+            dst[i] = RestrictRange(Round(value/dstScale) + dstZero, 0, 255);
+        }
+        \endverbatim
+
+        The current implementation creates a context only for equal input shapes and FP32/UINT8 input
+        and output tensor types. Supported optimized activation types are ::SimdConvolutionActivationIdentity
+        and ::SimdConvolutionActivationRelu. Call Init() before Forward(). Use Enable() to check
+        that a context was created. The context is released by Clear() or by the destructor.
+
+        Using example:
+        \verbatim
+        #include "Simd/SimdSynet.hpp"
+
+        int main()
+        {
+            const size_t n = 64;
+            std::vector<uint8_t> a(n, 50), b(n, 80), dst(n, 0);
+            Simd::Shape dims = Simd::Shape({ n });
+            float aScale = 0.010f, bScale = 0.020f, dstScale = 0.015f;
+            int32_t aZero = 47, bZero = 30, dstZero = 38;
+
+            Simd::SynetQuantizedAdd add;
+            add.Init(dims, SimdTensorData8u, aScale, aZero, dims, SimdTensorData8u, bScale, bZero,
+                SimdConvolutionActivationIdentity, NULL, SimdTensorData8u, dstScale, dstZero);
+            if (add.Enable())
+                add.Forward(a.data(), b.data(), dst.data());
+
+            return 0;
+        }
+        \endverbatim
+    */
+    class SynetQuantizedAdd
+    {
+    public:
+        /*!
+            Creates a new empty SynetQuantizedAdd class.
+        */
+        SynetQuantizedAdd()
+            : _context(NULL)
+        {
+        }
+
+        /*!
+            SynetQuantizedAdd class destructor. Releases internal context.
+        */
+        virtual ~SynetQuantizedAdd()
+        {
+            Clear();
+        }
+
+        /*!
+            Initializes (or re-initializes) element-wise quantized addition of two UINT8/FP32 tensors.
+
+            Creates an internal context with using of function ::SimdSynetQuantizedAddInit.
+            The context is recreated only if input tensor shapes were changed.
+
+            \note This function is a C++ wrapper for function ::SimdSynetQuantizedAddInit.
+
+            \param [in] aShape - a shape of input A tensor.
+            \param [in] aType - a type of input A tensor. Can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] aScale - a quantization scale of input A tensor.
+            \param [in] aZero - a quantization zero of input A tensor.
+            \param [in] bShape - a shape of input B tensor.
+            \param [in] bType - a type of input B tensor. Can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] bScale - a quantization scale of input B tensor.
+            \param [in] bZero - a quantization zero of input B tensor.
+            \param [in] actType - an activation function type applied after addition.
+            \param [in] actParams - a pointer to activation function parameters. Can be NULL.
+            \param [in] dstType - a type of output tensor. Can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] dstScale - an output quantization scale.
+            \param [in] dstZero - an output quantization zero.
+        */
+        SIMD_INLINE void Init(const Shape & aShape, SimdTensorDataType aType, float aScale, int32_t aZero,
+            const Shape & bShape, SimdTensorDataType bType, float bScale, int32_t bZero,
+            SimdConvolutionActivationType actType, const float * actParams,
+            SimdTensorDataType dstType, float dstScale, int32_t dstZero)
+        {
+            if (_aShape != aShape || _bShape != bShape)
+            {
+                Clear();
+                _aShape = aShape;
+                _bShape = bShape;
+                _context = SimdSynetQuantizedAddInit(_aShape.data(), _aShape.size(), aType, &aScale, aZero,
+                    _bShape.data(), _bShape.size(), bType, &bScale, bZero,
+                    actType, actParams, dstType, &dstScale, dstZero);
+            }
+        }
+
+        /*!
+            Checks that the internal quantized addition context was created.
+
+            \return true if the context exists and Forward() can be called.
+        */
+        SIMD_INLINE bool Enable() const
+        {
+            return _context != NULL;
+        }
+
+        /*!
+            Performs element-wise quantized addition of two UINT8/FP32 tensors.
+
+            The function adds corresponding elements of input tensors A and B with dequantization,
+            optional activation and output quantization. The actual data types, tensor shape,
+            quantization parameters and activation type are stored in the context created by Init().
+
+            \note This function is a C++ wrapper for function ::SimdSynetQuantizedAddForward.
+
+            \param [in] a - a pointer to input A tensor.
+            \param [in] b - a pointer to input B tensor.
+            \param [out] dst - a pointer to output tensor.
+        */
+        SIMD_INLINE void Forward(const uint8_t * a, const uint8_t * b, uint8_t * dst)
+        {
+            if (_context)
+                SimdSynetQuantizedAddForward(_context, a, b, dst);
+        }
+
+        /*!
+            Releases internal context and clears stored tensor shapes.
+        */
+        SIMD_INLINE void Clear()
+        {
+            if (_context)
+                SimdRelease(_context), _context = NULL;
+            _aShape.clear();
+            _bShape.clear();
+        }
+
+    private:
+        void * _context;
+        Shape _aShape, _bShape;
+    };
 }
 
 #endif

--- a/src/Test/TestCheckCpp.cpp
+++ b/src/Test/TestCheckCpp.cpp
@@ -226,6 +226,37 @@ namespace Test
                 std::cout << "TestSynetAdd16b is failed at " << i << " : " << dst1[i] << " != " << dst2[i] << std::endl;
         }
     }
+
+    static void TestSynetQuantizedAdd()
+    {
+        const size_t n = 64;
+        std::vector<uint8_t> a(n, 50), b(n, 80), dst1(n, 0), dst2(n, 0);
+        Simd::Shape dims = Simd::Shape({ n });
+        float aScale = 0.010f, bScale = 0.020f, dstScale = 0.015f;
+        int32_t aZero = 47, bZero = 30, dstZero = 38;
+        float actParams[2] = { 0.0f, 6.0f };
+
+        Simd::SynetQuantizedAdd add;
+        add.Init(dims, SimdTensorData8u, aScale, aZero, dims, SimdTensorData8u, bScale, bZero,
+            SimdConvolutionActivationIdentity, actParams, SimdTensorData8u, dstScale, dstZero);
+        if (add.Enable())
+            add.Forward(a.data(), b.data(), dst1.data());
+
+        void* context = SimdSynetQuantizedAddInit(dims.data(), dims.size(), SimdTensorData8u, &aScale, aZero,
+            dims.data(), dims.size(), SimdTensorData8u, &bScale, bZero,
+            SimdConvolutionActivationIdentity, actParams, SimdTensorData8u, &dstScale, dstZero);
+        if (context)
+        {
+            SimdSynetQuantizedAddForward(context, a.data(), b.data(), dst2.data());
+            SimdRelease(context);
+        }
+
+        for (size_t i = 0; i < n; ++i)
+        {
+            if (dst1[i] != dst2[i])
+                std::cout << "TestSynetQuantizedAdd is failed at " << i << " : " << (int)dst1[i] << " != " << (int)dst2[i] << std::endl;
+        }
+    }
 #endif
 
     void CheckCpp()
@@ -260,6 +291,7 @@ namespace Test
 
 #if defined(SIMD_SYNET_ENABLE)
         TestSynetAdd16b();
+        TestSynetQuantizedAdd();
 #endif
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a public C++ analogue of `Synet::QuantizedAdd` (`src/Synet/Utils/Add.h` in ermig1979/Synet, `dev` branch) to the Simd Library.

- New class `Simd::SynetQuantizedAdd` in `src/Simd/SimdSynet.hpp` wrapping `SimdSynetQuantizedAddInit` / `SimdSynetQuantizedAddForward` / `SimdRelease`.
- Doxygen description for the class (group `cpp_synet`) and C API notes pointing to the wrapper.
- `TestSynetQuantizedAdd()` in `src/Test/TestCheckCpp.cpp` compares the wrapper with the C API.
- `docs/2026.html` (release 7.2.165) updated.

`src/Simd/SimdSynet.hpp` is already listed in `prj/vs2022/Simd.vcxproj` and `prj/vs2022/Simd.vcxproj.filters` (added with `Simd::SynetAdd16b`).

## Testing

- CMake Release build (`g++`, `SIMD_SHARED=ON`) of the library and `Test`.
- `./Test "-r=.." -cc=1 -fi=SynetQuantizedAdd -tt=1 -ts=1`: CheckCpp (including `TestSynetQuantizedAdd`) and SynetQuantizedAdd C API tests finished successfully.
- Standalone check: `Simd::SynetQuantizedAdd::Enable()` is true; wrapper output matches the C API (UINT8 identity, all 8 sample values equal 107).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c36925c4-e3e2-4c03-b125-c6e68f03d336?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c36925c4-e3e2-4c03-b125-c6e68f03d336&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

