### PR TITLE
Improve SVE2 optimizations of SimdMinFilterSquare5x5

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,6 +84,7 @@
  <li>SVE2 optimizations of function GaussianBlur3x3.</li>
  <li>SVE2 optimizations of function MeanFilter3x3.</li>
  <li>SVE2 optimizations of function MaxFilterSquare5x5.</li>
+ <li>SVE2 optimizations of function MinFilterSquare5x5.</li>
  <li>SVE2 optimizations of function MidpointFilterSquare5x5.</li>
 </ul>
 <h5>Renaming</h5>

--- a/src/Simd/SimdSve2MinFilter.cpp
+++ b/src/Simd/SimdSve2MinFilter.cpp
@@ -180,102 +180,260 @@ namespace Simd
             return num >= threshold ? min : a[12];
         }
 
-        SIMD_INLINE void UpdateMin(const svuint8_t& value, svuint8_t& min, const svbool_t& mask)
+        SIMD_INLINE const uint8_t* SrcRow(const uint8_t* src, size_t srcStride, size_t height, int row)
         {
-            min = svmin_u8_x(mask, min, value);
+            if (row < 0)
+                row = 0;
+            else if (row >= (int)height)
+                row = (int)height - 1;
+            return src + srcStride * row;
         }
 
-        SIMD_INLINE void UpdateCount(const svuint8_t& value, const svuint8_t& min, svuint8_t& count, const svuint8_t& one, const svuint8_t& zero, const svbool_t& mask)
+        SIMD_INLINE void Edge25(const uint8_t* y0, const uint8_t* y1, const uint8_t* y2, const uint8_t* y3, const uint8_t* y4,
+            uint8_t* dst, size_t x0, size_t x1, size_t x2, size_t x3, size_t x4, int threshold)
         {
-            count = svadd_u8_x(mask, count, svsel_u8(svcmpeq_u8(mask, min, value), one, zero));
+            const uint8_t* y[5] = { y0, y1, y2, y3, y4 };
+            size_t x[5] = { x0, x1, x2, x3, x4 };
+            dst[x2] = Min25(y, x, threshold);
         }
 
-        template <size_t step> SIMD_INLINE svuint8_t Min25(const uint8_t* y[5], size_t offset, int threshold, const svbool_t& mask)
+        template <size_t step> SIMD_INLINE void Edges(const uint8_t* y0, const uint8_t* y1, const uint8_t* y2,
+            const uint8_t* y3, const uint8_t* y4, uint8_t* dst, size_t size, size_t end, int threshold)
         {
-            svuint8_t a00 = svld1_u8(mask, y[0] + offset - 2 * step);
-            svuint8_t a01 = svld1_u8(mask, y[0] + offset - step);
-            svuint8_t a02 = svld1_u8(mask, y[0] + offset);
-            svuint8_t a03 = svld1_u8(mask, y[0] + offset + step);
-            svuint8_t a04 = svld1_u8(mask, y[0] + offset + 2 * step);
-            svuint8_t a10 = svld1_u8(mask, y[1] + offset - 2 * step);
-            svuint8_t a11 = svld1_u8(mask, y[1] + offset - step);
-            svuint8_t a12 = svld1_u8(mask, y[1] + offset);
-            svuint8_t a13 = svld1_u8(mask, y[1] + offset + step);
-            svuint8_t a14 = svld1_u8(mask, y[1] + offset + 2 * step);
-            svuint8_t a20 = svld1_u8(mask, y[2] + offset - 2 * step);
-            svuint8_t a21 = svld1_u8(mask, y[2] + offset - step);
-            svuint8_t a22 = svld1_u8(mask, y[2] + offset);
-            svuint8_t a23 = svld1_u8(mask, y[2] + offset + step);
-            svuint8_t a24 = svld1_u8(mask, y[2] + offset + 2 * step);
-            svuint8_t a30 = svld1_u8(mask, y[3] + offset - 2 * step);
-            svuint8_t a31 = svld1_u8(mask, y[3] + offset - step);
-            svuint8_t a32 = svld1_u8(mask, y[3] + offset);
-            svuint8_t a33 = svld1_u8(mask, y[3] + offset + step);
-            svuint8_t a34 = svld1_u8(mask, y[3] + offset + 2 * step);
-            svuint8_t a40 = svld1_u8(mask, y[4] + offset - 2 * step);
-            svuint8_t a41 = svld1_u8(mask, y[4] + offset - step);
-            svuint8_t a42 = svld1_u8(mask, y[4] + offset);
-            svuint8_t a43 = svld1_u8(mask, y[4] + offset + step);
-            svuint8_t a44 = svld1_u8(mask, y[4] + offset + 2 * step);
-            svuint8_t min = a00;
-            UpdateMin(a01, min, mask);
-            UpdateMin(a02, min, mask);
-            UpdateMin(a03, min, mask);
-            UpdateMin(a04, min, mask);
-            UpdateMin(a10, min, mask);
-            UpdateMin(a11, min, mask);
-            UpdateMin(a12, min, mask);
-            UpdateMin(a13, min, mask);
-            UpdateMin(a14, min, mask);
-            UpdateMin(a20, min, mask);
-            UpdateMin(a21, min, mask);
-            UpdateMin(a22, min, mask);
-            UpdateMin(a23, min, mask);
-            UpdateMin(a24, min, mask);
-            UpdateMin(a30, min, mask);
-            UpdateMin(a31, min, mask);
-            UpdateMin(a32, min, mask);
-            UpdateMin(a33, min, mask);
-            UpdateMin(a34, min, mask);
-            UpdateMin(a40, min, mask);
-            UpdateMin(a41, min, mask);
-            UpdateMin(a42, min, mask);
-            UpdateMin(a43, min, mask);
-            UpdateMin(a44, min, mask);
+            for (size_t col = 0; col < 2 * step; ++col)
+            {
+                size_t x0 = col < step ? col : col - step;
+                Edge25(y0, y1, y2, y3, y4, dst, x0, x0, col, col + step, col + 2 * step, threshold);
+            }
+            for (size_t col = end; col < size; ++col)
+            {
+                size_t x3 = col + step < size ? col + step : col;
+                size_t x4 = col + 2 * step < size ? col + 2 * step : x3;
+                Edge25(y0, y1, y2, y3, y4, dst, col - 2 * step, col - step, col, x3, x4, threshold);
+            }
+        }
 
-            if (1 >= threshold)
-                return min;
+        template <size_t step> SIMD_INLINE void Load5(const uint8_t* src, const svbool_t& mask,
+            svuint8_t& a0, svuint8_t& a1, svuint8_t& a2, svuint8_t& a3, svuint8_t& a4)
+        {
+            a0 = svld1_u8(mask, src - 2 * step);
+            a1 = svld1_u8(mask, src - step);
+            a2 = svld1_u8(mask, src);
+            a3 = svld1_u8(mask, src + step);
+            a4 = svld1_u8(mask, src + 2 * step);
+        }
 
+        SIMD_INLINE svuint8_t Min5(const svuint8_t& a0, const svuint8_t& a1, const svuint8_t& a2,
+            const svuint8_t& a3, const svuint8_t& a4, const svbool_t& mask)
+        {
+            return svmin_u8_x(mask, svmin_u8_x(mask, a0, a1), svmin_u8_x(mask, svmin_u8_x(mask, a2, a3), a4));
+        }
+
+        template <size_t step> SIMD_INLINE svuint8_t HorizMin(const uint8_t* src, const svbool_t& mask)
+        {
+            svuint8_t a0, a1, a2, a3, a4;
+            Load5<step>(src, mask, a0, a1, a2, a3, a4);
+            return Min5(a0, a1, a2, a3, a4, mask);
+        }
+
+        SIMD_INLINE void AddEq(svuint8_t& count, const svuint8_t& value, const svuint8_t& min, const svuint8_t& one, const svbool_t& mask)
+        {
+            count = svadd_u8_m(svcmpeq_u8(mask, min, value), count, one);
+        }
+
+        SIMD_INLINE void AddEq5(svuint8_t& count, const svuint8_t& a0, const svuint8_t& a1, const svuint8_t& a2,
+            const svuint8_t& a3, const svuint8_t& a4, const svuint8_t& min, const svuint8_t& one, const svbool_t& mask)
+        {
+            AddEq(count, a0, min, one, mask);
+            AddEq(count, a1, min, one, mask);
+            AddEq(count, a2, min, one, mask);
+            AddEq(count, a3, min, one, mask);
+            AddEq(count, a4, min, one, mask);
+        }
+
+        template <size_t step> SIMD_INLINE void Min1(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            const uint8_t* src3, const uint8_t* src4, uint8_t* dst, const svbool_t& mask)
+        {
+            svst1_u8(mask, dst, Min5(HorizMin<step>(src0, mask), HorizMin<step>(src1, mask), HorizMin<step>(src2, mask),
+                HorizMin<step>(src3, mask), HorizMin<step>(src4, mask), mask));
+        }
+
+        template <size_t step> SIMD_INLINE void Min2(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3, const uint8_t* src4, const uint8_t* src5,
+            uint8_t* dst0, uint8_t* dst1, const svbool_t& mask)
+        {
+            svuint8_t h0 = HorizMin<step>(src0, mask);
+            svuint8_t h1 = HorizMin<step>(src1, mask);
+            svuint8_t h2 = HorizMin<step>(src2, mask);
+            svuint8_t h3 = HorizMin<step>(src3, mask);
+            svuint8_t h4 = HorizMin<step>(src4, mask);
+            svuint8_t h5 = HorizMin<step>(src5, mask);
+            svst1_u8(mask, dst0, Min5(h0, h1, h2, h3, h4, mask));
+            svst1_u8(mask, dst1, Min5(h1, h2, h3, h4, h5, mask));
+        }
+
+        template <size_t step> SIMD_INLINE void Min4(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3,
+            const uint8_t* src4, const uint8_t* src5, const uint8_t* src6, const uint8_t* src7,
+            uint8_t* dst0, uint8_t* dst1, uint8_t* dst2, uint8_t* dst3, const svbool_t& mask)
+        {
+            svuint8_t h0 = HorizMin<step>(src0, mask);
+            svuint8_t h1 = HorizMin<step>(src1, mask);
+            svuint8_t h2 = HorizMin<step>(src2, mask);
+            svuint8_t h3 = HorizMin<step>(src3, mask);
+            svuint8_t h4 = HorizMin<step>(src4, mask);
+            svuint8_t h5 = HorizMin<step>(src5, mask);
+            svuint8_t h6 = HorizMin<step>(src6, mask);
+            svuint8_t h7 = HorizMin<step>(src7, mask);
+            svst1_u8(mask, dst0, Min5(h0, h1, h2, h3, h4, mask));
+            svst1_u8(mask, dst1, Min5(h1, h2, h3, h4, h5, mask));
+            svst1_u8(mask, dst2, Min5(h2, h3, h4, h5, h6, mask));
+            svst1_u8(mask, dst3, Min5(h3, h4, h5, h6, h7, mask));
+        }
+
+        template <size_t step> SIMD_INLINE void MinThresh1(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            const uint8_t* src3, const uint8_t* src4, uint8_t* dst, int threshold, const svbool_t& mask)
+        {
+            svuint8_t a00, a01, a02, a03, a04;
+            svuint8_t a10, a11, a12, a13, a14;
+            svuint8_t a20, a21, a22, a23, a24;
+            svuint8_t a30, a31, a32, a33, a34;
+            svuint8_t a40, a41, a42, a43, a44;
+            Load5<step>(src0, mask, a00, a01, a02, a03, a04);
+            Load5<step>(src1, mask, a10, a11, a12, a13, a14);
+            Load5<step>(src2, mask, a20, a21, a22, a23, a24);
+            Load5<step>(src3, mask, a30, a31, a32, a33, a34);
+            Load5<step>(src4, mask, a40, a41, a42, a43, a44);
+            svuint8_t min = Min5(
+                Min5(a00, a01, a02, a03, a04, mask),
+                Min5(a10, a11, a12, a13, a14, mask),
+                Min5(a20, a21, a22, a23, a24, mask),
+                Min5(a30, a31, a32, a33, a34, mask),
+                Min5(a40, a41, a42, a43, a44, mask), mask);
             svuint8_t count = svdup_n_u8(0);
             const svuint8_t one = svdup_n_u8(1);
-            const svuint8_t zero = svdup_n_u8(0);
-            UpdateCount(a00, min, count, one, zero, mask);
-            UpdateCount(a01, min, count, one, zero, mask);
-            UpdateCount(a02, min, count, one, zero, mask);
-            UpdateCount(a03, min, count, one, zero, mask);
-            UpdateCount(a04, min, count, one, zero, mask);
-            UpdateCount(a10, min, count, one, zero, mask);
-            UpdateCount(a11, min, count, one, zero, mask);
-            UpdateCount(a12, min, count, one, zero, mask);
-            UpdateCount(a13, min, count, one, zero, mask);
-            UpdateCount(a14, min, count, one, zero, mask);
-            UpdateCount(a20, min, count, one, zero, mask);
-            UpdateCount(a21, min, count, one, zero, mask);
-            UpdateCount(a22, min, count, one, zero, mask);
-            UpdateCount(a23, min, count, one, zero, mask);
-            UpdateCount(a24, min, count, one, zero, mask);
-            UpdateCount(a30, min, count, one, zero, mask);
-            UpdateCount(a31, min, count, one, zero, mask);
-            UpdateCount(a32, min, count, one, zero, mask);
-            UpdateCount(a33, min, count, one, zero, mask);
-            UpdateCount(a34, min, count, one, zero, mask);
-            UpdateCount(a40, min, count, one, zero, mask);
-            UpdateCount(a41, min, count, one, zero, mask);
-            UpdateCount(a42, min, count, one, zero, mask);
-            UpdateCount(a43, min, count, one, zero, mask);
-            UpdateCount(a44, min, count, one, zero, mask);
+            AddEq5(count, a00, a01, a02, a03, a04, min, one, mask);
+            AddEq5(count, a10, a11, a12, a13, a14, min, one, mask);
+            AddEq5(count, a20, a21, a22, a23, a24, min, one, mask);
+            AddEq5(count, a30, a31, a32, a33, a34, min, one, mask);
+            AddEq5(count, a40, a41, a42, a43, a44, min, one, mask);
+            svst1_u8(mask, dst, svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), min, a22));
+        }
 
-            return svsel_u8(svcmpge_n_u8(mask, count, (uint8_t)threshold), min, a22);
+        template <size_t step> SIMD_INLINE void MinThresh2(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3, const uint8_t* src4, const uint8_t* src5,
+            uint8_t* dst0, uint8_t* dst1, int threshold, const svbool_t& mask)
+        {
+            svuint8_t a00, a01, a02, a03, a04;
+            svuint8_t a10, a11, a12, a13, a14;
+            svuint8_t a20, a21, a22, a23, a24;
+            svuint8_t a30, a31, a32, a33, a34;
+            svuint8_t a40, a41, a42, a43, a44;
+            svuint8_t a50, a51, a52, a53, a54;
+            Load5<step>(src0, mask, a00, a01, a02, a03, a04);
+            Load5<step>(src1, mask, a10, a11, a12, a13, a14);
+            Load5<step>(src2, mask, a20, a21, a22, a23, a24);
+            Load5<step>(src3, mask, a30, a31, a32, a33, a34);
+            Load5<step>(src4, mask, a40, a41, a42, a43, a44);
+            Load5<step>(src5, mask, a50, a51, a52, a53, a54);
+            svuint8_t h0 = Min5(a00, a01, a02, a03, a04, mask);
+            svuint8_t h1 = Min5(a10, a11, a12, a13, a14, mask);
+            svuint8_t h2 = Min5(a20, a21, a22, a23, a24, mask);
+            svuint8_t h3 = Min5(a30, a31, a32, a33, a34, mask);
+            svuint8_t h4 = Min5(a40, a41, a42, a43, a44, mask);
+            svuint8_t h5 = Min5(a50, a51, a52, a53, a54, mask);
+            svuint8_t min0 = Min5(h0, h1, h2, h3, h4, mask);
+            svuint8_t min1 = Min5(h1, h2, h3, h4, h5, mask);
+            svuint8_t count0 = svdup_n_u8(0);
+            svuint8_t count1 = svdup_n_u8(0);
+            const svuint8_t one = svdup_n_u8(1);
+            AddEq5(count0, a00, a01, a02, a03, a04, min0, one, mask);
+            AddEq5(count0, a10, a11, a12, a13, a14, min0, one, mask);
+            AddEq5(count1, a10, a11, a12, a13, a14, min1, one, mask);
+            AddEq5(count0, a20, a21, a22, a23, a24, min0, one, mask);
+            AddEq5(count1, a20, a21, a22, a23, a24, min1, one, mask);
+            AddEq5(count0, a30, a31, a32, a33, a34, min0, one, mask);
+            AddEq5(count1, a30, a31, a32, a33, a34, min1, one, mask);
+            AddEq5(count0, a40, a41, a42, a43, a44, min0, one, mask);
+            AddEq5(count1, a40, a41, a42, a43, a44, min1, one, mask);
+            AddEq5(count1, a50, a51, a52, a53, a54, min1, one, mask);
+            svst1_u8(mask, dst0, svsel_u8(svcmpge_n_u8(mask, count0, (uint8_t)threshold), min0, a22));
+            svst1_u8(mask, dst1, svsel_u8(svcmpge_n_u8(mask, count1, (uint8_t)threshold), min1, a32));
+        }
+
+        template <size_t step> void MinBody1(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            const uint8_t* src3, const uint8_t* src4, uint8_t* dst, size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = 2 * step;
+            for (; col + A2 <= end; col += A2)
+            {
+                Min1<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, dst + col, all);
+                Min1<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, src4 + col + A, dst + col + A, all);
+            }
+            for (; col < end; col += A)
+                Min1<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, dst + col, svwhilelt_b8(col, end));
+        }
+
+        template <size_t step> void MinBody2(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3, const uint8_t* src4, const uint8_t* src5,
+            uint8_t* dst0, uint8_t* dst1, size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = 2 * step;
+            for (; col + A2 <= end; col += A2)
+            {
+                Min2<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col, dst0 + col, dst1 + col, all);
+                Min2<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, src4 + col + A, src5 + col + A, dst0 + col + A, dst1 + col + A, all);
+            }
+            for (; col < end; col += A)
+                Min2<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col, dst0 + col, dst1 + col, svwhilelt_b8(col, end));
+        }
+
+        template <size_t step> void MinBody4(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3,
+            const uint8_t* src4, const uint8_t* src5, const uint8_t* src6, const uint8_t* src7,
+            uint8_t* dst0, uint8_t* dst1, uint8_t* dst2, uint8_t* dst3,
+            size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = 2 * step;
+            for (; col + A2 <= end; col += A2)
+            {
+                Min4<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col, src6 + col, src7 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, all);
+                Min4<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, src4 + col + A, src5 + col + A, src6 + col + A, src7 + col + A,
+                    dst0 + col + A, dst1 + col + A, dst2 + col + A, dst3 + col + A, all);
+            }
+            for (; col < end; col += A)
+                Min4<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col, src6 + col, src7 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, svwhilelt_b8(col, end));
+        }
+
+        template <size_t step> void MinThreshBody1(const uint8_t* src0, const uint8_t* src1, const uint8_t* src2,
+            const uint8_t* src3, const uint8_t* src4, uint8_t* dst, int threshold, size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = 2 * step;
+            for (; col + A2 <= end; col += A2)
+            {
+                MinThresh1<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, dst + col, threshold, all);
+                MinThresh1<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, src4 + col + A, dst + col + A, threshold, all);
+            }
+            for (; col < end; col += A)
+                MinThresh1<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, dst + col, threshold, svwhilelt_b8(col, end));
+        }
+
+        template <size_t step> void MinThreshBody2(
+            const uint8_t* src0, const uint8_t* src1, const uint8_t* src2, const uint8_t* src3, const uint8_t* src4, const uint8_t* src5,
+            uint8_t* dst0, uint8_t* dst1, int threshold, size_t end, size_t A, size_t A2, const svbool_t& all)
+        {
+            size_t col = 2 * step;
+            for (; col + A2 <= end; col += A2)
+            {
+                MinThresh2<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col, dst0 + col, dst1 + col, threshold, all);
+                MinThresh2<step>(src0 + col + A, src1 + col + A, src2 + col + A, src3 + col + A, src4 + col + A, src5 + col + A,
+                    dst0 + col + A, dst1 + col + A, threshold, all);
+            }
+            for (; col < end; col += A)
+                MinThresh2<step>(src0 + col, src1 + col, src2 + col, src3 + col, src4 + col, src5 + col,
+                    dst0 + col, dst1 + col, threshold, svwhilelt_b8(col, end));
         }
 
         template <size_t step> void MinFilterSquare5x5(
@@ -284,46 +442,68 @@ namespace Simd
             assert(width > 4 && step * (width - 4) >= svcntb());
 
             const size_t A = svcntb();
+            const size_t A2 = A * 2;
             const size_t size = step * width;
-            const size_t body = 2 * step;
             const size_t end = size - 2 * step;
-            const uint8_t* y[5];
-            size_t x[5];
+            const svbool_t all = svptrue_b8();
+            const bool fast = threshold <= 1;
 
-            for (size_t row = 0; row < height; ++row, dst += dstStride)
+            size_t row = 0;
+            if (fast)
             {
-                y[2] = src + srcStride * row;
-                y[1] = row ? y[2] - srcStride : y[2];
-                y[0] = row > 1 ? y[2] - 2 * srcStride : y[1];
-                y[3] = row + 1 < height ? y[2] + srcStride : y[2];
-                y[4] = row + 2 < height ? y[2] + 2 * srcStride : y[3];
-
-                for (size_t col = 0; col < 2 * body; ++col)
+                for (; row + 4 <= height; row += 4)
                 {
-                    if (col < body)
-                    {
-                        x[0] = col < step ? col : col - step;
-                        x[1] = x[0];
-                        x[2] = col;
-                        x[3] = x[2] + step;
-                        x[4] = x[3] + step;
-                    }
-                    else
-                    {
-                        x[0] = size - 6 * step + col;
-                        x[1] = x[0] + step;
-                        x[2] = x[1] + step;
-                        x[3] = col < 3 * step ? x[2] + step : x[2];
-                        x[4] = x[3];
-                    }
-                    dst[x[2]] = Min25(y, x, threshold);
+                    const uint8_t* src0 = SrcRow(src, srcStride, height, (int)row - 2);
+                    const uint8_t* src1 = SrcRow(src, srcStride, height, (int)row - 1);
+                    const uint8_t* src2 = SrcRow(src, srcStride, height, (int)row);
+                    const uint8_t* src3 = SrcRow(src, srcStride, height, (int)row + 1);
+                    const uint8_t* src4 = SrcRow(src, srcStride, height, (int)row + 2);
+                    const uint8_t* src5 = SrcRow(src, srcStride, height, (int)row + 3);
+                    const uint8_t* src6 = SrcRow(src, srcStride, height, (int)row + 4);
+                    const uint8_t* src7 = SrcRow(src, srcStride, height, (int)row + 5);
+                    uint8_t* dst0 = dst + dstStride * row;
+                    uint8_t* dst1 = dst0 + dstStride;
+                    uint8_t* dst2 = dst1 + dstStride;
+                    uint8_t* dst3 = dst2 + dstStride;
+                    Edges<step>(src0, src1, src2, src3, src4, dst0, size, end, threshold);
+                    Edges<step>(src1, src2, src3, src4, src5, dst1, size, end, threshold);
+                    Edges<step>(src2, src3, src4, src5, src6, dst2, size, end, threshold);
+                    Edges<step>(src3, src4, src5, src6, src7, dst3, size, end, threshold);
+                    MinBody4<step>(src0, src1, src2, src3, src4, src5, src6, src7, dst0, dst1, dst2, dst3, end, A, A2, all);
                 }
+            }
 
-                for (size_t col = body; col < end; col += A)
-                {
-                    svbool_t mask = svwhilelt_b8(col, end);
-                    svst1_u8(mask, dst + col, Min25<step>(y, col, threshold, mask));
-                }
+            for (; row + 2 <= height; row += 2)
+            {
+                const uint8_t* src0 = SrcRow(src, srcStride, height, (int)row - 2);
+                const uint8_t* src1 = SrcRow(src, srcStride, height, (int)row - 1);
+                const uint8_t* src2 = SrcRow(src, srcStride, height, (int)row);
+                const uint8_t* src3 = SrcRow(src, srcStride, height, (int)row + 1);
+                const uint8_t* src4 = SrcRow(src, srcStride, height, (int)row + 2);
+                const uint8_t* src5 = SrcRow(src, srcStride, height, (int)row + 3);
+                uint8_t* dst0 = dst + dstStride * row;
+                uint8_t* dst1 = dst0 + dstStride;
+                Edges<step>(src0, src1, src2, src3, src4, dst0, size, end, threshold);
+                Edges<step>(src1, src2, src3, src4, src5, dst1, size, end, threshold);
+                if (fast)
+                    MinBody2<step>(src0, src1, src2, src3, src4, src5, dst0, dst1, end, A, A2, all);
+                else
+                    MinThreshBody2<step>(src0, src1, src2, src3, src4, src5, dst0, dst1, threshold, end, A, A2, all);
+            }
+
+            if (row < height)
+            {
+                const uint8_t* src0 = SrcRow(src, srcStride, height, (int)row - 2);
+                const uint8_t* src1 = SrcRow(src, srcStride, height, (int)row - 1);
+                const uint8_t* src2 = SrcRow(src, srcStride, height, (int)row);
+                const uint8_t* src3 = SrcRow(src, srcStride, height, (int)row + 1);
+                const uint8_t* src4 = SrcRow(src, srcStride, height, (int)row + 2);
+                uint8_t* dst0 = dst + dstStride * row;
+                Edges<step>(src0, src1, src2, src3, src4, dst0, size, end, threshold);
+                if (fast)
+                    MinBody1<step>(src0, src1, src2, src3, src4, dst0, end, A, A2, all);
+                else
+                    MinThreshBody1<step>(src0, src1, src2, src3, src4, dst0, threshold, end, A, A2, all);
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves ARM SVE/SVE2 optimizations of `SimdMinFilterSquare5x5` in `SimdSve2MinFilter.cpp`. The previous SVE2 path reloaded a 5x5 neighborhood (25 overlapping loads) for every destination row, kept 25 live SVE registers, and used predicated `svwhilelt` on every vector. That was slower than the NEON implementation, which already reuses two output rows.

The rewrite follows the same approach as the recent `MaxFilterSquare5x5` / `MidpointFilterSquare5x5` SVE2 work:

- Separable 5-tap min: horizontal min of 5 neighbors, then vertical min of 5 row results
- Process 4 destination rows (then 2) so each horizontal min is reused across neighboring outputs
- Full-predicate main loop with 2-vector unroll; predicated tail only
- Threshold path (`threshold > 1`) keeps the 5x5 neighborhood only when counting equal minima, and still processes two rows at a time
- No interleave/deinterleave loads; no new macros

Also updates the release 7.2.165 notes in `docs/2026.html`.

## Test plan

This VM is x86_64, so SVE2 was validated by cross-compiling with `aarch64-linux-gnu-g++ -march=armv9-a+sve2` and running under QEMU.

- Cross-compile `SimdSve2MinFilter.cpp` with the library SVE2 flags (`-march=armv9-a+sve+sve2+i8mm+bf16 -msve-vector-bits=scalable`)
- QEMU: `Sve2::MinFilterSquare5x5` vs `Base::MinFilterSquare5x5` for widths, heights 2–96, channels 1–4, pads 0/1/3/16, thresholds 1/2/3/5/9, plus AutoTest-like and 640×480 cases, at SVE VL 16, 32, and 64 bytes — all passed (57020 / 47140 / 34220 cases)
- Native x86 `cmake` build and `./Test "-r=.." -fi=MinFilterSquare5x5` (Base vs SSE41/AVX2/AVX512) — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dfd3b4f-ec61-4a8a-baa3-83b29f9328dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dfd3b4f-ec61-4a8a-baa3-83b29f9328dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

