### PR TITLE
Improve SVE2 optimizations of SimdSynetQuantizedAdd

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -115,6 +115,7 @@
  <li>SVE2 optimizations of function SynetConvert32fTo8u.</li>
  <li>SVE2 optimizations of function SynetConvert8uTo32f.</li>
  <li>SVE2 optimizations of function SynetQuantizeLinear.</li>
+ <li>SVE2 optimizations of function SynetQuantizedAdd.</li>
  <li>SVE2 optimizations of function WinogradKernel3x3Block2x2SetInput.</li>
  <li>SVE2 optimizations of function GetColSums.</li>
  <li>SVE2 optimizations of function GetAbsDxColSums.</li>

--- a/src/Simd/SimdSve2SynetQuantizedAdd.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedAdd.cpp
@@ -23,35 +23,60 @@
 */
 #include "Simd/SimdSynetQuantizedAdd.h"
 #include "Simd/SimdSve2.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
 
 namespace Simd
 {
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Sve2
     {
-        SIMD_INLINE svint32_t Load8u(const uint8_t* src, const svbool_t& mask)
+        SIMD_INLINE void UnpackU8(const svuint8_t& src, svint32_t& d0, svint32_t& d1, svint32_t& d2, svint32_t& d3)
         {
-            return svreinterpret_s32_u32(svld1ub_u32(mask, src));
+            svuint16_t lo = svunpklo_u16(src);
+            svuint16_t hi = svunpkhi_u16(src);
+            d0 = svreinterpret_s32_u32(svunpklo_u32(lo));
+            d1 = svreinterpret_s32_u32(svunpkhi_u32(lo));
+            d2 = svreinterpret_s32_u32(svunpklo_u32(hi));
+            d3 = svreinterpret_s32_u32(svunpkhi_u32(hi));
         }
 
-        SIMD_INLINE void Store8u(const svint32_t& value, uint8_t* dst, const svbool_t& mask)
+        SIMD_INLINE svuint8_t PackU8(const svint32_t& d0, const svint32_t& d1, const svint32_t& d2, const svint32_t& d3)
         {
-            svint32_t lo = svmax_n_s32_x(mask, value, 0);
-            svuint32_t u32 = svreinterpret_u32_s32(svmin_n_s32_x(mask, lo, 255));
-            svst1b_u32(mask, dst, u32);
+            svuint16_t lo = svuzp1_u16(svreinterpret_u16_u32(svreinterpret_u32_s32(d0)), svreinterpret_u16_u32(svreinterpret_u32_s32(d1)));
+            svuint16_t hi = svuzp1_u16(svreinterpret_u16_u32(svreinterpret_u32_s32(d2)), svreinterpret_u16_u32(svreinterpret_u32_s32(d3)));
+            return svuzp1_u8(svreinterpret_u8_u16(lo), svreinterpret_u8_u16(hi));
         }
 
-        SIMD_INLINE svint32_t QuantizedAdd(const svint32_t& a, const svfloat32_t& adScale, const svint32_t& b, const svfloat32_t& bdScale, const svfloat32_t& term, const svbool_t& mask)
+        SIMD_INLINE svint32_t QuantizedAdd(const svint32_t& a, const svfloat32_t& adScale, const svint32_t& b, const svfloat32_t& bdScale,
+            const svfloat32_t& term, const svfloat32_t& one, const svint32_t& zero, const svbool_t& mask)
         {
             svfloat32_t value = svmla_f32_x(mask, term, svcvt_f32_s32_x(mask, a), adScale);
             value = svmla_f32_x(mask, value, svcvt_f32_s32_x(mask, b), bdScale);
-            svfloat32_t round = svsel_f32(svcmpgt_n_f32(mask, value, 0.0f), svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
-            return svcvt_s32_f32_x(mask, svadd_f32_x(mask, value, round));
+            svint32_t dst = QuantizeLinear(value, one, zero, mask);
+            return svmin_n_s32_x(mask, svmax_n_s32_x(mask, dst, 0), 255);
         }
 
-        SIMD_INLINE void QuantizedAdd8u8u8u(const uint8_t* a, const svfloat32_t& adScale, const uint8_t* b, const svfloat32_t& bdScale, const svfloat32_t& term, uint8_t* dst, const svbool_t& mask)
+        SIMD_INLINE void QuantizedAdd8u8u8u(const uint8_t* a, const svfloat32_t& adScale, const uint8_t* b, const svfloat32_t& bdScale,
+            const svfloat32_t& term, const svfloat32_t& one, const svint32_t& zero, uint8_t* dst, const svbool_t& mask)
         {
-            Store8u(QuantizedAdd(Load8u(a, mask), adScale, Load8u(b, mask), bdScale, term, mask), dst, mask);
+            svint32_t va = svreinterpret_s32_u32(svld1ub_u32(mask, a));
+            svint32_t vb = svreinterpret_s32_u32(svld1ub_u32(mask, b));
+            svst1b_u32(mask, dst, svreinterpret_u32_s32(QuantizedAdd(va, adScale, vb, bdScale, term, one, zero, mask)));
+        }
+
+        SIMD_INLINE void QuantizedAdd8u8u8uA(const uint8_t* a, const svfloat32_t& adScale, const uint8_t* b, const svfloat32_t& bdScale,
+            const svfloat32_t& term, const svfloat32_t& one, const svint32_t& zero, uint8_t* dst)
+        {
+            const svbool_t mask32 = svptrue_b32();
+            const svbool_t mask8 = svptrue_b8();
+            svint32_t a0, a1, a2, a3, b0, b1, b2, b3;
+            UnpackU8(svld1_u8(mask8, a), a0, a1, a2, a3);
+            UnpackU8(svld1_u8(mask8, b), b0, b1, b2, b3);
+            svint32_t d0 = QuantizedAdd(a0, adScale, b0, bdScale, term, one, zero, mask32);
+            svint32_t d1 = QuantizedAdd(a1, adScale, b1, bdScale, term, one, zero, mask32);
+            svint32_t d2 = QuantizedAdd(a2, adScale, b2, bdScale, term, one, zero, mask32);
+            svint32_t d3 = QuantizedAdd(a3, adScale, b3, bdScale, term, one, zero, mask32);
+            svst1_u8(mask8, dst, PackU8(d0, d1, d2, d3));
         }
 
         static void QuantizedAddUniform8u8u8u(const uint8_t* a, float aScale, int aZero, const uint8_t* b, float bScale, int bZero, size_t size, const float*, float dScale, int dZero, uint8_t* dst)
@@ -59,22 +84,25 @@ namespace Simd
             float adScale = aScale / dScale;
             float bdScale = bScale / dScale;
             float term = float(dZero) - (adScale * float(aZero) + bdScale * float(bZero));
-            const size_t F = svcntw(), QF = 4 * F;
-            const svbool_t full = svptrue_b32();
+            const size_t F = svcntw(), A = svcntb(), QA = 4 * A;
+            const svbool_t body = svptrue_b32();
             const svfloat32_t _adScale = svdup_n_f32(adScale), _bdScale = svdup_n_f32(bdScale), _term = svdup_n_f32(term);
+            const svfloat32_t _one = svdup_n_f32(1.0f);
+            const svint32_t _zero = svdup_n_s32(0);
             size_t i = 0;
-            for (; i + QF <= size; i += QF)
+            for (; i + QA <= size; i += QA)
             {
-                QuantizedAdd8u8u8u(a + i + 0 * F, _adScale, b + i + 0 * F, _bdScale, _term, dst + i + 0 * F, full);
-                QuantizedAdd8u8u8u(a + i + 1 * F, _adScale, b + i + 1 * F, _bdScale, _term, dst + i + 1 * F, full);
-                QuantizedAdd8u8u8u(a + i + 2 * F, _adScale, b + i + 2 * F, _bdScale, _term, dst + i + 2 * F, full);
-                QuantizedAdd8u8u8u(a + i + 3 * F, _adScale, b + i + 3 * F, _bdScale, _term, dst + i + 3 * F, full);
+                QuantizedAdd8u8u8uA(a + i + 0 * A, _adScale, b + i + 0 * A, _bdScale, _term, _one, _zero, dst + i + 0 * A);
+                QuantizedAdd8u8u8uA(a + i + 1 * A, _adScale, b + i + 1 * A, _bdScale, _term, _one, _zero, dst + i + 1 * A);
+                QuantizedAdd8u8u8uA(a + i + 2 * A, _adScale, b + i + 2 * A, _bdScale, _term, _one, _zero, dst + i + 2 * A);
+                QuantizedAdd8u8u8uA(a + i + 3 * A, _adScale, b + i + 3 * A, _bdScale, _term, _one, _zero, dst + i + 3 * A);
             }
-            for (; i < size; i += F)
-            {
-                svbool_t tail = svwhilelt_b32(i, size);
-                QuantizedAdd8u8u8u(a + i, _adScale, b + i, _bdScale, _term, dst + i, tail);
-            }
+            for (; i + A <= size; i += A)
+                QuantizedAdd8u8u8uA(a + i, _adScale, b + i, _bdScale, _term, _one, _zero, dst + i);
+            for (; i + F <= size; i += F)
+                QuantizedAdd8u8u8u(a + i, _adScale, b + i, _bdScale, _term, _one, _zero, dst + i, body);
+            if (i < size)
+                QuantizedAdd8u8u8u(a + i, _adScale, b + i, _bdScale, _term, _one, _zero, dst + i, svwhilelt_b32(i, size));
         }
 
         static SynetQuantizedAddUniform::UniformPtr GetQuantizedAddUniform8u8u8u(SimdConvolutionActivationType type)

--- a/src/Simd/SimdSve2SynetQuantizedAdd.cpp
+++ b/src/Simd/SimdSve2SynetQuantizedAdd.cpp
@@ -30,30 +30,12 @@ namespace Simd
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Sve2
     {
-        SIMD_INLINE void UnpackU8(const svuint8_t& src, svint32_t& d0, svint32_t& d1, svint32_t& d2, svint32_t& d3)
-        {
-            svuint16_t lo = svunpklo_u16(src);
-            svuint16_t hi = svunpkhi_u16(src);
-            d0 = svreinterpret_s32_u32(svunpklo_u32(lo));
-            d1 = svreinterpret_s32_u32(svunpkhi_u32(lo));
-            d2 = svreinterpret_s32_u32(svunpklo_u32(hi));
-            d3 = svreinterpret_s32_u32(svunpkhi_u32(hi));
-        }
-
-        SIMD_INLINE svuint8_t PackU8(const svint32_t& d0, const svint32_t& d1, const svint32_t& d2, const svint32_t& d3)
-        {
-            svuint16_t lo = svuzp1_u16(svreinterpret_u16_u32(svreinterpret_u32_s32(d0)), svreinterpret_u16_u32(svreinterpret_u32_s32(d1)));
-            svuint16_t hi = svuzp1_u16(svreinterpret_u16_u32(svreinterpret_u32_s32(d2)), svreinterpret_u16_u32(svreinterpret_u32_s32(d3)));
-            return svuzp1_u8(svreinterpret_u8_u16(lo), svreinterpret_u8_u16(hi));
-        }
-
         SIMD_INLINE svint32_t QuantizedAdd(const svint32_t& a, const svfloat32_t& adScale, const svint32_t& b, const svfloat32_t& bdScale,
             const svfloat32_t& term, const svfloat32_t& one, const svint32_t& zero, const svbool_t& mask)
         {
             svfloat32_t value = svmla_f32_x(mask, term, svcvt_f32_s32_x(mask, a), adScale);
             value = svmla_f32_x(mask, value, svcvt_f32_s32_x(mask, b), bdScale);
-            svint32_t dst = QuantizeLinear(value, one, zero, mask);
-            return svmin_n_s32_x(mask, svmax_n_s32_x(mask, dst, 0), 255);
+            return QuantizeLinear(value, one, zero, mask);
         }
 
         SIMD_INLINE void QuantizedAdd8u8u8u(const uint8_t* a, const svfloat32_t& adScale, const uint8_t* b, const svfloat32_t& bdScale,
@@ -61,22 +43,9 @@ namespace Simd
         {
             svint32_t va = svreinterpret_s32_u32(svld1ub_u32(mask, a));
             svint32_t vb = svreinterpret_s32_u32(svld1ub_u32(mask, b));
-            svst1b_u32(mask, dst, svreinterpret_u32_s32(QuantizedAdd(va, adScale, vb, bdScale, term, one, zero, mask)));
-        }
-
-        SIMD_INLINE void QuantizedAdd8u8u8uA(const uint8_t* a, const svfloat32_t& adScale, const uint8_t* b, const svfloat32_t& bdScale,
-            const svfloat32_t& term, const svfloat32_t& one, const svint32_t& zero, uint8_t* dst)
-        {
-            const svbool_t mask32 = svptrue_b32();
-            const svbool_t mask8 = svptrue_b8();
-            svint32_t a0, a1, a2, a3, b0, b1, b2, b3;
-            UnpackU8(svld1_u8(mask8, a), a0, a1, a2, a3);
-            UnpackU8(svld1_u8(mask8, b), b0, b1, b2, b3);
-            svint32_t d0 = QuantizedAdd(a0, adScale, b0, bdScale, term, one, zero, mask32);
-            svint32_t d1 = QuantizedAdd(a1, adScale, b1, bdScale, term, one, zero, mask32);
-            svint32_t d2 = QuantizedAdd(a2, adScale, b2, bdScale, term, one, zero, mask32);
-            svint32_t d3 = QuantizedAdd(a3, adScale, b3, bdScale, term, one, zero, mask32);
-            svst1_u8(mask8, dst, PackU8(d0, d1, d2, d3));
+            svint32_t dst32 = QuantizedAdd(va, adScale, vb, bdScale, term, one, zero, mask);
+            dst32 = svmin_n_s32_x(mask, svmax_n_s32_x(mask, dst32, 0), 255);
+            svst1b_u32(mask, dst, svreinterpret_u32_s32(dst32));
         }
 
         static void QuantizedAddUniform8u8u8u(const uint8_t* a, float aScale, int aZero, const uint8_t* b, float bScale, int bZero, size_t size, const float*, float dScale, int dZero, uint8_t* dst)
@@ -84,21 +53,19 @@ namespace Simd
             float adScale = aScale / dScale;
             float bdScale = bScale / dScale;
             float term = float(dZero) - (adScale * float(aZero) + bdScale * float(bZero));
-            const size_t F = svcntw(), A = svcntb(), QA = 4 * A;
+            const size_t F = svcntw(), QF = 4 * F;
             const svbool_t body = svptrue_b32();
             const svfloat32_t _adScale = svdup_n_f32(adScale), _bdScale = svdup_n_f32(bdScale), _term = svdup_n_f32(term);
             const svfloat32_t _one = svdup_n_f32(1.0f);
             const svint32_t _zero = svdup_n_s32(0);
             size_t i = 0;
-            for (; i + QA <= size; i += QA)
+            for (; i + QF <= size; i += QF)
             {
-                QuantizedAdd8u8u8uA(a + i + 0 * A, _adScale, b + i + 0 * A, _bdScale, _term, _one, _zero, dst + i + 0 * A);
-                QuantizedAdd8u8u8uA(a + i + 1 * A, _adScale, b + i + 1 * A, _bdScale, _term, _one, _zero, dst + i + 1 * A);
-                QuantizedAdd8u8u8uA(a + i + 2 * A, _adScale, b + i + 2 * A, _bdScale, _term, _one, _zero, dst + i + 2 * A);
-                QuantizedAdd8u8u8uA(a + i + 3 * A, _adScale, b + i + 3 * A, _bdScale, _term, _one, _zero, dst + i + 3 * A);
+                QuantizedAdd8u8u8u(a + i + 0 * F, _adScale, b + i + 0 * F, _bdScale, _term, _one, _zero, dst + i + 0 * F, body);
+                QuantizedAdd8u8u8u(a + i + 1 * F, _adScale, b + i + 1 * F, _bdScale, _term, _one, _zero, dst + i + 1 * F, body);
+                QuantizedAdd8u8u8u(a + i + 2 * F, _adScale, b + i + 2 * F, _bdScale, _term, _one, _zero, dst + i + 2 * F, body);
+                QuantizedAdd8u8u8u(a + i + 3 * F, _adScale, b + i + 3 * F, _bdScale, _term, _one, _zero, dst + i + 3 * F, body);
             }
-            for (; i + A <= size; i += A)
-                QuantizedAdd8u8u8uA(a + i, _adScale, b + i, _bdScale, _term, _one, _zero, dst + i);
             for (; i + F <= size; i += F)
                 QuantizedAdd8u8u8u(a + i, _adScale, b + i, _bdScale, _term, _one, _zero, dst + i, body);
             if (i < size)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improve SVE2 performance of `SimdSynetQuantizedAdd` for the uniform 8u+8u→8u path.

## Changes
- Round with `Sve2::QuantizeLinear` (`svrintn_f32`) from `SimdSynetQuantizeLinear.h` instead of compare/select rounding.
- Keep a modest `4*F` body loop (same factor as other SVE2 quantized kernels). The first revision unrolled `4*svcntb()` and unpacked/packed `u8` vectors; that was slower than the original kernel and has been removed.
- Add an unpredicated `F`-wide remainder plus a predicated tail.
- Document the improvement in release 7.2.165 (`docs/2026.html`).

## Testing
Cross-compiled aarch64 + SVE2 and ran `Test::SynetQuantizedAddForwardAutoTest` under qemu-user (128-bit and 512-bit VL). Base / Neon / Sve2 comparisons passed.

QEMU timing is not representative of real SVE2 hardware.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-719e460b-506e-4878-b934-9de92fe6d65f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719e460b-506e-4878-b934-9de92fe6d65f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

