### PR TITLE
Add SVE2 optimizations of ImageBmpSaver

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -77,6 +77,7 @@
  <li>SVE2 optimizations of class ImagePgmBinSaver.</li>
  <li>SVE2 optimizations of class ImagePpmTxtSaver.</li>
  <li>SVE2 optimizations of class ImagePpmBinSaver.</li>
+ <li>SVE2 optimizations of class ImageBmpSaver.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
  <li>C++ wrapper Simd::SynetQuantizedMul.</li>

--- a/src/Simd/SimdImageSave.h
+++ b/src/Simd/SimdImageSave.h
@@ -519,6 +519,12 @@ namespace Simd
             ImagePpmBinSaver(const ImageSaverParam& param);
         };
 
+        class ImageBmpSaver : public Neon::ImageBmpSaver
+        {
+        public:
+            ImageBmpSaver(const ImageSaverParam& param);
+        };
+
         //-------------------------------------------------------------------------------------------------
 
         uint8_t* ImageSaveToMemory(const uint8_t* src, size_t stride, size_t width, size_t height, SimdPixelFormatType format, SimdImageFileType file, int quality, size_t* size);

--- a/src/Simd/SimdSve2ImageSave.cpp
+++ b/src/Simd/SimdSve2ImageSave.cpp
@@ -100,6 +100,20 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
+        ImageBmpSaver::ImageBmpSaver(const ImageSaverParam& param)
+            : Neon::ImageBmpSaver(param)
+        {
+            switch (_param.format)
+            {
+            case SimdPixelFormatGray8: _convert = NULL; break;
+            case SimdPixelFormatRgb24: _convert = Sve2::BgrToRgb; break;
+            case SimdPixelFormatRgba32: _convert = Sve2::BgraToRgba; break;
+            default: break;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
         ImageSaver* CreateImageSaver(const ImageSaverParam& param)
         {
             switch (param.file)
@@ -110,7 +124,7 @@ namespace Simd
             case SimdImageFilePpmBin: return new ImagePpmBinSaver(param);
             case SimdImageFilePng: return new Neon::ImagePngSaver(param);
             case SimdImageFileJpeg: return new Neon::ImageJpegSaver(param);
-            case SimdImageFileBmp: return new Neon::ImageBmpSaver(param);
+            case SimdImageFileBmp: return new ImageBmpSaver(param);
             default:
                 return NULL;
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wire SVE2 `ImageBmpSaver` into `ImageSaveToMemory` so BMP encoding uses SVE2 color converters on ARM/ARM64.

## Changes
- Add `Sve2::ImageBmpSaver` (inherits `Neon::ImageBmpSaver`) in `SimdImageSave.h`.
- Implement the constructor in `SimdSve2ImageSave.cpp`: Gray8 stays a memcpy path; Rgb24 uses `Sve2::BgrToRgb`; Rgba32 uses `Sve2::BgraToRgba`. This matches the Neon/SSE41/AVX2 BMP saver pattern.
- Route `SimdImageFileBmp` through `Sve2::ImageBmpSaver` in `CreateImageSaver`.
- Document the feature in `docs/2026.html` (release 7.2.165).

`Test::ImageSaveToMemoryAutoTest` already compares `Simd::Sve2::ImageSaveToMemory` with `SimdImageSaveToMemory`. `SimdSve2ImageSave.cpp` is already listed in `prj/vs2022/Sve2.vcxproj` and `Sve2.vcxproj.filters`.

## Testing
- x86_64 CMake Release build of the library and `Test`.
- `./Test "-r=.." -fi=ImageSaveToMemory -tt=1 -ts=1` — all formats including BMP finished successfully (82.1 s).
- Cross-compiled `SimdSve2ImageSave.cpp` with `aarch64-linux-gnu-g++ -march=armv9-a+sve+sve2+i8mm+bf16`. The constructor stores `Sve2::BgrToRgb` / `Sve2::BgraToRgba` into `_convert`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f47db716-4f71-4925-9fc4-3b60ca24b997?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f47db716-4f71-4925-9fc4-3b60ca24b997&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

