### PR TITLE
Add C++ wrapper Simd::SynetPermute

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -84,6 +84,7 @@
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
  <li>C++ wrapper Simd::SynetQuantizedMul.</li>
  <li>C++ wrapper Simd::SynetGatherElements.</li>
+ <li>C++ wrapper Simd::SynetPermute.</li>
 </ul>
 <h5>Improving</h5>
 <ul>

--- a/prj/txt/DoxygenGroups.txt
+++ b/prj/txt/DoxygenGroups.txt
@@ -93,7 +93,7 @@
 
 /*! @ingroup cpp_types
     @defgroup cpp_synet Synet Wrappers
-    \short Simd::SynetAdd16b, Simd::SynetQuantizedAdd, Simd::SynetQuantizedMul and Simd::SynetGatherElements classes (C++ wrappers of Synet operations).
+    \short Simd::SynetAdd16b, Simd::SynetQuantizedAdd, Simd::SynetQuantizedMul, Simd::SynetGatherElements and Simd::SynetPermute classes (C++ wrappers of Synet operations).
 */
 
 /*! @ingroup cpp_types

--- a/src/Simd/SimdSynet.hpp
+++ b/src/Simd/SimdSynet.hpp
@@ -646,6 +646,144 @@ namespace Simd
         Shape _outer;
         size_t _srcCount, _inner, _idxCount;
     };
+
+    //-------------------------------------------------------------------------------------------------
+
+    /*! @ingroup cpp_synet
+
+        \short The SynetPermute class is a C++ wrapper of tensor dimension permutation.
+
+        The class wraps C API functions ::SimdSynetPermuteInit, ::SimdSynetPermuteInternalBufferSize
+        and ::SimdSynetPermuteForward. It reorders tensor dimensions. If input shape is
+        shape[0..count-1], then output dimension i has size shape[order[i]]:
+        \verbatim
+        dstShape[i] = srcShape[order[i]].
+        \endverbatim
+
+        Supported dimension count is from 2 to 5. Dimensions with size 1 can be skipped by the
+        implementation, but the requested permutation must change at least two non-unit dimensions.
+        Supported tensor types are FP32, INT32, INT8, UINT8, BF16 and FP16.
+        Call Init() before Forward(). Use Enable() to check that a context was created.
+        The context is released by Clear() or by the destructor.
+
+        Using example:
+        \verbatim
+        #include "Simd/SimdSynet.hpp"
+
+        int main()
+        {
+            const size_t n = 4, m = 8;
+            std::vector<float> src(n * m), dst(n * m);
+            for (size_t i = 0; i < src.size(); ++i)
+                src[i] = float(i);
+            Simd::Shape shape = Simd::Shape({ n, m });
+            Simd::Shape order = Simd::Shape({ 1, 0 });
+
+            Simd::SynetPermute permute;
+            permute.Init(shape, order, SimdTensorData32f);
+            if (permute.Enable())
+                permute.Forward((const uint8_t*)src.data(), (uint8_t*)dst.data());
+
+            return 0;
+        }
+        \endverbatim
+    */
+    class SynetPermute
+    {
+    public:
+        /*!
+            Creates a new empty SynetPermute class.
+        */
+        SynetPermute()
+            : _context(NULL)
+        {
+        }
+
+        /*!
+            SynetPermute class destructor. Releases internal context.
+        */
+        virtual ~SynetPermute()
+        {
+            Clear();
+        }
+
+        /*!
+            Initializes (or re-initializes) a tensor permutation context.
+
+            Creates an internal context with using of function ::SimdSynetPermuteInit.
+            The context is recreated only if input tensor shape or output dimension order were changed.
+
+            \note This function is a C++ wrapper for function ::SimdSynetPermuteInit.
+
+            \param [in] shape - a shape of input tensor. Dimension count must be from 2 to 5.
+            \param [in] order - an output dimension order. The size must be equal to shape size and contain a permutation of dimension indices.
+            \param [in] type - an input and output tensor data type.
+        */
+        SIMD_INLINE void Init(const Shape & shape, const Shape & order, SimdTensorDataType type)
+        {
+            if (_shape != shape || _order != order)
+            {
+                Clear();
+                _shape = shape;
+                _order = order;
+                _context = SimdSynetPermuteInit(_shape.data(), _order.data(), _shape.size(), type);
+            }
+        }
+
+        /*!
+            Checks that the internal permutation context was created.
+
+            \return true if the context exists and Forward() can be called.
+        */
+        SIMD_INLINE bool Enable() const
+        {
+            return _context != NULL;
+        }
+
+        /*!
+            Gets the size in bytes of internal storage used by the permutation context.
+
+            \note This function is a C++ wrapper for function ::SimdSynetPermuteInternalBufferSize.
+
+            \return size of internal buffer in bytes used inside permutation algorithm.
+        */
+        SIMD_INLINE size_t InternalBufferSize() const
+        {
+            return _context ? SimdSynetPermuteInternalBufferSize(_context) : 0;
+        }
+
+        /*!
+            Performs tensor dimension permutation.
+
+            The function reorders dimensions of \a src according to the order stored in the context
+            created by Init() and writes the result to \a dst.
+
+            \note This function is a C++ wrapper for function ::SimdSynetPermuteForward.
+
+            \param [in] src - a pointer to the input tensor bytes.
+            \param [out] dst - a pointer to the output tensor bytes.
+        */
+        SIMD_INLINE void Forward(const uint8_t * src, uint8_t * dst)
+        {
+            if (_context)
+                SimdSynetPermuteForward(_context, src, dst);
+        }
+
+        /*!
+            Releases internal context and clears stored tensor parameters.
+        */
+        SIMD_INLINE void Clear()
+        {
+            if (_context)
+                SimdRelease(_context), _context = NULL;
+            _shape.clear();
+            _order.clear();
+        }
+
+    private:
+        void * _context;
+        Shape _shape, _order;
+    };
 }
 
 #endif

--- a/src/Test/TestCheckCpp.cpp
+++ b/src/Test/TestCheckCpp.cpp
@@ -324,6 +324,36 @@ namespace Test
                 std::cout << "TestSynetGatherElements is failed at " << i << " : " << dst1[i] << " != " << dst2[i] << std::endl;
         }
     }
+
+    static void TestSynetPermute()
+    {
+        const size_t n = 4, m = 8;
+        Simd::Shape shape = Simd::Shape({ n, m });
+        Simd::Shape order = Simd::Shape({ 1, 0 });
+        std::vector<float> src(n * m, 0.0f), dst1(n * m, 0.0f), dst2(n * m, 0.0f);
+        for (size_t i = 0; i < src.size(); ++i)
+            src[i] = float(i);
+
+        Simd::SynetPermute permute;
+        permute.Init(shape, order, SimdTensorData32f);
+        if (permute.Enable())
+            permute.Forward((const uint8_t*)src.data(), (uint8_t*)dst1.data());
+
+        void* context = SimdSynetPermuteInit(shape.data(), order.data(), shape.size(), SimdTensorData32f);
+        if (context)
+        {
+            SimdSynetPermuteForward(context, (const uint8_t*)src.data(), (uint8_t*)dst2.data());
+            if (permute.InternalBufferSize() != SimdSynetPermuteInternalBufferSize(context))
+                std::cout << "TestSynetPermute is failed : InternalBufferSize mismatch" << std::endl;
+            SimdRelease(context);
+        }
+
+        for (size_t i = 0; i < dst1.size(); ++i)
+        {
+            if (dst1[i] != dst2[i])
+                std::cout << "TestSynetPermute is failed at " << i << " : " << dst1[i] << " != " << dst2[i] << std::endl;
+        }
+    }
 #endif
 
     void CheckCpp()
@@ -361,6 +391,7 @@ namespace Test
         TestSynetQuantizedAdd();
         TestSynetQuantizedMul();
         TestSynetGatherElements();
+        TestSynetPermute();
 #endif
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a public C++ analogue of `Synet::SimdPermute` (`src/Synet/Utils/Permute.h` in ermig1979/Synet) to the Simd Library.

- New class `Simd::SynetPermute` in `src/Simd/SimdSynet.hpp` wrapping `SimdSynetPermuteInit` / `SimdSynetPermuteInternalBufferSize` / `SimdSynetPermuteForward` / `SimdRelease`.
- Doxygen description for the class (group `cpp_synet`).
- `TestSynetPermute()` in `src/Test/TestCheckCpp.cpp` compares the wrapper with the C API.
- `docs/2026.html` (release 7.2.165) updated.

`src/Simd/SimdSynet.hpp` is already listed in `prj/vs2022/Simd.vcxproj` and `prj/vs2022/Simd.vcxproj.filters` (added with `Simd::SynetAdd16b`).

## Testing

- CMake Release build (`g++`, `SIMD_SHARED=ON`) of the library and `Test`.
- `./Test "-r=.." -cc=1 -fi=SynetPermute -tt=1 -ts=1`: CheckCpp (including `TestSynetPermute`) and SynetPermute C API tests finished successfully.
- Standalone check: `Simd::SynetPermute::Enable()` is true; wrapper output matches the C API and expected 4x8 FP32 transpose (`dst[0..7] = 0 8 16 24 1 9 17 25` for row-major `src[i]=i`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e028247-78b2-4ac5-949e-cca579d0ea42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e028247-78b2-4ac5-949e-cca579d0ea42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

