### PR TITLE
Improve SVE2 optimizations of SimdSobelDxAbsSum

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -92,6 +92,7 @@
  <li>SVE2 optimizations of function ReduceGray3x3.</li>
  <li>SVE2 optimizations of function ReduceGray4x4.</li>
  <li>SVE2 optimizations of function ReduceGray5x5.</li>
+ <li>SVE2 optimizations of function SobelDxAbsSum.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -98,36 +98,179 @@ namespace Simd
             SobelDx<true>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
         }
 
-        SIMD_INLINE uint64_t SobelDxAbsSum(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const svbool_t& mask)
+        SIMD_INLINE svint16x2_t DxDiff(const uint8_t* src, const svbool_t& mask)
         {
-            svuint16_t sobel = svreinterpret_u16_s16(SobelDx<true>(s0, s1, s2, mask));
-            return svaddv_u32(svptrue_b32(), svunpklo_u32(sobel)) + svaddv_u32(svptrue_b32(), svunpkhi_u32(sobel));
+            svuint8_t left = svld1_u8(mask, src - 1);
+            svuint8_t right = svld1_u8(mask, src + 1);
+            return svcreate2_s16(
+                svreinterpret_s16_u16(svsublb_u16(right, left)),
+                svreinterpret_s16_u16(svsublt_u16(right, left)));
+        }
+
+        SIMD_INLINE void AccumulateAbsDx(svint16x2_t d0, svint16x2_t d1, svint16x2_t d2, svuint32_t& sum)
+        {
+            const svbool_t mask16 = svptrue_b16();
+            const svbool_t mask32 = svptrue_b32();
+            svint16_t even = svadd_s16_x(mask16, svadd_s16_x(mask16, svget2(d0, 0), svlsl_n_s16_x(mask16, svget2(d1, 0), 1)), svget2(d2, 0));
+            svint16_t odd = svadd_s16_x(mask16, svadd_s16_x(mask16, svget2(d0, 1), svlsl_n_s16_x(mask16, svget2(d1, 1), 1)), svget2(d2, 1));
+            svuint16_t absEven = svreinterpret_u16_s16(svabs_s16_x(mask16, even));
+            svuint16_t absOdd = svreinterpret_u16_s16(svabs_s16_x(mask16, odd));
+            sum = svadd_u32_x(mask32, sum, svaddlb_u32(absEven, absOdd));
+            sum = svadd_u32_x(mask32, sum, svaddlt_u32(absEven, absOdd));
+        }
+
+        SIMD_INLINE void SobelDxAbsSum1(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            svuint32_t& sum, const svbool_t& mask)
+        {
+            AccumulateAbsDx(DxDiff(s0, mask), DxDiff(s1, mask), DxDiff(s2, mask), sum);
+        }
+
+        SIMD_INLINE void SobelDxAbsSum2(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const uint8_t* s3,
+            svuint32_t& sum, const svbool_t& mask)
+        {
+            svint16x2_t d0 = DxDiff(s0, mask);
+            svint16x2_t d1 = DxDiff(s1, mask);
+            svint16x2_t d2 = DxDiff(s2, mask);
+            svint16x2_t d3 = DxDiff(s3, mask);
+            AccumulateAbsDx(d0, d1, d2, sum);
+            AccumulateAbsDx(d1, d2, d3, sum);
+        }
+
+        SIMD_INLINE void SobelDxAbsSum4(
+            const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            const uint8_t* s3, const uint8_t* s4, const uint8_t* s5,
+            svuint32_t& sum, const svbool_t& mask)
+        {
+            svint16x2_t d0 = DxDiff(s0, mask);
+            svint16x2_t d1 = DxDiff(s1, mask);
+            svint16x2_t d2 = DxDiff(s2, mask);
+            svint16x2_t d3 = DxDiff(s3, mask);
+            svint16x2_t d4 = DxDiff(s4, mask);
+            svint16x2_t d5 = DxDiff(s5, mask);
+            AccumulateAbsDx(d0, d1, d2, sum);
+            AccumulateAbsDx(d1, d2, d3, sum);
+            AccumulateAbsDx(d2, d3, d4, sum);
+            AccumulateAbsDx(d3, d4, d5, sum);
+        }
+
+        SIMD_INLINE uint64_t EdgeAbsDx(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, size_t x0, size_t x2)
+        {
+            return (uint64_t)SobelDx<true>(s0, s1, s2, x0, x2);
+        }
+
+        void SobelDxAbsSumBody(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            size_t end, size_t A, size_t A2, const svbool_t& all, svuint32_t& sum)
+        {
+            size_t col = 1;
+            for (; col + A2 <= end; col += A2)
+            {
+                SobelDxAbsSum1(s0 + col, s1 + col, s2 + col, sum, all);
+                SobelDxAbsSum1(s0 + col + A, s1 + col + A, s2 + col + A, sum, all);
+            }
+            for (; col + A <= end; col += A)
+                SobelDxAbsSum1(s0 + col, s1 + col, s2 + col, sum, all);
+            if (col < end)
+                SobelDxAbsSum1(s0 + col, s1 + col, s2 + col, sum, svwhilelt_b8(col, end));
+        }
+
+        void SobelDxAbsSumBody2(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const uint8_t* s3,
+            size_t end, size_t A, size_t A2, const svbool_t& all, svuint32_t& sum)
+        {
+            size_t col = 1;
+            for (; col + A2 <= end; col += A2)
+            {
+                SobelDxAbsSum2(s0 + col, s1 + col, s2 + col, s3 + col, sum, all);
+                SobelDxAbsSum2(s0 + col + A, s1 + col + A, s2 + col + A, s3 + col + A, sum, all);
+            }
+            for (; col + A <= end; col += A)
+                SobelDxAbsSum2(s0 + col, s1 + col, s2 + col, s3 + col, sum, all);
+            if (col < end)
+                SobelDxAbsSum2(s0 + col, s1 + col, s2 + col, s3 + col, sum, svwhilelt_b8(col, end));
+        }
+
+        void SobelDxAbsSumBody4(
+            const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            const uint8_t* s3, const uint8_t* s4, const uint8_t* s5,
+            size_t end, size_t A, size_t A2, const svbool_t& all, svuint32_t& sum)
+        {
+            size_t col = 1;
+            for (; col + A2 <= end; col += A2)
+            {
+                SobelDxAbsSum4(s0 + col, s1 + col, s2 + col, s3 + col, s4 + col, s5 + col, sum, all);
+                SobelDxAbsSum4(s0 + col + A, s1 + col + A, s2 + col + A, s3 + col + A, s4 + col + A, s5 + col + A, sum, all);
+            }
+            for (; col + A <= end; col += A)
+                SobelDxAbsSum4(s0 + col, s1 + col, s2 + col, s3 + col, s4 + col, s5 + col, sum, all);
+            if (col < end)
+                SobelDxAbsSum4(s0 + col, s1 + col, s2 + col, s3 + col, s4 + col, s5 + col, sum, svwhilelt_b8(col, end));
         }
 
         void SobelDxAbsSum(const uint8_t* src, size_t stride, size_t width, size_t height, uint64_t* sum)
         {
             assert(width > 1);
 
-            const size_t A = svcnth();
-            const uint8_t* src0, * src1, * src2;
+            const size_t A = svcntb();
+            const size_t A2 = A * 2;
+            const size_t end = width - 1;
+            const svbool_t all = svptrue_b8();
             uint64_t fullSum = 0;
-            for (size_t row = 0; row < height; ++row)
+
+            size_t row = 0;
+            for (; row + 4 <= height; row += 4)
             {
-                src0 = src + stride * (row - 1);
-                src1 = src0 + stride;
-                src2 = src1 + stride;
-                if (row == 0)
-                    src0 = src1;
-                if (row == height - 1)
-                    src2 = src1;
+                const uint8_t* src1 = src + stride * row;
+                const uint8_t* src0 = row ? src1 - stride : src1;
+                const uint8_t* src2 = src1 + stride;
+                const uint8_t* src3 = src2 + stride;
+                const uint8_t* src4 = src3 + stride;
+                const uint8_t* src5 = row + 4 < height ? src4 + stride : src4;
 
-                uint64_t rowSum = SobelDx<true>(src0, src1, src2, 0, 1);
-                for (size_t col = 1; col < width - 1; col += A)
-                    rowSum += SobelDxAbsSum(src0 + col - 1, src1 + col - 1, src2 + col - 1, svwhilelt_b16(col, width - 1));
-                rowSum += SobelDx<true>(src0, src1, src2, width - 2, width - 1);
+                uint64_t edge = EdgeAbsDx(src0, src1, src2, 0, 1);
+                edge += EdgeAbsDx(src1, src2, src3, 0, 1);
+                edge += EdgeAbsDx(src2, src3, src4, 0, 1);
+                edge += EdgeAbsDx(src3, src4, src5, 0, 1);
+                edge += EdgeAbsDx(src0, src1, src2, width - 2, width - 1);
+                edge += EdgeAbsDx(src1, src2, src3, width - 2, width - 1);
+                edge += EdgeAbsDx(src2, src3, src4, width - 2, width - 1);
+                edge += EdgeAbsDx(src3, src4, src5, width - 2, width - 1);
 
-                fullSum += rowSum;
+                svuint32_t body = svdup_n_u32(0);
+                SobelDxAbsSumBody4(src0, src1, src2, src3, src4, src5, end, A, A2, all, body);
+                fullSum += edge + svaddv_u32(svptrue_b32(), body);
             }
+
+            if (row + 2 <= height)
+            {
+                const uint8_t* src1 = src + stride * row;
+                const uint8_t* src0 = row ? src1 - stride : src1;
+                const uint8_t* src2 = src1 + stride;
+                const uint8_t* src3 = row + 2 < height ? src2 + stride : src2;
+
+                uint64_t edge = EdgeAbsDx(src0, src1, src2, 0, 1);
+                edge += EdgeAbsDx(src1, src2, src3, 0, 1);
+                edge += EdgeAbsDx(src0, src1, src2, width - 2, width - 1);
+                edge += EdgeAbsDx(src1, src2, src3, width - 2, width - 1);
+
+                svuint32_t body = svdup_n_u32(0);
+                SobelDxAbsSumBody2(src0, src1, src2, src3, end, A, A2, all, body);
+                fullSum += edge + svaddv_u32(svptrue_b32(), body);
+                row += 2;
+            }
+
+            if (row < height)
+            {
+                const uint8_t* src1 = src + stride * row;
+                const uint8_t* src0 = row ? src1 - stride : src1;
+                const uint8_t* src2 = src1;
+
+                uint64_t edge = EdgeAbsDx(src0, src1, src2, 0, 1);
+                edge += EdgeAbsDx(src0, src1, src2, width - 2, width - 1);
+
+                svuint32_t body = svdup_n_u32(0);
+                SobelDxAbsSumBody(src0, src1, src2, end, A, A2, all, body);
+                fullSum += edge + svaddv_u32(svptrue_b32(), body);
+            }
+
             *sum = fullSum;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrite the ARM SVE2 implementation of `SimdSobelDxAbsSum` so it is no longer slower than the NEON path.

The previous SVE2 version loaded half-width 16-bit lanes (`svld1ub_s16`) and performed a horizontal reduction (`svaddv`) on every iteration. The new path:

- loads full 8-bit SVE vectors
- uses SVE2 widening even/odd subtracts (`svsublb` / `svsublt`)
- accumulates absolute Sobel Dx values in vector registers
- reuses per-row left/right differences across 2 and 4 output rows
- unrolls two vectors in the inner loop
- keeps first/last columns as scalar edge cases

`docs/2026.html` release 7.2.165 Improving section is updated.

## Testing

- Native `Test -fi=SobelDxAbsSum` (Base / SSE4.1 / AVX2 / AVX-512BW): passed
- Cross-compiled SVE2 vs Base under QEMU, 5717 cases each at VL=16/32/64 and `neoverse-n2`: all passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b04b9ca5-fe1f-4900-b7c4-1ca0d8232bbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b04b9ca5-fe1f-4900-b7c4-1ca0d8232bbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

