### PR TITLE
Add SVE2 optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV0

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -67,7 +67,7 @@
  <li>NEON, SVE2 optimizations of classes SynetQuantizedMergedConvolutionCd.</li>
  <li>NEON, SVE2 optimizations of classes SynetQuantizedMergedConvolutionDc.</li>
  <li>NEON, SVE2 optimizations of class SynetQuantizedInnerProductGemmV0.</li>
- <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV0.</li>
+ <li>NEON, SVE2 optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV0.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV1.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -153,6 +153,8 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedActivation.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConcat.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedInnerProduct.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedInnerProductGemmV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolution.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -470,6 +470,12 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConcat.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolution.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV0.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedInnerProduct.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -7316,7 +7316,7 @@ SIMD_API void* SimdSynetQuantizedConvolutionInit(size_t batch, const SimdConvolu
     SIMD_EMPTY();
 #if defined(SIMD_SYNET_ENABLE)
     typedef void* (*SimdSynetQuantizedConvolutionInitPtr) (size_t batch, const SimdConvolutionParameters* conv);
-    const static SimdSynetQuantizedConvolutionInitPtr simdSynetQuantizedConvolutionInit = SIMD_FUNC6(SynetQuantizedConvolutionInit, SIMD_AMXBF16_FUNC, SIMD_AVX512VNNI_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static SimdSynetQuantizedConvolutionInitPtr simdSynetQuantizedConvolutionInit = SIMD_FUNC7(SynetQuantizedConvolutionInit, SIMD_AMXBF16_FUNC, SIMD_AVX512VNNI_FUNC, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return simdSynetQuantizedConvolutionInit(batch, conv);
 #else

--- a/src/Simd/SimdSve2SynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedConvolution.cpp
@@ -1,0 +1,55 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv)
+        {
+            ConvParam param(batch, conv);
+            if (!ValidQuantized(param))
+                return NULL;
+            else if (SynetQuantizedConvolutionNhwcDepthwiseV0::Preferable(param, svcntw()))
+                return new SynetQuantizedConvolutionNhwcDepthwiseV0(param);
+#if defined(SIMD_NEON_ENABLE)
+            else
+                return Neon::SynetQuantizedConvolutionInit(batch, conv);
+#else
+            else
+                return Base::SynetQuantizedConvolutionInit(batch, conv);
+#endif
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetQuantizedConvolutionDepthwiseV0.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedConvolutionDepthwiseV0.cpp
@@ -1,0 +1,548 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizedDepthwise.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        using AlgParamV0 = SynetQuantizedConvolutionNhwcDepthwiseV0::AlgParam;
+
+        //------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svint32_t LoadAs32i(const uint8_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE svint32_t LoadAs32i(const int8_t* src, const svbool_t& mask)
+        {
+            return svld1sb_s32(mask, src);
+        }
+
+        SIMD_INLINE void Madd1(svint32_t& i32, const svint32_t& u8, const svint32_t& i8, const svbool_t& mask)
+        {
+            i32 = svmla_s32_x(mask, i32, u8, i8);
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term> void QuantizedConvolutionNhwcDepthwiseV0_Default(const uint8_t* src, uint32_t srcZero,
+            const ConvParam& p, const AlgParamV0& a, const int8_t* weight, const int32_t* bias, const float* norm, uint32_t dstZero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2, QF = F * 4;
+            const svbool_t body = svptrue_b32();
+            svint32_t _srcZero = svdup_n_s32(srcZero);
+            svint32_t _dstZero = svdup_n_s32(dstZero);
+            svint32_t d00, d01, d02, d03, w0, w1, w2, w3;
+            size_t size = p.group, sizeF = AlignLo(size, F), sizeDF = AlignLo(size, DF), sizeQF = AlignLo(size, QF);
+            svbool_t tail = svwhilelt_b32((size_t)0, size - sizeF);
+            for (size_t dy = 0; dy < p.dstH; ++dy)
+            {
+                for (size_t dx = 0; dx < p.dstW; ++dx)
+                {
+                    size_t i = 0;
+                    for (; i < sizeQF; i += QF)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        d02 = svdup_n_s32(0);
+                        d03 = svdup_n_s32(0);
+                        for (size_t ky = 0; ky < p.kernelY; ++ky)
+                        {
+                            size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                            for (size_t kx = 0; kx < p.kernelX; ++kx)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                size_t ow = (ky * p.kernelX + kx) * size + i;
+                                w0 = LoadAs32i(weight + ow + 0 * F, body);
+                                w1 = LoadAs32i(weight + ow + 1 * F, body);
+                                w2 = LoadAs32i(weight + ow + 2 * F, body);
+                                w3 = LoadAs32i(weight + ow + 3 * F, body);
+                                if (sy < p.srcH && sx < p.srcW)
+                                {
+                                    size_t os = (sy * p.srcW + sx) * size + i;
+                                    Madd1(d00, LoadAs32i(src + os + 0 * F, body), w0, body);
+                                    Madd1(d01, LoadAs32i(src + os + 1 * F, body), w1, body);
+                                    Madd1(d02, LoadAs32i(src + os + 2 * F, body), w2, body);
+                                    Madd1(d03, LoadAs32i(src + os + 3 * F, body), w3, body);
+                                }
+                                else
+                                {
+                                    Madd1(d00, _srcZero, w0, body);
+                                    Madd1(d01, _srcZero, w1, body);
+                                    Madd1(d02, _srcZero, w2, body);
+                                    Madd1(d03, _srcZero, w3, body);
+                                }
+                            }
+                        }
+                        Save1<term>(dst, d00, bias, norm, _dstZero, i + F * 0);
+                        Save1<term>(dst, d01, bias, norm, _dstZero, i + F * 1);
+                        Save1<term>(dst, d02, bias, norm, _dstZero, i + F * 2);
+                        Save1<term>(dst, d03, bias, norm, _dstZero, i + F * 3);
+                    }
+                    for (; i < sizeDF; i += DF)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        for (size_t ky = 0; ky < p.kernelY; ++ky)
+                        {
+                            size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                            for (size_t kx = 0; kx < p.kernelX; ++kx)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                size_t ow = (ky * p.kernelX + kx) * size + i;
+                                w0 = LoadAs32i(weight + ow + 0 * F, body);
+                                w1 = LoadAs32i(weight + ow + 1 * F, body);
+                                if (sy < p.srcH && sx < p.srcW)
+                                {
+                                    size_t os = (sy * p.srcW + sx) * size + i;
+                                    Madd1(d00, LoadAs32i(src + os + 0 * F, body), w0, body);
+                                    Madd1(d01, LoadAs32i(src + os + 1 * F, body), w1, body);
+                                }
+                                else
+                                {
+                                    Madd1(d00, _srcZero, w0, body);
+                                    Madd1(d01, _srcZero, w1, body);
+                                }
+                            }
+                        }
+                        Save1<term>(dst, d00, bias, norm, _dstZero, i + F * 0);
+                        Save1<term>(dst, d01, bias, norm, _dstZero, i + F * 1);
+                    }
+                    for (; i < sizeF; i += F)
+                    {
+                        d00 = svdup_n_s32(0);
+                        for (size_t ky = 0; ky < p.kernelY; ++ky)
+                        {
+                            size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                            for (size_t kx = 0; kx < p.kernelX; ++kx)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                w0 = LoadAs32i(weight + (ky * p.kernelX + kx) * size + i, body);
+                                if (sy < p.srcH && sx < p.srcW)
+                                    Madd1(d00, LoadAs32i(src + (sy * p.srcW + sx) * size + i, body), w0, body);
+                                else
+                                    Madd1(d00, _srcZero, w0, body);
+                            }
+                        }
+                        Save1<term>(dst, d00, bias, norm, _dstZero, i);
+                    }
+                    for (; i < size; i += F)
+                    {
+                        d00 = svdup_n_s32(0);
+                        for (size_t ky = 0; ky < p.kernelY; ++ky)
+                        {
+                            size_t sy = dy * p.strideY + ky * p.dilationY - p.padY;
+                            for (size_t kx = 0; kx < p.kernelX; ++kx)
+                            {
+                                size_t sx = dx * p.strideX + kx * p.dilationX - p.padX;
+                                w0 = LoadAs32i(weight + (ky * p.kernelX + kx) * size + i, tail);
+                                if (sy < p.srcH && sx < p.srcW)
+                                    Madd1(d00, LoadAs32i(src + (sy * p.srcW + sx) * size + i, tail), w0, tail);
+                                else
+                                    Madd1(d00, _srcZero, w0, tail);
+                            }
+                        }
+                        Save1<term>(dst, d00, bias, norm, _dstZero, i, tail);
+                    }
+                    dst += p.dstC * a.srcE;
+                }
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template<Term8iType term> SIMD_INLINE void QuantizedConvolutionNhwcDepthwiseV0_3x3Edge(
+            const uint8_t* src, const svint32_t& srcZero, const ConvParam& p, const AlgParamV0& a, size_t dy, size_t dx,
+            const int8_t* weight, const int32_t* bias, const float* norm, const svint32_t& dstZero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2, QF = F * 4;
+            const svbool_t body = svptrue_b32();
+            svint32_t d00, d01, d02, d03, w0, w1, w2, w3;
+            size_t size = p.group;
+            size_t sizeF = AlignLo(size, F), sizeDF = AlignLo(size, DF), sizeQF = AlignLo(size, QF);
+            svbool_t tail = svwhilelt_b32((size_t)0, size - sizeF);
+            size_t i = 0;
+            for (; i < sizeQF; i += QF)
+            {
+                d00 = svdup_n_s32(0);
+                d01 = svdup_n_s32(0);
+                d02 = svdup_n_s32(0);
+                d03 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    size_t sy = dy * p.strideY + ky - p.padY;
+                    for (size_t kx = 0; kx < 3; ++kx)
+                    {
+                        size_t sx = dx * p.strideX + kx - p.padX;
+                        size_t ow = (ky * p.kernelX + kx) * size + i;
+                        w0 = LoadAs32i(weight + ow + 0 * F, body);
+                        w1 = LoadAs32i(weight + ow + 1 * F, body);
+                        w2 = LoadAs32i(weight + ow + 2 * F, body);
+                        w3 = LoadAs32i(weight + ow + 3 * F, body);
+                        if (sy < p.srcH && sx < p.srcW)
+                        {
+                            size_t os = (sy * p.srcW + sx) * size + i;
+                            Madd1(d00, LoadAs32i(src + os + 0 * F, body), w0, body);
+                            Madd1(d01, LoadAs32i(src + os + 1 * F, body), w1, body);
+                            Madd1(d02, LoadAs32i(src + os + 2 * F, body), w2, body);
+                            Madd1(d03, LoadAs32i(src + os + 3 * F, body), w3, body);
+                        }
+                        else
+                        {
+                            Madd1(d00, srcZero, w0, body);
+                            Madd1(d01, srcZero, w1, body);
+                            Madd1(d02, srcZero, w2, body);
+                            Madd1(d03, srcZero, w3, body);
+                        }
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, i + F * 0);
+                Save1<term>(dst, d01, bias, norm, dstZero, i + F * 1);
+                Save1<term>(dst, d02, bias, norm, dstZero, i + F * 2);
+                Save1<term>(dst, d03, bias, norm, dstZero, i + F * 3);
+            }
+            for (; i < sizeDF; i += DF)
+            {
+                d00 = svdup_n_s32(0);
+                d01 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    size_t sy = dy * p.strideY + ky - p.padY;
+                    for (size_t kx = 0; kx < 3; ++kx)
+                    {
+                        size_t sx = dx * p.strideX + kx - p.padX;
+                        size_t ow = (ky * p.kernelX + kx) * size + i;
+                        w0 = LoadAs32i(weight + ow + 0 * F, body);
+                        w1 = LoadAs32i(weight + ow + 1 * F, body);
+                        if (sy < p.srcH && sx < p.srcW)
+                        {
+                            size_t os = (sy * p.srcW + sx) * size + i;
+                            Madd1(d00, LoadAs32i(src + os + 0 * F, body), w0, body);
+                            Madd1(d01, LoadAs32i(src + os + 1 * F, body), w1, body);
+                        }
+                        else
+                        {
+                            Madd1(d00, srcZero, w0, body);
+                            Madd1(d01, srcZero, w1, body);
+                        }
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, i + F * 0);
+                Save1<term>(dst, d01, bias, norm, dstZero, i + F * 1);
+            }
+            for (; i < sizeF; i += F)
+            {
+                d00 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    size_t sy = dy * p.strideY + ky - p.padY;
+                    for (size_t kx = 0; kx < 3; ++kx)
+                    {
+                        size_t sx = dx * p.strideX + kx - p.padX;
+                        w0 = LoadAs32i(weight + (ky * p.kernelX + kx) * size + i, body);
+                        if (sy < p.srcH && sx < p.srcW)
+                            Madd1(d00, LoadAs32i(src + (sy * p.srcW + sx) * size + i, body), w0, body);
+                        else
+                            Madd1(d00, srcZero, w0, body);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, i);
+            }
+            for (; i < size; i += F)
+            {
+                d00 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    size_t sy = dy * p.strideY + ky - p.padY;
+                    for (size_t kx = 0; kx < 3; ++kx)
+                    {
+                        size_t sx = dx * p.strideX + kx - p.padX;
+                        w0 = LoadAs32i(weight + (ky * p.kernelX + kx) * size + i, tail);
+                        if (sy < p.srcH && sx < p.srcW)
+                            Madd1(d00, LoadAs32i(src + (sy * p.srcW + sx) * size + i, tail), w0, tail);
+                        else
+                            Madd1(d00, srcZero, w0, tail);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, i, tail);
+            }
+        }
+
+        template<Term8iType term> SIMD_INLINE void QuantizedConvolutionNhwcDepthwiseV0_3x3Main1(
+            const uint8_t* src, const ConvParam& p, const AlgParamV0& a,
+            const int8_t* weight, const int32_t* bias, const float* norm, const svint32_t& dstZero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2, QF = F * 4;
+            const svbool_t body = svptrue_b32();
+            svint32_t d00, d01, d02, d03;
+            size_t srcC = p.srcC;
+            size_t srcCF = AlignLo(srcC, F), srcCDF = AlignLo(srcC, DF), srcCQF = AlignLo(srcC, QF);
+            svbool_t tail = svwhilelt_b32((size_t)0, srcC - srcCF);
+            size_t srcS = srcC * p.srcW;
+            size_t c = 0;
+            for (; c < srcCQF; c += QF)
+            {
+                d00 = svdup_n_s32(0);
+                d01 = svdup_n_s32(0);
+                d02 = svdup_n_s32(0);
+                d03 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                    {
+                        Madd1(d00, LoadAs32i(ps + 0 * F, body), LoadAs32i(pw + 0 * F, body), body);
+                        Madd1(d01, LoadAs32i(ps + 1 * F, body), LoadAs32i(pw + 1 * F, body), body);
+                        Madd1(d02, LoadAs32i(ps + 2 * F, body), LoadAs32i(pw + 2 * F, body), body);
+                        Madd1(d03, LoadAs32i(ps + 3 * F, body), LoadAs32i(pw + 3 * F, body), body);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c + F * 0);
+                Save1<term>(dst, d01, bias, norm, dstZero, c + F * 1);
+                Save1<term>(dst, d02, bias, norm, dstZero, c + F * 2);
+                Save1<term>(dst, d03, bias, norm, dstZero, c + F * 3);
+            }
+            for (; c < srcCDF; c += DF)
+            {
+                d00 = svdup_n_s32(0);
+                d01 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                    {
+                        Madd1(d00, LoadAs32i(ps + 0 * F, body), LoadAs32i(pw + 0 * F, body), body);
+                        Madd1(d01, LoadAs32i(ps + 1 * F, body), LoadAs32i(pw + 1 * F, body), body);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c + F * 0);
+                Save1<term>(dst, d01, bias, norm, dstZero, c + F * 1);
+            }
+            for (; c < srcCF; c += F)
+            {
+                d00 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                        Madd1(d00, LoadAs32i(ps, body), LoadAs32i(pw, body), body);
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c);
+            }
+            for (; c < srcC; c += F)
+            {
+                d00 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                        Madd1(d00, LoadAs32i(ps, tail), LoadAs32i(pw, tail), tail);
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c, tail);
+            }
+        }
+
+        template<Term8iType term> SIMD_INLINE void QuantizedConvolutionNhwcDepthwiseV0_3x3Main2(
+            const uint8_t* src, const ConvParam& p, const AlgParamV0& a,
+            const int8_t* weight, const int32_t* bias, const float* norm, const svint32_t& dstZero, uint8_t* dst)
+        {
+            const size_t F = svcntw(), DF = F * 2, QF = F * 4;
+            const svbool_t body = svptrue_b32();
+            svint32_t d00, d01, d02, d03, d10, d11, d12, d13, w0;
+            size_t srcC = p.srcC;
+            size_t srcCF = AlignLo(srcC, F), srcCDF = AlignLo(srcC, DF), srcCQF = AlignLo(srcC, QF);
+            svbool_t tail = svwhilelt_b32((size_t)0, srcC - srcCF);
+            size_t srcS = srcC * p.srcW;
+            size_t srcX = srcC * p.strideX;
+            size_t c = 0;
+            for (; c < srcCQF; c += QF)
+            {
+                d00 = svdup_n_s32(0);
+                d01 = svdup_n_s32(0);
+                d02 = svdup_n_s32(0);
+                d03 = svdup_n_s32(0);
+                d10 = svdup_n_s32(0);
+                d11 = svdup_n_s32(0);
+                d12 = svdup_n_s32(0);
+                d13 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                    {
+                        w0 = LoadAs32i(pw + 0 * F, body);
+                        Madd1(d00, LoadAs32i(ps + 0 * F + 0 * srcX, body), w0, body);
+                        Madd1(d10, LoadAs32i(ps + 0 * F + 1 * srcX, body), w0, body);
+                        w0 = LoadAs32i(pw + 1 * F, body);
+                        Madd1(d01, LoadAs32i(ps + 1 * F + 0 * srcX, body), w0, body);
+                        Madd1(d11, LoadAs32i(ps + 1 * F + 1 * srcX, body), w0, body);
+                        w0 = LoadAs32i(pw + 2 * F, body);
+                        Madd1(d02, LoadAs32i(ps + 2 * F + 0 * srcX, body), w0, body);
+                        Madd1(d12, LoadAs32i(ps + 2 * F + 1 * srcX, body), w0, body);
+                        w0 = LoadAs32i(pw + 3 * F, body);
+                        Madd1(d03, LoadAs32i(ps + 3 * F + 0 * srcX, body), w0, body);
+                        Madd1(d13, LoadAs32i(ps + 3 * F + 1 * srcX, body), w0, body);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c + F * 0);
+                Save1<term>(dst, d01, bias, norm, dstZero, c + F * 1);
+                Save1<term>(dst, d02, bias, norm, dstZero, c + F * 2);
+                Save1<term>(dst, d03, bias, norm, dstZero, c + F * 3);
+                Save1<term>(dst + srcC, d10, bias, norm, dstZero, c + F * 0);
+                Save1<term>(dst + srcC, d11, bias, norm, dstZero, c + F * 1);
+                Save1<term>(dst + srcC, d12, bias, norm, dstZero, c + F * 2);
+                Save1<term>(dst + srcC, d13, bias, norm, dstZero, c + F * 3);
+            }
+            for (; c < srcCDF; c += DF)
+            {
+                d00 = svdup_n_s32(0);
+                d01 = svdup_n_s32(0);
+                d10 = svdup_n_s32(0);
+                d11 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                    {
+                        w0 = LoadAs32i(pw + 0 * F, body);
+                        Madd1(d00, LoadAs32i(ps + 0 * F + 0 * srcX, body), w0, body);
+                        Madd1(d10, LoadAs32i(ps + 0 * F + 1 * srcX, body), w0, body);
+                        w0 = LoadAs32i(pw + 1 * F, body);
+                        Madd1(d01, LoadAs32i(ps + 1 * F + 0 * srcX, body), w0, body);
+                        Madd1(d11, LoadAs32i(ps + 1 * F + 1 * srcX, body), w0, body);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c + F * 0);
+                Save1<term>(dst, d01, bias, norm, dstZero, c + F * 1);
+                Save1<term>(dst + srcC, d10, bias, norm, dstZero, c + F * 0);
+                Save1<term>(dst + srcC, d11, bias, norm, dstZero, c + F * 1);
+            }
+            for (; c < srcCF; c += F)
+            {
+                d00 = svdup_n_s32(0);
+                d10 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                    {
+                        w0 = LoadAs32i(pw, body);
+                        Madd1(d00, LoadAs32i(ps + 0 * srcX, body), w0, body);
+                        Madd1(d10, LoadAs32i(ps + 1 * srcX, body), w0, body);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c);
+                Save1<term>(dst + srcC, d10, bias, norm, dstZero, c);
+            }
+            for (; c < srcC; c += F)
+            {
+                d00 = svdup_n_s32(0);
+                d10 = svdup_n_s32(0);
+                for (size_t ky = 0; ky < 3; ++ky)
+                {
+                    const uint8_t* ps = src + ky * srcS + c;
+                    const int8_t* pw = weight + ky * 3 * srcC + c;
+                    for (size_t kx = 0; kx < 3; ++kx, ps += srcC, pw += srcC)
+                    {
+                        w0 = LoadAs32i(pw, tail);
+                        Madd1(d00, LoadAs32i(ps + 0 * srcX, tail), w0, tail);
+                        Madd1(d10, LoadAs32i(ps + 1 * srcX, tail), w0, tail);
+                    }
+                }
+                Save1<term>(dst, d00, bias, norm, dstZero, c, tail);
+                Save1<term>(dst + srcC, d10, bias, norm, dstZero, c, tail);
+            }
+        }
+
+        template<Term8iType term> void QuantizedConvolutionNhwcDepthwiseV0_3x3(const uint8_t* src, uint32_t srcZero,
+            const ConvParam& p, const AlgParamV0& a, const int8_t* weight, const int32_t* bias, const float* norm, uint32_t dstZero, uint8_t* dst)
+        {
+            svint32_t _srcZero = svdup_n_s32(srcZero);
+            svint32_t _dstZero = svdup_n_s32(dstZero);
+            size_t srcX = p.srcC * p.strideX;
+            size_t dstH = p.dstH - p.padH;
+            size_t dstW = p.dstW - p.padW;
+            size_t dstC = p.dstC * a.dstE;
+            size_t dstW2 = AlignLo(dstW - p.padX, 2) + p.padX;
+            size_t dy = 0;
+            for (; dy < p.padY; ++dy)
+                for (size_t dx = 0; dx < p.dstW; ++dx)
+                    QuantizedConvolutionNhwcDepthwiseV0_3x3Edge<term>(src, _srcZero, p, a, dy, dx, weight, bias, norm, _dstZero, dst), dst += dstC;
+            for (; dy < dstH; ++dy)
+            {
+                size_t dx = 0;
+                for (; dx < p.padX; ++dx)
+                    QuantizedConvolutionNhwcDepthwiseV0_3x3Edge<term>(src, _srcZero, p, a, dy, dx, weight, bias, norm, _dstZero, dst), dst += dstC;
+                size_t offset = ((dy * p.strideY - p.padY) * p.srcW + dx * p.strideX - p.padX) * p.srcC;
+                for (; dx < dstW2; dx += 2)
+                    QuantizedConvolutionNhwcDepthwiseV0_3x3Main2<term>(src + offset, p, a, weight, bias, norm, _dstZero, dst), dst += dstC * 2, offset += srcX * 2;
+                for (; dx < dstW; dx += 1)
+                    QuantizedConvolutionNhwcDepthwiseV0_3x3Main1<term>(src + offset, p, a, weight, bias, norm, _dstZero, dst), dst += dstC, offset += srcX;
+                for (; dx < p.dstW; ++dx)
+                    QuantizedConvolutionNhwcDepthwiseV0_3x3Edge<term>(src, _srcZero, p, a, dy, dx, weight, bias, norm, _dstZero, dst), dst += dstC;
+            }
+            for (; dy < p.dstH; ++dy)
+                for (size_t dx = 0; dx < p.dstW; ++dx)
+                    QuantizedConvolutionNhwcDepthwiseV0_3x3Edge<term>(src, _srcZero, p, a, dy, dx, weight, bias, norm, _dstZero, dst), dst += dstC;
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term> void SetV0(const ConvParam& p, SynetQuantizedConvolutionNhwcDepthwiseV0::ConvolutionPtr& convolution)
+        {
+            if (p.IsKernel(3) && p.IsDilation(1))
+                convolution = QuantizedConvolutionNhwcDepthwiseV0_3x3<term>;
+            else
+                convolution = QuantizedConvolutionNhwcDepthwiseV0_Default<term>;
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        SynetQuantizedConvolutionNhwcDepthwiseV0::SynetQuantizedConvolutionNhwcDepthwiseV0(const ConvParam& p)
+            : Base::SynetQuantizedConvolutionNhwcDepthwiseV0(p)
+        {
+            if (p.dstT == SimdTensorData8u)
+                SetV0<Term8iLast8u>(p, _convolution);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -770,6 +770,23 @@ namespace Simd
         void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        class SynetQuantizedConvolutionNhwcDepthwiseV0 : public Base::SynetQuantizedConvolutionNhwcDepthwiseV0
+        {
+        public:
+            SynetQuantizedConvolutionNhwcDepthwiseV0(const ConvParam& p);
+
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
+        void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv);
+    }
+#endif
 }
 
 #endif

--- a/src/Simd/SimdSynetQuantizedDepthwise.h
+++ b/src/Simd/SimdSynetQuantizedDepthwise.h
@@ -243,6 +243,23 @@ namespace Simd
         }
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        template <Term8iType term> SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const int32_t* bias, const float* norm, const svint32_t& zero, size_t offset, const svbool_t& mask)
+        {
+            svint32_t _bias = svld1_s32(mask, bias + offset);
+            svfloat32_t _norm = svld1_f32(mask, norm + offset);
+            QuntizedTerm8i<term>::template Save<0>(dst + offset, (int32_t*)NULL, sum, _bias, _bias, _norm, _norm, zero, mask);
+        }
+
+        template <Term8iType term> SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const int32_t* bias, const float* norm, const svint32_t& zero, size_t offset)
+        {
+            Save1<term>(dst, sum, bias, norm, zero, offset, svptrue_b32());
+        }
+    }
+#endif
 }
 
 #endif

--- a/src/Test/TestSynetQuantizedConvolution.cpp
+++ b/src/Test/TestSynetQuantizedConvolution.cpp
@@ -385,7 +385,7 @@ namespace Test
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 576, 14, 14, 576, _3, _1, _2, _1, _1, 576, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 960, 7, 7, 960, _3, _1, _1, _1, _1, 960, aId, t, u8, u8), o, f1, f2);
 #endif
-#if 0
+#if 1
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 5, 8, 8, 5, _3, _1, _1, _1, _1, 5, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 7, 9, 9, 7, _5, _1, _2, _2, _2, 7, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 99, 15, 15, 99, _3, _1, _1, _1, _1, 99, aId, t, u8, u8), o, f1, f2);
@@ -517,6 +517,11 @@ namespace Test
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && SynetQuantizedConvolutionForwardAutoTest(t, FUNC_QC(Simd::Neon::SynetQuantizedConvolutionInit), FUNC_QC(SimdSynetQuantizedConvolutionInit));
+#endif
+
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && SynetQuantizedConvolutionForwardAutoTest(t, FUNC_QC(Simd::Sve2::SynetQuantizedConvolutionInit), FUNC_QC(SimdSynetQuantizedConvolutionInit));
 #endif
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds SVE2 optimizations of `SynetQuantizedConvolutionNhwcDepthwiseV0` for ARM/ARM64, following the existing NEON and AVX-512 depthwise V0 algorithm.

## Changes

- New `Sve2::SynetQuantizedConvolutionNhwcDepthwiseV0` with default (any kernel/dilation) and specialized 3x3 kernels in `SimdSve2SynetQuantizedConvolutionDepthwiseV0.cpp`.
- Channel loops: QF (4×F), DF (2×F), F, then a predicated tail via `svwhilelt_b32`.
- `Sve2::SynetQuantizedConvolutionInit` selects DepthwiseV0 when `Preferable(param, svcntw())` and otherwise falls back to the NEON implementation.
- `SimdSynetQuantizedConvolutionInit` dispatch in `SimdLib.cpp` now includes `SIMD_SVE2_FUNC`.
- Tests register the Sve2 AutoTest path and enable remainder-channel depthwise cases (groups 5, 7, 99).
- VS2022 Sve2 project files and `docs/2026.html` (release 7.2.165) are updated.

## Testing

Host is x86_64. ARM64 was cross-compiled with `g++-aarch64-linux-gnu` (`-DSIMD_SVE2=ON`, Release, shared `libSimd.so`) and run under `qemu-aarch64`.

**Official `Test` remainder AutoTest** (`-fi=SynetQuantizedConvolution -mt=1`): Base vs Neon vs Sve2 vs API, all passed.

- SVE 512-bit (`qemu -cpu max`, F=16): groups 5/7 fall back to Neon (`group < F`); group 99 uses Sve2 V0.
- SVE 128-bit (`qemu -cpu neoverse-n2`, F=4): groups 5/7/99 all use Sve2 V0.

**Exact uint8 harness** (Base GEMM vs Sve2 V0): 3×3 / 5×5 / 7×7, stride 1/2, dilation 2, remainder channels 17/19/33/99, asymmetric pad, batch 2. Passed at 512-bit, 256-bit, and 128-bit SVE.

QEMU times are not a hardware performance signal. Full AutoTest shapes (for example 128×56×56) were not run end-to-end under QEMU because they are too slow there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f90202f-421b-4054-b8b9-8f0615fab8ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f90202f-421b-4054-b8b9-8f0615fab8ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

