### PR TITLE
Add NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -69,6 +69,7 @@
  <li>NEON, SVE2 optimizations of class SynetQuantizedInnerProductGemmV0.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV0.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV1.</li>
+ <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
 </ul>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolution.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV1.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedInnerProduct.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedInnerProductGemmV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedMergedConvolution.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -373,6 +373,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV1.cpp">
       <Filter>Neon\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp">
+      <Filter>Neon\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedInnerProduct.cpp">
       <Filter>Neon\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdNeonSynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedConvolution.cpp
@@ -40,6 +40,8 @@ namespace Simd
             ConvParam param(batch, conv);
             if (!ValidQuantized(param))
                 return NULL;
+            else if (SynetQuantizedConvolutionNhwcDepthwiseV2::Preferable(param, F))
+                return new SynetQuantizedConvolutionNhwcDepthwiseV2(param);
             else if (SynetQuantizedConvolutionNhwcDepthwiseV1::Preferable(param, F))
                 return new SynetQuantizedConvolutionNhwcDepthwiseV1(param);
             else if (SynetQuantizedConvolutionNhwcDepthwiseV0::Preferable(param, F))

--- a/src/Simd/SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp
@@ -1,0 +1,690 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizedDepthwise.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdNeon.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Neon
+    {
+        using AlgParam = SynetQuantizedConvolutionNhwcDepthwiseV2::AlgParam;
+
+        //------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE int32x4_t UnpackU8x4(const uint8_t* src)
+        {
+            uint8x8_t u8 = vreinterpret_u8_u32(vdup_n_u32(*(const uint32_t*)src));
+            return vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(vmovl_u8(u8))));
+        }
+
+        SIMD_INLINE int32x4_t PackRows(int32x4_t s0, int32x4_t s1)
+        {
+            return vorrq_s32(s0, vshlq_n_s32(s1, 16));
+        }
+
+        SIMD_INLINE int32x4_t ShiftLeft16(int32x4_t value)
+        {
+            return vshlq_n_s32(value, 16);
+        }
+
+        SIMD_INLINE int32x4_t ShiftRight16(int32x4_t value)
+        {
+            return vreinterpretq_s32_u32(vshrq_n_u32(vreinterpretq_u32_s32(value), 16));
+        }
+
+        SIMD_INLINE int32x4_t LoadI16(const int16_t* src)
+        {
+            return vld1q_s32((const int32_t*)src);
+        }
+
+        SIMD_INLINE void Madd2(int32x4_t& i32, int32x4_t u8, int32x4_t i8)
+        {
+            int16x8_t a = vreinterpretq_s16_s32(u8);
+            int16x8_t b = vreinterpretq_s16_s32(i8);
+            int32x4_t lo = vmull_s16(vget_low_s16(a), vget_low_s16(b));
+            int32x4_t hi = vmull_s16(vget_high_s16(a), vget_high_s16(b));
+#if defined(__aarch64__)
+            i32 = vaddq_s32(i32, vpaddq_s32(lo, hi));
+#else
+            i32 = vaddq_s32(i32, vcombine_s32(
+                vpadd_s32(vget_low_s32(lo), vget_high_s32(lo)),
+                vpadd_s32(vget_low_s32(hi), vget_high_s32(hi))));
+#endif
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        static void QuantizedConvolutionNhwcDepthwiseV2_Preprocess(const uint8_t* src, const uint8_t* zero, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd, int16_t* dst)
+        {
+            int16x8_t _zero = vdupq_n_s16(zero[0]);
+            size_t srcC = p.srcC, srcCF = Simd::AlignLo(p.srcC, a.F), byMask = a.bufH - 1;
+            size_t byPad = p.kernelY - 1, srcR = p.srcW * p.srcC, bufR = a.bufW * a.bufC;
+            size_t byBeg = dyBeg ? dyBeg * p.strideY + byPad : 0, byEnd = dyEnd * p.strideY + byPad;
+            if (a.reorderType == 0)
+            {
+                size_t bxPad = p.padX * a.bufC * 2, bwPad = p.padW * a.bufC * 2;
+                for (size_t by = byBeg; by < byEnd; by += 2)
+                {
+                    int16_t* pd = dst + (by & byMask) * bufR;
+                    size_t sy = by - p.padY;
+                    const uint8_t* ps0 = (sy + 0) < p.srcH ? src + (sy + 0) * srcR : zero;
+                    const uint8_t* ps1 = (sy + 1) < p.srcH ? src + (sy + 1) * srcR : zero;
+                    if (bxPad)
+                    {
+                        for (size_t i = 0; i < bxPad; i += DF)
+                            vst1q_s16(pd + i, _zero);
+                        pd += bxPad;
+                    }
+                    for (size_t sx = 0; sx < p.srcW; sx++)
+                    {
+                        size_t sc = 0;
+                        for (; sc < srcC; sc += F, pd += DF)
+                        {
+                            int32x4_t s0 = UnpackU8x4(ps0 + sc);
+                            int32x4_t s1 = UnpackU8x4(ps1 + sc);
+                            vst1q_s32((int32_t*)pd, PackRows(s0, s1));
+                        }
+                        ps0 += p.srcC;
+                        ps1 += p.srcC;
+                    }
+                    if (bwPad)
+                    {
+                        for (size_t i = 0; i < bwPad; i += DF)
+                            vst1q_s16(pd + i, _zero);
+                        pd += bwPad;
+                    }
+                }
+            }
+            else
+            {
+                size_t bW = a.bufW * 2, bC = a.bufC, xPad = p.padX * 2, wPad = p.padW * 2;
+                for (size_t by = byBeg; by < byEnd; by += 2)
+                {
+                    int16_t* pd = dst + (by & byMask) * bufR;
+                    size_t sy = by - p.padY;
+                    const uint8_t* ps0 = (sy + 0) < p.srcH ? src + (sy + 0) * srcR : zero;
+                    const uint8_t* ps1 = (sy + 1) < p.srcH ? src + (sy + 1) * srcR : zero;
+                    if (xPad)
+                    {
+                        for (size_t x = 0; x < xPad; x += 2, pd += DF)
+                            for (size_t c = 0; c < bC; c += F)
+                                vst1q_s16(pd + c * bW, _zero);
+                    }
+                    for (size_t sx = 0; sx < p.srcW; sx++, pd += DF)
+                    {
+                        for (size_t sc = 0; sc < bC; sc += F)
+                        {
+                            int32x4_t s0 = UnpackU8x4(ps0 + sc);
+                            int32x4_t s1 = UnpackU8x4(ps1 + sc);
+                            vst1q_s32((int32_t*)(pd + sc * bW), PackRows(s0, s1));
+                        }
+                        ps0 += p.srcC;
+                        ps1 += p.srcC;
+                    }
+                    if (wPad)
+                    {
+                        for (size_t x = 0; x < wPad; x += 2, pd += DF)
+                            for (size_t c = 0; c < bC; c += F)
+                                vst1q_s16(pd + c * bW, _zero);
+                    }
+                }
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> void QuantizedConvolutionNhwcDepthwiseV2_AnyR1(const int16_t* src, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd,
+            const int16_t* weight, const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, uint8_t* dst)
+        {
+            float32x4_t _sNorm, _iScale, _params[2], _dNorm;
+            int32x4_t _dZero = vdupq_n_s32(dZero), _sBias, _iLo, _iHi;
+            int32x4_t d00, d10, d20, d30, d01, d11, d21, d31, w0, w1, s0;
+            size_t srcC = p.srcC, srcCF = AlignLo(srcC, F), kY = p.kernelY, kX = p.kernelX, sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.stepW;
+            size_t byMask = a.bufH - 1, bW = a.bufW * 2, bufR = a.bufR, dstW2 = AlignLo(p.dstW, 2), dstW4 = AlignLo(p.dstW, 4), dD = p.dstC * a.srcE;
+            size_t dyEnd2 = dyBeg + (sY == 1 ? AlignLo(dyEnd - dyBeg, 2) : 0), sizeW = a.sizeW, dyD = p.dstW * dD;
+            dst += dyBeg * p.dstW * dD;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = vdupq_n_s32(-iZero);
+                _iHi = vdupq_n_s32(255 - iZero);
+                _iScale = vdupq_n_f32(iScale);
+                _dNorm = vdupq_n_f32(dNorm);
+                _params[0] = vdupq_n_f32(params[0]);
+                _params[1] = vdupq_n_f32(params[1]);
+            }
+            size_t dy = dyBeg;
+            for (; dy < dyEnd2; dy += 2)
+            {
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcCF; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = vld1q_s32(sBias + sc);
+                    _sNorm = vld1q_f32(sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = vld1q_f32(params + sc);
+                    size_t dx = 0;
+                    for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        d10 = vdupq_n_s32(0);
+                        d20 = vdupq_n_s32(0);
+                        d30 = vdupq_n_s32(0);
+                        d01 = vdupq_n_s32(0);
+                        d11 = vdupq_n_s32(0);
+                        d21 = vdupq_n_s32(0);
+                        d31 = vdupq_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                                s0 = LoadI16(ps + 1 * dX);
+                                Madd2(d10, s0, w0);
+                                Madd2(d11, s0, w1);
+                                s0 = LoadI16(ps + 2 * dX);
+                                Madd2(d20, s0, w0);
+                                Madd2(d21, s0, w1);
+                                s0 = LoadI16(ps + 3 * dX);
+                                Madd2(d30, s0, w0);
+                                Madd2(d31, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 2 * dD, d21, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 3 * dD, d31, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd0 += 4 * dD;
+                        pd1 += 4 * dD;
+                    }
+                    for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        d10 = vdupq_n_s32(0);
+                        d01 = vdupq_n_s32(0);
+                        d11 = vdupq_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                                s0 = LoadI16(ps + 1 * dX);
+                                Madd2(d10, s0, w0);
+                                Madd2(d11, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd0 += 2 * dD;
+                        pd1 += 2 * dD;
+                    }
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        d01 = vdupq_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd0 += dD;
+                        pd1 += dD;
+                    }
+                }
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = vld1q_s32(sBias + sc);
+                    _sNorm = vld1q_f32(sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = vld1q_f32(params + sc);
+                    size_t dx = 0, tail = srcC - srcCF;
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        d01 = vdupq_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0);
+                                w1 = LoadI16(pw1);
+                                s0 = LoadI16(ps + 0 * dX);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        pd0 += dD;
+                        pd1 += dD;
+                    }
+                }
+                dst += p.dstW * 2 * dD;
+            }
+            for (; dy < dyEnd; ++dy)
+            {
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcCF; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = vld1q_s32(sBias + sc);
+                    _sNorm = vld1q_f32(sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = vld1q_f32(params + sc);
+                    size_t dx = 0;
+                    for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        d10 = vdupq_n_s32(0);
+                        d20 = vdupq_n_s32(0);
+                        d30 = vdupq_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps + 0 * dX), w0);
+                                Madd2(d10, LoadI16(ps + 1 * dX), w0);
+                                Madd2(d20, LoadI16(ps + 2 * dX), w0);
+                                Madd2(d30, LoadI16(ps + 3 * dX), w0);
+                            }
+                        }
+                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd += 4 * dD;
+                    }
+                    for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        d10 = vdupq_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps + 0 * dX), w0);
+                                Madd2(d10, LoadI16(ps + 1 * dX), w0);
+                            }
+                        }
+                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd += 2 * dD;
+                    }
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps), w0);
+                            }
+                        }
+                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd += dD;
+                    }
+                }
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = vld1q_s32(sBias + sc);
+                    _sNorm = vld1q_f32(sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = vld1q_f32(params + sc);
+                    size_t dx = 0, tail = srcC - srcCF;
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = vdupq_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw);
+                                Madd2(d00, LoadI16(ps), w0);
+                            }
+                        }
+                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        pd += dD;
+                    }
+                }
+                dst += p.dstW * dD;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> void QuantizedConvolutionNhwcDepthwiseV2_3x3R1(const int16_t* src, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd,
+            const int16_t* weight, const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, uint8_t* dst)
+        {
+            float32x4_t _sNorm, _iScale, _params[2], _dNorm;
+            int32x4_t _dZero = vdupq_n_s32(dZero), _sBias, _iLo, _iHi;
+            int32x4_t d00, d10, w03, w14, w25, s0;
+            size_t srcC = p.srcC, srcCF = AlignLo(srcC, F), sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.stepW;
+            size_t byMask = a.bufH - 1, bW = a.bufW * 2, bufR = a.bufW * a.bufC, dstW2 = sX == 1 ? AlignLo(p.dstW, 2) : 0, dD = p.dstC * a.srcE;
+            size_t dyEnd2 = dyBeg + (sY == 1 ? AlignLo(dyEnd - dyBeg, 2) : 0), sizeW = a.sizeW, dyD = p.dstW * dD;
+            dst += dyBeg * p.dstW * dD;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = vdupq_n_s32(-iZero);
+                _iHi = vdupq_n_s32(255 - iZero);
+                _iScale = vdupq_n_f32(iScale);
+                _dNorm = vdupq_n_f32(dNorm);
+                _params[0] = vdupq_n_f32(params[0]);
+                _params[1] = vdupq_n_f32(params[1]);
+            }
+            size_t dy = dyBeg;
+            for (; dy < dyEnd2; dy += 2)
+            {
+                int32x4_t d01, w36, w47, w58;
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + ((sy + 0) & byMask) * bufR + sc * bW;
+                    const int16_t* ps2 = src + ((sy + 2) & byMask) * bufR + sc * bW;
+                    const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                    _sBias = vld1q_s32(sBias + sc);
+                    _sNorm = vld1q_f32(sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = vld1q_f32(params + sc);
+                    w03 = LoadI16(pw0 + 0 * 8);
+                    w14 = LoadI16(pw0 + 1 * 8);
+                    w25 = LoadI16(pw0 + 2 * 8);
+                    w36 = LoadI16(pw1 + 3 * 8);
+                    w47 = LoadI16(pw1 + 4 * 8);
+                    w58 = LoadI16(pw1 + 5 * 8);
+                    if (sc < srcCF)
+                    {
+                        size_t dx = 0;
+                        for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = vdupq_n_s32(0);
+                            d01 = vdupq_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * 8);
+                            Madd2(d00, s0, w03);
+                            Madd2(d01, s0, ShiftLeft16(w03));
+                            s0 = LoadI16(ps0 + 1 * 8);
+                            Madd2(d00, s0, w14);
+                            Madd2(d01, s0, ShiftLeft16(w14));
+                            s0 = LoadI16(ps0 + 2 * 8);
+                            Madd2(d00, s0, w25);
+                            Madd2(d01, s0, ShiftLeft16(w25));
+                            s0 = LoadI16(ps2 + 0 * 8);
+                            Madd2(d00, s0, ShiftRight16(w36));
+                            Madd2(d01, s0, w36);
+                            s0 = LoadI16(ps2 + 1 * 8);
+                            Madd2(d00, s0, ShiftRight16(w47));
+                            Madd2(d01, s0, w47);
+                            s0 = LoadI16(ps2 + 2 * 8);
+                            Madd2(d00, s0, ShiftRight16(w58));
+                            Madd2(d01, s0, w58);
+
+                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            pd0 += dD;
+                            pd1 += dD;
+                        }
+                    }
+                    else
+                    {
+                        size_t tail = srcC - srcCF;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = vdupq_n_s32(0);
+                            d01 = vdupq_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * 8);
+                            Madd2(d00, s0, w03);
+                            Madd2(d01, s0, ShiftLeft16(w03));
+                            s0 = LoadI16(ps0 + 1 * 8);
+                            Madd2(d00, s0, w14);
+                            Madd2(d01, s0, ShiftLeft16(w14));
+                            s0 = LoadI16(ps0 + 2 * 8);
+                            Madd2(d00, s0, w25);
+                            Madd2(d01, s0, ShiftLeft16(w25));
+                            s0 = LoadI16(ps2 + 0 * 8);
+                            Madd2(d00, s0, ShiftRight16(w36));
+                            Madd2(d01, s0, w36);
+                            s0 = LoadI16(ps2 + 1 * 8);
+                            Madd2(d00, s0, ShiftRight16(w47));
+                            Madd2(d01, s0, w47);
+                            s0 = LoadI16(ps2 + 2 * 8);
+                            Madd2(d00, s0, ShiftRight16(w58));
+                            Madd2(d01, s0, w58);
+
+                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            pd0 += dD;
+                            pd1 += dD;
+                        }
+                    }
+                }
+                dst += p.dstW * dD * 2;
+            }
+            for (; dy < dyEnd; ++dy)
+            {
+                int32x4_t w6, w7, w8;
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + ((sy + 0) & byMask) * bufR + sc * bW;
+                    const int16_t* ps2 = src + ((sy + 2) & byMask) * bufR + sc * bW;
+                    const int16_t* pw = weight + sc * dW;
+                    _sBias = vld1q_s32(sBias + sc);
+                    _sNorm = vld1q_f32(sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = vld1q_f32(params + sc);
+                    w03 = LoadI16(pw + 0 * 8);
+                    w14 = LoadI16(pw + 1 * 8);
+                    w25 = LoadI16(pw + 2 * 8);
+                    w6 = LoadI16(pw + 3 * 8);
+                    w7 = LoadI16(pw + 4 * 8);
+                    w8 = LoadI16(pw + 5 * 8);
+                    if (sc < srcCF)
+                    {
+                        size_t dx = 0;
+                        for (; dx < dstW2; dx += 2, ps0 += QF, ps2 += QF)
+                        {
+                            d00 = vdupq_n_s32(0);
+                            d10 = vdupq_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * 8);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * 8);
+                            Madd2(d00, s0, w14);
+                            Madd2(d10, s0, w03);
+                            s0 = LoadI16(ps0 + 2 * 8);
+                            Madd2(d00, s0, w25);
+                            Madd2(d10, s0, w14);
+                            s0 = LoadI16(ps0 + 3 * 8);
+                            Madd2(d10, s0, w25);
+
+                            s0 = LoadI16(ps2 + 0 * 8);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * 8);
+                            Madd2(d00, s0, w7);
+                            Madd2(d10, s0, w6);
+                            s0 = LoadI16(ps2 + 2 * 8);
+                            Madd2(d00, s0, w8);
+                            Madd2(d10, s0, w7);
+                            s0 = LoadI16(ps2 + 3 * 8);
+                            Madd2(d10, s0, w8);
+
+                            Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            pd += 2 * dD;
+                        }
+                        for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = vdupq_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * 8);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * 8);
+                            Madd2(d00, s0, w14);
+                            s0 = LoadI16(ps0 + 2 * 8);
+                            Madd2(d00, s0, w25);
+                            s0 = LoadI16(ps2 + 0 * 8);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * 8);
+                            Madd2(d00, s0, w7);
+                            s0 = LoadI16(ps2 + 2 * 8);
+                            Madd2(d00, s0, w8);
+
+                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            pd += dD;
+                        }
+                    }
+                    else
+                    {
+                        size_t tail = srcC - srcCF;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = vdupq_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * 8);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * 8);
+                            Madd2(d00, s0, w14);
+                            s0 = LoadI16(ps0 + 2 * 8);
+                            Madd2(d00, s0, w25);
+                            s0 = LoadI16(ps2 + 0 * 8);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * 8);
+                            Madd2(d00, s0, w7);
+                            s0 = LoadI16(ps2 + 2 * 8);
+                            Madd2(d00, s0, w8);
+
+                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            pd += dD;
+                        }
+                    }
+                }
+                dst += p.dstW * dD;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> void SetV2(const ConvParam& p, const AlgParam& a, SynetQuantizedConvolutionNhwcDepthwiseV2::ConvolutionPtr& convolution)
+        {
+            if (p.IsKernel(3) && p.IsDilation(1) && a.reorderType == 1)
+                convolution = QuantizedConvolutionNhwcDepthwiseV2_3x3R1<term, type>;
+            else
+            {
+                if (a.reorderType == 1)
+                    convolution = QuantizedConvolutionNhwcDepthwiseV2_AnyR1<term, type>;
+                else
+                    assert(0);
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        SynetQuantizedConvolutionNhwcDepthwiseV2::SynetQuantizedConvolutionNhwcDepthwiseV2(const ConvParam& p)
+            : Base::SynetQuantizedConvolutionNhwcDepthwiseV2(p)
+        {
+            SetAlgParam(F);
+            _preprocess = QuantizedConvolutionNhwcDepthwiseV2_Preprocess;
+            if (p.dstT == SimdTensorData8u)
+            {
+                switch (p.activation)
+                {
+                case SimdConvolutionActivationIdentity: SetV2<Term8iLast8u, SimdConvolutionActivationIdentity>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationRelu: SetV2<Term8iLast8u, SimdConvolutionActivationRelu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationLeakyRelu: SetV2<Term8iLast8u, SimdConvolutionActivationLeakyRelu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationRestrictRange: SetV2<Term8iLast8u, SimdConvolutionActivationRestrictRange>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationPrelu: SetV2<Term8iLast8u, SimdConvolutionActivationPrelu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationElu: SetV2<Term8iLast8u, SimdConvolutionActivationElu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationHswish: SetV2<Term8iLast8u, SimdConvolutionActivationHswish>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationMish: SetV2<Term8iLast8u, SimdConvolutionActivationMish>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationHardSigmoid: SetV2<Term8iLast8u, SimdConvolutionActivationHardSigmoid>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationSwish: SetV2<Term8iLast8u, SimdConvolutionActivationSwish>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationGelu: SetV2<Term8iLast8u, SimdConvolutionActivationGelu>(p, _alg, _convolution); break;
+                default:
+                    assert(0);
+                }
+            }
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -781,6 +781,77 @@ namespace Simd
             QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias, norm, zero);
             QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias, norm, zero, tail);
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type, int index> SIMD_INLINE int32x4_t ToSave32i(int32x4_t sum, const int32x4_t* sBias, const float32x4_t* sNorm,
+            const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero)
+        {
+            if (type == SimdConvolutionActivationIdentity)
+            {
+                return vaddq_s32(NearbyInt(vmulq_f32(vcvtq_f32_s32(vaddq_s32(sum, sBias[index])), sNorm[index])), dZero);
+            }
+            else
+            {
+                int32x4_t i32 = NearbyInt(vmulq_f32(vcvtq_f32_s32(vaddq_s32(sum, sBias[index])), sNorm[index]));
+                float32x4_t f32 = vmulq_f32(vcvtq_f32_s32(vminq_s32(vmaxq_s32(iLo, i32), iHi)), iScale);
+                return QuantizeLinear(Activate<type>(f32, params, index), dNorm, dZero);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type, int index> SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, int32x4_t sum,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero)
+        {
+            if (term == Term8iInterim)
+            {
+                vst1q_s32(buf + index * F, sum);
+            }
+            else if (term == Term8iLast8u)
+            {
+                int32x4_t d0 = ToSave32i<type, index>(sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+                uint8x8_t u8 = vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vdup_n_s16(0)));
+                ((int32_t*)dst)[index] = vget_lane_s32(vreinterpret_s32_u8(u8), 0);
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, int32x4_t sum,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero, size_t tail)
+        {
+            if (term == Term8iInterim)
+            {
+                int32_t tmp[F];
+                vst1q_s32(tmp, sum);
+                for (size_t i = 0; i < tail; ++i)
+                    buf[index * F + i] = tmp[i];
+            }
+            else if (term == Term8iLast8u)
+            {
+                uint8_t tmp[F];
+                Save<term, type, index>(tmp - index * F, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+                for (size_t i = 0; i < tail; ++i)
+                    dst[index * F + i] = tmp[i];
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, int32x4_t sum,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero)
+        {
+            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, int32x4_t sum,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero, size_t tail)
+        {
+            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
+        }
     }
 #endif
 

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -737,6 +737,16 @@ namespace Simd
 
         //------------------------------------------------------------------------------------------------
 
+        class SynetQuantizedConvolutionNhwcDepthwiseV2 : public Base::SynetQuantizedConvolutionNhwcDepthwiseV2
+        {
+        public:
+            SynetQuantizedConvolutionNhwcDepthwiseV2(const ConvParam& p);
+
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
         void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv);
     }
 #endif

--- a/src/Simd/SimdSynetQuantizedDepthwise.h
+++ b/src/Simd/SimdSynetQuantizedDepthwise.h
@@ -227,6 +227,20 @@ namespace Simd
             QuntizedTerm8i<term>::template Save<0>(dst0 + offset, (int32_t*)NULL, sum0, &_bias, &_norm, zero, tail);
             QuntizedTerm8i<term>::template Save<0>(dst1 + offset, (int32_t*)NULL, sum1, &_bias, &_norm, zero, tail);
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32x4_t sum, const int32x4_t& sBias,
+            const float32x4_t& sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero)
+        {
+            Save<term, type, 0>(dst, (int32_t*)NULL, sum, &sBias, &sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+        }
+
+        template <Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32x4_t sum, const int32x4_t& sBias,
+            const float32x4_t& sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero, size_t tail)
+        {
+            Save<term, type, 0>(dst, (int32_t*)NULL, sum, &sBias, &sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
+        }
     }
 #endif
 }

--- a/src/Test/TestSynetQuantizedConvolution.cpp
+++ b/src/Test/TestSynetQuantizedConvolution.cpp
@@ -397,6 +397,11 @@ namespace Test
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 17, 11, 11, 17, _5, _1, _1, _2, _2, 17, aId, t, u8, u8), o, f1, f2);
 #endif
 #if 1
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 6, 9, 9, 6, _7, _1, _1, _3, _3, 6, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 9, 11, 11, 9, _7, _1, _2, _3, _3, 9, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 8, 9, 9, 8, _3, _1, _1, _1, _1, 8, aId, t, u8, u8), o, f1, f2);
+#endif
+#if 1
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 128, 56, 56, 128, _3, _1, _1, _1, _1, 128, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 128, 56, 56, 128, _3, _1, _2, _1, _1, 128, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 128, 56, 56, 128, _5, _1, _1, _2, _2, 128, aId, t, u8, u8), o, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.

Port the SSE41 depthwise V2 preprocess and convolution kernels (AnyR1, 3x3R1) to NEON, prefer V2 over V1/V0 in `Neon::SynetQuantizedConvolutionInit`, and update tests, VS project files, and the 7.2.165 release notes.

## Summary

Adds ARM/ARM64 NEON optimizations for `SynetQuantizedConvolutionNhwcDepthwiseV2`, following the existing SSE4.1 implementation and the recently merged NEON V0/V1 work.

- Port V2 preprocess (`uint8` → packed `int16` buffer, reorder types 0 and 1) and convolution kernels (`AnyR1`, `3x3R1`) to NEON in `SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp`.
- Add activation-aware NEON `ToSave32i` / `Save` / `Save1` helpers so V2 can apply Identity through Gelu, matching SSE4.1.
- Declare `Neon::SynetQuantizedConvolutionNhwcDepthwiseV2` and prefer it over V1/V0 in `Neon::SynetQuantizedConvolutionInit` when `Preferable` is true (depthwise, dilation 1, stride 1 or 2, kernel 3/5/7).
- Extend `Test::SynetQuantizedConvolutionAutoTest` with V2-focused 7x7 cases and an activation sweep on 3x3 depthwise.
- Register the new source in `prj/vs2022/Neon.vcxproj` and `Neon.vcxproj.filters`.
- Document the change in `docs/2026.html` under release 7.2.165.

## Test plan

- Native x86_64 Release build with g++ (`SIMD_SHARED=ON`): `./Test "-r=.." -fi=QuantizedConvolution -tt=1 -ts=1` — all tests finished successfully (50.6s), including the new 7x7 depthwise cases and all activation types on 8-channel 3x3.
- AArch64 cross-compile of the new NEON sources with `aarch64-linux-gnu-g++ -O3 -std=c++11 -march=armv8-a+crc` — `DepthwiseV2.o` contains `Preprocess`, `AnyR1`, `3x3R1` (all 11 activations), and the V2 constructor. Existing V0/V1 sources still compile with the shared header updates.
- This VM is x86_64, so NEON runtime selection (`Neon::NhwcDepthwiseV2-*`) needs an ARM host.

[QuantizedConvolution test success](https://cursor.com/agents/bc-bd8dc7c3-ef19-45a5-ba3f-796eb9bb3bcd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquantized_convolution_tests_success.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd8dc7c3-ef19-45a5-ba3f-796eb9bb3bcd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd8dc7c3-ef19-45a5-ba3f-796eb9bb3bcd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

