### PR TITLE
Improve SVE2 optimizations of SimdGaussianBlur3x3

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -81,6 +81,7 @@
 <ul>
  <li>SVE2 optimizations of function Gemm32fNN.</li>
  <li>SVE2 optimizations of function Gemm32fNT.</li>
+ <li>SVE2 optimizations of function GaussianBlur3x3.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2GaussianBlur3x3.cpp
+++ b/src/Simd/SimdSve2GaussianBlur3x3.cpp
@@ -31,13 +31,13 @@ namespace Simd
         SIMD_INLINE svuint16_t BinomialSumLo(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            return svadd_u16_x(mask, svaddlb_u16(left, right), svaddlb_u16(center, center));
+            return svadd_u16_x(mask, svadd_u16_x(mask, svunpklo_u16(left), svunpklo_u16(right)), svlsl_n_u16_x(mask, svunpklo_u16(center), 1));
         }
 
         SIMD_INLINE svuint16_t BinomialSumHi(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            return svadd_u16_x(mask, svaddlt_u16(left, right), svaddlt_u16(center, center));
+            return svadd_u16_x(mask, svadd_u16_x(mask, svunpkhi_u16(left), svunpkhi_u16(right)), svlsl_n_u16_x(mask, svunpkhi_u16(center), 1));
         }
 
         SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c)
@@ -87,16 +87,11 @@ namespace Simd
                 const uint8_t* src1 = src + srcStride * row;
                 const uint8_t* src0 = row ? src1 - srcStride : src1;
                 const uint8_t* src2 = row + 1 < height ? src1 + srcStride : src1;
-                if (width == 1)
-                {
-                    for (size_t col = 0; col < step; ++col)
-                        dst[col] = (uint8_t)Base::GaussianBlur3x3<true>(src0, src1, src2, col, col, col);
-                }
-                else
-                {
-                    for (size_t col = 0; col < step; ++col)
-                        dst[col] = (uint8_t)Base::GaussianBlur3x3<true>(src0, src1, src2, col, col, col + step);
+                for (size_t col = 0; col < step; ++col)
+                    dst[col] = (uint8_t)Base::GaussianBlur3x3<true>(src0, src1, src2, col, col, col + step);
 
+                if (width > 1)
+                {
                     const size_t end = size - step;
                     size_t col = step;
                     for (; col + A2 <= end; col += A2)

--- a/src/Simd/SimdSve2GaussianBlur3x3.cpp
+++ b/src/Simd/SimdSve2GaussianBlur3x3.cpp
@@ -21,188 +21,100 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-#include "Simd/SimdMemory.h"
+#include "Simd/SimdMath.h"
 
 namespace Simd
 {
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        namespace
-        {
-            struct Buffer
-            {
-                Buffer(size_t width)
-                {
-                    _p = Allocate(sizeof(uint16_t) * 3 * width);
-                    src0 = (uint16_t*)_p;
-                    src1 = src0 + width;
-                    src2 = src1 + width;
-                }
-
-                ~Buffer()
-                {
-                    Free(_p);
-                }
-
-                uint16_t* src0;
-                uint16_t* src1;
-                uint16_t* src2;
-            private:
-                void* _p;
-            };
-        }
-
-        template <size_t step> SIMD_INLINE svuint8_t LoadBeforeFirst(const svuint8_t& first)
-        {
-            const svbool_t mask = svptrue_b8();
-            svuint8_t iota = svindex_u8(0, 1);
-            svuint8_t idx = svsel_u8(svcmplt_n_u8(mask, iota, step), iota, svsub_n_u8_x(mask, iota, step));
-            return svtbl_u8(first, idx);
-        }
-
-        template <size_t step> SIMD_INLINE svuint8_t LoadAfterLast(const svuint8_t& last)
-        {
-            const svbool_t mask = svptrue_b8();
-            const size_t A = svcntb();
-            svuint8_t iota = svindex_u8(0, 1);
-            svuint8_t idx = svsel_u8(svcmplt_n_u8(mask, iota, A - step), svadd_n_u8_x(mask, iota, step), iota);
-            return svtbl_u8(last, idx);
-        }
-
-        SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svbool_t& mask)
-        {
-            return svadd_u16_x(mask, svadd_u16_x(mask, a, c), svadd_u16_x(mask, b, b));
-        }
-
-        SIMD_INLINE void BlurCol(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right, uint16_t* dst)
+        SIMD_INLINE svuint16_t BinomialSumLo(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            const size_t HA = svcnth();
-            svst1_u16(mask, dst + 0, BinomialSum16(svunpklo_u16(left), svunpklo_u16(center), svunpklo_u16(right), mask));
-            svst1_u16(mask, dst + HA, BinomialSum16(svunpkhi_u16(left), svunpkhi_u16(center), svunpkhi_u16(right), mask));
+            return svadd_u16_x(mask, svaddlb_u16(left, right), svaddlb_u16(center, center));
         }
 
-        template <size_t step> SIMD_INLINE void BlurColNose(const uint8_t* p, uint16_t* dst)
+        SIMD_INLINE svuint16_t BinomialSumHi(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
-            const svbool_t mask = svptrue_b8();
-            svuint8_t center = svld1_u8(mask, p);
-            BlurCol(LoadBeforeFirst<step>(center), center, svld1_u8(mask, p + step), dst);
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svaddlt_u16(left, right), svaddlt_u16(center, center));
         }
 
-        template <size_t step> SIMD_INLINE void BlurColBody(const uint8_t* p, uint16_t* dst)
+        SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c)
         {
-            const svbool_t mask = svptrue_b8();
-            BlurCol(svld1_u8(mask, p - step), svld1_u8(mask, p), svld1_u8(mask, p + step), dst);
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svadd_u16_x(mask, a, c), svlsl_n_u16_x(mask, b, 1));
         }
 
-        template <size_t step> SIMD_INLINE void BlurColTail(const uint8_t* p, uint16_t* dst)
+        SIMD_INLINE svuint16_t DivideBy16(const svuint16_t& value)
         {
-            const svbool_t mask = svptrue_b8();
-            svuint8_t center = svld1_u8(mask, p);
-            BlurCol(svld1_u8(mask, p - step), center, LoadAfterLast<step>(center), dst);
-        }
-
-        SIMD_INLINE svuint16_t DivideBy16(const svuint16_t& value, const svbool_t& mask)
-        {
+            const svbool_t mask = svptrue_b16();
             return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 8), 4);
         }
 
-        SIMD_INLINE void BlurRow(const Buffer& buffer, size_t offset, uint8_t* dst)
+        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
         {
-            const svbool_t mask = svptrue_b16();
-            const size_t HA = svcnth();
-            svuint16_t lo = DivideBy16(BinomialSum16(
-                svld1_u16(mask, buffer.src0 + offset),
-                svld1_u16(mask, buffer.src1 + offset),
-                svld1_u16(mask, buffer.src2 + offset), mask), mask);
-            svuint16_t hi = DivideBy16(BinomialSum16(
-                svld1_u16(mask, buffer.src0 + offset + HA),
-                svld1_u16(mask, buffer.src1 + offset + HA),
-                svld1_u16(mask, buffer.src2 + offset + HA), mask), mask);
-            svst1b_u16(mask, dst + offset, lo);
-            svst1b_u16(mask, dst + offset + HA, hi);
+            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+        }
+
+        SIMD_INLINE svuint8_t GaussianBlur3x3(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            size_t step, const svbool_t& mask8)
+        {
+            svuint8_t left0 = svld1_u8(mask8, src0 - step);
+            svuint8_t center0 = svld1_u8(mask8, src0);
+            svuint8_t right0 = svld1_u8(mask8, src0 + step);
+            svuint8_t left1 = svld1_u8(mask8, src1 - step);
+            svuint8_t center1 = svld1_u8(mask8, src1);
+            svuint8_t right1 = svld1_u8(mask8, src1 + step);
+            svuint8_t left2 = svld1_u8(mask8, src2 - step);
+            svuint8_t center2 = svld1_u8(mask8, src2);
+            svuint8_t right2 = svld1_u8(mask8, src2 + step);
+            svuint16_t lo = BinomialSum16(BinomialSumLo(left0, center0, right0),
+                BinomialSumLo(left1, center1, right1), BinomialSumLo(left2, center2, right2));
+            svuint16_t hi = BinomialSum16(BinomialSumHi(left0, center0, right0),
+                BinomialSumHi(left1, center1, right1), BinomialSumHi(left2, center2, right2));
+            return PackU16ToU8(DivideBy16(lo), DivideBy16(hi));
         }
 
         template <size_t step> void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
         {
+            const size_t size = width * step;
             const size_t A = svcntb();
-            assert(step * (width - 1) >= A);
-
-            size_t size = step * width;
-            size_t bodySize = Simd::AlignHi(size, A) - A;
-
-            Buffer buffer(Simd::AlignHi(size, A));
-
-            BlurColNose<step>(src + 0, buffer.src0 + 0);
-            for (size_t col = A; col < bodySize; col += A)
-                BlurColBody<step>(src + col, buffer.src0 + col);
-            BlurColTail<step>(src + size - A, buffer.src0 + size - A);
-
-            memcpy(buffer.src1, buffer.src0, sizeof(uint16_t) * size);
-
-            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            const size_t A2 = A * 2;
+            const svbool_t all = svptrue_b8();
+            for (size_t row = 0; row < height; ++row)
             {
-                const uint8_t* src2 = src + srcStride * (row + 1);
-                if (row >= height - 2)
-                    src2 = src + srcStride * (height - 1);
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = row + 1 < height ? src1 + srcStride : src1;
+                if (width == 1)
+                {
+                    for (size_t col = 0; col < step; ++col)
+                        dst[col] = (uint8_t)Base::GaussianBlur3x3<true>(src0, src1, src2, col, col, col);
+                }
+                else
+                {
+                    for (size_t col = 0; col < step; ++col)
+                        dst[col] = (uint8_t)Base::GaussianBlur3x3<true>(src0, src1, src2, col, col, col + step);
 
-                BlurColNose<step>(src2 + 0, buffer.src2 + 0);
-                for (size_t col = A; col < bodySize; col += A)
-                    BlurColBody<step>(src2 + col, buffer.src2 + col);
-                BlurColTail<step>(src2 + size - A, buffer.src2 + size - A);
+                    const size_t end = size - step;
+                    size_t col = step;
+                    for (; col + A2 <= end; col += A2)
+                    {
+                        svst1_u8(all, dst + col, GaussianBlur3x3(src0 + col, src1 + col, src2 + col, step, all));
+                        svst1_u8(all, dst + col + A, GaussianBlur3x3(src0 + col + A, src1 + col + A, src2 + col + A, step, all));
+                    }
+                    for (; col < end; col += A)
+                    {
+                        svbool_t mask = svwhilelt_b8(col, end);
+                        svst1_u8(mask, dst + col, GaussianBlur3x3(src0 + col, src1 + col, src2 + col, step, mask));
+                    }
 
-                for (size_t col = 0; col < bodySize; col += A)
-                    BlurRow(buffer, col, dst);
-                BlurRow(buffer, size - A, dst);
-
-                Swap(buffer.src0, buffer.src2);
-                Swap(buffer.src0, buffer.src1);
+                    for (col = end; col < size; ++col)
+                        dst[col] = (uint8_t)Base::GaussianBlur3x3<true>(src0, src1, src2, col - step, col, col);
+                }
+                dst += dstStride;
             }
-        }
-
-        template <size_t step> void BlurRowSmall(const uint8_t* src, size_t width, uint16_t* dst)
-        {
-            size_t size = width * step;
-            if (width == 1)
-            {
-                for (size_t col = 0; col < size; ++col)
-                    dst[col] = uint16_t(src[col]) << 2;
-                return;
-            }
-            for (size_t col = 0; col < step; ++col)
-                dst[col] = uint16_t(src[col]) * 3 + src[col + step];
-            for (size_t col = step; col < size - step; ++col)
-                dst[col] = src[col - step] + (uint16_t(src[col]) << 1) + src[col + step];
-            for (size_t col = size - step; col < size; ++col)
-                dst[col] = src[col - step] + uint16_t(src[col]) * 3;
-        }
-
-        template <size_t step> void GaussianBlur3x3Small(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
-        {
-            size_t size = width * step;
-            Buffer buffer(size);
-
-            BlurRowSmall<step>(src, width, buffer.src0);
-            memcpy(buffer.src1, buffer.src0, sizeof(uint16_t) * size);
-
-            for (size_t row = 0; row < height; ++row, dst += dstStride)
-            {
-                const uint8_t* src2 = src + srcStride * (row + 1 < height ? row + 1 : height - 1);
-                BlurRowSmall<step>(src2, width, buffer.src2);
-                for (size_t col = 0; col < size; ++col)
-                    dst[col] = uint8_t((buffer.src0[col] + 2 * buffer.src1[col] + buffer.src2[col] + 8) >> 4);
-                Swap(buffer.src0, buffer.src2);
-                Swap(buffer.src0, buffer.src1);
-            }
-        }
-
-        template <size_t step> void GaussianBlur3x3Auto(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
-        {
-            if (step * (width - 1) >= svcntb())
-                GaussianBlur3x3<step>(src, srcStride, width, height, dst, dstStride);
-            else
-                GaussianBlur3x3Small<step>(src, srcStride, width, height, dst, dstStride);
         }
 
         void GaussianBlur3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height,
@@ -212,10 +124,10 @@ namespace Simd
 
             switch (channelCount)
             {
-            case 1: GaussianBlur3x3Auto<1>(src, srcStride, width, height, dst, dstStride); break;
-            case 2: GaussianBlur3x3Auto<2>(src, srcStride, width, height, dst, dstStride); break;
-            case 3: GaussianBlur3x3Auto<3>(src, srcStride, width, height, dst, dstStride); break;
-            case 4: GaussianBlur3x3Auto<4>(src, srcStride, width, height, dst, dstStride); break;
+            case 1: GaussianBlur3x3<1>(src, srcStride, width, height, dst, dstStride); break;
+            case 2: GaussianBlur3x3<2>(src, srcStride, width, height, dst, dstStride); break;
+            case 3: GaussianBlur3x3<3>(src, srcStride, width, height, dst, dstStride); break;
+            case 4: GaussianBlur3x3<4>(src, srcStride, width, height, dst, dstStride); break;
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the ARM SVE/SVE2 implementation of `SimdGaussianBlur3x3` in `SimdSve2GaussianBlur3x3.cpp` and records the change in release 7.2.165.

The previous SVE2 path used a NEON-style separable nose/body/tail buffer and fell back to scalar code when `step * (width - 1)` was smaller than one SVE vector. The new kernel:

- Computes the 3x3 binomial filter directly, without a 16-bit row buffer
- Unrolls the body by two vectors and uses predicated tails (`svwhilelt_b8`)
- Packs 16-bit sums with `svqxtnb` / `svuzp1`
- Handles first/last channel edges with the shared `Base::GaussianBlur3x3` formula
- Avoids macros

`Test::GaussianBlur3x3AutoTest` remains the correctness check.

## Test plan

- Native CMake Release build and `./Test "-r=.." -fi=GaussianBlur3x3 -tt=1 -ts=1` (Base vs SSE41/AVX2/AVX512)
- Cross-compiled the SVE2 translation unit with `aarch64-linux-gnu-g++ -march=armv9-a+sve+sve2`
- QEMU user-mode compare of SVE2 vs Base: 480 sizes (widths 1–640, heights 1/2/3/5/16, channels 1–4) at 128-bit, 256-bit, and 512-bit SVE vector lengths — all passed

[Native GaussianBlur3x3 test](https://cursor.com/agents/bc-f33a3c81-db8d-493d-968c-56ef488ee782/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnative_gaussian_blur3x3_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f33a3c81-db8d-493d-968c-56ef488ee782?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f33a3c81-db8d-493d-968c-56ef488ee782&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

