### PR TITLE
Add C++ wrapper Simd::SynetQuantizedMul

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -73,6 +73,7 @@
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
+ <li>C++ wrapper Simd::SynetQuantizedMul.</li>
 </ul>
 <h5>Improving</h5>
 <ul>
@@ -95,6 +96,7 @@
 <h5>Improving</h5>
 <ul>
  <li>Added description of class Simd::SynetAdd16b.</li>
+ <li>Added description of class Simd::SynetQuantizedMul.</li>
  <li>Improved description of function Simd::BackgroundGrowRangeSlow.</li>
  <li>Improved description of function Simd::BackgroundGrowRangeFast.</li>
  <li>Improved description of function Simd::BackgroundIncrementCount.</li>

--- a/prj/txt/DoxygenGroups.txt
+++ b/prj/txt/DoxygenGroups.txt
@@ -93,7 +93,7 @@
 
 /*! @ingroup cpp_types
     @defgroup cpp_synet Synet Wrappers
-    \short Simd::SynetAdd16b and Simd::SynetQuantizedAdd classes (C++ wrappers of Synet addition).
+    \short Simd::SynetAdd16b, Simd::SynetQuantizedAdd and Simd::SynetQuantizedMul classes (C++ wrappers of Synet operations).
 */
 
 /*! @ingroup cpp_types

--- a/src/Simd/SimdLib.h
+++ b/src/Simd/SimdLib.h
@@ -10164,13 +10164,15 @@ extern "C"
 
     /*! @ingroup synet_quantized_mul
 
-        \fn void* SimdSynetQuantizedMulInit(const size_t* aShape, size_t aCount, SimdTensorDataType aType, const float* aScale, int32_t aZero, const size_t* bShape, size_t bCount, SimdTensorDataType bType, const float* bScale, int32_t bZero, SimdConvolutionActivationType actType, const float* actParams, SimdTensorDataType dstType, const float* dstScale, int32_t dstZero);
+        \fn void* SimdSynetQuantizedMulInit(const size_t* aShape, size_t aCount, SimdTensorDataType aType, const float* aScale, int32_t aZero, const size_t* bShape, size_t bCount, SimdTensorDataType bType, const float* bScale, int32_t bZero, SimdTensorDataType dstType, const float* dstScale, int32_t dstZero);
 
-        \short Initializes element-wise quantized multiplication of two tensors with optional activation.
+        \short Initializes element-wise quantized multiplication of two tensors.
 
-        The current implementation supports equal input shapes. For each element it dequantizes UINT8 inputs
-        as (value - zero)*scale, multiplicates the two values and converts the result to FP32 or UINT8 output. 
+        The current implementation supports compatible input shapes (equal or broadcast). For each element it dequantizes UINT8 inputs
+        as (value - zero)*scale, multiplies the two values and converts the result to FP32 or UINT8 output. 
         FP32 inputs and outputs ignore the corresponding quantization zero.
+
+        \note This function has a C++ wrapper: Simd::SynetQuantizedMul.
 
         \param [in] aShape - a pointer to shape of input A tensor.
         \param [in] aCount - a count of dimensions of input A tensor.
@@ -10208,6 +10210,8 @@ extern "C"
             dst[i] = RestrictRange(Round((_a * _b)/dstScale) + dstZero, 0, 255);
         }
         \endverbatim
+
+        \note This function has a C++ wrapper: Simd::SynetQuantizedMul.
 
         \param [in] context - a pointer to quantized multiplication context. It must be created by function ::SimdSynetQuantizedMulInit and released by function ::SimdRelease.
         \param [in] a - a pointer to input A tensor data. Its type is defined by parameter aType of ::SimdSynetQuantizedMulInit.

--- a/src/Simd/SimdSynet.hpp
+++ b/src/Simd/SimdSynet.hpp
@@ -314,6 +314,149 @@ namespace Simd
         void * _context;
         Shape _aShape, _bShape;
     };
+
+    //-------------------------------------------------------------------------------------------------
+
+    /*! @ingroup cpp_synet
+
+        \short The SynetQuantizedMul class is a C++ wrapper of quantized (UINT8/FP32) element-wise multiplication.
+
+        The class wraps C API functions ::SimdSynetQuantizedMulInit and ::SimdSynetQuantizedMulForward.
+        It dequantizes UINT8 inputs as (value - zero)*scale, multiplies the two values and converts
+        the result to FP32 or UINT8 output. FP32 inputs and outputs ignore the corresponding
+        quantization zero. Algorithm's details for UINT8 output:
+        \verbatim
+        for(i = 0; i < size; ++i)
+        {
+            _a = (a[i] - aZero)*aScale;
+            _b = (b[i] - bZero)*bScale;
+            dst[i] = RestrictRange(Round((_a * _b)/dstScale) + dstZero, 0, 255);
+        }
+        \endverbatim
+
+        The current implementation creates a context for compatible input shapes (equal or broadcast)
+        and FP32/UINT8 input and output tensor types. Call Init() before Forward(). Use Enable() to check
+        that a context was created. The context is released by Clear() or by the destructor.
+
+        Using example:
+        \verbatim
+        #include "Simd/SimdSynet.hpp"
+
+        int main()
+        {
+            const size_t n = 64;
+            std::vector<uint8_t> a(n, 50), b(n, 80), dst(n, 0);
+            Simd::Shape dims = Simd::Shape({ n });
+            float aScale = 0.010f, bScale = 0.020f, dstScale = 0.015f;
+            int32_t aZero = 47, bZero = 30, dstZero = 38;
+
+            Simd::SynetQuantizedMul mul;
+            mul.Init(dims, SimdTensorData8u, aScale, aZero, dims, SimdTensorData8u, bScale, bZero,
+                SimdTensorData8u, dstScale, dstZero);
+            if (mul.Enable())
+                mul.Forward(a.data(), b.data(), dst.data());
+
+            return 0;
+        }
+        \endverbatim
+    */
+    class SynetQuantizedMul
+    {
+    public:
+        /*!
+            Creates a new empty SynetQuantizedMul class.
+        */
+        SynetQuantizedMul()
+            : _context(NULL)
+        {
+        }
+
+        /*!
+            SynetQuantizedMul class destructor. Releases internal context.
+        */
+        virtual ~SynetQuantizedMul()
+        {
+            Clear();
+        }
+
+        /*!
+            Initializes (or re-initializes) element-wise quantized multiplication of two UINT8/FP32 tensors.
+
+            Creates an internal context with using of function ::SimdSynetQuantizedMulInit.
+            The context is recreated only if input tensor shapes were changed.
+
+            \note This function is a C++ wrapper for function ::SimdSynetQuantizedMulInit.
+
+            \param [in] aShape - a shape of input A tensor.
+            \param [in] aType - a type of input A tensor. Can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] aScale - a quantization scale of input A tensor.
+            \param [in] aZero - a quantization zero of input A tensor.
+            \param [in] bShape - a shape of input B tensor.
+            \param [in] bType - a type of input B tensor. Can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] bScale - a quantization scale of input B tensor.
+            \param [in] bZero - a quantization zero of input B tensor.
+            \param [in] dstType - a type of output tensor. Can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] dstScale - an output quantization scale.
+            \param [in] dstZero - an output quantization zero.
+        */
+        SIMD_INLINE void Init(const Shape & aShape, SimdTensorDataType aType, float aScale, int32_t aZero,
+            const Shape & bShape, SimdTensorDataType bType, float bScale, int32_t bZero,
+            SimdTensorDataType dstType, float dstScale, int32_t dstZero)
+        {
+            if (_aShape != aShape || _bShape != bShape)
+            {
+                Clear();
+                _aShape = aShape;
+                _bShape = bShape;
+                _context = SimdSynetQuantizedMulInit(_aShape.data(), _aShape.size(), aType, &aScale, aZero,
+                    _bShape.data(), _bShape.size(), bType, &bScale, bZero, dstType, &dstScale, dstZero);
+            }
+        }
+
+        /*!
+            Checks that the internal quantized multiplication context was created.
+
+            \return true if the context exists and Forward() can be called.
+        */
+        SIMD_INLINE bool Enable() const
+        {
+            return _context != NULL;
+        }
+
+        /*!
+            Performs element-wise quantized multiplication of two UINT8/FP32 tensors.
+
+            The function multiplies corresponding elements of input tensors A and B with dequantization
+            and output quantization. The actual data types, tensor shape and quantization parameters
+            are stored in the context created by Init().
+
+            \note This function is a C++ wrapper for function ::SimdSynetQuantizedMulForward.
+
+            \param [in] a - a pointer to input A tensor.
+            \param [in] b - a pointer to input B tensor.
+            \param [out] dst - a pointer to output tensor.
+        */
+        SIMD_INLINE void Forward(const uint8_t * a, const uint8_t * b, uint8_t * dst)
+        {
+            if (_context)
+                SimdSynetQuantizedMulForward(_context, a, b, dst);
+        }
+
+        /*!
+            Releases internal context and clears stored tensor shapes.
+        */
+        SIMD_INLINE void Clear()
+        {
+            if (_context)
+                SimdRelease(_context), _context = NULL;
+            _aShape.clear();
+            _bShape.clear();
+        }
+
+    private:
+        void * _context;
+        Shape _aShape, _bShape;
+    };
 }
 
 #endif

--- a/src/Test/TestCheckCpp.cpp
+++ b/src/Test/TestCheckCpp.cpp
@@ -257,6 +257,36 @@ namespace Test
                 std::cout << "TestSynetQuantizedAdd is failed at " << i << " : " << (int)dst1[i] << " != " << (int)dst2[i] << std::endl;
         }
     }
+
+    static void TestSynetQuantizedMul()
+    {
+        const size_t n = 64;
+        std::vector<uint8_t> a(n, 50), b(n, 80), dst1(n, 0), dst2(n, 0);
+        Simd::Shape dims = Simd::Shape({ n });
+        float aScale = 0.010f, bScale = 0.020f, dstScale = 0.015f;
+        int32_t aZero = 47, bZero = 30, dstZero = 38;
+
+        Simd::SynetQuantizedMul mul;
+        mul.Init(dims, SimdTensorData8u, aScale, aZero, dims, SimdTensorData8u, bScale, bZero,
+            SimdTensorData8u, dstScale, dstZero);
+        if (mul.Enable())
+            mul.Forward(a.data(), b.data(), dst1.data());
+
+        void* context = SimdSynetQuantizedMulInit(dims.data(), dims.size(), SimdTensorData8u, &aScale, aZero,
+            dims.data(), dims.size(), SimdTensorData8u, &bScale, bZero,
+            SimdTensorData8u, &dstScale, dstZero);
+        if (context)
+        {
+            SimdSynetQuantizedMulForward(context, a.data(), b.data(), dst2.data());
+            SimdRelease(context);
+        }
+
+        for (size_t i = 0; i < n; ++i)
+        {
+            if (dst1[i] != dst2[i])
+                std::cout << "TestSynetQuantizedMul is failed at " << i << " : " << (int)dst1[i] << " != " << (int)dst2[i] << std::endl;
+        }
+    }
 #endif
 
     void CheckCpp()
@@ -292,6 +322,7 @@ namespace Test
 #if defined(SIMD_SYNET_ENABLE)
         TestSynetAdd16b();
         TestSynetQuantizedAdd();
+        TestSynetQuantizedMul();
 #endif
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a public C++ analogue of `Synet::QuantizedMul` (`src/Synet/Utils/Mul.h` in ermig1979/Synet, `dev` branch) to the Simd Library.

- New class `Simd::SynetQuantizedMul` in `src/Simd/SimdSynet.hpp` wrapping `SimdSynetQuantizedMulInit` / `SimdSynetQuantizedMulForward` / `SimdRelease`.
- Doxygen description for the class (group `cpp_synet`) and C API notes pointing to the wrapper.
- `TestSynetQuantizedMul()` in `src/Test/TestCheckCpp.cpp` compares the wrapper with the C API.
- `docs/2026.html` (release 7.2.165) updated.

`src/Simd/SimdSynet.hpp` is already listed in `prj/vs2022/Simd.vcxproj` and `prj/vs2022/Simd.vcxproj.filters` (added with `Simd::SynetAdd16b`).

## Testing

- CMake Release build (`g++`, `SIMD_SHARED=ON`) of the library and `Test`.
- `./Test "-r=.." -cc=1 -fi=SynetQuantizedMul -tt=1 -ts=1`: CheckCpp (including `TestSynetQuantizedMul`) and SynetQuantizedMul C API tests finished successfully.
- Standalone check: `Simd::SynetQuantizedMul::Enable()` is true; wrapper output matches the C API (UINT8, all 8 sample values equal 40, matching dequant-mul-requant: `(50-47)*0.01*(80-30)*0.02/0.015+38`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c3c7320-57c9-487f-a6b4-20ecb9aa943c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c3c7320-57c9-487f-a6b4-20ecb9aa943c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

