### PR TITLE
Improve SVE2 optimizations of SimdReduceGray2x2

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -88,6 +88,7 @@
  <li>SVE2 optimizations of function MidpointFilterSquare5x5.</li>
  <li>SVE2 optimizations of function LaplaceAbsSum.</li>
  <li>SVE2 optimizations of function ReduceColor2x2.</li>
+ <li>SVE2 optimizations of function ReduceGray2x2.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2ReduceGray2x2.cpp
+++ b/src/Simd/SimdSve2ReduceGray2x2.cpp
@@ -29,37 +29,72 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint16_t Average16(const uint8_t* src0, const uint8_t* src1, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE svuint16_t Average16(const svuint8_t& s0, const svuint8_t& s1)
         {
-            svuint8_t s0 = svld1_u8(mask8, src0);
-            svuint8_t s1 = svld1_u8(mask8, src1);
-            svuint16_t sum0 = svaddlb_u16(s0, svext_u8(s0, s0, 1));
-            svuint16_t sum1 = svaddlb_u16(s1, svext_u8(s1, s1, 1));
-            return svlsr_n_u16_x(mask16, svadd_n_u16_x(mask16, svadd_u16_x(mask16, sum0, sum1), 2), 2);
+            const svbool_t mask = svptrue_b16();
+            return svlsr_n_u16_x(mask, svadalp_u16_x(mask, svadalp_u16_x(mask, svdup_n_u16(2), s0), s1), 2);
         }
 
-        SIMD_INLINE svuint8_t Average8(const uint8_t* src0, const uint8_t* src1, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE svuint8_t Average8(const svuint8_t& s00, const svuint8_t& s01, const svuint8_t& s10, const svuint8_t& s11)
         {
-            svuint8_t even = svqxtnb_u16(Average16(src0, src1, mask8, mask16));
-            return svuzp1_u8(even, even);
+            return svuzp1_u8(svreinterpret_u8_u16(Average16(s00, s10)), svreinterpret_u8_u16(Average16(s01, s11)));
+        }
+
+        SIMD_INLINE void ReduceGray2x2(const uint8_t* src0, const uint8_t* src1, uint8_t* dst, size_t A)
+        {
+            const svbool_t all = svptrue_b8();
+            svuint8_t s00 = svld1_u8(all, src0 + 0);
+            svuint8_t s01 = svld1_u8(all, src0 + A);
+            svuint8_t s10 = svld1_u8(all, src1 + 0);
+            svuint8_t s11 = svld1_u8(all, src1 + A);
+            svst1_u8(all, dst, Average8(s00, s01, s10, s11));
+        }
+
+        SIMD_INLINE void ReduceGray2x2(const uint8_t* src0, const uint8_t* src1, uint8_t* dst)
+        {
+            const svbool_t all = svptrue_b8();
+            svst1b_u16(svptrue_b16(), dst, Average16(svld1_u8(all, src0), svld1_u8(all, src1)));
         }
 
         void ReduceGray2x2(const uint8_t* src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t* dst, size_t dstWidth, size_t dstHeight, size_t dstStride)
         {
-            assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight);
+            assert((srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight && srcWidth >= svcntb());
 
-            const size_t A = svcntb(), HA = svcnth();
-            const size_t evenWidth = AlignLo(srcWidth, 2), dstEvenWidth = evenWidth / 2;
+            const size_t A = svcntb(), DA = A * 2, QA = A * 4;
+            const size_t evenWidth = AlignLo(srcWidth, 2);
+            const size_t alignedQa = AlignLo(evenWidth, QA);
+            const size_t alignedDa = AlignLo(evenWidth, DA);
             for (size_t srcRow = 0; srcRow < srcHeight; srcRow += 2)
             {
                 const uint8_t* src0 = src;
                 const uint8_t* src1 = (srcRow == srcHeight - 1 ? src : src + srcStride);
-                for (size_t dstCol = 0, srcCol = 0; dstCol < dstEvenWidth; dstCol += HA, srcCol += A)
+                size_t srcOffset = 0, dstOffset = 0;
+                for (; srcOffset < alignedQa; srcOffset += QA, dstOffset += DA)
                 {
-                    svbool_t mask16 = svwhilelt_b16(dstCol, dstEvenWidth);
-                    svst1_u8(svwhilelt_b8(dstCol, dstEvenWidth), dst + dstCol,
-                        Average8(src0 + srcCol, src1 + srcCol, svwhilelt_b8(srcCol, evenWidth), mask16));
+                    ReduceGray2x2(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A);
+                    ReduceGray2x2(src0 + srcOffset + DA, src1 + srcOffset + DA, dst + dstOffset + A, A);
+                }
+                for (; srcOffset < alignedDa; srcOffset += DA, dstOffset += A)
+                    ReduceGray2x2(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A);
+                if (alignedDa != evenWidth)
+                {
+                    if (evenWidth >= DA)
+                    {
+                        srcOffset = evenWidth - DA;
+                        dstOffset = srcOffset / 2;
+                        ReduceGray2x2(src0 + srcOffset, src1 + srcOffset, dst + dstOffset, A);
+                    }
+                    else
+                    {
+                        ReduceGray2x2(src0, src1, dst);
+                        if (evenWidth != A)
+                        {
+                            srcOffset = evenWidth - A;
+                            dstOffset = srcOffset / 2;
+                            ReduceGray2x2(src0 + srcOffset, src1 + srcOffset, dst + dstOffset);
+                        }
+                    }
                 }
                 if (evenWidth != srcWidth)
                     dst[dstWidth - 1] = Base::Average(src0[evenWidth], src1[evenWidth]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rework SVE2 `SimdReduceGray2x2` so the inner loop no longer uses predicated half-vector loads/stores (`svwhilelt` + `svext`/`svaddlb` + `svqxtnb`).
- Main path loads two source vectors per row, averages 2x2 blocks with SVE2 pairwise `ADALP`, packs with `svuzp1`, and stores a full destination vector. The body is unrolled by two destination vectors. Remainders overlap the last full vector; widths in `[svcntb(), 2*svcntb())` use a single-vector `svst1b` path.
- Record the change in `docs/2026.html` for release 7.2.165.

## Test plan
- Native Release `./Test "-r=.." -fi=ReduceGray2x2 -tt=1 -ts=1` — passed (x86 AVX-512 host vs Base).
- Cross-compiled SVE2 vs `Base::ReduceGray2x2` under QEMU:
  - `sve-max-vq=1` (16-byte VL): 2516 cases OK
  - `sve-max-vq=2` (32-byte VL): 2176 cases OK
  - `sve-max-vq=4` (64-byte VL): 1904 cases OK
  - `neoverse-n2`: 2516 cases OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff5e314-8d24-4000-9a27-9032fd43525d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff5e314-8d24-4000-9a27-9032fd43525d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

