### PR TITLE
Improve SVE2 optimizations of SimdGetMoments

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -107,6 +107,8 @@
  <li>SVE2 optimizations of function WinogradKernel3x3Block2x2SetInput.</li>
  <li>SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>
+ <li>SVE2 optimizations of function GetMoments.</li>
+ <li>SVE2 optimizations of function GetObjectMoments.</li>
 </ul>
 <h5>Renaming</h5>
 <ul>

--- a/src/Simd/SimdSve2StatisticMoments.cpp
+++ b/src/Simd/SimdSve2StatisticMoments.cpp
@@ -28,38 +28,52 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE void GetObjectMoments16(const svuint16_t& src, const svuint16_t& col, size_t offset, size_t end, svuint32_t& sx, svuint32_t& sxx)
+        SIMD_INLINE void GetObjectMoments8(const svuint8_t& src, const svuint8_t& count, const svuint8_t& col,
+            const svuint8_t& one, svuint32_t& n, svuint32_t& s, svuint32_t& sx, svuint32_t& sxx)
         {
-            const size_t F = svcntw();
-
-            svbool_t lo = svwhilelt_b32(offset, end);
-            svuint32_t srcLo = svunpklo_u32(src);
-            svuint32_t colLo = svunpklo_u32(col);
-            sx = svmla_u32_m(lo, sx, srcLo, colLo);
-            sxx = svmla_u32_m(lo, sxx, srcLo, svmul_u32_x(lo, colLo, colLo));
-
-            svbool_t hi = svwhilelt_b32(offset + F, end);
-            svuint32_t srcHi = svunpkhi_u32(src);
-            svuint32_t colHi = svunpkhi_u32(col);
-            sx = svmla_u32_m(hi, sx, srcHi, colHi);
-            sxx = svmla_u32_m(hi, sxx, srcHi, svmul_u32_x(hi, colHi, colHi));
-        }
-
-        SIMD_INLINE void GetObjectMoments8(const svuint8_t& src, const svuint8_t& count, size_t offset, size_t end, const svuint8_t& one,
-            svuint32_t& n, svuint32_t& s, svuint32_t& sx, svuint32_t& sxx)
-        {
-            const size_t HA = svcnth();
-
             n = svdot_u32(n, count, one);
             s = svdot_u32(s, src, one);
+            sx = svdot_u32(sx, src, col);
 
-            svuint16_t srcLo = svunpklo_u16(src);
-            svuint16_t colLo = svindex_u16((uint16_t)offset, 1);
-            GetObjectMoments16(srcLo, colLo, offset, end, sx, sxx);
+            svuint16_t srcEven = svmovlb_u16(src);
+            svuint16_t srcOdd = svmovlt_u16(src);
+            svuint16_t col2Even = svmullb_u16(col, col);
+            svuint16_t col2Odd = svmullt_u16(col, col);
+            sxx = svmlalb_u32(sxx, srcEven, col2Even);
+            sxx = svmlalt_u32(sxx, srcEven, col2Even);
+            sxx = svmlalb_u32(sxx, srcOdd, col2Odd);
+            sxx = svmlalt_u32(sxx, srcOdd, col2Odd);
+        }
 
-            svuint16_t srcHi = svunpkhi_u16(src);
-            svuint16_t colHi = svindex_u16((uint16_t)(offset + HA), 1);
-            GetObjectMoments16(srcHi, colHi, offset + HA, end, sx, sxx);
+        SIMD_INLINE void AddWide(svuint64_t& sum, const svuint32_t& value)
+        {
+            const svbool_t mask64 = svptrue_b64();
+            sum = svadd_u64_x(mask64, sum, svunpklo_u64(value));
+            sum = svadd_u64_x(mask64, sum, svunpkhi_u64(value));
+        }
+
+        SIMD_INLINE void AddWideMul(svuint64_t& sum, const svuint32_t& value, uint64_t factor)
+        {
+            const svbool_t mask64 = svptrue_b64();
+            sum = svmla_n_u64_x(mask64, sum, svunpklo_u64(value), factor);
+            sum = svmla_n_u64_x(mask64, sum, svunpkhi_u64(value), factor);
+        }
+
+        SIMD_INLINE void AddBlockMoments(svuint32_t n, svuint32_t s, svuint32_t sx, svuint32_t sxx,
+            uint64_t x, uint64_t y, svuint64_t& n64, svuint64_t& s64, svuint64_t& sx64, svuint64_t& sy64,
+            svuint64_t& sxx64, svuint64_t& sxy64, svuint64_t& syy64)
+        {
+            AddWide(n64, n);
+            AddWide(s64, s);
+            AddWide(sx64, sx);
+            AddWideMul(sx64, s, x);
+            AddWideMul(sy64, s, y);
+            AddWide(sxx64, sxx);
+            AddWideMul(sxx64, sx, x * 2);
+            AddWideMul(sxx64, s, x * x);
+            AddWideMul(sxy64, sx, y);
+            AddWideMul(sxy64, s, x * y);
+            AddWideMul(syy64, s, y * y);
         }
 
         void GetObjectMoments(const uint8_t* src, size_t srcStride, size_t width, size_t height, const uint8_t* mask, size_t maskStride, uint8_t index,
@@ -67,78 +81,114 @@ namespace Simd
         {
             assert(src || mask);
 
-            *n = 0;
-            *s = 0;
-            *sx = 0;
-            *sy = 0;
-            *sxx = 0;
-            *sxy = 0;
-            *syy = 0;
-
             const size_t A = svcntb();
-            const size_t B = 181;
+            const size_t B = A > 181 ? 181 : AlignLo(181, A);
+            const svbool_t body = svptrue_b8();
+            const svbool_t body32 = svptrue_b32();
             const svuint8_t _index = svdup_n_u8(index);
             const svuint8_t one = svdup_n_u8(1);
             const svuint8_t zero = svdup_n_u8(0);
+            const svuint8_t addA = svdup_n_u8((uint8_t)A);
+            const svuint8_t col0 = svindex_u8(0, 1);
+
+            svuint64_t n64 = svdup_n_u64(0);
+            svuint64_t s64 = svdup_n_u64(0);
+            svuint64_t sx64 = svdup_n_u64(0);
+            svuint64_t sy64 = svdup_n_u64(0);
+            svuint64_t sxx64 = svdup_n_u64(0);
+            svuint64_t sxy64 = svdup_n_u64(0);
+            svuint64_t syy64 = svdup_n_u64(0);
 
             for (size_t row = 0; row < height; ++row)
             {
                 for (size_t colB = 0; colB < width;)
                 {
                     size_t colE = Simd::Min(colB + B, width);
-                    svuint32_t _n = svdup_n_u32(0);
-                    svuint32_t _s = svdup_n_u32(0);
-                    svuint32_t _sx = svdup_n_u32(0);
-                    svuint32_t _sxx = svdup_n_u32(0);
+                    svuint32_t n0 = svdup_n_u32(0), n1 = svdup_n_u32(0);
+                    svuint32_t s0 = svdup_n_u32(0), s1 = svdup_n_u32(0);
+                    svuint32_t sx0 = svdup_n_u32(0), sx1 = svdup_n_u32(0);
+                    svuint32_t sxx0 = svdup_n_u32(0), sxx1 = svdup_n_u32(0);
+                    svuint8_t colIdx = col0;
+                    size_t col = colB;
 
                     if (mask == NULL)
                     {
-                        for (size_t col = colB; col < colE; col += A)
+                        for (; col + 2 * A <= colE; col += 2 * A)
                         {
-                            svbool_t pg = svwhilelt_b8(col, colE);
-                            svuint8_t _src = svld1_u8(pg, src + col);
-                            svuint8_t _count = svand_u8_z(pg, one, one);
-                            GetObjectMoments8(_src, _count, col - colB, colE - colB, one, _n, _s, _sx, _sxx);
+                            GetObjectMoments8(svld1_u8(body, src + col), one, colIdx, one, n0, s0, sx0, sxx0);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                            GetObjectMoments8(svld1_u8(body, src + col + A), one, colIdx, one, n1, s1, sx1, sxx1);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                        }
+                        for (; col + A <= colE; col += A)
+                        {
+                            GetObjectMoments8(svld1_u8(body, src + col), one, colIdx, one, n0, s0, sx0, sxx0);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                        }
+                        if (col < colE)
+                        {
+                            svbool_t tail = svwhilelt_b8(col, colE);
+                            GetObjectMoments8(svld1_u8(tail, src + col), svsel_u8(tail, one, zero), colIdx, one, n0, s0, sx0, sxx0);
                         }
                     }
                     else if (src == NULL)
                     {
-                        for (size_t col = colB; col < colE; col += A)
+                        for (; col + 2 * A <= colE; col += 2 * A)
                         {
-                            svbool_t pg = svwhilelt_b8(col, colE);
-                            svbool_t equal = svcmpeq_u8(pg, svld1_u8(pg, mask + col), _index);
+                            svbool_t equal0 = svcmpeq_u8(body, svld1_u8(body, mask + col), _index);
+                            svuint8_t src0 = svand_u8_z(equal0, one, one);
+                            GetObjectMoments8(src0, src0, colIdx, one, n0, s0, sx0, sxx0);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                            svbool_t equal1 = svcmpeq_u8(body, svld1_u8(body, mask + col + A), _index);
+                            svuint8_t src1 = svand_u8_z(equal1, one, one);
+                            GetObjectMoments8(src1, src1, colIdx, one, n1, s1, sx1, sxx1);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                        }
+                        for (; col + A <= colE; col += A)
+                        {
+                            svbool_t equal = svcmpeq_u8(body, svld1_u8(body, mask + col), _index);
                             svuint8_t _src = svand_u8_z(equal, one, one);
-                            GetObjectMoments8(_src, _src, col - colB, colE - colB, one, _n, _s, _sx, _sxx);
+                            GetObjectMoments8(_src, _src, colIdx, one, n0, s0, sx0, sxx0);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                        }
+                        if (col < colE)
+                        {
+                            svbool_t tail = svwhilelt_b8(col, colE);
+                            svbool_t equal = svcmpeq_u8(tail, svld1_u8(tail, mask + col), _index);
+                            svuint8_t _src = svand_u8_z(equal, one, one);
+                            GetObjectMoments8(_src, _src, colIdx, one, n0, s0, sx0, sxx0);
                         }
                     }
                     else
                     {
-                        for (size_t col = colB; col < colE; col += A)
+                        for (; col + 2 * A <= colE; col += 2 * A)
                         {
-                            svbool_t pg = svwhilelt_b8(col, colE);
-                            svbool_t equal = svcmpeq_u8(pg, svld1_u8(pg, mask + col), _index);
-                            svuint8_t _src = svsel_u8(equal, svld1_u8(pg, src + col), zero);
-                            svuint8_t _count = svand_u8_z(equal, one, one);
-                            GetObjectMoments8(_src, _count, col - colB, colE - colB, one, _n, _s, _sx, _sxx);
+                            svbool_t equal0 = svcmpeq_u8(body, svld1_u8(body, mask + col), _index);
+                            GetObjectMoments8(svsel_u8(equal0, svld1_u8(body, src + col), zero), svand_u8_z(equal0, one, one), colIdx, one, n0, s0, sx0, sxx0);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                            svbool_t equal1 = svcmpeq_u8(body, svld1_u8(body, mask + col + A), _index);
+                            GetObjectMoments8(svsel_u8(equal1, svld1_u8(body, src + col + A), zero), svand_u8_z(equal1, one, one), colIdx, one, n1, s1, sx1, sxx1);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                        }
+                        for (; col + A <= colE; col += A)
+                        {
+                            svbool_t equal = svcmpeq_u8(body, svld1_u8(body, mask + col), _index);
+                            GetObjectMoments8(svsel_u8(equal, svld1_u8(body, src + col), zero), svand_u8_z(equal, one, one), colIdx, one, n0, s0, sx0, sxx0);
+                            colIdx = svadd_u8_x(body, colIdx, addA);
+                        }
+                        if (col < colE)
+                        {
+                            svbool_t tail = svwhilelt_b8(col, colE);
+                            svbool_t equal = svcmpeq_u8(tail, svld1_u8(tail, mask + col), _index);
+                            GetObjectMoments8(svsel_u8(equal, svld1_u8(tail, src + col), zero), svand_u8_z(equal, one, one), colIdx, one, n0, s0, sx0, sxx0);
                         }
                     }
 
-                    uint64_t _sn = svaddv_u32(svptrue_b32(), _n);
-                    uint64_t _ss = svaddv_u32(svptrue_b32(), _s);
-                    uint64_t _ssx = svaddv_u32(svptrue_b32(), _sx);
-                    uint64_t _ssxx = svaddv_u32(svptrue_b32(), _sxx);
-                    uint64_t _x = colB;
-                    uint64_t _y = row;
-
-                    *n += _sn;
-                    *s += _ss;
-
-                    *sx += _ssx + _ss * _x;
-                    *sy += _ss * _y;
-
-                    *sxx += _ssxx + _ssx * _x * 2 + _ss * _x * _x;
-                    *sxy += _ssx * _y + _ss * _x * _y;
-                    *syy += _ss * _y * _y;
+                    n0 = svadd_u32_x(body32, n0, n1);
+                    s0 = svadd_u32_x(body32, s0, s1);
+                    sx0 = svadd_u32_x(body32, sx0, sx1);
+                    sxx0 = svadd_u32_x(body32, sxx0, sxx1);
+                    AddBlockMoments(n0, s0, sx0, sxx0, colB, row, n64, s64, sx64, sy64, sxx64, sxy64, syy64);
 
                     colB = colE;
                 }
@@ -147,6 +197,15 @@ namespace Simd
                 if (mask)
                     mask += maskStride;
             }
+
+            const svbool_t mask64 = svptrue_b64();
+            *n = svaddv_u64(mask64, n64);
+            *s = svaddv_u64(mask64, s64);
+            *sx = svaddv_u64(mask64, sx64);
+            *sy = svaddv_u64(mask64, sy64);
+            *sxx = svaddv_u64(mask64, sxx64);
+            *sxy = svaddv_u64(mask64, sxy64);
+            *syy = svaddv_u64(mask64, syy64);
         }
 
         void GetMoments(const uint8_t* mask, size_t stride, size_t width, size_t height, uint8_t index,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The SVE2 implementation of `SimdGetMoments` rebuilt column indices with `svindex` on every vector, unpacked 8/16-bit values all the way to 32-bit, and used predicated `svmla` plus `svwhilelt` in the inner kernel. That is more work than NEON `vmlal_u16` and was much slower.

This change:

- Uses SVE2 `svdot_u32` for `n`, `s`, and `sx` with a running uint8 column index (`0..180` in each 181-wide block)
- Accumulates `sxx` with even/odd widening `svmullb`/`svmullt` + `svmlalb`/`svmlalt` (no `svunpk` to 32-bit)
- Increments the column vector instead of regenerating it, and uses `svptrue` for full vectors with a predicated tail
- Keeps 64-bit moment accumulators in registers and reduces once at the end
- Unrolls two vectors in the inner loop for more ILP
- Does not use structured `svld4`/`svst4` loads/stores, and does not add macros

Release notes for 7.2.165 list the improvement.

`GetMoments` is implemented through `GetObjectMoments`, so both APIs benefit.

The AArch64 object dump of the inner loop is `ld1b` + `udot` + `umullb`/`umullt` + `umlalb`/`umlalt`. `index` is used once per block; the column vector is then `add z.b`. Tail uses `whilelo` + predicated `ld1b`. No `ld4`/`st4`.

Correctness:

- Scalar simulation of even/odd UDOT/MLA vs Base, for SVE lengths 128/256/512/1024/2048 bits and AutoTest-like shapes (720 cases)
- Cross-compiled with `aarch64-linux-gnu-g++` (`-march=armv9-a+sve+sve2`, scalable VL)
- Real `Sve2::GetObjectMoments` / `GetMoments` vs `Base` under QEMU `neoverse-n2`, `cortex-a710`, and `max` with `sve-max-vq=1/2/4` (`svcntb` 16/32/64). 22 sizes × 3 use-modes = 66 cases per CPU, all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a18918a-b73b-4cb4-b765-582a56ae56e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a18918a-b73b-4cb4-b765-582a56ae56e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

