### PR TITLE
Guard RGB transform bounds for small images

### DIFF
--- a/src/Simd/SimdAvx2Transform.cpp
+++ b/src/Simd/SimdAvx2Transform.cpp
@@ -115,10 +115,10 @@ namespace Simd
         template<> void TransformImageRotate90<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             dst += (width - 1) * dstStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 4);
             size_t row = 0;
             for (; row < height8; row += 8)
             {
@@ -303,10 +303,10 @@ namespace Simd
         template<> void TransformImageRotate270<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t row = 0;
             for (; row < height8; row += 8)
             {
@@ -467,10 +467,10 @@ namespace Simd
 
         template<> void TransformImageTransposeRotate0<3>(const uint8_t * src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t * dst, ptrdiff_t dstStride)
         {
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t row = 0;
             for (; row < height8; row += 8)
             {
@@ -654,10 +654,10 @@ namespace Simd
         template<> void TransformImageTransposeRotate180<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride + (width - 1) * 3;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t row = 0;
             for (; row < height8; row += 8)
             {

--- a/src/Simd/SimdAvx512bwTransform.cpp
+++ b/src/Simd/SimdAvx512bwTransform.cpp
@@ -139,11 +139,11 @@ namespace Simd
         template<> void TransformImageRotate90<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             dst += (width - 1) * dstStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
             size_t width16 = AlignLo(width, 16);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t height16 = AlignLo(height, 16);
             size_t row = 0;
             for (; row < height16; row += 16)
@@ -448,11 +448,11 @@ namespace Simd
         template<> void TransformImageRotate270<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
             size_t width16 = AlignLo(width, 16);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t height16 = AlignLo(height, 16);
             size_t row = 0;
             for (; row < height16; row += 16)
@@ -672,11 +672,11 @@ namespace Simd
 
         template<> void TransformImageTransposeRotate0<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
             size_t width16 = AlignLo(width, 16);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t height16 = AlignLo(height, 16);
             size_t row = 0;
             for (; row < height16; row += 16)
@@ -981,11 +981,11 @@ namespace Simd
         template<> void TransformImageTransposeRotate180<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride + (width - 1) * 3;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t width8 = AlignLo(width - 9, 8);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t width8 = AlignLo(Max<size_t>(width, 9) - 9, 8);
             size_t width16 = AlignLo(width, 16);
-            size_t height4 = AlignLo(height - 5, 4);
-            size_t height8 = AlignLo(height - 9, 8);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
+            size_t height8 = AlignLo(Max<size_t>(height, 9) - 9, 8);
             size_t height16 = AlignLo(height, 16);
             size_t row = 0;
             for (; row < height16; row += 16)

--- a/src/Simd/SimdNeonTransform.cpp
+++ b/src/Simd/SimdNeonTransform.cpp
@@ -88,8 +88,8 @@ namespace Simd
         template<> void TransformImageRotate90<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             dst += (width - 1) * dstStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {
@@ -217,8 +217,8 @@ namespace Simd
         template<> void TransformImageRotate270<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {
@@ -322,8 +322,8 @@ namespace Simd
 
         template<> void TransformImageTransposeRotate0<3>(const uint8_t * src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t * dst, ptrdiff_t dstStride)
         {
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {
@@ -450,8 +450,8 @@ namespace Simd
         template<> void TransformImageTransposeRotate180<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride + (width - 1) * 3;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {

--- a/src/Simd/SimdSse41Transform.cpp
+++ b/src/Simd/SimdSse41Transform.cpp
@@ -88,8 +88,8 @@ namespace Simd
         template<> void TransformImageRotate90<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             dst += (width - 1) * dstStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {
@@ -217,8 +217,8 @@ namespace Simd
         template<> void TransformImageRotate270<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {
@@ -322,8 +322,8 @@ namespace Simd
 
         template<> void TransformImageTransposeRotate0<3>(const uint8_t * src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t * dst, ptrdiff_t dstStride)
         {
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {
@@ -450,8 +450,8 @@ namespace Simd
         template<> void TransformImageTransposeRotate180<3>(const uint8_t* src, ptrdiff_t srcStride, size_t width, size_t height, uint8_t* dst, ptrdiff_t dstStride)
         {
             src += (height - 1) * srcStride + (width - 1) * 3;
-            size_t width4 = AlignLo(width - 5, 4);
-            size_t height4 = AlignLo(height - 5, 4);
+            size_t width4 = AlignLo(Max<size_t>(width, 5) - 5, 4);
+            size_t height4 = AlignLo(Max<size_t>(height, 5) - 5, 4);
             size_t row = 0;
             for (; row < height4; row += 4)
             {

--- a/src/Test/TestTransform.cpp
+++ b/src/Test/TestTransform.cpp
@@ -135,6 +135,30 @@ namespace Test
             }
         }
 
+        const ::SimdTransformType smallHeightTransforms[] =
+        {
+            ::SimdTransformRotate90,
+            ::SimdTransformRotate270,
+            ::SimdTransformTransposeRotate0,
+            ::SimdTransformTransposeRotate180,
+        };
+        for (int height = 1; height <= 9 && result; ++height)
+        {
+            for (size_t i = 0; i < sizeof(smallHeightTransforms) / sizeof(smallHeightTransforms[0]); ++i)
+            {
+                const ::SimdTransformType transform = smallHeightTransforms[i];
+                View src(W, height, View::Bgr24, NULL, TEST_ALIGN(W));
+                FillRandom(src);
+                Size dstSize = Simd::TransformSize(src.Size(), transform);
+                View dst1(dstSize.x, dstSize.y, View::Bgr24, NULL, TEST_ALIGN(W));
+                View dst2(dstSize.x, dstSize.y, View::Bgr24, NULL, TEST_ALIGN(W));
+
+                f1.func(src.data, src.stride, src.width, src.height, src.PixelSize(), transform, dst1.data, dst1.stride);
+                f2.func(src.data, src.stride, src.width, src.height, src.PixelSize(), transform, dst2.data, dst2.stride);
+                result = result && Compare(dst1, dst2, 0, true, 64);
+            }
+        }
+
         return result;
     }
 


### PR DESCRIPTION
## Summary

- prevent unsigned underflow when the optimized 3-byte image transforms calculate 4-row and 8-row vector bounds
- apply the same bounds fix to SSE4.1, AVX2, AVX-512BW, and NEON
- add small-height RGB coverage for the four affected transform directions

The affected calculations subtracted 5 or 9 from an unsigned image dimension before alignment. For short images, the result wrapped to a very large value and the vector loop read and wrote beyond the image buffers.

Fixes #832. Thanks to @krzysztof-zajdel for the report and reproducer.

## Verification

- the padded 16x1 RGB reproducer fails on `edf5baf1a79d468fa78f0f3fdeaabb4374738f0b` with an AddressSanitizer heap-buffer-overflow in `Neon::TransformImageRotate90<3>`
- the same reproducer checks all eight transforms for heights 1 through 9 and passes after this patch
- `Test -fi=TransformImage -tt=1 -ts=1` passes under AddressSanitizer on arm64
- the modified SSE4.1, AVX2, and AVX-512BW translation units compile successfully for x86_64

Assisted-by: OpenAI Codex
