### PR TITLE
Add SVE2 optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -69,7 +69,7 @@
  <li>NEON, SVE2 optimizations of class SynetQuantizedInnerProductGemmV0.</li>
  <li>NEON, SVE2 optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV0.</li>
  <li>NEON, SVE2 optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV1.</li>
- <li>NEON optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.</li>
+ <li>NEON, SVE2 optimizations of class SynetQuantizedConvolutionNhwcDepthwiseV2.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcGemmV0.</li>
  <li>NEON optimizations of class SynetQuantizedConvolutionNhwcSpecV0.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolution.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV1.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedInnerProduct.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedInnerProductGemmV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedMergedConvolution.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -479,6 +479,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV1.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp">
+      <Filter>Sve2\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2SynetQuantizedInnerProduct.cpp">
       <Filter>Sve2\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdSve2SynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedConvolution.cpp
@@ -40,6 +40,8 @@ namespace Simd
             ConvParam param(batch, conv);
             if (!ValidQuantized(param))
                 return NULL;
+            else if (SynetQuantizedConvolutionNhwcDepthwiseV2::Preferable(param, svcntw()))
+                return new SynetQuantizedConvolutionNhwcDepthwiseV2(param);
             else if (SynetQuantizedConvolutionNhwcDepthwiseV1::Preferable(param, svcntw()))
                 return new SynetQuantizedConvolutionNhwcDepthwiseV1(param);
             else if (SynetQuantizedConvolutionNhwcDepthwiseV0::Preferable(param, svcntw()))

--- a/src/Simd/SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp
@@ -1,0 +1,686 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizedDepthwise.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdSve2.h"
+#include "Simd/SimdCpu.h"
+
+namespace Simd
+{
+#if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
+    namespace Sve2
+    {
+        using AlgParam = SynetQuantizedConvolutionNhwcDepthwiseV2::AlgParam;
+
+        //------------------------------------------------------------------------------------------------
+
+        SIMD_INLINE svint32_t LoadAs32i(const uint8_t* src, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+        }
+
+        SIMD_INLINE svint32_t PackRows(const svint32_t& s0, const svint32_t& s1, const svbool_t& mask)
+        {
+            return svorr_s32_x(mask, s0, svlsl_n_s32_x(mask, s1, 16));
+        }
+
+        SIMD_INLINE svint32_t ShiftLeft16(const svint32_t& value, const svbool_t& mask)
+        {
+            return svlsl_n_s32_x(mask, value, 16);
+        }
+
+        SIMD_INLINE svint32_t ShiftRight16(const svint32_t& value, const svbool_t& mask)
+        {
+            return svreinterpret_s32_u32(svlsr_n_u32_x(mask, svreinterpret_u32_s32(value), 16));
+        }
+
+        SIMD_INLINE svint32_t LoadI16(const int16_t* src, const svbool_t& mask)
+        {
+            return svld1_s32(mask, (const int32_t*)src);
+        }
+
+        SIMD_INLINE void Madd2(svint32_t& i32, const svint32_t& u8, const svint32_t& i8)
+        {
+            svint16_t a = svreinterpret_s16_s32(u8);
+            svint16_t b = svreinterpret_s16_s32(i8);
+            i32 = svmlalb_s32(i32, a, b);
+            i32 = svmlalt_s32(i32, a, b);
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        static void QuantizedConvolutionNhwcDepthwiseV2_Preprocess(const uint8_t* src, const uint8_t* zero, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd, int16_t* dst)
+        {
+            const size_t F = a.F, DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            svint32_t _zero = svdup_n_s32(int32_t(zero[0]) | (int32_t(zero[0]) << 16));
+            size_t srcC = p.srcC, byMask = a.bufH - 1;
+            size_t byPad = p.kernelY - 1, srcR = p.srcW * p.srcC, bufR = a.bufW * a.bufC;
+            size_t byBeg = dyBeg ? dyBeg * p.strideY + byPad : 0, byEnd = dyEnd * p.strideY + byPad;
+            if (a.reorderType == 0)
+            {
+                size_t bxPad = p.padX * a.bufC * 2, bwPad = p.padW * a.bufC * 2;
+                for (size_t by = byBeg; by < byEnd; by += 2)
+                {
+                    int16_t* pd = dst + (by & byMask) * bufR;
+                    size_t sy = by - p.padY;
+                    const uint8_t* ps0 = (sy + 0) < p.srcH ? src + (sy + 0) * srcR : zero;
+                    const uint8_t* ps1 = (sy + 1) < p.srcH ? src + (sy + 1) * srcR : zero;
+                    if (bxPad)
+                    {
+                        for (size_t i = 0; i < bxPad; i += DF)
+                            svst1_s32(body, (int32_t*)(pd + i), _zero);
+                        pd += bxPad;
+                    }
+                    for (size_t sx = 0; sx < p.srcW; sx++)
+                    {
+                        size_t sc = 0;
+                        for (; sc < srcC; sc += F, pd += DF)
+                        {
+                            svbool_t mask = svwhilelt_b32(sc, srcC);
+                            svst1_s32(body, (int32_t*)pd, PackRows(LoadAs32i(ps0 + sc, mask), LoadAs32i(ps1 + sc, mask), body));
+                        }
+                        ps0 += p.srcC;
+                        ps1 += p.srcC;
+                    }
+                    if (bwPad)
+                    {
+                        for (size_t i = 0; i < bwPad; i += DF)
+                            svst1_s32(body, (int32_t*)(pd + i), _zero);
+                        pd += bwPad;
+                    }
+                }
+            }
+            else
+            {
+                size_t bW = a.bufW * 2, bC = a.bufC, xPad = p.padX * 2, wPad = p.padW * 2;
+                for (size_t by = byBeg; by < byEnd; by += 2)
+                {
+                    int16_t* pd = dst + (by & byMask) * bufR;
+                    size_t sy = by - p.padY;
+                    const uint8_t* ps0 = (sy + 0) < p.srcH ? src + (sy + 0) * srcR : zero;
+                    const uint8_t* ps1 = (sy + 1) < p.srcH ? src + (sy + 1) * srcR : zero;
+                    if (xPad)
+                    {
+                        for (size_t x = 0; x < xPad; x += 2, pd += DF)
+                            for (size_t c = 0; c < bC; c += F)
+                                svst1_s32(body, (int32_t*)(pd + c * bW), _zero);
+                    }
+                    for (size_t sx = 0; sx < p.srcW; sx++, pd += DF)
+                    {
+                        for (size_t sc = 0; sc < bC; sc += F)
+                        {
+                            svbool_t mask = svwhilelt_b32(sc, srcC);
+                            svst1_s32(body, (int32_t*)(pd + sc * bW), PackRows(LoadAs32i(ps0 + sc, mask), LoadAs32i(ps1 + sc, mask), body));
+                        }
+                        ps0 += p.srcC;
+                        ps1 += p.srcC;
+                    }
+                    if (wPad)
+                    {
+                        for (size_t x = 0; x < wPad; x += 2, pd += DF)
+                            for (size_t c = 0; c < bC; c += F)
+                                svst1_s32(body, (int32_t*)(pd + c * bW), _zero);
+                    }
+                }
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> void QuantizedConvolutionNhwcDepthwiseV2_AnyR1(const int16_t* src, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd,
+            const int16_t* weight, const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, uint8_t* dst)
+        {
+            const size_t F = a.F, DF = F * 2;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _sNorm, _iScale, _params[2], _dNorm;
+            svint32_t _dZero = svdup_n_s32(dZero), _sBias, _iLo, _iHi;
+            svint32_t d00, d10, d20, d30, d01, d11, d21, d31, w0, w1, s0;
+            size_t srcC = p.srcC, srcCF = AlignLo(srcC, F), kY = p.kernelY, kX = p.kernelX, sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.stepW;
+            size_t byMask = a.bufH - 1, bW = a.bufW * 2, bufR = a.bufR, dstW2 = AlignLo(p.dstW, 2), dstW4 = AlignLo(p.dstW, 4), dD = p.dstC * a.srcE;
+            size_t dyEnd2 = dyBeg + (sY == 1 ? AlignLo(dyEnd - dyBeg, 2) : 0), sizeW = a.sizeW, dyD = p.dstW * dD;
+            dst += dyBeg * p.dstW * dD;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = svdup_n_s32(-iZero);
+                _iHi = svdup_n_s32(255 - iZero);
+                _iScale = svdup_n_f32(iScale);
+                _dNorm = svdup_n_f32(dNorm);
+                _params[0] = svdup_n_f32(params[0]);
+                _params[1] = svdup_n_f32(params[1]);
+            }
+            size_t dy = dyBeg;
+            for (; dy < dyEnd2; dy += 2)
+            {
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcCF; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = svld1_s32(body, sBias + sc);
+                    _sNorm = svld1_f32(body, sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = svld1_f32(body, params + sc);
+                    size_t dx = 0;
+                    for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        d20 = svdup_n_s32(0);
+                        d30 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        d11 = svdup_n_s32(0);
+                        d21 = svdup_n_s32(0);
+                        d31 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0, body);
+                                w1 = LoadI16(pw1, body);
+                                s0 = LoadI16(ps + 0 * dX, body);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                                s0 = LoadI16(ps + 1 * dX, body);
+                                Madd2(d10, s0, w0);
+                                Madd2(d11, s0, w1);
+                                s0 = LoadI16(ps + 2 * dX, body);
+                                Madd2(d20, s0, w0);
+                                Madd2(d21, s0, w1);
+                                s0 = LoadI16(ps + 3 * dX, body);
+                                Madd2(d30, s0, w0);
+                                Madd2(d31, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 2 * dD, d21, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 3 * dD, d31, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd0 += 4 * dD;
+                        pd1 += 4 * dD;
+                    }
+                    for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        d11 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0, body);
+                                w1 = LoadI16(pw1, body);
+                                s0 = LoadI16(ps + 0 * dX, body);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                                s0 = LoadI16(ps + 1 * dX, body);
+                                Madd2(d10, s0, w0);
+                                Madd2(d11, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd0 += 2 * dD;
+                        pd1 += 2 * dD;
+                    }
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0, body);
+                                w1 = LoadI16(pw1, body);
+                                s0 = LoadI16(ps + 0 * dX, body);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd0 += dD;
+                        pd1 += dD;
+                    }
+                }
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = svld1_s32(body, sBias + sc);
+                    _sNorm = svld1_f32(body, sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = svld1_f32(body, params + sc);
+                    size_t dx = 0, tail = srcC - srcCF;
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d01 = svdup_n_s32(0);
+                        const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw0 += DF, pw1 += DF)
+                            {
+                                w0 = LoadI16(pw0, body);
+                                w1 = LoadI16(pw1, body);
+                                s0 = LoadI16(ps + 0 * dX, body);
+                                Madd2(d00, s0, w0);
+                                Madd2(d01, s0, w1);
+                            }
+                        }
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        pd0 += dD;
+                        pd1 += dD;
+                    }
+                }
+                dst += p.dstW * 2 * dD;
+            }
+            for (; dy < dyEnd; ++dy)
+            {
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcCF; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = svld1_s32(body, sBias + sc);
+                    _sNorm = svld1_f32(body, sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = svld1_f32(body, params + sc);
+                    size_t dx = 0;
+                    for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        d20 = svdup_n_s32(0);
+                        d30 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw, body);
+                                Madd2(d00, LoadI16(ps + 0 * dX, body), w0);
+                                Madd2(d10, LoadI16(ps + 1 * dX, body), w0);
+                                Madd2(d20, LoadI16(ps + 2 * dX, body), w0);
+                                Madd2(d30, LoadI16(ps + 3 * dX, body), w0);
+                            }
+                        }
+                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd += 4 * dD;
+                    }
+                    for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        d10 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw, body);
+                                Madd2(d00, LoadI16(ps + 0 * dX, body), w0);
+                                Madd2(d10, LoadI16(ps + 1 * dX, body), w0);
+                            }
+                        }
+                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd += 2 * dD;
+                    }
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw, body);
+                                Madd2(d00, LoadI16(ps, body), w0);
+                            }
+                        }
+                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        pd += dD;
+                    }
+                }
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + sc * bW;
+                    _sBias = svld1_s32(body, sBias + sc);
+                    _sNorm = svld1_f32(body, sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = svld1_f32(body, params + sc);
+                    size_t dx = 0, tail = srcC - srcCF;
+                    for (; dx < p.dstW; ++dx, ps0 += dX)
+                    {
+                        d00 = svdup_n_s32(0);
+                        const int16_t* pw = weight + sc * dW;
+                        for (size_t ky = 0; ky < kY; ky += 2)
+                        {
+                            const int16_t* ps = ps0 + ((sy + ky) & byMask) * bufR;
+                            for (size_t kx = 0; kx < kX; ++kx, ps += DF, pw += DF)
+                            {
+                                w0 = LoadI16(pw, body);
+                                Madd2(d00, LoadI16(ps, body), w0);
+                            }
+                        }
+                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        pd += dD;
+                    }
+                }
+                dst += p.dstW * dD;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> void QuantizedConvolutionNhwcDepthwiseV2_3x3R1(const int16_t* src, const ConvParam& p, const AlgParam& a, size_t dyBeg, size_t dyEnd,
+            const int16_t* weight, const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, uint8_t* dst)
+        {
+            const size_t F = a.F, DF = F * 2, QF = F * 4;
+            const svbool_t body = svptrue_b32();
+            svfloat32_t _sNorm, _iScale, _params[2], _dNorm;
+            svint32_t _dZero = svdup_n_s32(dZero), _sBias, _iLo, _iHi;
+            svint32_t d00, d10, w03, w14, w25, s0;
+            size_t srcC = p.srcC, srcCF = AlignLo(srcC, F), sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.stepW;
+            size_t byMask = a.bufH - 1, bW = a.bufW * 2, bufR = a.bufW * a.bufC, dstW2 = sX == 1 ? AlignLo(p.dstW, 2) : 0, dD = p.dstC * a.srcE;
+            size_t dyEnd2 = dyBeg + (sY == 1 ? AlignLo(dyEnd - dyBeg, 2) : 0), sizeW = a.sizeW, dyD = p.dstW * dD;
+            dst += dyBeg * p.dstW * dD;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = svdup_n_s32(-iZero);
+                _iHi = svdup_n_s32(255 - iZero);
+                _iScale = svdup_n_f32(iScale);
+                _dNorm = svdup_n_f32(dNorm);
+                _params[0] = svdup_n_f32(params[0]);
+                _params[1] = svdup_n_f32(params[1]);
+            }
+            size_t dy = dyBeg;
+            for (; dy < dyEnd2; dy += 2)
+            {
+                svint32_t d01, w36, w47, w58;
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd0 = dst + sc, * pd1 = pd0 + dyD;
+                    const int16_t* ps0 = src + ((sy + 0) & byMask) * bufR + sc * bW;
+                    const int16_t* ps2 = src + ((sy + 2) & byMask) * bufR + sc * bW;
+                    const int16_t* pw0 = weight + sc * dW, * pw1 = pw0 + sizeW;
+                    _sBias = svld1_s32(body, sBias + sc);
+                    _sNorm = svld1_f32(body, sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = svld1_f32(body, params + sc);
+                    w03 = LoadI16(pw0 + 0 * DF, body);
+                    w14 = LoadI16(pw0 + 1 * DF, body);
+                    w25 = LoadI16(pw0 + 2 * DF, body);
+                    w36 = LoadI16(pw1 + 3 * DF, body);
+                    w47 = LoadI16(pw1 + 4 * DF, body);
+                    w58 = LoadI16(pw1 + 5 * DF, body);
+                    if (sc < srcCF)
+                    {
+                        size_t dx = 0;
+                        for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+                            d01 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF, body);
+                            Madd2(d00, s0, w03);
+                            Madd2(d01, s0, ShiftLeft16(w03, body));
+                            s0 = LoadI16(ps0 + 1 * DF, body);
+                            Madd2(d00, s0, w14);
+                            Madd2(d01, s0, ShiftLeft16(w14, body));
+                            s0 = LoadI16(ps0 + 2 * DF, body);
+                            Madd2(d00, s0, w25);
+                            Madd2(d01, s0, ShiftLeft16(w25, body));
+                            s0 = LoadI16(ps2 + 0 * DF, body);
+                            Madd2(d00, s0, ShiftRight16(w36, body));
+                            Madd2(d01, s0, w36);
+                            s0 = LoadI16(ps2 + 1 * DF, body);
+                            Madd2(d00, s0, ShiftRight16(w47, body));
+                            Madd2(d01, s0, w47);
+                            s0 = LoadI16(ps2 + 2 * DF, body);
+                            Madd2(d00, s0, ShiftRight16(w58, body));
+                            Madd2(d01, s0, w58);
+
+                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            pd0 += dD;
+                            pd1 += dD;
+                        }
+                    }
+                    else
+                    {
+                        size_t tail = srcC - srcCF;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+                            d01 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF, body);
+                            Madd2(d00, s0, w03);
+                            Madd2(d01, s0, ShiftLeft16(w03, body));
+                            s0 = LoadI16(ps0 + 1 * DF, body);
+                            Madd2(d00, s0, w14);
+                            Madd2(d01, s0, ShiftLeft16(w14, body));
+                            s0 = LoadI16(ps0 + 2 * DF, body);
+                            Madd2(d00, s0, w25);
+                            Madd2(d01, s0, ShiftLeft16(w25, body));
+                            s0 = LoadI16(ps2 + 0 * DF, body);
+                            Madd2(d00, s0, ShiftRight16(w36, body));
+                            Madd2(d01, s0, w36);
+                            s0 = LoadI16(ps2 + 1 * DF, body);
+                            Madd2(d00, s0, ShiftRight16(w47, body));
+                            Madd2(d01, s0, w47);
+                            s0 = LoadI16(ps2 + 2 * DF, body);
+                            Madd2(d00, s0, ShiftRight16(w58, body));
+                            Madd2(d01, s0, w58);
+
+                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            pd0 += dD;
+                            pd1 += dD;
+                        }
+                    }
+                }
+                dst += p.dstW * dD * 2;
+            }
+            for (; dy < dyEnd; ++dy)
+            {
+                svint32_t w6, w7, w8;
+                size_t sc = 0, sy = dy * sY;
+                for (; sc < srcC; sc += F)
+                {
+                    uint8_t* pd = dst + sc;
+                    const int16_t* ps0 = src + ((sy + 0) & byMask) * bufR + sc * bW;
+                    const int16_t* ps2 = src + ((sy + 2) & byMask) * bufR + sc * bW;
+                    const int16_t* pw = weight + sc * dW;
+                    _sBias = svld1_s32(body, sBias + sc);
+                    _sNorm = svld1_f32(body, sNorm + sc);
+                    if (type == SimdConvolutionActivationPrelu)
+                        _params[0] = svld1_f32(body, params + sc);
+                    w03 = LoadI16(pw + 0 * DF, body);
+                    w14 = LoadI16(pw + 1 * DF, body);
+                    w25 = LoadI16(pw + 2 * DF, body);
+                    w6 = LoadI16(pw + 3 * DF, body);
+                    w7 = LoadI16(pw + 4 * DF, body);
+                    w8 = LoadI16(pw + 5 * DF, body);
+                    if (sc < srcCF)
+                    {
+                        size_t dx = 0;
+                        for (; dx < dstW2; dx += 2, ps0 += QF, ps2 += QF)
+                        {
+                            d00 = svdup_n_s32(0);
+                            d10 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF, body);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * DF, body);
+                            Madd2(d00, s0, w14);
+                            Madd2(d10, s0, w03);
+                            s0 = LoadI16(ps0 + 2 * DF, body);
+                            Madd2(d00, s0, w25);
+                            Madd2(d10, s0, w14);
+                            s0 = LoadI16(ps0 + 3 * DF, body);
+                            Madd2(d10, s0, w25);
+
+                            s0 = LoadI16(ps2 + 0 * DF, body);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * DF, body);
+                            Madd2(d00, s0, w7);
+                            Madd2(d10, s0, w6);
+                            s0 = LoadI16(ps2 + 2 * DF, body);
+                            Madd2(d00, s0, w8);
+                            Madd2(d10, s0, w7);
+                            s0 = LoadI16(ps2 + 3 * DF, body);
+                            Madd2(d10, s0, w8);
+
+                            Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            pd += 2 * dD;
+                        }
+                        for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF, body);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * DF, body);
+                            Madd2(d00, s0, w14);
+                            s0 = LoadI16(ps0 + 2 * DF, body);
+                            Madd2(d00, s0, w25);
+                            s0 = LoadI16(ps2 + 0 * DF, body);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * DF, body);
+                            Madd2(d00, s0, w7);
+                            s0 = LoadI16(ps2 + 2 * DF, body);
+                            Madd2(d00, s0, w8);
+
+                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            pd += dD;
+                        }
+                    }
+                    else
+                    {
+                        size_t tail = srcC - srcCF;
+                        for (size_t dx = 0; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
+                        {
+                            d00 = svdup_n_s32(0);
+
+                            s0 = LoadI16(ps0 + 0 * DF, body);
+                            Madd2(d00, s0, w03);
+                            s0 = LoadI16(ps0 + 1 * DF, body);
+                            Madd2(d00, s0, w14);
+                            s0 = LoadI16(ps0 + 2 * DF, body);
+                            Madd2(d00, s0, w25);
+                            s0 = LoadI16(ps2 + 0 * DF, body);
+                            Madd2(d00, s0, w6);
+                            s0 = LoadI16(ps2 + 1 * DF, body);
+                            Madd2(d00, s0, w7);
+                            s0 = LoadI16(ps2 + 2 * DF, body);
+                            Madd2(d00, s0, w8);
+
+                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            pd += dD;
+                        }
+                    }
+                }
+                dst += p.dstW * dD;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> void SetV2(const ConvParam& p, const AlgParam& a, SynetQuantizedConvolutionNhwcDepthwiseV2::ConvolutionPtr& convolution)
+        {
+            if (p.IsKernel(3) && p.IsDilation(1) && a.reorderType == 1)
+                convolution = QuantizedConvolutionNhwcDepthwiseV2_3x3R1<term, type>;
+            else
+            {
+                if (a.reorderType == 1)
+                    convolution = QuantizedConvolutionNhwcDepthwiseV2_AnyR1<term, type>;
+                else
+                    assert(0);
+            }
+        }
+
+        //------------------------------------------------------------------------------------------------
+
+        SynetQuantizedConvolutionNhwcDepthwiseV2::SynetQuantizedConvolutionNhwcDepthwiseV2(const ConvParam& p)
+            : Base::SynetQuantizedConvolutionNhwcDepthwiseV2(p)
+        {
+            SetAlgParam(svcntw());
+            _preprocess = QuantizedConvolutionNhwcDepthwiseV2_Preprocess;
+            if (p.dstT == SimdTensorData8u)
+            {
+                switch (p.activation)
+                {
+                case SimdConvolutionActivationIdentity: SetV2<Term8iLast8u, SimdConvolutionActivationIdentity>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationRelu: SetV2<Term8iLast8u, SimdConvolutionActivationRelu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationLeakyRelu: SetV2<Term8iLast8u, SimdConvolutionActivationLeakyRelu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationRestrictRange: SetV2<Term8iLast8u, SimdConvolutionActivationRestrictRange>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationPrelu: SetV2<Term8iLast8u, SimdConvolutionActivationPrelu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationElu: SetV2<Term8iLast8u, SimdConvolutionActivationElu>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationHswish: SetV2<Term8iLast8u, SimdConvolutionActivationHswish>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationMish: SetV2<Term8iLast8u, SimdConvolutionActivationMish>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationHardSigmoid: SetV2<Term8iLast8u, SimdConvolutionActivationHardSigmoid>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationSwish: SetV2<Term8iLast8u, SimdConvolutionActivationSwish>(p, _alg, _convolution); break;
+                case SimdConvolutionActivationGelu: SetV2<Term8iLast8u, SimdConvolutionActivationGelu>(p, _alg, _convolution); break;
+                default:
+                    assert(0);
+                }
+            }
+            else
+                assert(0);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp
@@ -159,7 +159,7 @@ namespace Simd
         {
             const size_t F = a.F, DF = F * 2;
             const svbool_t body = svptrue_b32();
-            svfloat32_t _sNorm, _iScale, _params[2], _dNorm;
+            svfloat32_t _sNorm, _iScale, _param0, _param1, _dNorm;
             svint32_t _dZero = svdup_n_s32(dZero), _sBias, _iLo, _iHi;
             svint32_t d00, d10, d20, d30, d01, d11, d21, d31, w0, w1, s0;
             size_t srcC = p.srcC, srcCF = AlignLo(srcC, F), kY = p.kernelY, kX = p.kernelX, sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.stepW;
@@ -172,8 +172,8 @@ namespace Simd
                 _iHi = svdup_n_s32(255 - iZero);
                 _iScale = svdup_n_f32(iScale);
                 _dNorm = svdup_n_f32(dNorm);
-                _params[0] = svdup_n_f32(params[0]);
-                _params[1] = svdup_n_f32(params[1]);
+                _param0 = svdup_n_f32(params[0]);
+                _param1 = svdup_n_f32(params[1]);
             }
             size_t dy = dyBeg;
             for (; dy < dyEnd2; dy += 2)
@@ -186,7 +186,7 @@ namespace Simd
                     _sBias = svld1_s32(body, sBias + sc);
                     _sNorm = svld1_f32(body, sNorm + sc);
                     if (type == SimdConvolutionActivationPrelu)
-                        _params[0] = svld1_f32(body, params + sc);
+                        _param0 = svld1_f32(body, params + sc);
                     size_t dx = 0;
                     for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
                     {
@@ -220,14 +220,14 @@ namespace Simd
                                 Madd2(d31, s0, w1);
                             }
                         }
-                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd0 + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd0 + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 2 * dD, d21, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 3 * dD, d31, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 2 * dD, d21, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 3 * dD, d31, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                         pd0 += 4 * dD;
                         pd1 += 4 * dD;
                     }
@@ -253,10 +253,10 @@ namespace Simd
                                 Madd2(d11, s0, w1);
                             }
                         }
-                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 1 * dD, d11, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                         pd0 += 2 * dD;
                         pd1 += 2 * dD;
                     }
@@ -277,8 +277,8 @@ namespace Simd
                                 Madd2(d01, s0, w1);
                             }
                         }
-                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                         pd0 += dD;
                         pd1 += dD;
                     }
@@ -290,7 +290,7 @@ namespace Simd
                     _sBias = svld1_s32(body, sBias + sc);
                     _sNorm = svld1_f32(body, sNorm + sc);
                     if (type == SimdConvolutionActivationPrelu)
-                        _params[0] = svld1_f32(body, params + sc);
+                        _param0 = svld1_f32(body, params + sc);
                     size_t dx = 0, tail = srcC - srcCF;
                     for (; dx < p.dstW; ++dx, ps0 += dX)
                     {
@@ -309,8 +309,8 @@ namespace Simd
                                 Madd2(d01, s0, w1);
                             }
                         }
-                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
-                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        Save1<term, type>(pd0 + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero, tail);
+                        Save1<term, type>(pd1 + 0 * dD, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero, tail);
                         pd0 += dD;
                         pd1 += dD;
                     }
@@ -327,7 +327,7 @@ namespace Simd
                     _sBias = svld1_s32(body, sBias + sc);
                     _sNorm = svld1_f32(body, sNorm + sc);
                     if (type == SimdConvolutionActivationPrelu)
-                        _params[0] = svld1_f32(body, params + sc);
+                        _param0 = svld1_f32(body, params + sc);
                     size_t dx = 0;
                     for (; dx < dstW4; dx += 4, ps0 += 4 * dX)
                     {
@@ -348,10 +348,10 @@ namespace Simd
                                 Madd2(d30, LoadI16(ps + 3 * dX, body), w0);
                             }
                         }
-                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd + 2 * dD, d20, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd + 3 * dD, d30, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                         pd += 4 * dD;
                     }
                     for (; dx < dstW2; dx += 2, ps0 += 2 * dX)
@@ -369,8 +369,8 @@ namespace Simd
                                 Madd2(d10, LoadI16(ps + 1 * dX, body), w0);
                             }
                         }
-                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                        Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                         pd += 2 * dD;
                     }
                     for (; dx < p.dstW; ++dx, ps0 += dX)
@@ -386,7 +386,7 @@ namespace Simd
                                 Madd2(d00, LoadI16(ps, body), w0);
                             }
                         }
-                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                         pd += dD;
                     }
                 }
@@ -397,7 +397,7 @@ namespace Simd
                     _sBias = svld1_s32(body, sBias + sc);
                     _sNorm = svld1_f32(body, sNorm + sc);
                     if (type == SimdConvolutionActivationPrelu)
-                        _params[0] = svld1_f32(body, params + sc);
+                        _param0 = svld1_f32(body, params + sc);
                     size_t dx = 0, tail = srcC - srcCF;
                     for (; dx < p.dstW; ++dx, ps0 += dX)
                     {
@@ -412,7 +412,7 @@ namespace Simd
                                 Madd2(d00, LoadI16(ps, body), w0);
                             }
                         }
-                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                        Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero, tail);
                         pd += dD;
                     }
                 }
@@ -427,7 +427,7 @@ namespace Simd
         {
             const size_t F = a.F, DF = F * 2, QF = F * 4;
             const svbool_t body = svptrue_b32();
-            svfloat32_t _sNorm, _iScale, _params[2], _dNorm;
+            svfloat32_t _sNorm, _iScale, _param0, _param1, _dNorm;
             svint32_t _dZero = svdup_n_s32(dZero), _sBias, _iLo, _iHi;
             svint32_t d00, d10, w03, w14, w25, s0;
             size_t srcC = p.srcC, srcCF = AlignLo(srcC, F), sY = p.strideY, sX = p.strideX, dX = sX * DF, dW = a.stepW;
@@ -440,8 +440,8 @@ namespace Simd
                 _iHi = svdup_n_s32(255 - iZero);
                 _iScale = svdup_n_f32(iScale);
                 _dNorm = svdup_n_f32(dNorm);
-                _params[0] = svdup_n_f32(params[0]);
-                _params[1] = svdup_n_f32(params[1]);
+                _param0 = svdup_n_f32(params[0]);
+                _param1 = svdup_n_f32(params[1]);
             }
             size_t dy = dyBeg;
             for (; dy < dyEnd2; dy += 2)
@@ -457,7 +457,7 @@ namespace Simd
                     _sBias = svld1_s32(body, sBias + sc);
                     _sNorm = svld1_f32(body, sNorm + sc);
                     if (type == SimdConvolutionActivationPrelu)
-                        _params[0] = svld1_f32(body, params + sc);
+                        _param0 = svld1_f32(body, params + sc);
                     w03 = LoadI16(pw0 + 0 * DF, body);
                     w14 = LoadI16(pw0 + 1 * DF, body);
                     w25 = LoadI16(pw0 + 2 * DF, body);
@@ -491,8 +491,8 @@ namespace Simd
                             Madd2(d00, s0, ShiftRight16(w58, body));
                             Madd2(d01, s0, w58);
 
-                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                             pd0 += dD;
                             pd1 += dD;
                         }
@@ -524,8 +524,8 @@ namespace Simd
                             Madd2(d00, s0, ShiftRight16(w58, body));
                             Madd2(d01, s0, w58);
 
-                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
-                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            Save1<term, type>(pd0, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero, tail);
+                            Save1<term, type>(pd1, d01, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero, tail);
                             pd0 += dD;
                             pd1 += dD;
                         }
@@ -546,7 +546,7 @@ namespace Simd
                     _sBias = svld1_s32(body, sBias + sc);
                     _sNorm = svld1_f32(body, sNorm + sc);
                     if (type == SimdConvolutionActivationPrelu)
-                        _params[0] = svld1_f32(body, params + sc);
+                        _param0 = svld1_f32(body, params + sc);
                     w03 = LoadI16(pw + 0 * DF, body);
                     w14 = LoadI16(pw + 1 * DF, body);
                     w25 = LoadI16(pw + 2 * DF, body);
@@ -583,8 +583,8 @@ namespace Simd
                             s0 = LoadI16(ps2 + 3 * DF, body);
                             Madd2(d10, s0, w8);
 
-                            Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
-                            Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd + 0 * dD, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
+                            Save1<term, type>(pd + 1 * dD, d10, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                             pd += 2 * dD;
                         }
                         for (; dx < p.dstW; ++dx, ps0 += dX, ps2 += dX)
@@ -604,7 +604,7 @@ namespace Simd
                             s0 = LoadI16(ps2 + 2 * DF, body);
                             Madd2(d00, s0, w8);
 
-                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero);
+                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero);
                             pd += dD;
                         }
                     }
@@ -628,7 +628,7 @@ namespace Simd
                             s0 = LoadI16(ps2 + 2 * DF, body);
                             Madd2(d00, s0, w8);
 
-                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _params, _dNorm, _dZero, tail);
+                            Save1<term, type>(pd, d00, _sBias, _sNorm, _iLo, _iHi, _iScale, _param0, _param1, _dNorm, _dZero, tail);
                             pd += dD;
                         }
                     }

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -953,7 +953,7 @@ namespace Simd
         //--------------------------------------------------------------------------------------------------
 
         template<SimdConvolutionActivationType type, int index> SIMD_INLINE svint32_t ToSave32i(const svint32_t& sum, const svint32_t& sBias, const svfloat32_t& sNorm,
-            const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+            const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t& param0, const svfloat32_t& param1, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
         {
             if (type == SimdConvolutionActivationIdentity)
             {
@@ -964,12 +964,12 @@ namespace Simd
             {
                 svint32_t i32 = NearbyInt(svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, sBias)), sNorm), mask);
                 svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svmin_s32_x(mask, svmax_s32_x(mask, iLo, i32), iHi)), iScale);
-                return svadd_s32_x(mask, Round(svmul_f32_x(mask, Activate<type>(f32, params[0], params[1], index, mask), dNorm), mask), dZero);
+                return svadd_s32_x(mask, Round(svmul_f32_x(mask, Activate<type>(f32, param0, param1, index, mask), dNorm), mask), dZero);
             }
         }
 
         template<Term8iType term, SimdConvolutionActivationType type, int index> SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t& param0, const svfloat32_t& param1, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
         {
             const size_t F = svcntw();
             if (term == Term8iInterim)
@@ -978,7 +978,7 @@ namespace Simd
             }
             else if (term == Term8iLast8u)
             {
-                svint32_t d0 = ToSave32i<type, index>(sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, mask);
+                svint32_t d0 = ToSave32i<type, index>(sum, sBias, sNorm, iLo, iHi, iScale, param0, param1, dNorm, dZero, mask);
                 d0 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, d0, 0), 255);
                 svst1b_u32(mask, dst + index * F, svreinterpret_u32_s32(d0));
             }
@@ -989,15 +989,15 @@ namespace Simd
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero)
+            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t& param0, const svfloat32_t& param1, const svfloat32_t& dNorm, const svint32_t& dZero)
         {
-            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svptrue_b32());
+            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, param0, param1, dNorm, dZero, svptrue_b32());
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
-            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, size_t tail)
+            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t& param0, const svfloat32_t& param1, const svfloat32_t& dNorm, const svint32_t& dZero, size_t tail)
         {
-            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svwhilelt_b32((size_t)0, tail));
+            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, param0, param1, dNorm, dZero, svwhilelt_b32((size_t)0, tail));
         }
     }
 #endif

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -949,6 +949,56 @@ namespace Simd
             QuntizedTerm8i<term>::template Save<0>(dst, buf, sum0, bias0, bias1, norm0, norm1, zero, svptrue_b32());
             QuntizedTerm8i<term>::template Save<1>(dst, buf, sum1, bias0, bias1, norm0, norm1, zero, svwhilelt_b32((size_t)0, tail));
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type, int index> SIMD_INLINE svint32_t ToSave32i(const svint32_t& sum, const svint32_t& sBias, const svfloat32_t& sNorm,
+            const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            if (type == SimdConvolutionActivationIdentity)
+            {
+                svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, sBias)), sNorm);
+                return svadd_s32_x(mask, NearbyInt(f32, mask), dZero);
+            }
+            else
+            {
+                svint32_t i32 = NearbyInt(svmul_f32_x(mask, svcvt_f32_s32_x(mask, svadd_s32_x(mask, sum, sBias)), sNorm), mask);
+                svfloat32_t f32 = svmul_f32_x(mask, svcvt_f32_s32_x(mask, svmin_s32_x(mask, svmax_s32_x(mask, iLo, i32), iHi)), iScale);
+                return svadd_s32_x(mask, Round(svmul_f32_x(mask, Activate<type>(f32, params[0], params[1], index, mask), dNorm), mask), dZero);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type, int index> SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, const svbool_t& mask)
+        {
+            const size_t F = svcntw();
+            if (term == Term8iInterim)
+            {
+                svst1_s32(mask, buf + index * F, sum);
+            }
+            else if (term == Term8iLast8u)
+            {
+                svint32_t d0 = ToSave32i<type, index>(sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, mask);
+                d0 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, d0, 0), 255);
+                svst1b_u32(mask, dst + index * F, svreinterpret_u32_s32(d0));
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero)
+        {
+            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svptrue_b32());
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, const svint32_t& sum,
+            const svint32_t& sBias, const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, size_t tail)
+        {
+            Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svwhilelt_b32((size_t)0, tail));
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -794,6 +794,16 @@ namespace Simd
 
         //------------------------------------------------------------------------------------------------
 
+        class SynetQuantizedConvolutionNhwcDepthwiseV2 : public Base::SynetQuantizedConvolutionNhwcDepthwiseV2
+        {
+        public:
+            SynetQuantizedConvolutionNhwcDepthwiseV2(const ConvParam& p);
+
+            virtual String Ext() const { return "Sve2"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
         void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv);
     }
 #endif

--- a/src/Simd/SimdSynetQuantizedDepthwise.h
+++ b/src/Simd/SimdSynetQuantizedDepthwise.h
@@ -291,6 +291,20 @@ namespace Simd
         {
             Save2<term>(dst0, dst1, sum0, sum1, bias, norm, zero, offset, svwhilelt_b32((size_t)0, tail));
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template <Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& sBias,
+            const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero)
+        {
+            Save<term, type, 0>(dst, (int32_t*)NULL, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svptrue_b32());
+        }
+
+        template <Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& sBias,
+            const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, size_t tail)
+        {
+            Save<term, type, 0>(dst, (int32_t*)NULL, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svwhilelt_b32((size_t)0, tail));
+        }
     }
 #endif
 }

--- a/src/Simd/SimdSynetQuantizedDepthwise.h
+++ b/src/Simd/SimdSynetQuantizedDepthwise.h
@@ -295,15 +295,15 @@ namespace Simd
         //--------------------------------------------------------------------------------------------------
 
         template <Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& sBias,
-            const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero)
+            const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t& param0, const svfloat32_t& param1, const svfloat32_t& dNorm, const svint32_t& dZero)
         {
-            Save<term, type, 0>(dst, (int32_t*)NULL, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svptrue_b32());
+            Save<term, type, 0>(dst, (int32_t*)NULL, sum, sBias, sNorm, iLo, iHi, iScale, param0, param1, dNorm, dZero, svptrue_b32());
         }
 
         template <Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, const svint32_t& sum, const svint32_t& sBias,
-            const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t* params, const svfloat32_t& dNorm, const svint32_t& dZero, size_t tail)
+            const svfloat32_t& sNorm, const svint32_t& iLo, const svint32_t& iHi, const svfloat32_t& iScale, const svfloat32_t& param0, const svfloat32_t& param1, const svfloat32_t& dNorm, const svint32_t& dZero, size_t tail)
         {
-            Save<term, type, 0>(dst, (int32_t*)NULL, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, svwhilelt_b32((size_t)0, tail));
+            Save<term, type, 0>(dst, (int32_t*)NULL, sum, sBias, sNorm, iLo, iHi, iScale, param0, param1, dNorm, dZero, svwhilelt_b32((size_t)0, tail));
         }
     }
 #endif

--- a/src/Test/TestSynetQuantizedConvolution.cpp
+++ b/src/Test/TestSynetQuantizedConvolution.cpp
@@ -412,6 +412,12 @@ namespace Test
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 960, 14, 14, 960, _5, _1, _1, _2, _2, 960, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 960, 14, 14, 960, _5, _1, _2, _1, _2, 960, aId, t, u8, u8), o, f1, f2);
 #endif
+#if 1
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 16, 11, 11, 16, _3, _1, _1, _1, _1, 16, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 16, 11, 11, 16, _3, _1, _2, _1, _1, 16, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 32, 13, 13, 32, _5, _1, _1, _2, _2, 32, aId, t, u8, u8), o, f1, f2);
+        result = result && SynetQuantizedConvolutionForwardAutoTestA(e, Param(1, 32, 13, 13, 32, _7, _1, _2, _3, _3, 32, aId, t, u8, u8), o, f1, f2);
+#endif
 #if 0
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 3, 224, 224, 24, _3, _1, _2, _1, _1, 1, aId, t, u8, u8), o, f1, f2);
         result = result && SynetQuantizedConvolutionForwardAutoTest(e, Param(1, 3, 224, 224, 32, _3, _1, _2, _1, _1, 1, aId, t, u8, u8), o, f1, f2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add SVE2 optimizations of class `SynetQuantizedConvolutionNhwcDepthwiseV2` for the ARM/ARM64 `SimdSynetQuantizedConvolution` API.

## Changes
- Port NEON depthwise V2 preprocess and convolution kernels (`AnyR1`, `3x3R1`) to SVE2 using packed int16 multiply-add (`svmlalb_s32` / `svmlalt_s32`).
- Add SVE2 activation-aware `Save1` helpers so V2 supports the same activation set as NEON.
- Prefer V2 in `Sve2::SynetQuantizedConvolutionInit` when `Preferable` matches (depthwise, dilation 1, stride 1/2, kernel 3/5/7).
- Register `SimdSve2SynetQuantizedConvolutionDepthwiseV2.cpp` in `prj/vs2022/Sve2.vcxproj` and filters.
- Enable additional `SynetQuantizedConvolution` auto-tests covering V2 activations (3x3, 5x5, 7x7).
- Update release 7.2.165 notes in `docs/2026.html`.
- Fix ARM GCC build: SVE types are sizeless, so `_params[2]` is replaced with two `svfloat32_t` scalars.

## Validation
- CMake Release build with g++ succeeded (`build/Test`, `build/libSimd.so`).
- `./Test "-r=.." -fi=SynetQuantizedConvolution -tt=$(nproc) -ts=1` finished successfully (87.8 s), including the new V2 activation cases.
- This VM is x86_64, so SVE2 kernels compile only on ARM/ARM64. The x86 run validates the updated tests and headers against Base/SSE41/AVX2/AVX-512/VNNI/AMX.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d992444d-2ef7-4c61-8e3d-794552d0ebb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d992444d-2ef7-4c61-8e3d-794552d0ebb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

