### PR TITLE
Improve SVE2 optimizations of class ResizerByteBilinear

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -94,6 +94,7 @@
  <li>SVE2 optimizations of function ReduceGray5x5.</li>
  <li>SVE2 optimizations of class ResizerByteArea1x1.</li>
  <li>SVE2 optimizations of class ResizerByteArea2x2.</li>
+ <li>SVE2 optimizations of class ResizerByteBilinear.</li>
  <li>SVE2 optimizations of function SobelDx.</li>
  <li>SVE2 optimizations of function SobelDxAbs.</li>
  <li>SVE2 optimizations of function SobelDxAbsSum.</li>

--- a/src/Simd/SimdSve2ResizerBilinear.cpp
+++ b/src/Simd/SimdSve2ResizerBilinear.cpp
@@ -171,35 +171,6 @@ namespace Simd
             svst1_u16(mask16, (uint16_t*)buffer, ResizerByteBilinearMaddubs(src, svld1_u8(mask8, alpha)));
         }
 
-        SIMD_INLINE void ResizerByteBilinearInitShuffleX3(uint8_t* idx, size_t A)
-        {
-            size_t step = AlignLo(2 * A, size_t(6));
-            for (size_t i = 0; i < 2 * A; ++i)
-            {
-                if (i < step)
-                {
-                    size_t pair = i / 2;
-                    idx[i] = (uint8_t)((pair / 3) * 6 + (i & 1) * 3 + (pair % 3));
-                }
-                else
-                    idx[i] = 0;
-            }
-        }
-
-        SIMD_INLINE void ResizerByteBilinearInterpolateX3(const uint8_t* alpha, uint8_t* buffer, size_t n,
-            const svuint8_t& idx0, const svuint8_t& idx1)
-        {
-            const size_t A = svcntb();
-            const size_t HA = svcnth();
-            svbool_t mask0 = svwhilelt_b8((size_t)0, n);
-            svbool_t mask1 = svwhilelt_b8(A, n);
-            svuint8x2_t src = svcreate2_u8(svld1_u8(mask0, buffer), svld1_u8(mask1, buffer + A));
-            svst1_u16(svwhilelt_b16((size_t)0, n / 2), (uint16_t*)buffer,
-                ResizerByteBilinearMaddubs(svtbl2_u8(src, idx0), svld1_u8(mask0, alpha)));
-            svst1_u16(svwhilelt_b16(HA, n / 2), (uint16_t*)buffer + HA,
-                ResizerByteBilinearMaddubs(svtbl2_u8(src, idx1), svld1_u8(mask1, alpha + A)));
-        }
-
         SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
         {
             return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
@@ -250,16 +221,6 @@ namespace Simd
             else if (N == 4)
                 shuffle = ResizerByteBilinearShuffleX4();
 
-            uint8_t idx3[2 * SIMD_SVE2_VECTOR_SIZE_MAX];
-            svuint8_t idx30 = shuffle, idx31 = shuffle;
-            size_t step3 = AlignLo(2 * A, size_t(6));
-            if (N == 3)
-            {
-                ResizerByteBilinearInitShuffleX3(idx3, A);
-                idx30 = svld1_u8(svptrue_b8(), idx3);
-                idx31 = svld1_u8(svptrue_b8(), idx3 + A);
-            }
-
             for (size_t yDst = 0; yDst < _param.dstH; yDst++, dst += dstStride)
             {
                 svuint16_t a0 = svdup_n_u16((uint16_t)(Base::FRACTION_RANGE - _ay[yDst]));
@@ -280,24 +241,44 @@ namespace Simd
 
                 for (; k < 2; k++)
                 {
-                    Two* pb = (Two*)bx[k];
-                    const One* psrc = (const One*)(src + (sy + k) * srcStride);
-                    for (size_t x = 0; x < dstW; x++)
-                        pb[x] = *(Two*)(psrc + ix[x]);
-
                     uint8_t* pbx = bx[k];
+                    const uint8_t* psrc = src + (sy + k) * srcStride;
                     if (N == 3)
                     {
-                        size_t i = 0;
-                        for (; i + step3 <= size; i += step3)
-                            ResizerByteBilinearInterpolateX3(ax + i, pbx + i, step3, idx30, idx31);
-                        if (i < size)
-                            ResizerByteBilinearInterpolateX3(ax + i, pbx + i, size - i, idx30, idx31);
+                        for (size_t x = 0; x < dstW; x++)
+                        {
+                            const uint8_t* ps = psrc + ix[x] * 3;
+                            uint8_t* pd = pbx + x * 6;
+                            pd[0] = ps[0];
+                            pd[1] = ps[3];
+                            pd[2] = ps[1];
+                            pd[3] = ps[4];
+                            pd[4] = ps[2];
+                            pd[5] = ps[5];
+                        }
                     }
                     else
                     {
-                        size_t aligned = AlignLo(size, 2 * A);
-                        size_t i = 0;
+                        Two* pb = (Two*)pbx;
+                        const One* ps = (const One*)psrc;
+                        for (size_t x = 0; x < dstW; x++)
+                            pb[x] = *(Two*)(ps + ix[x]);
+                    }
+
+                    size_t aligned = AlignLo(size, 2 * A);
+                    size_t i = 0;
+                    if (N == 3)
+                    {
+                        for (; i < aligned; i += 2 * A)
+                        {
+                            ResizerByteBilinearInterpolateX<1>(ax + i, pbx + i, shuffle);
+                            ResizerByteBilinearInterpolateX<1>(ax + i + A, pbx + i + A, shuffle);
+                        }
+                        for (; i < size; i += A)
+                            ResizerByteBilinearInterpolateX<1>(ax + i, pbx + i, shuffle);
+                    }
+                    else
+                    {
                         for (; i < aligned; i += 2 * A)
                         {
                             ResizerByteBilinearInterpolateX<N>(ax + i, pbx + i, shuffle);

--- a/src/Simd/SimdSve2ResizerBilinear.cpp
+++ b/src/Simd/SimdSve2ResizerBilinear.cpp
@@ -129,14 +129,75 @@ namespace Simd
             _bx[1].Resize(size, false, _param.align);
         }
 
-        SIMD_INLINE void ResizerByteBilinearInterpolateX(const uint8_t* alpha, uint8_t* buffer)
+        SIMD_INLINE svuint16_t ResizerByteBilinearMaddubs(const svuint8_t& src, const svuint8_t& alpha)
         {
-            const svbool_t mask8 = svptrue_b8(), mask16 = svptrue_b16();
-            svuint8_t _src = svld1_u8(mask8, buffer);
-            svuint8_t _alpha = svld1_u8(mask8, alpha);
-            svuint16_t lo = svmul_u16_x(mask16, svunpklo_u16(svuzp1_u8(_src, _src)), svunpklo_u16(svuzp1_u8(_alpha, _alpha)));
-            lo = svmla_u16_x(mask16, lo, svunpklo_u16(svuzp2_u8(_src, _src)), svunpklo_u16(svuzp2_u8(_alpha, _alpha)));
-            svst1_u16(mask16, (uint16_t*)buffer, lo);
+            return svmlalt_u16(svmlalb_u16(svdup_n_u16(0), src, alpha), src, alpha);
+        }
+
+        SIMD_INLINE svuint8_t ResizerByteBilinearShuffleX2()
+        {
+            const svbool_t all = svptrue_b8();
+            svuint8_t i = svindex_u8(0, 1);
+            svuint8_t base = svand_n_u8_x(all, i, 0xFC);
+            svuint8_t even = svlsl_n_u8_x(all, svand_n_u8_x(all, i, 1), 1);
+            svuint8_t odd = svlsr_n_u8_x(all, svand_n_u8_x(all, i, 2), 1);
+            return svadd_u8_x(all, base, svadd_u8_x(all, even, odd));
+        }
+
+        SIMD_INLINE svuint8_t ResizerByteBilinearShuffleX4()
+        {
+            const svbool_t all = svptrue_b8();
+            svuint8_t i = svindex_u8(0, 1);
+            svuint8_t base = svand_n_u8_x(all, i, 0xF8);
+            svuint8_t p = svand_n_u8_x(all, i, 7);
+            svuint8_t lo = svlsl_n_u8_x(all, svand_n_u8_x(all, p, 1), 2);
+            svuint8_t hi = svlsr_n_u8_x(all, p, 1);
+            return svadd_u8_x(all, base, svadd_u8_x(all, lo, hi));
+        }
+
+        template<size_t N> SIMD_INLINE svuint8_t ResizerByteBilinearShuffleX(const svuint8_t& src, const svuint8_t& index)
+        {
+            if (N == 1)
+                return src;
+            else
+                return svtbl_u8(src, index);
+        }
+
+        template<size_t N> SIMD_INLINE void ResizerByteBilinearInterpolateX(const uint8_t* alpha, uint8_t* buffer, const svuint8_t& index)
+        {
+            const svbool_t mask8 = svptrue_b8();
+            const svbool_t mask16 = svptrue_b16();
+            svuint8_t src = ResizerByteBilinearShuffleX<N>(svld1_u8(mask8, buffer), index);
+            svst1_u16(mask16, (uint16_t*)buffer, ResizerByteBilinearMaddubs(src, svld1_u8(mask8, alpha)));
+        }
+
+        SIMD_INLINE void ResizerByteBilinearInitShuffleX3(uint8_t* idx, size_t A)
+        {
+            size_t step = AlignLo(2 * A, size_t(6));
+            for (size_t i = 0; i < 2 * A; ++i)
+            {
+                if (i < step)
+                {
+                    size_t pair = i / 2;
+                    idx[i] = (uint8_t)((pair / 3) * 6 + (i & 1) * 3 + (pair % 3));
+                }
+                else
+                    idx[i] = 0;
+            }
+        }
+
+        SIMD_INLINE void ResizerByteBilinearInterpolateX3(const uint8_t* alpha, uint8_t* buffer, size_t n,
+            const svuint8_t& idx0, const svuint8_t& idx1)
+        {
+            const size_t A = svcntb();
+            const size_t HA = svcnth();
+            svbool_t mask0 = svwhilelt_b8((size_t)0, n);
+            svbool_t mask1 = svwhilelt_b8(A, n);
+            svuint8x2_t src = svcreate2_u8(svld1_u8(mask0, buffer), svld1_u8(mask1, buffer + A));
+            svst1_u16(svwhilelt_b16((size_t)0, n / 2), (uint16_t*)buffer,
+                ResizerByteBilinearMaddubs(svtbl2_u8(src, idx0), svld1_u8(mask0, alpha)));
+            svst1_u16(svwhilelt_b16(HA, n / 2), (uint16_t*)buffer + HA,
+                ResizerByteBilinearMaddubs(svtbl2_u8(src, idx1), svld1_u8(mask1, alpha + A)));
         }
 
         SIMD_INLINE svuint8_t PackU16ToU8(const svuint16_t& lo, const svuint16_t& hi)
@@ -144,33 +205,60 @@ namespace Simd
             return svuzp1_u8(svqxtnb_u16(lo), svqxtnb_u16(hi));
         }
 
-        SIMD_INLINE svuint16_t ResizerByteBilinearInterpolateY(const uint16_t* pbx0, const uint16_t* pbx1,
-            const svuint16_t& alpha0, const svuint16_t& alpha1, const svbool_t& mask)
+        SIMD_INLINE void ResizerByteBilinearInterpolateY(const uint16_t* bx0, const uint16_t* bx1,
+            const svuint16_t& alpha0, const svuint16_t& alpha1, uint8_t* dst, const svbool_t& mask)
         {
-            svuint16_t sum = svmul_u16_x(mask, svld1_u16(mask, pbx0), alpha0);
-            sum = svmla_u16_x(mask, sum, svld1_u16(mask, pbx1), alpha1);
-            return svlsr_n_u16_x(mask, svadd_n_u16_x(mask, sum, Base::BILINEAR_ROUND_TERM), Base::BILINEAR_SHIFT);
+            svuint16_t sum = svmul_u16_x(mask, svld1_u16(mask, bx0), alpha0);
+            sum = svmla_u16_x(mask, sum, svld1_u16(mask, bx1), alpha1);
+            svst1b_u16(mask, dst, svrshr_n_u16_x(mask, sum, Base::BILINEAR_SHIFT));
         }
 
-        SIMD_INLINE void ResizerByteBilinearInterpolateY(const uint8_t* bx0, const uint8_t* bx1,
-            const svuint16_t& alpha0, const svuint16_t& alpha1, uint8_t* dst,
-            const svbool_t& mask8, const svbool_t& maskLo, const svbool_t& maskHi, size_t half)
+        SIMD_INLINE void ResizerByteBilinearInterpolateYRow(const uint8_t* bx0, const uint8_t* bx1,
+            const svuint16_t& alpha0, const svuint16_t& alpha1, uint8_t* dst, size_t rs)
         {
-            svuint16_t lo = ResizerByteBilinearInterpolateY((uint16_t*)bx0, (uint16_t*)bx1, alpha0, alpha1, maskLo);
-            svuint16_t hi = ResizerByteBilinearInterpolateY((uint16_t*)(bx0 + half * 2), (uint16_t*)(bx1 + half * 2), alpha0, alpha1, maskHi);
-            svst1_u8(mask8, dst, PackU16ToU8(lo, hi));
+            const size_t HA = svcnth();
+            const svbool_t mask16 = svptrue_b16();
+            size_t i = 0;
+            for (; i + 2 * HA <= rs; i += 2 * HA)
+            {
+                ResizerByteBilinearInterpolateY((const uint16_t*)(bx0 + 2 * i), (const uint16_t*)(bx1 + 2 * i), alpha0, alpha1, dst + i, mask16);
+                ResizerByteBilinearInterpolateY((const uint16_t*)(bx0 + 2 * (i + HA)), (const uint16_t*)(bx1 + 2 * (i + HA)), alpha0, alpha1, dst + i + HA, mask16);
+            }
+            for (; i + HA <= rs; i += HA)
+                ResizerByteBilinearInterpolateY((const uint16_t*)(bx0 + 2 * i), (const uint16_t*)(bx1 + 2 * i), alpha0, alpha1, dst + i, mask16);
+            if (i < rs)
+                ResizerByteBilinearInterpolateY((const uint16_t*)(bx0 + 2 * i), (const uint16_t*)(bx1 + 2 * i), alpha0, alpha1, dst + i, svwhilelt_b16(i, rs));
         }
 
         template<size_t N> void ResizerByteBilinear::Run(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
         {
+            struct One { uint8_t val[N]; };
+            struct Two { uint8_t val[N * 2]; };
+
             size_t size = 2 * _param.dstW * N;
-            const size_t A = svcntb(), HA = svcnth(), DA = 2 * A;
-            size_t aligned = AlignHi(size, DA) - DA;
+            size_t rs = _param.dstW * N;
+            const size_t A = svcntb();
             ptrdiff_t previous = -2;
             uint8_t* bx[2] = { _bx[0].data, _bx[1].data };
             const uint8_t* ax = _ax.data;
             const int32_t* ix = _ix.data;
             size_t dstW = _param.dstW;
+
+            svuint8_t shuffle = svindex_u8(0, 1);
+            if (N == 2)
+                shuffle = ResizerByteBilinearShuffleX2();
+            else if (N == 4)
+                shuffle = ResizerByteBilinearShuffleX4();
+
+            uint8_t idx3[2 * SIMD_SVE2_VECTOR_SIZE_MAX];
+            svuint8_t idx30 = shuffle, idx31 = shuffle;
+            size_t step3 = AlignLo(2 * A, size_t(6));
+            if (N == 3)
+            {
+                ResizerByteBilinearInitShuffleX3(idx3, A);
+                idx30 = svld1_u8(svptrue_b8(), idx3);
+                idx31 = svld1_u8(svptrue_b8(), idx3 + A);
+            }
 
             for (size_t yDst = 0; yDst < _param.dstH; yDst++, dst += dstStride)
             {
@@ -192,46 +280,49 @@ namespace Simd
 
                 for (; k < 2; k++)
                 {
-                    uint8_t* pb = bx[k];
-                    const uint8_t* psrc = src + (sy + k) * srcStride;
+                    Two* pb = (Two*)bx[k];
+                    const One* psrc = (const One*)(src + (sy + k) * srcStride);
                     for (size_t x = 0; x < dstW; x++)
-                    {
-                        const uint8_t* ps = psrc + ix[x] * N;
-                        uint8_t* pd = pb + 2 * x * N;
-                        for (size_t c = 0; c < N; c++)
-                        {
-                            pd[2 * c + 0] = ps[c];
-                            pd[2 * c + 1] = ps[c + N];
-                        }
-                    }
+                        pb[x] = *(Two*)(psrc + ix[x]);
 
-                    for (size_t i = 0; i < size; i += A)
-                        ResizerByteBilinearInterpolateX(ax + i, pb + i);
+                    uint8_t* pbx = bx[k];
+                    if (N == 3)
+                    {
+                        size_t i = 0;
+                        for (; i + step3 <= size; i += step3)
+                            ResizerByteBilinearInterpolateX3(ax + i, pbx + i, step3, idx30, idx31);
+                        if (i < size)
+                            ResizerByteBilinearInterpolateX3(ax + i, pbx + i, size - i, idx30, idx31);
+                    }
+                    else
+                    {
+                        size_t aligned = AlignLo(size, 2 * A);
+                        size_t i = 0;
+                        for (; i < aligned; i += 2 * A)
+                        {
+                            ResizerByteBilinearInterpolateX<N>(ax + i, pbx + i, shuffle);
+                            ResizerByteBilinearInterpolateX<N>(ax + i + A, pbx + i + A, shuffle);
+                        }
+                        for (; i < size; i += A)
+                            ResizerByteBilinearInterpolateX<N>(ax + i, pbx + i, shuffle);
+                    }
                 }
 
-                for (size_t ib = 0, id = 0; ib < aligned; ib += DA, id += A)
-                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a0, a1, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
-                size_t i = size - DA;
-                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a0, a1, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
-                    svwhilelt_b16(i / 2, size / 2), svwhilelt_b16(i / 2 + HA, size / 2), HA);
+                ResizerByteBilinearInterpolateYRow(bx[0], bx[1], a0, a1, dst, rs);
             }
         }
 
         template <class Idx> SIMD_INLINE void ResizerByteBilinearLoadGrayInterpolated(const uint8_t* src, const Idx& index, const uint8_t* alpha, uint8_t* dst)
         {
             const svbool_t mask8 = svptrue_b8();
-            svuint8_t _src = svld1_u8(mask8, src + index.src);
-            svuint8_t _shuffle = svld1_u8(mask8, index.shuffle);
-            svuint8_t _buffer = svtbl_u8(_src, _shuffle);
-            svst1_u8(mask8, dst + index.dst, _buffer);
-            ResizerByteBilinearInterpolateX(alpha + index.dst, dst + index.dst);
+            const svbool_t mask16 = svptrue_b16();
+            svuint8_t gathered = svtbl_u8(svld1_u8(mask8, src + index.src), svld1_u8(mask8, index.shuffle));
+            svst1_u16(mask16, (uint16_t*)(dst + index.dst), ResizerByteBilinearMaddubs(gathered, svld1_u8(mask8, alpha + index.dst)));
         }
 
         void ResizerByteBilinear::RunG(const uint8_t* src, size_t srcStride, uint8_t* dst, size_t dstStride)
         {
-            size_t size = 2 * _param.dstW;
-            const size_t A = svcntb(), HA = svcnth(), DA = 2 * A;
-            size_t aligned = AlignHi(size, DA) - DA;
+            size_t rs = _param.dstW;
             size_t blocks = _blocks;
             ptrdiff_t previous = -2;
             uint8_t* bx[2] = { _bx[0].data, _bx[1].data };
@@ -264,11 +355,7 @@ namespace Simd
                         ResizerByteBilinearLoadGrayInterpolated(psrc, ixg[i], ax, pdst);
                 }
 
-                for (size_t ib = 0, id = 0; ib < aligned; ib += DA, id += A)
-                    ResizerByteBilinearInterpolateY(bx[0] + ib, bx[1] + ib, a0, a1, dst + id, svptrue_b8(), svptrue_b16(), svptrue_b16(), HA);
-                size_t i = size - DA;
-                ResizerByteBilinearInterpolateY(bx[0] + i, bx[1] + i, a0, a1, dst + i / 2, svwhilelt_b8(i / 2, size / 2),
-                    svwhilelt_b16(i / 2, size / 2), svwhilelt_b16(i / 2 + HA, size / 2), HA);
+                ResizerByteBilinearInterpolateYRow(bx[0], bx[1], a0, a1, dst, rs);
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Speed up SVE2 `ResizerByteBilinear` by replacing `svuzp` deinterleave in X interpolation with SVE2 `svmlalb`/`svmlalt` (adjacent unsigned 8-bit madd, same as SSE `maddubs`).
- Reorder 2/4-channel paired pixels with `svtbl` (no structured `ld2`/`ld4`). Gray load and X interpolation are merged via `svtbl` + madd. 3-channel gather writes samples in pair layout, then uses the same madd kernel.
- Y interpolation uses `svrshr` + `svst1b` instead of packing through `svuzp`. 1/2/4-channel gather uses NEON-style 2-pixel copies.
- Record the improvement under release 7.2.165 in `docs/2026.html`.

## Test plan
- Cross-compiled `SimdSve2ResizerBilinear.cpp` + `SimdBaseResizerBilinear.cpp` for AArch64+SVE2 and compared Sve2 vs Base `Run` (104 size cases, channels 1–4):
  - `sve-max-vq=1` (16-byte VL): passed=104 failed=0
  - `sve-max-vq=2` (32-byte VL): passed=104 failed=0
  - `sve-max-vq=4` (64-byte VL): passed=104 failed=0
- Native Release `./Test "-r=.." -fi=Resizer -tt=1 -ts=1` — ALL TESTS ARE FINISHED SUCCESSFULLY (x86 AVX-512 host vs Base), elapsed 89.4 s.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d587df8-c936-45d3-8d6e-a19cc8d0d4a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d587df8-c936-45d3-8d6e-a19cc8d0d4a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

