### PR TITLE
Improve SVE2 optimizations of SimdReduceGray3x3

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -89,6 +89,7 @@
  <li>SVE2 optimizations of function LaplaceAbsSum.</li>
  <li>SVE2 optimizations of function ReduceColor2x2.</li>
  <li>SVE2 optimizations of function ReduceGray2x2.</li>
+ <li>SVE2 optimizations of function ReduceGray3x3.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2ReduceGray3x3.cpp
+++ b/src/Simd/SimdSve2ReduceGray3x3.cpp
@@ -29,55 +29,83 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint8_t PrependFirst(const svuint8_t& value)
+        template <bool compensation> SIMD_INLINE svuint16_t DivideBy16(const svuint16_t& value);
+
+        template <> SIMD_INLINE svuint16_t DivideBy16<true>(const svuint16_t& value)
         {
-            const svbool_t mask = svptrue_b8();
-            svuint8_t iota = svindex_u8(0, 1);
-            svuint8_t idx = svqsub_u8_x(mask, iota, svdup_n_u8(1));
-            idx = svsel_u8(svcmpeq_n_u8(mask, idx, 255), svdup_n_u8(0), idx);
-            return svtbl_u8(value, idx);
+            return svrshr_n_u16_x(svptrue_b16(), value, 4);
         }
 
-        template <bool compensation> SIMD_INLINE svuint16_t DivideBy16(const svuint16_t& value, const svbool_t& mask);
-
-        template <> SIMD_INLINE svuint16_t DivideBy16<true>(const svuint16_t& value, const svbool_t& mask)
+        template <> SIMD_INLINE svuint16_t DivideBy16<false>(const svuint16_t& value)
         {
-            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, value, 8), 4);
+            return svlsr_n_u16_x(svptrue_b16(), value, 4);
         }
 
-        template <> SIMD_INLINE svuint16_t DivideBy16<false>(const svuint16_t& value, const svbool_t& mask)
+        SIMD_INLINE svuint16_t ReduceCol(const svuint8_t& t01, const svuint8_t& t12)
         {
-            return svlsr_n_u16_x(mask, value, 4);
+            return svadalp_u16_x(svptrue_b16(), svaddlp_u16(t01), t12);
         }
 
-        SIMD_INLINE svuint16_t PairSum(const svuint8_t& value)
+        SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src)
         {
-            return svaddlb_u16(value, svext_u8(value, value, 1));
+            const svbool_t all = svptrue_b8();
+            svuint8_t t12 = svld1_u8(all, src);
+            return ReduceCol(svinsr_n_u8(t12, src[0]), t12);
         }
 
-        SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src)
         {
-            svuint8_t t12 = svld1_u8(mask8, src);
-            svuint8_t t01 = PrependFirst(t12);
-            return svadd_u16_x(mask16, PairSum(t01), PairSum(t12));
+            const svbool_t all = svptrue_b8();
+            return ReduceCol(svld1_u8(all, src - 1), svld1_u8(all, src));
         }
 
-        SIMD_INLINE svuint16_t ReduceColBody(const uint8_t* src, const svbool_t& mask8, const svbool_t& mask16)
+        SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c)
         {
-            svuint8_t t01 = svld1_u8(mask8, src - 1);
-            svuint8_t t12 = svld1_u8(mask8, src);
-            return svadd_u16_x(mask16, PairSum(t01), PairSum(t12));
+            const svbool_t mask = svptrue_b16();
+            return svmla_n_u16_x(mask, svadd_u16_x(mask, a, c), b, 2);
         }
 
-        SIMD_INLINE svuint16_t BinomialSum16(const svuint16_t& a, const svuint16_t& b, const svuint16_t& c, const svbool_t& mask)
+        template <bool compensation> SIMD_INLINE svuint16_t ReduceRow(const svuint16_t& r0, const svuint16_t& r1, const svuint16_t& r2)
         {
-            return svadd_u16_x(mask, svadd_u16_x(mask, a, c), svlsl_n_u16_x(mask, b, 1));
+            return DivideBy16<compensation>(BinomialSum16(r0, r1, r2));
         }
 
-        template <bool compensation> SIMD_INLINE svuint8_t ReduceRow(const svuint16_t& r0, const svuint16_t& r1, const svuint16_t& r2, const svbool_t& mask16)
+        template <bool compensation> SIMD_INLINE svuint8_t ReduceRow8(
+            const svuint16_t& r00, const svuint16_t& r01,
+            const svuint16_t& r10, const svuint16_t& r11,
+            const svuint16_t& r20, const svuint16_t& r21)
         {
-            svuint8_t value = svqxtnb_u16(DivideBy16<compensation>(BinomialSum16(r0, r1, r2, mask16), mask16));
-            return svuzp1_u8(value, value);
+            return svuzp1_u8(
+                svreinterpret_u8_u16(ReduceRow<compensation>(r00, r10, r20)),
+                svreinterpret_u8_u16(ReduceRow<compensation>(r01, r11, r21)));
+        }
+
+        template <bool compensation> SIMD_INLINE void ReduceGray3x3Nose(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, uint8_t* dst, size_t A)
+        {
+            svst1_u8(svptrue_b8(), dst, ReduceRow8<compensation>(
+                ReduceColNose(s0), ReduceColBody(s0 + A),
+                ReduceColNose(s1), ReduceColBody(s1 + A),
+                ReduceColNose(s2), ReduceColBody(s2 + A)));
+        }
+
+        template <bool compensation> SIMD_INLINE void ReduceGray3x3(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, uint8_t* dst, size_t A)
+        {
+            svst1_u8(svptrue_b8(), dst, ReduceRow8<compensation>(
+                ReduceColBody(s0), ReduceColBody(s0 + A),
+                ReduceColBody(s1), ReduceColBody(s1 + A),
+                ReduceColBody(s2), ReduceColBody(s2 + A)));
+        }
+
+        template <bool compensation> SIMD_INLINE void ReduceGray3x3Nose(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, uint8_t* dst)
+        {
+            svst1b_u16(svptrue_b16(), dst, ReduceRow<compensation>(
+                ReduceColNose(s0), ReduceColNose(s1), ReduceColNose(s2)));
+        }
+
+        template <bool compensation> SIMD_INLINE void ReduceGray3x3(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, uint8_t* dst)
+        {
+            svst1b_u16(svptrue_b16(), dst, ReduceRow<compensation>(
+                ReduceColBody(s0), ReduceColBody(s1), ReduceColBody(s2)));
         }
 
         template <bool compensation> void ReduceGray3x3(
@@ -86,48 +114,44 @@ namespace Simd
         {
             assert(srcWidth >= svcntb() && (srcWidth + 1) / 2 == dstWidth && (srcHeight + 1) / 2 == dstHeight);
 
-            const size_t A = svcntb(), HA = svcnth();
-            size_t lastOddCol = srcWidth - AlignLo(srcWidth, 2);
-            size_t bodyWidth = AlignLo(srcWidth, A);
+            const size_t A = svcntb(), DA = A * 2, QA = A * 4;
+            const size_t evenWidth = AlignLo(srcWidth, 2);
             for (size_t row = 0; row < srcHeight; row += 2, dst += dstStride, src += 2 * srcStride)
             {
                 const uint8_t* s1 = src;
                 const uint8_t* s0 = s1 - (row ? srcStride : 0);
                 const uint8_t* s2 = s1 + (row != srcHeight - 1 ? srcStride : 0);
 
-                svbool_t noseMask8 = svwhilelt_b8(size_t(0), Simd::Min(srcWidth, A));
-                svbool_t noseMask16 = svwhilelt_b16(size_t(0), Simd::Min(dstWidth, HA));
-                svbool_t noseStore = svwhilelt_b8(size_t(0), Simd::Min(dstWidth, HA));
-                svst1_u8(noseStore, dst, ReduceRow<compensation>(
-                    ReduceColNose(s0, noseMask8, noseMask16),
-                    ReduceColNose(s1, noseMask8, noseMask16),
-                    ReduceColNose(s2, noseMask8, noseMask16), noseMask16));
-
-                for (size_t srcCol = A, dstCol = HA; srcCol < bodyWidth; srcCol += A, dstCol += HA)
+                if (evenWidth >= DA)
                 {
-                    svbool_t bodyMask8 = svwhilelt_b8(srcCol, srcWidth);
-                    svbool_t bodyMask16 = svwhilelt_b16(dstCol, dstWidth);
-                    svbool_t bodyStore = svwhilelt_b8(dstCol, dstWidth);
-                    svst1_u8(bodyStore, dst + dstCol, ReduceRow<compensation>(
-                        ReduceColBody(s0 + srcCol, bodyMask8, bodyMask16),
-                        ReduceColBody(s1 + srcCol, bodyMask8, bodyMask16),
-                        ReduceColBody(s2 + srcCol, bodyMask8, bodyMask16), bodyMask16));
+                    ReduceGray3x3Nose<compensation>(s0, s1, s2, dst, A);
+                    size_t srcCol = DA, dstCol = A;
+                    for (; srcCol + QA <= evenWidth; srcCol += QA, dstCol += DA)
+                    {
+                        ReduceGray3x3<compensation>(s0 + srcCol, s1 + srcCol, s2 + srcCol, dst + dstCol, A);
+                        ReduceGray3x3<compensation>(s0 + srcCol + DA, s1 + srcCol + DA, s2 + srcCol + DA, dst + dstCol + A, A);
+                    }
+                    for (; srcCol + DA <= evenWidth; srcCol += DA, dstCol += A)
+                        ReduceGray3x3<compensation>(s0 + srcCol, s1 + srcCol, s2 + srcCol, dst + dstCol, A);
+                    if (srcCol != evenWidth)
+                    {
+                        srcCol = evenWidth - DA;
+                        dstCol = srcCol / 2;
+                        ReduceGray3x3<compensation>(s0 + srcCol, s1 + srcCol, s2 + srcCol, dst + dstCol, A);
+                    }
                 }
-
-                if (bodyWidth != srcWidth)
+                else
                 {
-                    size_t srcCol = srcWidth - A - lastOddCol;
-                    size_t dstCol = dstWidth - HA - lastOddCol;
-                    svbool_t tailMask8 = svwhilelt_b8(srcCol, srcWidth);
-                    svbool_t tailMask16 = svwhilelt_b16(dstCol, dstWidth);
-                    svbool_t tailStore = svwhilelt_b8(dstCol, dstWidth);
-                    svst1_u8(tailStore, dst + dstCol, ReduceRow<compensation>(
-                        ReduceColBody(s0 + srcCol, tailMask8, tailMask16),
-                        ReduceColBody(s1 + srcCol, tailMask8, tailMask16),
-                        ReduceColBody(s2 + srcCol, tailMask8, tailMask16), tailMask16));
-                    if (lastOddCol)
-                        dst[dstWidth - 1] = Base::GaussianBlur3x3<compensation>(s0 + srcWidth, s1 + srcWidth, s2 + srcWidth, -2, -1, -1);
+                    ReduceGray3x3Nose<compensation>(s0, s1, s2, dst);
+                    if (evenWidth != A)
+                    {
+                        size_t srcCol = evenWidth - A;
+                        size_t dstCol = srcCol / 2;
+                        ReduceGray3x3<compensation>(s0 + srcCol, s1 + srcCol, s2 + srcCol, dst + dstCol);
+                    }
                 }
+                if (evenWidth != srcWidth)
+                    dst[dstWidth - 1] = Base::GaussianBlur3x3<compensation>(s0 + srcWidth, s1 + srcWidth, s2 + srcWidth, -2, -1, -1);
             }
         }
 

--- a/src/Simd/SimdSve2ReduceGray3x3.cpp
+++ b/src/Simd/SimdSve2ReduceGray3x3.cpp
@@ -43,7 +43,8 @@ namespace Simd
 
         SIMD_INLINE svuint16_t ReduceCol(const svuint8_t& t01, const svuint8_t& t12)
         {
-            return svadalp_u16_x(svptrue_b16(), svaddlp_u16(t01), t12);
+            const svbool_t mask = svptrue_b16();
+            return svadalp_u16_x(mask, svadalp_u16_x(mask, svdup_n_u16(0), t01), t12);
         }
 
         SIMD_INLINE svuint16_t ReduceColNose(const uint8_t* src)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rework SVE2 `SimdReduceGray3x3` so the inner loop no longer uses predicated half-vector loads/stores (`svwhilelt` + `svext`/`svaddlb` + `svqxtnb`/`svuzp1`).
- Column reduction uses SVE2 pairwise `ADALP` on two adjacent source loads (nose inserts the first pixel with `INSR`). Vertical `[1 2 1]` is applied with `MLA`, then divide-by-16 (`RSHR` with compensation, `LSR` without).
- The main path processes two source vectors per row and stores a full destination vector (`svuzp1`). The body is unrolled by two destination vectors. Remainders overlap the last full vector; widths in `[svcntb(), 2*svcntb())` use a single-vector `svst1b` path.
- Record the change in `docs/2026.html` for release 7.2.165.

## Test plan
- Native Release `./Test "-r=.." -fi=ReduceGray3x3 -tt=1 -ts=1` — passed (x86 AVX-512 host vs Base).
- Cross-compiled SVE2 vs `Base::ReduceGray3x3` under QEMU:
  - `sve-max-vq=1` (16-byte VL): 3136 cases OK
  - `sve-max-vq=2` (32-byte VL): 3136 cases OK
  - `sve-max-vq=4` (64-byte VL): 3024 cases OK
  - `neoverse-n2`: 3136 cases OK

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbf24f53-43ba-4f3b-9415-6504a23f020f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbf24f53-43ba-4f3b-9415-6504a23f020f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

