### PR TITLE
Improve SVE2 optimizations of SimdSobelDy

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -95,6 +95,7 @@
  <li>SVE2 optimizations of function SobelDx.</li>
  <li>SVE2 optimizations of function SobelDxAbs.</li>
  <li>SVE2 optimizations of function SobelDxAbsSum.</li>
+ <li>SVE2 optimizations of function SobelDy.</li>
  <li>SVE2 optimizations of function SobelDyAbs.</li>
  <li>SVE2 optimizations of function SobelDyAbsSum.</li>
 </ul>

--- a/src/Simd/SimdSve2Sobel.cpp
+++ b/src/Simd/SimdSve2Sobel.cpp
@@ -562,62 +562,11 @@ namespace Simd
             return (int16_t)Simd::Abs(SobelDy<false>(s0, s2, x0, x1, x2));
         }
 
-        template <bool abs> SIMD_INLINE svint16_t SobelDy(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask);
-
-        template <> SIMD_INLINE svint16_t SobelDy<false>(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
-        {
-            svint16_t top = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s0 + 1), 1)), svld1ub_s16(mask, s0 + 2));
-            svint16_t bottom = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s2 + 1), 1)), svld1ub_s16(mask, s2 + 2));
-            return svsub_s16_x(mask, bottom, top);
-        }
-
-        template <> SIMD_INLINE svint16_t SobelDy<true>(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
-        {
-            return svabs_s16_x(mask, SobelDy<false>(s0, s2, mask));
-        }
-
         SIMD_INLINE svint16_t SobelDyAbs(const uint8_t* s0, const uint8_t* s2, const svbool_t& mask)
         {
             svint16_t top = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s0), svlsl_n_s16_x(mask, svld1ub_s16(mask, s0 + 1), 1)), svld1ub_s16(mask, s0 + 2));
             svint16_t bottom = svadd_s16_x(mask, svadd_s16_x(mask, svld1ub_s16(mask, s2), svlsl_n_s16_x(mask, svld1ub_s16(mask, s2 + 1), 1)), svld1ub_s16(mask, s2 + 2));
             return svabs_s16_x(mask, svsub_s16_x(mask, bottom, top));
-        }
-
-        template <bool abs> SIMD_INLINE void SobelDy(const uint8_t* s0, const uint8_t* s2, int16_t* dst, const svbool_t& mask)
-        {
-            svst1_s16(mask, dst, SobelDy<abs>(s0, s2, mask));
-        }
-
-        template <bool abs> void SobelDy(const uint8_t* src, size_t srcStride, size_t width, size_t height, int16_t* dst, size_t dstStride)
-        {
-            assert(width > 1);
-
-            const size_t A = svcnth();
-            const uint8_t* src0, * src1, * src2;
-            for (size_t row = 0; row < height; ++row)
-            {
-                src0 = src + srcStride * (row - 1);
-                src1 = src0 + srcStride;
-                src2 = src1 + srcStride;
-                if (row == 0)
-                    src0 = src1;
-                if (row == height - 1)
-                    src2 = src1;
-
-                dst[0] = SobelDy<abs>(src0, src2, 0, 0, 1);
-                for (size_t col = 1; col < width - 1; col += A)
-                    SobelDy<abs>(src0 + col - 1, src2 + col - 1, dst + col, svwhilelt_b16(col, width - 1));
-                dst[width - 1] = SobelDy<abs>(src0, src2, width - 2, width - 1, width - 1);
-
-                dst += dstStride;
-            }
-        }
-
-        void SobelDy(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
-        {
-            assert(dstStride % sizeof(int16_t) == 0);
-
-            SobelDy<false>(src, srcStride, width, height, (int16_t*)dst, dstStride / sizeof(int16_t));
         }
 
         SIMD_INLINE svuint16x2_t DyHoriz(const uint8_t* src, const svbool_t& mask)
@@ -628,6 +577,173 @@ namespace Simd
             return svcreate2_u16(
                 svmlalb_n_u16(svaddlb_u16(left, right), center, 2),
                 svmlalt_n_u16(svaddlt_u16(left, right), center, 2));
+        }
+
+        SIMD_INLINE void StoreDy(svuint16x2_t top, svuint16x2_t bot, int16_t* dst, const svbool_t& lo, const svbool_t& hi)
+        {
+            const svbool_t mask16 = svptrue_b16();
+            svint16_t even = svsub_s16_x(mask16, svreinterpret_s16_u16(svget2(bot, 0)), svreinterpret_s16_u16(svget2(top, 0)));
+            svint16_t odd = svsub_s16_x(mask16, svreinterpret_s16_u16(svget2(bot, 1)), svreinterpret_s16_u16(svget2(top, 1)));
+            svst1_s16(lo, dst, svzip1_s16(even, odd));
+            svst1_s16(hi, dst + svcnth(), svzip2_s16(even, odd));
+        }
+
+        SIMD_INLINE void SobelDy1(const uint8_t* s0, const uint8_t* s2,
+            int16_t* dst, const svbool_t& mask, const svbool_t& lo, const svbool_t& hi)
+        {
+            StoreDy(DyHoriz(s0, mask), DyHoriz(s2, mask), dst, lo, hi);
+        }
+
+        SIMD_INLINE void SobelDy2(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const uint8_t* s3,
+            int16_t* dst0, int16_t* dst1, const svbool_t& mask, const svbool_t& lo, const svbool_t& hi)
+        {
+            svuint16x2_t h0 = DyHoriz(s0, mask);
+            svuint16x2_t h1 = DyHoriz(s1, mask);
+            svuint16x2_t h2 = DyHoriz(s2, mask);
+            svuint16x2_t h3 = DyHoriz(s3, mask);
+            StoreDy(h0, h2, dst0, lo, hi);
+            StoreDy(h1, h3, dst1, lo, hi);
+        }
+
+        SIMD_INLINE void SobelDy4(
+            const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            const uint8_t* s3, const uint8_t* s4, const uint8_t* s5,
+            int16_t* dst0, int16_t* dst1, int16_t* dst2, int16_t* dst3,
+            const svbool_t& mask, const svbool_t& lo, const svbool_t& hi)
+        {
+            svuint16x2_t h0 = DyHoriz(s0, mask);
+            svuint16x2_t h1 = DyHoriz(s1, mask);
+            svuint16x2_t h2 = DyHoriz(s2, mask);
+            svuint16x2_t h3 = DyHoriz(s3, mask);
+            svuint16x2_t h4 = DyHoriz(s4, mask);
+            svuint16x2_t h5 = DyHoriz(s5, mask);
+            StoreDy(h0, h2, dst0, lo, hi);
+            StoreDy(h1, h3, dst1, lo, hi);
+            StoreDy(h2, h4, dst2, lo, hi);
+            StoreDy(h3, h5, dst3, lo, hi);
+        }
+
+        SIMD_INLINE void SobelDyEdge(const uint8_t* s0, const uint8_t* s2, int16_t* dst, size_t width)
+        {
+            dst[0] = SobelDy<false>(s0, s2, 0, 0, 1);
+            dst[width - 1] = SobelDy<false>(s0, s2, width - 2, width - 1, width - 1);
+        }
+
+        void SobelDyBody(const uint8_t* s0, const uint8_t* s2,
+            int16_t* dst, size_t end, size_t A, size_t A2, size_t HA, const svbool_t& all8, const svbool_t& all16)
+        {
+            size_t col = 1;
+            for (; col + A2 <= end; col += A2)
+            {
+                SobelDy1(s0 + col, s2 + col, dst + col, all8, all16, all16);
+                SobelDy1(s0 + col + A, s2 + col + A, dst + col + A, all8, all16, all16);
+            }
+            for (; col + A <= end; col += A)
+                SobelDy1(s0 + col, s2 + col, dst + col, all8, all16, all16);
+            if (col < end)
+                SobelDy1(s0 + col, s2 + col, dst + col, svwhilelt_b8(col, end),
+                    svwhilelt_b16(col, end), svwhilelt_b16(col + HA, end));
+        }
+
+        void SobelDyBody2(const uint8_t* s0, const uint8_t* s1, const uint8_t* s2, const uint8_t* s3,
+            int16_t* dst0, int16_t* dst1, size_t end, size_t A, size_t A2, size_t HA, const svbool_t& all8, const svbool_t& all16)
+        {
+            size_t col = 1;
+            for (; col + A2 <= end; col += A2)
+            {
+                SobelDy2(s0 + col, s1 + col, s2 + col, s3 + col, dst0 + col, dst1 + col, all8, all16, all16);
+                SobelDy2(s0 + col + A, s1 + col + A, s2 + col + A, s3 + col + A, dst0 + col + A, dst1 + col + A, all8, all16, all16);
+            }
+            for (; col + A <= end; col += A)
+                SobelDy2(s0 + col, s1 + col, s2 + col, s3 + col, dst0 + col, dst1 + col, all8, all16, all16);
+            if (col < end)
+                SobelDy2(s0 + col, s1 + col, s2 + col, s3 + col, dst0 + col, dst1 + col, svwhilelt_b8(col, end),
+                    svwhilelt_b16(col, end), svwhilelt_b16(col + HA, end));
+        }
+
+        void SobelDyBody4(
+            const uint8_t* s0, const uint8_t* s1, const uint8_t* s2,
+            const uint8_t* s3, const uint8_t* s4, const uint8_t* s5,
+            int16_t* dst0, int16_t* dst1, int16_t* dst2, int16_t* dst3,
+            size_t end, size_t A, size_t A2, size_t HA, const svbool_t& all8, const svbool_t& all16)
+        {
+            size_t col = 1;
+            for (; col + A2 <= end; col += A2)
+            {
+                SobelDy4(s0 + col, s1 + col, s2 + col, s3 + col, s4 + col, s5 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, all8, all16, all16);
+                SobelDy4(s0 + col + A, s1 + col + A, s2 + col + A, s3 + col + A, s4 + col + A, s5 + col + A,
+                    dst0 + col + A, dst1 + col + A, dst2 + col + A, dst3 + col + A, all8, all16, all16);
+            }
+            for (; col + A <= end; col += A)
+                SobelDy4(s0 + col, s1 + col, s2 + col, s3 + col, s4 + col, s5 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, all8, all16, all16);
+            if (col < end)
+                SobelDy4(s0 + col, s1 + col, s2 + col, s3 + col, s4 + col, s5 + col,
+                    dst0 + col, dst1 + col, dst2 + col, dst3 + col, svwhilelt_b8(col, end),
+                    svwhilelt_b16(col, end), svwhilelt_b16(col + HA, end));
+        }
+
+        void SobelDy(const uint8_t* src, size_t srcStride, size_t width, size_t height, uint8_t* dst, size_t dstStride)
+        {
+            assert(dstStride % sizeof(int16_t) == 0);
+            assert(width > 1);
+
+            const size_t A = svcntb();
+            const size_t A2 = A * 2;
+            const size_t HA = svcnth();
+            const size_t end = width - 1;
+            const svbool_t all8 = svptrue_b8();
+            const svbool_t all16 = svptrue_b16();
+            int16_t* dst16 = (int16_t*)dst;
+            size_t dst16Stride = dstStride / sizeof(int16_t);
+
+            size_t row = 0;
+            for (; row + 4 <= height; row += 4)
+            {
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = src1 + srcStride;
+                const uint8_t* src3 = src2 + srcStride;
+                const uint8_t* src4 = src3 + srcStride;
+                const uint8_t* src5 = row + 4 < height ? src4 + srcStride : src4;
+                int16_t* dst0 = dst16 + dst16Stride * row;
+                int16_t* dst1 = dst0 + dst16Stride;
+                int16_t* dst2 = dst1 + dst16Stride;
+                int16_t* dst3 = dst2 + dst16Stride;
+
+                SobelDyEdge(src0, src2, dst0, width);
+                SobelDyEdge(src1, src3, dst1, width);
+                SobelDyEdge(src2, src4, dst2, width);
+                SobelDyEdge(src3, src5, dst3, width);
+                SobelDyBody4(src0, src1, src2, src3, src4, src5, dst0, dst1, dst2, dst3, end, A, A2, HA, all8, all16);
+            }
+
+            if (row + 2 <= height)
+            {
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = src1 + srcStride;
+                const uint8_t* src3 = row + 2 < height ? src2 + srcStride : src2;
+                int16_t* dst0 = dst16 + dst16Stride * row;
+                int16_t* dst1 = dst0 + dst16Stride;
+
+                SobelDyEdge(src0, src2, dst0, width);
+                SobelDyEdge(src1, src3, dst1, width);
+                SobelDyBody2(src0, src1, src2, src3, dst0, dst1, end, A, A2, HA, all8, all16);
+                row += 2;
+            }
+
+            if (row < height)
+            {
+                const uint8_t* src1 = src + srcStride * row;
+                const uint8_t* src0 = row ? src1 - srcStride : src1;
+                const uint8_t* src2 = src1;
+                int16_t* dst0 = dst16 + dst16Stride * row;
+
+                SobelDyEdge(src0, src2, dst0, width);
+                SobelDyBody(src0, src2, dst0, end, A, A2, HA, all8, all16);
+            }
         }
 
         SIMD_INLINE void StoreAbsDy(svuint16x2_t top, svuint16x2_t bot, int16_t* dst, const svbool_t& lo, const svbool_t& hi)

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -888,7 +888,7 @@ namespace
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
         {
-            const int A = (int)svcnth();
+            const int A = (int)svcntb();
             result = result && GrayFilterAutoTest(View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));
             result = result && GrayFilterAutoTest(2, 3, View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));
             result = result && GrayFilterAutoTest(A + 1, 5, View::Int16, FUNC_G(Simd::Sve2::SobelDy), FUNC_G(SimdSobelDy));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrite the ARM SVE2 implementation of `SimdSobelDy` so it is no longer slower than the NEON path.

The previous SVE2 version loaded half-width 16-bit lanes (`svld1ub_s16`) and processed only `svcnth()` pixels per iteration. The new path:

- loads full 8-bit SVE vectors
- uses SVE2 widening 1-2-1 horizontals (`svaddlb` / `svaddlt` / `svmlalb` / `svmlalt`)
- reorders even/odd 16-bit results with `svzip1` / `svzip2` and scalar stores (no structured `svst2`)
- reuses per-row horizontal sums across 2 and 4 output rows
- unrolls two vectors in the inner loop
- keeps first/last columns as scalar edge cases

`docs/2026.html` release 7.2.165 Improving section is updated. `Test::SobelDyAutoTest` extra SVE2 sizes now use `svcntb()`.

## Testing

- Native `Test -fi=SobelDy` (Base / SSE4.1 / AVX2 / AVX-512BW): passed
- Cross-compiled SVE2 vs Base under QEMU: 4758 cases at VL=16, 7638 at VL=32, 13398 at VL=64, and 4758 on `neoverse-n2`: all passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd8ebec8-8b1c-4cca-87e8-4eb620d046c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd8ebec8-8b1c-4cca-87e8-4eb620d046c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

