### PR TITLE
Add NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -70,6 +70,7 @@
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV0.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV1.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.</li>
+ <li>NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
 </ul>
@@ -496,6 +497,7 @@
  <li>Tests for verifying functionality of function SynetQuantizedHswish.</li>
  <li>Tests for verifying functionality of function SynetQuantizedMulInit.</li>
  <li>Tests for verifying functionality of function SynetQuantizedPoolingAverage.</li>
+ <li>Tests for verifying functionality of NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -147,6 +147,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution8iInput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution8iOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV1.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -367,6 +367,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolution.cpp">
       <Filter>Neon\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp">
+      <Filter>Neon\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV0.cpp">
       <Filter>Neon\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdNeonSynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedConvolution.cpp
@@ -46,6 +46,8 @@ namespace Simd
                 return new SynetQuantizedConvolutionNhwcDepthwiseV1(param);
             else if (SynetQuantizedConvolutionNhwcDepthwiseV0::Preferable(param, F))
                 return new SynetQuantizedConvolutionNhwcDepthwiseV0(param);
+            else if (SynetQuantizedConvolutionNhwcGemmV0::Preferable(param))
+                return new SynetQuantizedConvolutionNhwcGemmV0(param);
             else
                 return Base::SynetQuantizedConvolutionInit(batch, conv);
         }

--- a/src/Simd/SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp
@@ -1,0 +1,296 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Neon
+    {
+        typedef Base::SynetQuantizedConvolutionNhwcGemmV0::AlgParam AlgParam;
+        typedef Base::SynetQuantizedConvolutionNhwcGemmV0::ConvolutionPtr Convolution;
+
+        //-----------------------------------------------------------------------------------------
+
+        static void QuantizedConvolutionNhwcGemmV0_Reorder(const uint8_t* src, uint8_t zero, const ConvParam& p, const AlgParam& a, size_t yBeg, size_t yEnd, uint8_t* dst)
+        {
+            size_t gap = a.bufK - a.K;
+            for (size_t dy = yBeg, dr = 0; dy < yEnd; ++dy)
+            {
+                for (size_t dx = 0; dx < p.dstW; ++dx, ++dr)
+                {
+                    uint8_t* row = dst + dr * a.bufK;
+                    for (size_t ky = 0, k = 0; ky < p.kernelY; ky++)
+                    {
+                        size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                        if (sy < p.srcH)
+                        {
+                            for (size_t kx = 0; kx < p.kernelX; kx++)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                if (sx < p.srcW)
+                                {
+                                    const uint8_t* ps = src + (sy * p.srcW + sx) * p.srcC;
+                                    memcpy(row, ps, p.srcC);
+                                    row += p.srcC;
+                                }
+                                else
+                                {
+                                    memset(row, zero, p.srcC);
+                                    row += p.srcC;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            memset(row, zero, p.kernelX * p.srcC);
+                            row += p.kernelX * p.srcC;
+                        }
+                    }
+                    for (size_t g = 0; g < gap; ++g)
+                        *(row++) = 0;
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<Term8iType term, SimdConvolutionActivationType type, int M> void QuantizedConvolutionNhwcGemmV0_i2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC,
+            int update, const int8_t* weight0, const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero, int32_t* buf, uint8_t* dst)
+        {
+            int32x4_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41;
+            uint8x16_t s0;
+            int8x16_t w0, w1;
+            size_t dB = a.dB, dD = p.dstC * a.elem, dS = a.bufK;
+            const int8_t* weight1 = weight0 + a.bufK * F;
+            const uint8_t* src1 = src0 + 1 * dS;
+            const uint8_t* src2 = src0 + 2 * dS;
+            const uint8_t* src3 = src0 + 3 * dS;
+            const uint8_t* src4 = src0 + 4 * dS;
+            if (dstC > F)
+            {
+                if (update)
+                {
+                    if (M > 0) d00 = vld1q_s32(buf + 0 * dB + 0), d01 = vld1q_s32(buf + 0 * dB + F);
+                    if (M > 1) d10 = vld1q_s32(buf + 1 * dB + 0), d11 = vld1q_s32(buf + 1 * dB + F);
+                    if (M > 2) d20 = vld1q_s32(buf + 2 * dB + 0), d21 = vld1q_s32(buf + 2 * dB + F);
+                    if (M > 3) d30 = vld1q_s32(buf + 3 * dB + 0), d31 = vld1q_s32(buf + 3 * dB + F);
+                    if (M > 4) d40 = vld1q_s32(buf + 4 * dB + 0), d41 = vld1q_s32(buf + 4 * dB + F);
+                }
+                else
+                {
+                    if (M > 0) d00 = vdupq_n_s32(0), d01 = vdupq_n_s32(0);
+                    if (M > 1) d10 = vdupq_n_s32(0), d11 = vdupq_n_s32(0);
+                    if (M > 2) d20 = vdupq_n_s32(0), d21 = vdupq_n_s32(0);
+                    if (M > 3) d30 = vdupq_n_s32(0), d31 = vdupq_n_s32(0);
+                    if (M > 4) d40 = vdupq_n_s32(0), d41 = vdupq_n_s32(0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 4)
+                {
+                    w0 = vld1q_s8(weight0);
+                    w1 = vld1q_s8(weight1);
+                    if (M > 0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0), Madd4<true>(d01, s0, w1);
+                    if (M > 1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0), Madd4<true>(d11, s0, w1);
+                    if (M > 2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0), Madd4<true>(d21, s0, w1);
+                    if (M > 3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0), Madd4<true>(d31, s0, w1);
+                    if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0), Madd4<true>(d41, s0, w1);
+                    weight0 += A, weight1 += A;
+                }
+                if (dstC == DF)
+                {
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                }
+                else
+                {
+                    dstC -= F;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                }
+            }
+            else
+            {
+                if (update)
+                {
+                    if (M > 0) d00 = vld1q_s32(buf + 0 * dB);
+                    if (M > 1) d10 = vld1q_s32(buf + 1 * dB);
+                    if (M > 2) d20 = vld1q_s32(buf + 2 * dB);
+                    if (M > 3) d30 = vld1q_s32(buf + 3 * dB);
+                    if (M > 4) d40 = vld1q_s32(buf + 4 * dB);
+                }
+                else
+                {
+                    if (M > 0) d00 = vdupq_n_s32(0);
+                    if (M > 1) d10 = vdupq_n_s32(0);
+                    if (M > 2) d20 = vdupq_n_s32(0);
+                    if (M > 3) d30 = vdupq_n_s32(0);
+                    if (M > 4) d40 = vdupq_n_s32(0);
+                }
+                for (size_t offs = 0; offs < srcC; offs += 4)
+                {
+                    w0 = vld1q_s8(weight0);
+                    if (M > 0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0);
+                    if (M > 1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0);
+                    if (M > 2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0);
+                    if (M > 3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0);
+                    if (M > 4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0);
+                    weight0 += A;
+                }
+                if (dstC == F)
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero), dst += dD, buf += dB;
+                }
+                else
+                {
+                    if (M > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, dstC), dst += dD, buf += dB;
+                }
+            }
+        }
+
+        typedef void(*QuantizedConvolutionNhwcGemmV0_i2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a, size_t srcC, size_t dstC, int update, const int8_t* weight,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero, int32_t* buf, uint8_t* dst);
+
+        template<Term8iType term, SimdConvolutionActivationType type> QuantizedConvolutionNhwcGemmV0_i2xM_Ptr GetQuantizedConvolutionNhwcGemmV0_i2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0: return NULL;
+            case 1: return QuantizedConvolutionNhwcGemmV0_i2xM<term, type, 1>;
+            case 2: return QuantizedConvolutionNhwcGemmV0_i2xM<term, type, 2>;
+            case 3: return QuantizedConvolutionNhwcGemmV0_i2xM<term, type, 3>;
+            case 4: return QuantizedConvolutionNhwcGemmV0_i2xM<term, type, 4>;
+            case 5: return QuantizedConvolutionNhwcGemmV0_i2xM<term, type, 5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> void QuantizedConvolutionNhwcGemmV0_i2(const uint8_t* src, const ConvParam& p, const AlgParam& a, size_t dstC, size_t dstH, size_t srcC, int update, const int8_t* weight,
+            const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, int32_t* buf, uint8_t* dst)
+        {
+            size_t n1 = dstH * p.dstW, n = 5;
+            size_t nn = AlignLoAny(n1, n), m = n1 - nn, dW = a.bufK * DF;
+            size_t dB = a.dB, dD = p.dstC * a.elem, dS = a.bufK;
+            QuantizedConvolutionNhwcGemmV0_i2xM_Ptr convolution_i2xN = GetQuantizedConvolutionNhwcGemmV0_i2xM<term, type>(n);
+            QuantizedConvolutionNhwcGemmV0_i2xM_Ptr convolution_i2xM = GetQuantizedConvolutionNhwcGemmV0_i2xM<term, type>(m);
+
+            float32x4_t _sNorm[2], _iScale, _params[2], _dNorm;
+            int32x4_t _sBias[2], _dZero = vdupq_n_s32(dZero), _iLo, _iHi;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = vdupq_n_s32(-iZero);
+                _iHi = vdupq_n_s32(255 - iZero);
+                _iScale = vdupq_n_f32(iScale);
+                _dNorm = vdupq_n_f32(dNorm);
+                _params[0] = vdupq_n_f32(params[0]);
+                _params[1] = vdupq_n_f32(params[1]);
+            }
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                _sBias[0] = vld1q_s32(sBias + dc + 0);
+                _sBias[1] = vld1q_s32(sBias + dc + F);
+                _sNorm[0] = vld1q_f32(sNorm + dc + 0);
+                _sNorm[1] = vld1q_f32(sNorm + dc + F);
+                if (type == SimdConvolutionActivationPrelu)
+                {
+                    _params[0] = vld1q_f32(params + dc + 0);
+                    _params[1] = vld1q_f32(params + dc + F);
+                }
+                const uint8_t* s = src;
+                int32_t* b = buf + dc;
+                uint8_t* d = dst + dc * a.elem;
+                size_t i = 0;
+                for (; i < nn; i += n, s += n * dS, b += n * dB, d += n * dD)
+                    convolution_i2xN(s, p, a, srcC, dC, update, weight, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, b, d);
+                for (; i < n1; i += m, s += m * dS, b += m * dB, d += m * dD)
+                    convolution_i2xM(s, p, a, srcC, dC, update, weight, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, b, d);
+                weight += dW;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE void Set(const ConvParam& p, const AlgParam& a, Convolution* convolutions)
+        {
+            convolutions[0] = QuantizedConvolutionNhwcGemmV0_i2<Term8iInterim, SimdConvolutionActivationIdentity>;
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationIdentity>; break;
+            case SimdConvolutionActivationRelu: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationRelu>; break;
+            case SimdConvolutionActivationLeakyRelu: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationLeakyRelu>; break;
+            case SimdConvolutionActivationRestrictRange: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationRestrictRange>; break;
+            case SimdConvolutionActivationPrelu: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationPrelu>; break;
+            case SimdConvolutionActivationElu: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationElu>; break;
+            case SimdConvolutionActivationHswish: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationHswish>; break;
+            case SimdConvolutionActivationMish: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationMish>; break;
+            case SimdConvolutionActivationHardSigmoid: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationHardSigmoid>; break;
+            case SimdConvolutionActivationSwish: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationSwish>; break;
+            case SimdConvolutionActivationGelu: convolutions[1] = QuantizedConvolutionNhwcGemmV0_i2<Term8iLast8u, SimdConvolutionActivationGelu>; break;
+            default:
+                convolutions[1] = NULL;
+            }
+        }
+
+        SynetQuantizedConvolutionNhwcGemmV0::SynetQuantizedConvolutionNhwcGemmV0(const ConvParam& p)
+            : Base::SynetQuantizedConvolutionNhwcGemmV0(p)
+        {
+            SetAlgParam(F, F * 2, 5, 4, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3());
+            if (_src8u)
+            {
+                AlgParam& a = _alg;
+                if (_is1x1 && a.K == a.bufK)
+                    _convert = NULL;
+                else
+                    _convert = QuantizedConvolutionNhwcGemmV0_Reorder;
+            }
+            else
+                assert(0);
+            Set(p, _alg, _convolutions);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -852,6 +852,34 @@ namespace Simd
         {
             Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
         }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, int32x4_t sum0, int32x4_t sum1,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero)
+        {
+            if (term == Term8iInterim)
+            {
+                vst1q_s32(buf + 0 * F, sum0);
+                vst1q_s32(buf + 1 * F, sum1);
+            }
+            else if (term == Term8iLast8u)
+            {
+                int32x4_t d0 = ToSave32i<type, 0>(sum0, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+                int32x4_t d1 = ToSave32i<type, 1>(sum1, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+                uint8x8_t u8 = vqmovun_s16(vcombine_s16(vqmovn_s32(d0), vqmovn_s32(d1)));
+                vst1_u8(dst, u8);
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, int32x4_t sum0, int32x4_t sum1,
+            const int32x4_t* sBias, const float32x4_t* sNorm, const int32x4_t& iLo, const int32x4_t& iHi, const float32x4_t& iScale, const float32x4_t* params, const float32x4_t& dNorm, const int32x4_t& dZero, size_t tail)
+        {
+            Save<term, type, 0>(dst, buf, sum0, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero);
+            Save<term, type, 1>(dst, buf, sum1, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
+        }
     }
 #endif
 

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -717,6 +717,16 @@ namespace Simd
 #ifdef SIMD_NEON_ENABLE    
     namespace Neon
     {
+        class SynetQuantizedConvolutionNhwcGemmV0 : public Base::SynetQuantizedConvolutionNhwcGemmV0
+        {
+        public:
+            SynetQuantizedConvolutionNhwcGemmV0(const ConvParam& p);
+
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
         class SynetQuantizedConvolutionNhwcDepthwiseV0 : public Base::SynetQuantizedConvolutionNhwcDepthwiseV0
         {
         public:

--- a/src/Test/TestSynetQuantizedConvolution.cpp
+++ b/src/Test/TestSynetQuantizedConvolution.cpp
@@ -478,6 +478,12 @@ namespace Test
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 1024, 7, 7, 2048, _1, _1, _1, _0, _0, 1, aId, t, u8, u8), o, f1, f2);
 #endif
 #if 1
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 7, 8, 8, 5, _1, _1, _1, _0, _0, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 16, 9, 9, 11, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(2, 15, 8, 8, 17, _3, _1, _2, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 8, 6, 6, 12, _1, _1, _1, _0, _0, 1, aId, t, u8, u8), o, f1, f2);
+#endif
+#if 1
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 64, 32, 32, 64, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 128, 32, 32, 128, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 256, 16, 16, 256, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Port the SSE4.1 `SynetQuantizedConvolutionNhwcGemmV0` implementation to NEON for ARM/ARM64.

### Changes
- Add `Neon::SynetQuantizedConvolutionNhwcGemmV0` in `SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp` (reorder + i2xM GEMM kernels, micro-kernel 2x5, `microK=4`).
- Add Neon `Save2` helpers with activation in `SimdSynetQuantizedActivation.h`.
- Prefer NhwcGemmV0 in `Neon::SynetQuantizedConvolutionInit` after depthwise algorithms.
- Extend `Test::SynetQuantizedConvolutionAutoTest` with 1x1/3x3 Gemm cases (tail channels, batch>1, all activations).
- Register the new source in `prj/vs2022/Neon.vcxproj` and `Neon.vcxproj.filters`.
- Document the feature in `docs/2026.html` (release 7.2.165).

### Testing
- ARM64 cross-compile (`aarch64-linux-gnu-g++`) of `libSimd.so` and `Test` succeeded, including `SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp`.
- `Test -fi=SynetQuantizedConvolution` under qemu-aarch64: **ALL TESTS ARE FINISHED SUCCESSFULLY** (Base vs Neon). Typical NhwcGemmV0 cases are about 2.1–3.4x vs Base under qemu; depthwise cases keep the existing Neon speedups.
- Native x86 Release build and the same test filter also passed (Base / SSE4.1 / AVX2 / AVX-512 / VNNI / AMX).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a13878ed-80f3-488d-8a96-ee8a98a5c063?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a13878ed-80f3-488d-8a96-ee8a98a5c063&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

