### PR TITLE
Add NEON optimizations of class SynetQuantizedConvolutionNhwcSpecV0

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -71,6 +71,7 @@
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV1.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>
+ <li>NEON optimizations of class SynetQuantizedConvolutionNhwcSpecV0.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
  <li>C++ wrapper Simd::SynetQuantizedMul.</li>
@@ -500,6 +501,7 @@
  <li>Tests for verifying functionality of function SynetQuantizedMulInit.</li>
  <li>Tests for verifying functionality of function SynetQuantizedPoolingAverage.</li>
  <li>Tests for verifying functionality of NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>
+ <li>Tests for verifying functionality of NEON optimizations of class SynetQuantizedConvolutionNhwcSpecV0.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Neon.vcxproj
+++ b/prj/vs2022/Neon.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetMergedConvolution8iOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolution.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionNhwcSpecV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV1.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV2.cpp" />

--- a/prj/vs2022/Neon.vcxproj.filters
+++ b/prj/vs2022/Neon.vcxproj.filters
@@ -370,6 +370,9 @@
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionNhwcGemmV0.cpp">
       <Filter>Neon\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionNhwcSpecV0.cpp">
+      <Filter>Neon\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdNeonSynetQuantizedConvolutionDepthwiseV0.cpp">
       <Filter>Neon\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdNeonSynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedConvolution.cpp
@@ -46,6 +46,8 @@ namespace Simd
                 return new SynetQuantizedConvolutionNhwcDepthwiseV1(param);
             else if (SynetQuantizedConvolutionNhwcDepthwiseV0::Preferable(param, F))
                 return new SynetQuantizedConvolutionNhwcDepthwiseV0(param);
+            else if (SynetQuantizedConvolutionNhwcSpecV0::Preferable(param))
+                return new SynetQuantizedConvolutionNhwcSpecV0(param);
             else if (SynetQuantizedConvolutionNhwcGemmV0::Preferable(param))
                 return new SynetQuantizedConvolutionNhwcGemmV0(param);
             else

--- a/src/Simd/SimdNeonSynetQuantizedConvolutionNhwcSpecV0.cpp
+++ b/src/Simd/SimdNeonSynetQuantizedConvolutionNhwcSpecV0.cpp
@@ -1,0 +1,321 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetQuantizedDepthwise.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+#include "Simd/SimdCopy.h"
+
+namespace Simd
+{
+#if defined(SIMD_NEON_ENABLE) && defined(SIMD_SYNET_ENABLE)   
+    namespace Neon
+    {
+        typedef Base::SynetQuantizedConvolutionNhwcSpecV0::AlgParam AlgParam;
+        typedef Base::SynetQuantizedConvolutionNhwcSpecV0::ConvolutionPtr Convolution;
+
+        SIMD_INLINE void Copy(const uint8_t* src, size_t size, uint8_t* dst)
+        {
+            size_t i = 0;
+            for (; i < size; ++i)
+                dst[i] = src[i];
+            for (; i < A; ++i)
+                dst[i] = 0;
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        static void QuantizedConvolutionNhwcSpecV0Reorder(const uint8_t* src, uint8_t zero, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd, int end, uint8_t* dst)
+        {
+            assert(a.microC == A);
+            uint8x16_t _zero = vdupq_n_u8(zero);
+            size_t srcCA = Simd::AlignLo(p.srcC, A), tailC = p.srcC - srcCA;
+            size_t syPad = p.kernelY - 1 - p.padY, syBeg, syEnd = (dyEnd == p.dstH ? p.srcH : dyEnd + syPad);
+            size_t cD = a.batch * a.srcH * a.srcW + a.padE, sD = a.microC;
+            if (dyBeg == 0)
+            {
+                for (size_t s = 0, n = a.padV * a.srcW; s < n; ++s)
+                    for (size_t c = 0; c < a.srcC; c += a.microC)
+                        vst1q_u8(dst + c * cD + s * sD, _zero);
+                dst += a.padV * a.srcW * sD;
+                syBeg = 0;
+            }
+            else
+            {
+                syBeg = dyBeg + syPad;
+                src += syBeg * p.srcW * p.srcC;
+                dst += (dyBeg + p.kernelY - 1 + a.padV - p.padY) * a.srcW * sD;
+            }
+            for (size_t sy = syBeg; sy < syEnd; ++sy)
+            {
+                if (a.padH)
+                {
+                    for (size_t s = 0; s < a.padH; ++s)
+                        for (size_t c = 0; c < a.srcC; c += a.microC)
+                            vst1q_u8(dst + c * cD + s * sD, _zero);
+                    dst += a.padH * sD;
+                }
+                for (size_t sx = 0; sx < p.srcW; ++sx)
+                {
+                    size_t sc = 0;
+                    for (; sc < srcCA; sc += A)
+                        Neon::Copy(src + sc, dst + sc * cD);
+                    if (tailC)
+                        Copy(src + sc, tailC, dst + sc * cD);
+                    src += p.srcC;
+                    dst += sD;
+                }
+            }
+            if (end)
+            {
+                for (size_t s = 0, n = a.padE; s < n; ++s)
+                    for (size_t c = 0; c < a.srcC; c += a.microC)
+                        vst1q_u8(dst + c * cD + s * sD, _zero);
+            }
+            else if (dyEnd != p.dstH)
+            {
+                for (size_t s = 0, n = a.padH; s < n; ++s)
+                    for (size_t c = 0; c < a.srcC; c += a.microC)
+                        vst1q_u8(dst + c * cD + s * sD, _zero);
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<int M> void QuantizedConvolutionNhwcSpecV0_2xM(const uint8_t* src0, const ConvParam& p, const AlgParam& a, const int* offset, size_t nK, size_t dstC, int update, const int8_t* weight0, int32_t* dst)
+        {
+            int32x4_t d00, d01, d10, d11, d20, d21, d30, d31, d40, d41;
+            uint8x16_t s0;
+            int8x16_t w0, w1;
+            size_t dD = a.macroD, dX = a.microC;
+            const int8_t* weight1 = weight0 + a.K * F;
+            const uint8_t* src1 = src0 + 1 * dX;
+            const uint8_t* src2 = src0 + 2 * dX;
+            const uint8_t* src3 = src0 + 3 * dX;
+            const uint8_t* src4 = src0 + 4 * dX;
+            if (dstC > F)
+            {
+                if (update)
+                {
+                    if (M > 0x0) d00 = vld1q_s32(dst + 0 * dD + 0), d01 = vld1q_s32(dst + 0 * dD + F);
+                    if (M > 0x1) d10 = vld1q_s32(dst + 1 * dD + 0), d11 = vld1q_s32(dst + 1 * dD + F);
+                    if (M > 0x2) d20 = vld1q_s32(dst + 2 * dD + 0), d21 = vld1q_s32(dst + 2 * dD + F);
+                    if (M > 0x3) d30 = vld1q_s32(dst + 3 * dD + 0), d31 = vld1q_s32(dst + 3 * dD + F);
+                    if (M > 0x4) d40 = vld1q_s32(dst + 4 * dD + 0), d41 = vld1q_s32(dst + 4 * dD + F);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = vdupq_n_s32(0), d01 = vdupq_n_s32(0);
+                    if (M > 0x1) d10 = vdupq_n_s32(0), d11 = vdupq_n_s32(0);
+                    if (M > 0x2) d20 = vdupq_n_s32(0), d21 = vdupq_n_s32(0);
+                    if (M > 0x3) d30 = vdupq_n_s32(0), d31 = vdupq_n_s32(0);
+                    if (M > 0x4) d40 = vdupq_n_s32(0), d41 = vdupq_n_s32(0);
+                }
+                for (size_t k = 0; k < nK; k += 1)
+                {
+                    for (size_t offs = offset[k], end = offs + dX; offs < end; offs += 4)
+                    {
+                        w0 = vld1q_s8(weight0);
+                        w1 = vld1q_s8(weight1);
+                        if (M > 0x0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0), Madd4<true>(d01, s0, w1);
+                        if (M > 0x1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0), Madd4<true>(d11, s0, w1);
+                        if (M > 0x2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0), Madd4<true>(d21, s0, w1);
+                        if (M > 0x3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0), Madd4<true>(d31, s0, w1);
+                        if (M > 0x4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0), Madd4<true>(d41, s0, w1);
+                        weight0 += A;
+                        weight1 += A;
+                    }
+                }
+                if (M > 0x0) vst1q_s32(dst + 0 * dD + 0, d00), vst1q_s32(dst + 0 * dD + F, d01);
+                if (M > 0x1) vst1q_s32(dst + 1 * dD + 0, d10), vst1q_s32(dst + 1 * dD + F, d11);
+                if (M > 0x2) vst1q_s32(dst + 2 * dD + 0, d20), vst1q_s32(dst + 2 * dD + F, d21);
+                if (M > 0x3) vst1q_s32(dst + 3 * dD + 0, d30), vst1q_s32(dst + 3 * dD + F, d31);
+                if (M > 0x4) vst1q_s32(dst + 4 * dD + 0, d40), vst1q_s32(dst + 4 * dD + F, d41);
+            }
+            else
+            {
+                if (update)
+                {
+                    if (M > 0x0) d00 = vld1q_s32(dst + 0 * dD + 0);
+                    if (M > 0x1) d10 = vld1q_s32(dst + 1 * dD + 0);
+                    if (M > 0x2) d20 = vld1q_s32(dst + 2 * dD + 0);
+                    if (M > 0x3) d30 = vld1q_s32(dst + 3 * dD + 0);
+                    if (M > 0x4) d40 = vld1q_s32(dst + 4 * dD + 0);
+                }
+                else
+                {
+                    if (M > 0x0) d00 = vdupq_n_s32(0);
+                    if (M > 0x1) d10 = vdupq_n_s32(0);
+                    if (M > 0x2) d20 = vdupq_n_s32(0);
+                    if (M > 0x3) d30 = vdupq_n_s32(0);
+                    if (M > 0x4) d40 = vdupq_n_s32(0);
+                }
+                for (size_t k = 0; k < nK; k += 1)
+                {
+                    for (size_t offs = offset[k], end = offs + dX; offs < end; offs += 4)
+                    {
+                        w0 = vld1q_s8(weight0);
+                        if (M > 0x0) s0 = Set4(src0 + offs), Madd4<true>(d00, s0, w0);
+                        if (M > 0x1) s0 = Set4(src1 + offs), Madd4<true>(d10, s0, w0);
+                        if (M > 0x2) s0 = Set4(src2 + offs), Madd4<true>(d20, s0, w0);
+                        if (M > 0x3) s0 = Set4(src3 + offs), Madd4<true>(d30, s0, w0);
+                        if (M > 0x4) s0 = Set4(src4 + offs), Madd4<true>(d40, s0, w0);
+                        weight0 += A;
+                    }
+                }
+                if (M > 0x0) vst1q_s32(dst + 0 * dD + 0, d00);
+                if (M > 0x1) vst1q_s32(dst + 1 * dD + 0, d10);
+                if (M > 0x2) vst1q_s32(dst + 2 * dD + 0, d20);
+                if (M > 0x3) vst1q_s32(dst + 3 * dD + 0, d30);
+                if (M > 0x4) vst1q_s32(dst + 4 * dD + 0, d40);
+            }
+        }
+
+        typedef void(*QuantizedConvolutionNhwcSpecV0_2xM_Ptr)(const uint8_t* src0, const ConvParam& p, const AlgParam& a, const int* offs, size_t nK, size_t dstC, int update, const int8_t* weight0, int32_t* dst);
+
+        static QuantizedConvolutionNhwcSpecV0_2xM_Ptr GetQuantizedConvolutionNhwcSpecV0_2xM(size_t M)
+        {
+            switch (M)
+            {
+            case 0x0: return NULL;
+            case 0x1: return QuantizedConvolutionNhwcSpecV0_2xM<0x1>;
+            case 0x2: return QuantizedConvolutionNhwcSpecV0_2xM<0x2>;
+            case 0x3: return QuantizedConvolutionNhwcSpecV0_2xM<0x3>;
+            case 0x4: return QuantizedConvolutionNhwcSpecV0_2xM<0x4>;
+            case 0x5: return QuantizedConvolutionNhwcSpecV0_2xM<0x5>;
+            }
+            assert(0);
+            return NULL;
+        }
+
+        static void QuantizedConvolutionNhwcSpecV0_2(const uint8_t* src, const ConvParam& p, const AlgParam& a, const int* offs, size_t dstC, size_t dstH, size_t nK, int update, const int8_t* weight, int32_t* dst)
+        {
+            size_t n1 = dstH * a.srcW - a.gapH, n = 5;
+            size_t nn = AlignLoAny(n1, n), m = n1 - nn, dW = a.K * DF;
+            size_t dD = a.macroD, dS = a.microC;
+            QuantizedConvolutionNhwcSpecV0_2xM_Ptr convolution_2xN = GetQuantizedConvolutionNhwcSpecV0_2xM(n);
+            QuantizedConvolutionNhwcSpecV0_2xM_Ptr convolution_2xM = GetQuantizedConvolutionNhwcSpecV0_2xM(m);
+            for (size_t dc = 0; dc < dstC; dc += DF)
+            {
+                size_t dC = Simd::Min(DF, dstC - dc);
+                size_t i = 0;
+                for (; i < nn; i += n)
+                    convolution_2xN(src + i * dS, p, a, offs, nK, dC, update, weight, dst + i * dD);
+                for (; i < n1; i += m)
+                    convolution_2xM(src + i * dS, p, a, offs, nK, dC, update, weight, dst + i * dD);
+                weight += dW;
+                dst += DF;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type> void SynetQuantizedConvolutionNhwcSpecV0Postprocess(const int32_t* src, const ConvParam& p, const AlgParam& a, 
+            size_t dstC, size_t dyBeg, size_t dyEnd, const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, uint8_t* dst)
+        {
+            size_t dstCF = AlignLo(dstC, F), tailD = dstC - dstCF;
+            size_t rowGap = a.gapH * a.macroD;
+            src += dyBeg * a.srcW * a.macroD;
+            dst += dyBeg * p.dstW * p.dstC * a.elem;
+            float32x4_t _sNorm, _iScale, _params[2], _dNorm;
+            int32x4_t _src, _dZero = vdupq_n_s32(dZero), _sBias, _iLo, _iHi;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = vdupq_n_s32(-iZero);
+                _iHi = vdupq_n_s32(255 - iZero);
+                _iScale = vdupq_n_f32(iScale);
+                _dNorm = vdupq_n_f32(dNorm);
+                _params[0] = vdupq_n_f32(params[0]);
+                _params[1] = vdupq_n_f32(params[1]);
+            }
+            for (size_t dy = dyBeg; dy < dyEnd; ++dy)
+            {
+                for (size_t dx = 0; dx < p.dstW; ++dx)
+                {
+                    size_t dc = 0;
+                    for (; dc < dstCF; dc += F)
+                    {
+                        _src = vld1q_s32(src + dc);
+                        _sBias = vld1q_s32(sBias + dc);
+                        _sNorm = vld1q_f32(sNorm + dc);
+                        if (type == SimdConvolutionActivationPrelu)
+                            _params[0] = vld1q_f32(params + dc);
+                        Save1<Term8iLast8u, type>(dst + dc, _src, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                    }
+                    if (tailD)
+                    {
+                        _src = vld1q_s32(src + dc);
+                        _sBias = vld1q_s32(sBias + dc);
+                        _sNorm = vld1q_f32(sNorm + dc);
+                        if (type == SimdConvolutionActivationPrelu)
+                            _params[0] = vld1q_f32(params + dc);
+                        Save1<Term8iLast8u, type>(dst + dc, _src, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tailD);
+                    }
+                    src += a.macroD;
+                    dst += p.dstC * a.elem;
+                }
+                src += rowGap;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetQuantizedConvolutionNhwcSpecV0::SynetQuantizedConvolutionNhwcSpecV0(const ConvParam& p)
+            : Base::SynetQuantizedConvolutionNhwcSpecV0(p)
+        {
+            SetAlgParam(F, F * 2, 5, F * 4, Base::AlgCacheL1(), Base::AlgCacheL2(), Base::AlgCacheL3());
+            if (_src8u)
+            {
+                _preprocess = QuantizedConvolutionNhwcSpecV0Reorder;
+            }
+            else
+                assert(0);
+            _convolution = QuantizedConvolutionNhwcSpecV0_2;
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationIdentity>; break;
+            case SimdConvolutionActivationRelu: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationRelu>; break;
+            case SimdConvolutionActivationLeakyRelu: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationLeakyRelu>; break;
+            case SimdConvolutionActivationRestrictRange: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationRestrictRange>; break;
+            case SimdConvolutionActivationPrelu: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationPrelu>; break;
+            case SimdConvolutionActivationElu: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationElu>; break;
+            case SimdConvolutionActivationHswish: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationHswish>; break;
+            case SimdConvolutionActivationMish: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationMish>; break;
+            case SimdConvolutionActivationHardSigmoid: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationHardSigmoid>; break;
+            case SimdConvolutionActivationSwish: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationSwish>; break;
+            case SimdConvolutionActivationGelu: _postprocess = SynetQuantizedConvolutionNhwcSpecV0Postprocess<SimdConvolutionActivationGelu>; break;
+            default:
+                _postprocess = NULL;
+                assert(0);
+            }
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -727,6 +727,16 @@ namespace Simd
 
         //------------------------------------------------------------------------------------------------
 
+        class SynetQuantizedConvolutionNhwcSpecV0 : public Base::SynetQuantizedConvolutionNhwcSpecV0
+        {
+        public:
+            SynetQuantizedConvolutionNhwcSpecV0(const ConvParam& p);
+
+            virtual String Ext() const { return "Neon"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
         class SynetQuantizedConvolutionNhwcDepthwiseV0 : public Base::SynetQuantizedConvolutionNhwcDepthwiseV0
         {
         public:

--- a/src/Test/TestSynetQuantizedConvolution.cpp
+++ b/src/Test/TestSynetQuantizedConvolution.cpp
@@ -468,6 +468,14 @@ namespace Test
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 1024, 7, 7, 2048, _1, _1, _1, _0, _0, 1, aId, t, u8, u8), o, f1, f2);
 #endif
 #if 1
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 16, 9, 9, 11, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 20, 8, 8, 8, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 32, 7, 7, 5, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(2, 18, 8, 8, 12, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 16, 8, 8, 16, _5, _1, _1, _2, _2, 1, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 16, 6, 6, 16, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
+#endif
+#if 1
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 64, 32, 32, 64, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 128, 32, 32, 128, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 256, 16, 16, 256, _3, _1, _1, _1, _1, 1, aId, t, u8, u8), o, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add NEON (ARM/ARM64) optimizations of class `SynetQuantizedConvolutionNhwcSpecV0` for the `SimdSynetQuantizedConvolution` API.

This ports the SSE4.1 NhwcSpecV0 path:
- source reorder/preprocess
- 2xM quantized convolution kernel (`Madd4` over 4-byte source groups)
- activation postprocess (`Identity` through `Gelu`)

The class is selected in `Neon::SynetQuantizedConvolutionInit` after the depthwise implementations and before `NhwcGemmV0`, matching SSE4.1.

Also updates:
- `Test::SynetQuantizedConvolutionAutoTest` with SpecV0 coverage (unaligned channels, tail `dstC`, remainder `M`, 5x5 kernel, batch, all activations)
- `prj/vs2022/Neon.vcxproj` and `Neon.vcxproj.filters`
- `docs/2026.html` release 7.2.165 notes

Testing:
- Native x86_64 Release build of `Simd` and `Test` succeeded
- `./Test -m=a -fi=SynetQuantizedConvolution` finished successfully (new SpecV0 cases included; host ran SSE4.1/AVX2/AVX-512/AMX)
- Cross-compiled `SimdNeonSynetQuantizedConvolutionNhwcSpecV0.cpp` and Init with `aarch64-linux-gnu-g++ -march=armv8-a+crc`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e097b8ed-a443-4620-9cd7-e3239b3cd48f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e097b8ed-a443-4620-9cd7-e3239b3cd48f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

