### PR TITLE
Improve SVE2 optimizations of SimdMeanFilter3x3

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -82,6 +82,7 @@
  <li>SVE2 optimizations of function Gemm32fNN.</li>
  <li>SVE2 optimizations of function Gemm32fNT.</li>
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
+ <li>SVE2 optimizations of function MeanFilter3x3.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2MeanFilter3x3.cpp
+++ b/src/Simd/SimdSve2MeanFilter3x3.cpp
@@ -35,83 +35,223 @@ namespace Simd
 
         SIMD_INLINE svuint16_t DivideBy9(const svuint16_t& value)
         {
-            const svbool_t mask = svptrue_b32();
-            svuint16_t value5 = svadd_n_u16_x(svptrue_b16(), value, 5);
-            svuint32_t lo = svlsr_n_u32_x(mask, svmul_n_u32_x(mask, svunpklo_u32(value5),
-                Base::DIVISION_BY_9_FACTOR), Base::DIVISION_BY_9_SHIFT);
-            svuint32_t hi = svlsr_n_u32_x(mask, svmul_n_u32_x(mask, svunpkhi_u32(value5),
-                Base::DIVISION_BY_9_FACTOR), Base::DIVISION_BY_9_SHIFT);
-            return svuzp1_u16(svreinterpret_u16_u32(lo), svreinterpret_u16_u32(hi));
+            const svbool_t mask = svptrue_b16();
+            return svmulh_u16_x(mask, svadd_n_u16_x(mask, value, 5), svdup_n_u16(uint16_t(Base::DIVISION_BY_9_FACTOR)));
         }
 
-        SIMD_INLINE svuint16_t RowSumLo(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
+        SIMD_INLINE svuint16_t SumEven(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            return svadd_u16_x(mask, svadd_u16_x(mask, svunpklo_u16(left), svunpklo_u16(center)), svunpklo_u16(right));
+            return svadd_u16_x(mask, svaddlb_u16(left, right), svmovlb_u16(center));
         }
 
-        SIMD_INLINE svuint16_t RowSumHi(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
+        SIMD_INLINE svuint16_t SumOdd(const svuint8_t& left, const svuint8_t& center, const svuint8_t& right)
         {
             const svbool_t mask = svptrue_b16();
-            return svadd_u16_x(mask, svadd_u16_x(mask, svunpkhi_u16(left), svunpkhi_u16(center)), svunpkhi_u16(right));
+            return svadd_u16_x(mask, svaddlt_u16(left, right), svmovlt_u16(center));
         }
 
-        SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
+        SIMD_INLINE svuint16_t Sum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c)
         {
-            return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
+            const svbool_t mask = svptrue_b16();
+            return svadd_u16_x(mask, svadd_u16_x(mask, a, b), c);
         }
 
-        SIMD_INLINE void MeanFilter3x3(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
-            size_t step, uint8_t* dst, const svbool_t& mask8)
+        SIMD_INLINE svuint8_t PackEvenOdd(const svuint16_t& even, const svuint16_t& odd)
         {
-            const svbool_t mask16 = svptrue_b16();
-            svuint8_t left0 = svld1_u8(mask8, src0 - step);
-            svuint8_t center0 = svld1_u8(mask8, src0);
-            svuint8_t right0 = svld1_u8(mask8, src0 + step);
-            svuint8_t left1 = svld1_u8(mask8, src1 - step);
-            svuint8_t center1 = svld1_u8(mask8, src1);
-            svuint8_t right1 = svld1_u8(mask8, src1 + step);
-            svuint8_t left2 = svld1_u8(mask8, src2 - step);
-            svuint8_t center2 = svld1_u8(mask8, src2);
-            svuint8_t right2 = svld1_u8(mask8, src2 + step);
-            svuint16_t lo = svadd_u16_x(mask16, svadd_u16_x(mask16, RowSumLo(left0, center0, right0),
-                RowSumLo(left1, center1, right1)), RowSumLo(left2, center2, right2));
-            svuint16_t hi = svadd_u16_x(mask16, svadd_u16_x(mask16, RowSumHi(left0, center0, right0),
-                RowSumHi(left1, center1, right1)), RowSumHi(left2, center2, right2));
-            svst1_u8(mask8, dst, PackU16ToU8(DivideBy9(lo), DivideBy9(hi)));
+            return svqxtnt_u16(svqxtnb_u16(even), odd);
+        }
+
+        SIMD_INLINE svuint8_t Vert3(svuint16x2_t a, svuint16x2_t b, svuint16x2_t c)
+        {
+            return PackEvenOdd(
+                DivideBy9(Sum16(svget2(a, 0), svget2(b, 0), svget2(c, 0))),
+                DivideBy9(Sum16(svget2(a, 1), svget2(b, 1), svget2(c, 1))));
+        }
+
+        template <size_t step> SIMD_INLINE svuint16x2_t Horiz(const uint8_t* src, const svbool_t& mask)
+        {
+            svuint8_t left = svld1_u8(mask, src - step);
+            svuint8_t center = svld1_u8(mask, src);
+            svuint8_t right = svld1_u8(mask, src + step);
+            return svcreate2_u16(SumEven(left, center, right), SumOdd(left, center, right));
+        }
+
+        template <size_t step> SIMD_INLINE void Mean1(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            uint8_t* dst, const svbool_t& mask)
+        {
+            svst1_u8(mask, dst, Vert3(Horiz<step>(src0, mask), Horiz<step>(src1, mask), Horiz<step>(src2, mask)));
+        }
+
+        template <size_t step> SIMD_INLINE void Mean2(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3,
+            uint8_t* dst0, uint8_t* dst1, const svbool_t& mask)
+        {
+            svuint16x2_t h0 = Horiz<step>(src0, mask);
+            svuint16x2_t h1 = Horiz<step>(src1, mask);
+            svuint16x2_t h2 = Horiz<step>(src2, mask);
+            svuint16x2_t h3 = Horiz<step>(src3, mask);
+            svst1_u8(mask, dst0, Vert3(h0, h1, h2));
+            svst1_u8(mask, dst1, Vert3(h1, h2, h3));
+        }
+
+        template <size_t step> SIMD_INLINE void Mean4(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            const uint8_t* src3, const uint8_t* src4, const uint8_t* src5,
+            uint8_t* dst0, uint8_t* dst1, uint8_t* dst2, uint8_t* dst3, const svbool_t& mask)
+        {
+            svuint16x2_t h0 = Horiz<step>(src0, mask);
+            svuint16x2_t h1 = Horiz<step>(src1, mask);
+            svuint16x2_t h2 = Horiz<step>(src2, mask);
+            svuint16x2_t h3 = Horiz<step>(src3, mask);
+            svuint16x2_t h4 = Horiz<step>(src4, mask);
+            svuint16x2_t h5 = Horiz<step>(src5, mask);
+            svst1_u8(mask, dst0, Vert3(h0, h1, h2));
+            svst1_u8(mask, dst1, Vert3(h1, h2, h3));
+            svst1_u8(mask, dst2, Vert3(h2, h3, h4));
+            svst1_u8(mask, dst3, Vert3(h3, h4, h5));
+        }
+
+        SIMD_INLINE void Edge(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            uint8_t* dst, size_t x0, size_t x1, size_t x2)
+        {
+            dst[x1] = DivideBy9(src0[x0] + src0[x1] + src0[x2] +
+                src1[x0] + src1[x1] + src1[x2] +
+                src2[x0] + src2[x1] + src2[x2]);
+        }
+
+        template <size_t step> void MeanBody(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            uint8_t* dst, size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = step;
+            for (; col + A2 <= end; col += A2)
+            {
+                Mean1<step>(src0 + col, src1 + col, src2 + col, dst + col, all);
+                Mean1<step>(src0 + col + A, src1 + col + A, src2 + col + A, dst + col + A, all);
+            }
+            for (; col < end; col += A)
+                Mean1<step>(src0 + col, src1 + col, src2 + col, dst + col, svwhilelt_b8(col, end));
+        }
+
+        template <size_t step> void MeanBody2(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3,
+            uint8_t* dst0, uint8_t* dst1, size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = step;
+            for (; col + A2 <= end; col += A2)
+            {
+                Mean2<step>(src0 + col, src1 + col, src2 + col, src3 + col, dst0 + col, dst1 + col, all);
+                Mean2<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, dst0 + col + A, dst1 + col + A, all);
+            }
+            for (; col < end; col += A)
+                Mean2<step>(src0 + col, src1 + col, src2 + col, src3 + col, dst0 + col, dst1 + col, svwhilelt_b8(col, end));
+        }
+
+        template <size_t step> void MeanBody4(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            const uint8_t* src3, const uint8_t* src4, const uint8_t* src5,
+            uint8_t* dst0, uint8_t* dst1, uint8_t* dst2, uint8_t* dst3,
+            size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = step;
+            for (; col + A2 <= end; col += A2)
+            {
+                Mean4<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, all);
+                Mean4<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, src4 + col + A, src5 + col + A,
+                    dst0 + col + A, dst1 + col + A, dst2 + col + A, dst3 + col + A, all);
+            }
+            for (; col < end; col += A)
+                Mean4<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, svwhilelt_b8(col, end));
         }
 
         template <size_t step> void MeanFilter3x3(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
         {
-            size_t size = width * step;
-            for (size_t row = 0; row < height; ++row)
+            const size_t size = width * step;
+            const size_t A = svcntb();
+            const size_t A2 = A * 2;
+            const svbool_t all = svptrue_b8();
+
+            if (width == 1)
+            {
+                for (size_t row = 0; row < height; ++row)
+                {
+                    const uint8_t* src1 = src + srcStride * row;
+                    const uint8_t* src0 = row ? src1 - srcStride : src1;
+                    const uint8_t* src2 = row + 1 < height ? src1 + srcStride : src1;
+                    for (size_t col = 0; col < step; ++col)
+                        dst[col] = DivideBy9((src0[col] + src1[col] + src2[col]) * 3);
+                    dst += dstStride;
+                }
+                return;
+            }
+
+            const size_t end = size - step;
+            size_t row = 0;
+            for (; row + 4 <= height; row += 4)
             {
                 const uint8_t* src1 = src + srcStride * row;
                 const uint8_t* src0 = row ? src1 - srcStride : src1;
-                const uint8_t* src2 = row + 1 < height ? src1 + srcStride : src1;
-                if (width == 1)
-                {
-                    for (size_t col = 0; col < step; ++col)
-                        dst[col] = DivideBy9((src0[col] + src1[col] + src2[col]) * 3);
-                }
-                else
-                {
-                    for (size_t col = 0; col < step; ++col)
-                        dst[col] = DivideBy9(src0[col] + src0[col] + src0[col + step] +
-                            src1[col] + src1[col] + src1[col + step] +
-                            src2[col] + src2[col] + src2[col + step]);
+                const uint8_t* src2 = src1 + srcStride;
+                const uint8_t* src3 = src2 + srcStride;
+                const uint8_t* src4 = src3 + srcStride;
+                const uint8_t* src5 = row + 4 < height ? src4 + srcStride : src4;
+                uint8_t* dst0 = dst + dstStride * row;
+                uint8_t* dst1 = dst0 + dstStride;
+                uint8_t* dst2 = dst1 + dstStride;
+                uint8_t* dst3 = dst2 + dstStride;
 
-                    const size_t end = size - step, A = svcntb();
-                    size_t col = step;
-                    for (; col < end; col += A)
-                        MeanFilter3x3(src0 + col, src1 + col, src2 + col, step, dst + col, svwhilelt_b8(col, end));
-
-                    for (col = end; col < size; ++col)
-                        dst[col] = DivideBy9(src0[col - step] + src0[col] + src0[col] +
-                            src1[col - step] + src1[col] + src1[col] +
-                            src2[col - step] + src2[col] + src2[col]);
+                for (size_t x = 0; x < step; ++x)
+                {
+                    Edge(src0, src1, src2, dst0, x, x, x + step);
+                    Edge(src1, src2, src3, dst1, x, x, x + step);
+                    Edge(src2, src3, src4, dst2, x, x, x + step);
+                    Edge(src3, src4, src5, dst3, x, x, x + step);
                 }
-                dst += dstStride;
+                MeanBody4<step>(src0, src1, src2, src3, src4, src5, dst0, dst1, dst2, dst3, end, A, A2, all);
+                for (size_t x = end; x < size; ++x)
+                {
+                    Edge(src0, src1, src2, dst0, x - step, x, x);
+                    Edge(src1, src2, src3, dst1, x - step, x, x);
+                    Edge(src2, src3, src4, dst2, x - step, x, x);
+                    Edge(src3, src4, src5, dst3, x - step, x, x);
+                }
+            }
+
+            if (row + 2 <= height)
+            {
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = src1 + srcStride;
+                const uint8_t* src3 = row + 2 < height ? src2 + srcStride : src2;
+                uint8_t* dst0 = dst + dstStride * row;
+                uint8_t* dst1 = dst0 + dstStride;
+
+                for (size_t x = 0; x < step; ++x)
+                {
+                    Edge(src0, src1, src2, dst0, x, x, x + step);
+                    Edge(src1, src2, src3, dst1, x, x, x + step);
+                }
+                MeanBody2<step>(src0, src1, src2, src3, dst0, dst1, end, A, A2, all);
+                for (size_t x = end; x < size; ++x)
+                {
+                    Edge(src0, src1, src2, dst0, x - step, x, x);
+                    Edge(src1, src2, src3, dst1, x - step, x, x);
+                }
+                row += 2;
+            }
+
+            if (row < height)
+            {
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = src1;
+                uint8_t* dst0 = dst + dstStride * row;
+
+                for (size_t x = 0; x < step; ++x)
+                    Edge(src0, src1, src2, dst0, x, x, x + step);
+                MeanBody<step>(src0, src1, src2, dst0, end, A, A2, all);
+                for (size_t x = end; x < size; ++x)
+                    Edge(src0, src1, src2, dst0, x - step, x, x);
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves ARM SVE/SVE2 optimizations of `SimdMeanFilter3x3` in `SimdSve2MeanFilter3x3.cpp`. The previous SVE2 path reloaded a 3x3 neighborhood for every destination row, unpacked to 32-bit for divide-by-9, and used predicated `svwhilelt` on every vector. That was slower than the NEON implementation.

The rewrite follows the same approach as the recent `GaussianBlur3x3` SVE2 work:

- Separable widening kernel with SVE2 `svaddlb`/`svaddlt` even/odd horizontal sums
- `svmulh` for the existing `((sum + 5) * DIVISION_BY_9_FACTOR) >> 16` divide-by-9
- `svqxtnb`/`svqxtnt` even/odd packing (no interleave/deinterleave loads)
- Process 4 destination rows (then 2) so each horizontal sum is reused
- Full-predicate main loop with 2-vector unroll; predicated tail only
- No new macros

Also updates the release 7.2.165 notes in `docs/2026.html`.

## Test plan

This VM is x86_64, so SVE2 was validated by cross-compiling with `aarch64-linux-gnu-g++ -march=armv9-a+sve2` and running under QEMU.

- Cross-compile `SimdSve2MeanFilter3x3.cpp` with the library SVE2 flags
- QEMU: `Sve2::MeanFilter3x3` vs `Base::MeanFilter3x3` for 23296 size/channel/padding cases at SVE VL 16, 32, and 64 bytes — all passed
- QEMU: AutoTest sizes `128x96` and `137x87` (W+O / H-O) for 1–4 channels — all passed
- QEMU: large images including `640x480` for 1–4 channels — all passed
- Native x86 `cmake` build and `./Test "-r=.." -fi=MeanFilter3x3` (Base vs SSE41/AVX2/AVX512) — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a130651-4152-49fe-92a2-e163305a1049?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a130651-4152-49fe-92a2-e163305a1049&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

