### PR TITLE
Improve SVE2 optimizations of SimdSegmentationChangeIndex

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -101,6 +101,7 @@
  <li>SVE2 optimizations of function SobelDy.</li>
  <li>SVE2 optimizations of function SobelDyAbs.</li>
  <li>SVE2 optimizations of function SobelDyAbsSum.</li>
+ <li>SVE2 optimizations of function SegmentationChangeIndex.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2Segmentation.cpp
+++ b/src/Simd/SimdSve2Segmentation.cpp
@@ -58,21 +58,43 @@ namespace Simd
             }
         }
 
-        SIMD_INLINE void ChangeIndex(uint8_t* mask, const svuint8_t& oldIndex, const svuint8_t& newIndex, const svbool_t& tail)
+        SIMD_INLINE void ChangeIndex(uint8_t* mask, const svbool_t& pg, const svuint8_t& oldIndex, const svuint8_t& newIndex)
         {
-            svuint8_t _mask = svld1_u8(tail, mask);
-            svst1_u8(tail, mask, svsel_u8(svcmpeq_u8(tail, _mask, oldIndex), newIndex, _mask));
+            const svuint8_t value = svld1_u8(pg, mask);
+            svst1_u8(pg, mask, svsel_u8(svcmpeq_u8(pg, value, oldIndex), newIndex, value));
+        }
+
+        SIMD_INLINE void ChangeIndex4(uint8_t* mask, size_t A, const svbool_t& pg, const svuint8_t& oldIndex, const svuint8_t& newIndex)
+        {
+            const svuint8_t v0 = svld1_u8(pg, mask + 0 * A);
+            const svuint8_t v1 = svld1_u8(pg, mask + 1 * A);
+            const svuint8_t v2 = svld1_u8(pg, mask + 2 * A);
+            const svuint8_t v3 = svld1_u8(pg, mask + 3 * A);
+            svst1_u8(pg, mask + 0 * A, svsel_u8(svcmpeq_u8(pg, v0, oldIndex), newIndex, v0));
+            svst1_u8(pg, mask + 1 * A, svsel_u8(svcmpeq_u8(pg, v1, oldIndex), newIndex, v1));
+            svst1_u8(pg, mask + 2 * A, svsel_u8(svcmpeq_u8(pg, v2, oldIndex), newIndex, v2));
+            svst1_u8(pg, mask + 3 * A, svsel_u8(svcmpeq_u8(pg, v3, oldIndex), newIndex, v3));
         }
 
         void SegmentationChangeIndex(uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t oldIndex, uint8_t newIndex)
         {
             const size_t A = svcntb();
+            const size_t QA = A * 4;
+            const size_t widthA = AlignLo(width, A);
+            const size_t widthQA = AlignLo(width, QA);
+            const svbool_t body = svptrue_b8();
+            const svbool_t tail = svwhilelt_b8(widthA, width);
             const svuint8_t _oldIndex = svdup_n_u8(oldIndex);
             const svuint8_t _newIndex = svdup_n_u8(newIndex);
             for (size_t row = 0; row < height; ++row)
             {
-                for (size_t col = 0; col < width; col += A)
-                    ChangeIndex(mask + col, _oldIndex, _newIndex, svwhilelt_b8(col, width));
+                size_t col = 0;
+                for (; col < widthQA; col += QA)
+                    ChangeIndex4(mask + col, A, body, _oldIndex, _newIndex);
+                for (; col < widthA; col += A)
+                    ChangeIndex(mask + col, body, _oldIndex, _newIndex);
+                if (col < width)
+                    ChangeIndex(mask + col, tail, _oldIndex, _newIndex);
                 mask += stride;
             }
         }

--- a/src/Test/TestSegmentation.cpp
+++ b/src/Test/TestSegmentation.cpp
@@ -286,7 +286,13 @@ namespace Test
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
+        {
+            const int A = (int)svcntb();
             result = result && SegmentationChangeIndexAutoTest(FUNC_CI(Simd::Sve2::SegmentationChangeIndex), FUNC_CI(SimdSegmentationChangeIndex));
+            result = result && SegmentationChangeIndexAutoTest(A + 1, 5, FUNC_CI(Simd::Base::SegmentationChangeIndex), FUNC_CI(Simd::Sve2::SegmentationChangeIndex));
+            result = result && SegmentationChangeIndexAutoTest(A + 3, 7, FUNC_CI(Simd::Base::SegmentationChangeIndex), FUNC_CI(Simd::Sve2::SegmentationChangeIndex));
+            result = result && SegmentationChangeIndexAutoTest(3, 4, FUNC_CI(Simd::Base::SegmentationChangeIndex), FUNC_CI(Simd::Sve2::SegmentationChangeIndex));
+        }
 #endif
 
         return result;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrite the ARM SVE2 implementation of `SimdSegmentationChangeIndex` so it is no longer slower than the NEON path.

The previous SVE2 version rebuilt a `svwhilelt` predicate on every inner-loop iteration. The new path:

- uses a hoisted `svptrue_b8()` predicate for the main body
- unrolls four full SVE vectors per inner iteration (`ChangeIndex4`)
- finishes remaining full vectors, then a single tail predicate
- avoids macros

`docs/2026.html` release 7.2.165 Improving section is updated. `Test::SegmentationChangeIndexAutoTest` adds extra SVE2 sizes for tails and `width < svcntb()`.

## Testing

- Native `Test -fi=SegmentationChangeIndex` (Base / SSE4.1 / AVX2 / AVX-512BW): passed
- Cross-compiled SVE2 vs Base/NEON under QEMU: passed at VL=16 (`neoverse-n2` and `max,sve128`), VL=64 (`max`), including extra sizes `A+1`, `A+3`, and `3x4`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a543612-064a-4f31-b93c-07d0d36fd909?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a543612-064a-4f31-b93c-07d0d36fd909&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

