### PR TITLE
Improve SVE2 optimizations of SimdFloat32ToBFloat16

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -113,6 +113,7 @@
  <li>SVE2 optimizations of function GetObjectMoments.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
+ <li>SVE2 optimizations of function Float32ToBFloat16.</li>
  <li>C++ wrapper Simd::FillFrame.</li>
 </ul>
 <h5>Renaming</h5>

--- a/src/Simd/SimdSve2BFloat16.cpp
+++ b/src/Simd/SimdSve2BFloat16.cpp
@@ -29,26 +29,31 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svuint32_t Float32ToBFloat16(svfloat32_t value, const svbool_t& mask)
+        SIMD_INLINE svbfloat16_t Float32ToBFloat16(svfloat32_t even, svfloat32_t odd, const svbool_t& mask)
         {
-            svuint32_t bits = svreinterpret_u32_f32(value);
-            svuint32_t round = svadd_n_u32_x(mask, svand_n_u32_x(mask, svlsr_n_u32_x(mask, bits, Base::Bf16::SHIFT), 1), Base::Bf16::ROUND);
-            return svlsr_n_u32_x(mask, svadd_u32_x(mask, bits, round), Base::Bf16::SHIFT);
+            return svcvtnt_bf16_f32_x(svcvt_bf16_f32_x(mask, even), mask, odd);
         }
 
         SIMD_INLINE void Float32ToBFloat16(const float* src, const svbool_t& lo, const svbool_t& hi, const svbool_t& store, uint16_t* dst)
         {
-            size_t F = svlen(svfloat32_t());
-            svuint16_t _lo = svreinterpret_u16_u32(Float32ToBFloat16(svld1_f32(lo, src + 0), lo));
-            svuint16_t _hi = svreinterpret_u16_u32(Float32ToBFloat16(svld1_f32(hi, src + F), hi));
-            svst1_u16(store, dst, svuzp1_u16(_lo, _hi));
+            size_t F = svcntw();
+            svfloat32_t s0 = svld1_f32(lo, src + 0);
+            svfloat32_t s1 = svld1_f32(hi, src + F);
+            svst1_u16(store, dst, svreinterpret_u16_bf16(Float32ToBFloat16(svuzp1_f32(s0, s1), svuzp2_f32(s0, s1), svptrue_b32())));
         }
 
         void Float32ToBFloat16(const float* src, size_t size, uint16_t* dst)
         {
-            size_t A = svlen(svuint16_t()), F = svlen(svfloat32_t()), sizeA = AlignLo(size, A), i = 0;
+            size_t A = svcnth(), F = svcntw(), QA = A * 4, sizeQA = AlignLo(size, QA), sizeA = AlignLo(size, A), i = 0;
             const svbool_t body16 = svptrue_b16();
             const svbool_t body32 = svptrue_b32();
+            for (; i < sizeQA; i += QA)
+            {
+                Float32ToBFloat16(src + i + 0 * A, body32, body32, body16, dst + i + 0 * A);
+                Float32ToBFloat16(src + i + 1 * A, body32, body32, body16, dst + i + 1 * A);
+                Float32ToBFloat16(src + i + 2 * A, body32, body32, body16, dst + i + 2 * A);
+                Float32ToBFloat16(src + i + 3 * A, body32, body32, body16, dst + i + 3 * A);
+            }
             for (; i < sizeA; i += A)
                 Float32ToBFloat16(src + i, body32, body32, body16, dst + i);
             if (i < size)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace the SVE2 software rounding path of `SimdFloat32ToBFloat16` with hardware BFloat16 conversion.

## Changes
- Use `svcvt_bf16_f32_x` + `svcvtnt_bf16_f32_x` (BFCVT / BFCVTNT) in `SimdSve2BFloat16.cpp` instead of shift/add rounding.
- Deinterleave consecutive `f32` vectors with `svuzp1_f32` / `svuzp2_f32` so the convert pair writes sequential `bf16` values.
- Unroll the main loop by 4 destination vectors.
- Add the change to the Improving list of release 7.2.165 in `docs/2026.html`.

## Test results
- AArch64 cross-compile of `SimdSve2BFloat16.cpp` emits `bfcvt` / `bfcvtnt`.
- QEMU user-mode SVE (VL 128/256/512): hardware `svcvt`/`svcvtnt` matches `Base::Float32ToBFloat16` for 39 sizes per VL, including tails.
- Packing simulation of `uzp1`/`uzp2` + even/odd convert matches Base for F=4/8/16 and aligned/tail sizes.
- Native x86 `./Test "-r=.." -fi=Float32ToBFloat16 -tt=1 -ts=1 -w=640 -h=480`: ALL TESTS ARE FINISHED SUCCESSFULLY (Base / SSE4.1 / AVX2 / AVX-512BW / AMX).

[Test log](https://cursor.com/agents/bc-b8d15370-c1c3-4185-867b-6b39123f0c2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffloat32_to_bfloat16_test_log.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d15370-c1c3-4185-867b-6b39123f0c2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d15370-c1c3-4185-867b-6b39123f0c2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

