### PR TITLE
Improve SVE2 optimizations of ImageJpegSaver

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -125,6 +125,7 @@
  <li>SVE2 optimizations of function DescrIntCosineDistance.</li>
  <li>SVE2 optimizations of function DescrIntCosineDistancesMxNa.</li>
  <li>SVE2 optimizations of function Float32ToBFloat16.</li>
+ <li>SVE2 optimizations of class ImageJpegSaver.</li>
  <li>C++ wrapper Simd::FillFrame.</li>
 </ul>
 <h5>Renaming</h5>

--- a/src/Simd/SimdSve2ImageSaveJpeg.cpp
+++ b/src/Simd/SimdSve2ImageSaveJpeg.cpp
@@ -34,7 +34,7 @@ namespace Simd
     {
         SIMD_INLINE svint32_t Round(const svbool_t& mask, const svfloat32_t& value)
         {
-            return svcvt_s32_f32_x(mask, svrintn_f32_x(mask, value));
+            return svcvt_s32_f32_x(mask, svrinta_f32_x(mask, value));
         }
 
         SIMD_INLINE svfloat32_t LoadU8AsF32(const svbool_t& mask, const uint8_t* src)

--- a/src/Simd/SimdSve2ImageSaveJpeg.cpp
+++ b/src/Simd/SimdSve2ImageSaveJpeg.cpp
@@ -34,7 +34,9 @@ namespace Simd
     {
         SIMD_INLINE svint32_t Round(const svbool_t& mask, const svfloat32_t& value)
         {
-            return svcvt_s32_f32_x(mask, svrinta_f32_x(mask, value));
+            svbool_t pos = svcmpge_n_f32(mask, value, 0.0f);
+            svfloat32_t offset = svsel_f32(pos, svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
+            return svcvt_s32_f32_x(mask, svadd_f32_x(mask, value, offset));
         }
 
         SIMD_INLINE svfloat32_t LoadU8AsF32(const svbool_t& mask, const uint8_t* src)
@@ -68,9 +70,9 @@ namespace Simd
             d0 = svadd_f32_x(mask, tmp10, tmp11);
             d4 = svsub_f32_x(mask, tmp10, tmp11);
 
-            svfloat32_t z1s = svadd_f32_x(mask, tmp12, tmp13);
-            d2 = svmla_f32_x(mask, tmp13, z1s, c0707);
-            d6 = svmls_f32_x(mask, tmp13, z1s, c0707);
+            svfloat32_t z1 = svmul_f32_x(mask, svadd_f32_x(mask, tmp12, tmp13), c0707);
+            d2 = svadd_f32_x(mask, tmp13, z1);
+            d6 = svsub_f32_x(mask, tmp13, z1);
 
             tmp10 = svadd_f32_x(mask, tmp4, tmp5);
             tmp11 = svadd_f32_x(mask, tmp5, tmp6);

--- a/src/Simd/SimdSve2ImageSaveJpeg.cpp
+++ b/src/Simd/SimdSve2ImageSaveJpeg.cpp
@@ -302,16 +302,16 @@ namespace Simd
         SIMD_INLINE void RgbToYuv(const uint8_t* r, const uint8_t* g, const uint8_t* b, int stride, int height,
             float* y, float* u, float* v, int size)
         {
-            const svfloat32_t kY0 = svdup_n_f32(+0.29900f);
-            const svfloat32_t kY1 = svdup_n_f32(+0.58700f);
-            const svfloat32_t kY2 = svdup_n_f32(+0.11400f);
-            const svfloat32_t kY3 = svdup_n_f32(-128.000f);
-            const svfloat32_t kU0 = svdup_n_f32(+0.16874f);
-            const svfloat32_t kU1 = svdup_n_f32(+0.33126f);
-            const svfloat32_t kU2 = svdup_n_f32(+0.50000f);
-            const svfloat32_t kV0 = svdup_n_f32(+0.50000f);
-            const svfloat32_t kV1 = svdup_n_f32(+0.41869f);
-            const svfloat32_t kV2 = svdup_n_f32(+0.08131f);
+            const svfloat32_t k0 = svdup_n_f32(+0.29900f);
+            const svfloat32_t k1 = svdup_n_f32(+0.58700f);
+            const svfloat32_t k2 = svdup_n_f32(+0.11400f);
+            const svfloat32_t k3 = svdup_n_f32(-128.000f);
+            const svfloat32_t k4 = svdup_n_f32(-0.16874f);
+            const svfloat32_t k5 = svdup_n_f32(-0.33126f);
+            const svfloat32_t k6 = svdup_n_f32(+0.50000f);
+            const svfloat32_t k7 = svdup_n_f32(+0.50000f);
+            const svfloat32_t k8 = svdup_n_f32(-0.41869f);
+            const svfloat32_t k9 = svdup_n_f32(-0.08131f);
             const size_t F = svcntw();
             for (int row = 0; row < size;)
             {
@@ -321,18 +321,12 @@ namespace Simd
                     svfloat32_t _r = LoadU8AsF32(mask, r + col);
                     svfloat32_t _g = LoadU8AsF32(mask, g + col);
                     svfloat32_t _b = LoadU8AsF32(mask, b + col);
-                    svfloat32_t _y = svmla_f32_x(mask, kY3, _r, kY0);
-                    _y = svmla_f32_x(mask, _y, _g, kY1);
-                    _y = svmla_f32_x(mask, _y, _b, kY2);
-                    svfloat32_t _u = svmul_f32_x(mask, _b, kU2);
-                    _u = svmls_f32_x(mask, _u, _r, kU0);
-                    _u = svmls_f32_x(mask, _u, _g, kU1);
-                    svfloat32_t _v = svmul_f32_x(mask, _r, kV0);
-                    _v = svmls_f32_x(mask, _v, _g, kV1);
-                    _v = svmls_f32_x(mask, _v, _b, kV2);
-                    svst1_f32(mask, y + col, _y);
-                    svst1_f32(mask, u + col, _u);
-                    svst1_f32(mask, v + col, _v);
+                    svst1_f32(mask, y + col, svadd_f32_x(mask, svadd_f32_x(mask, svadd_f32_x(mask,
+                        svmul_f32_x(mask, _r, k0), svmul_f32_x(mask, _g, k1)), svmul_f32_x(mask, _b, k2)), k3));
+                    svst1_f32(mask, u + col, svadd_f32_x(mask, svadd_f32_x(mask,
+                        svmul_f32_x(mask, _r, k4), svmul_f32_x(mask, _g, k5)), svmul_f32_x(mask, _b, k6)));
+                    svst1_f32(mask, v + col, svadd_f32_x(mask, svadd_f32_x(mask,
+                        svmul_f32_x(mask, _r, k7), svmul_f32_x(mask, _g, k8)), svmul_f32_x(mask, _b, k9)));
                 }
                 if (++row < height)
                     r += stride, g += stride, b += stride;

--- a/src/Simd/SimdSve2ImageSaveJpeg.cpp
+++ b/src/Simd/SimdSve2ImageSaveJpeg.cpp
@@ -34,9 +34,7 @@ namespace Simd
     {
         SIMD_INLINE svint32_t Round(const svbool_t& mask, const svfloat32_t& value)
         {
-            svbool_t pos = svcmpge_n_f32(mask, value, 0.0f);
-            svfloat32_t round = svsel_f32(pos, svdup_n_f32(0.5f), svdup_n_f32(-0.5f));
-            return svcvt_s32_f32_x(mask, svadd_f32_x(mask, value, round));
+            return svcvt_s32_f32_x(mask, svrintn_f32_x(mask, value));
         }
 
         SIMD_INLINE svfloat32_t LoadU8AsF32(const svbool_t& mask, const uint8_t* src)
@@ -70,9 +68,9 @@ namespace Simd
             d0 = svadd_f32_x(mask, tmp10, tmp11);
             d4 = svsub_f32_x(mask, tmp10, tmp11);
 
-            svfloat32_t z1 = svmul_f32_x(mask, svadd_f32_x(mask, tmp12, tmp13), c0707);
-            d2 = svadd_f32_x(mask, tmp13, z1);
-            d6 = svsub_f32_x(mask, tmp13, z1);
+            svfloat32_t z1s = svadd_f32_x(mask, tmp12, tmp13);
+            d2 = svmla_f32_x(mask, tmp13, z1s, c0707);
+            d6 = svmls_f32_x(mask, tmp13, z1s, c0707);
 
             tmp10 = svadd_f32_x(mask, tmp4, tmp5);
             tmp11 = svadd_f32_x(mask, tmp5, tmp6);
@@ -90,6 +88,73 @@ namespace Simd
             d3 = svsub_f32_x(mask, z13, z2);
             d5 = svadd_f32_x(mask, z13, z2);
             d7 = svsub_f32_x(mask, z11, z4);
+        }
+
+        SIMD_INLINE void Transpose4x4(
+            svfloat32_t r0, svfloat32_t r1, svfloat32_t r2, svfloat32_t r3,
+            svfloat32_t& c0, svfloat32_t& c1, svfloat32_t& c2, svfloat32_t& c3)
+        {
+            svfloat32_t t0 = svzip1_f32(r0, r2);
+            svfloat32_t t1 = svzip2_f32(r0, r2);
+            svfloat32_t t2 = svzip1_f32(r1, r3);
+            svfloat32_t t3 = svzip2_f32(r1, r3);
+            c0 = svzip1_f32(t0, t2);
+            c1 = svzip2_f32(t0, t2);
+            c2 = svzip1_f32(t1, t3);
+            c3 = svzip2_f32(t1, t3);
+        }
+
+        SIMD_INLINE svfloat32_t Zip128Lo(const svfloat32_t& a, const svfloat32_t& b)
+        {
+            const svbool_t lo = svwhilelt_b32((uint64_t)0, (uint64_t)4);
+            return svsel_f32(lo, a, svext_f32(b, b, 4));
+        }
+
+        SIMD_INLINE svfloat32_t Zip128Hi(const svfloat32_t& a, const svfloat32_t& b)
+        {
+            const svbool_t lo = svwhilelt_b32((uint64_t)0, (uint64_t)4);
+            return svsel_f32(lo, svext_f32(a, a, 4), b);
+        }
+
+        SIMD_INLINE void Transpose8x8(
+            svfloat32_t& r0, svfloat32_t& r1, svfloat32_t& r2, svfloat32_t& r3,
+            svfloat32_t& r4, svfloat32_t& r5, svfloat32_t& r6, svfloat32_t& r7)
+        {
+            svfloat32_t a0 = svzip1_f32(r0, r1);
+            svfloat32_t a1 = svzip2_f32(r0, r1);
+            svfloat32_t a2 = svzip1_f32(r2, r3);
+            svfloat32_t a3 = svzip2_f32(r2, r3);
+            svfloat32_t a4 = svzip1_f32(r4, r5);
+            svfloat32_t a5 = svzip2_f32(r4, r5);
+            svfloat32_t a6 = svzip1_f32(r6, r7);
+            svfloat32_t a7 = svzip2_f32(r6, r7);
+
+            svfloat64_t b0 = svzip1_f64(svreinterpret_f64_f32(a0), svreinterpret_f64_f32(a2));
+            svfloat64_t b1 = svzip2_f64(svreinterpret_f64_f32(a0), svreinterpret_f64_f32(a2));
+            svfloat64_t b2 = svzip1_f64(svreinterpret_f64_f32(a1), svreinterpret_f64_f32(a3));
+            svfloat64_t b3 = svzip2_f64(svreinterpret_f64_f32(a1), svreinterpret_f64_f32(a3));
+            svfloat64_t b4 = svzip1_f64(svreinterpret_f64_f32(a4), svreinterpret_f64_f32(a6));
+            svfloat64_t b5 = svzip2_f64(svreinterpret_f64_f32(a4), svreinterpret_f64_f32(a6));
+            svfloat64_t b6 = svzip1_f64(svreinterpret_f64_f32(a5), svreinterpret_f64_f32(a7));
+            svfloat64_t b7 = svzip2_f64(svreinterpret_f64_f32(a5), svreinterpret_f64_f32(a7));
+
+            svfloat32_t c0 = svreinterpret_f32_f64(b0);
+            svfloat32_t c1 = svreinterpret_f32_f64(b1);
+            svfloat32_t c2 = svreinterpret_f32_f64(b2);
+            svfloat32_t c3 = svreinterpret_f32_f64(b3);
+            svfloat32_t c4 = svreinterpret_f32_f64(b4);
+            svfloat32_t c5 = svreinterpret_f32_f64(b5);
+            svfloat32_t c6 = svreinterpret_f32_f64(b6);
+            svfloat32_t c7 = svreinterpret_f32_f64(b7);
+
+            r0 = Zip128Lo(c0, c4);
+            r1 = Zip128Hi(c0, c4);
+            r2 = Zip128Lo(c1, c5);
+            r3 = Zip128Hi(c1, c5);
+            r4 = Zip128Lo(c2, c6);
+            r5 = Zip128Hi(c2, c6);
+            r6 = Zip128Lo(c3, c7);
+            r7 = Zip128Hi(c3, c7);
         }
 
         SIMD_INLINE void JpegDctV(const float* src, size_t srcStride, float* dst, size_t dstStride)
@@ -126,71 +191,18 @@ namespace Simd
                 svfloat32_t r1 = svld1_f32(m4, src + 1 * srcStride);
                 svfloat32_t r2 = svld1_f32(m4, src + 2 * srcStride);
                 svfloat32_t r3 = svld1_f32(m4, src + 3 * srcStride);
-                svfloat32_t t0l = svzip1_f32(r0, r2);
-                svfloat32_t t0h = svzip2_f32(r0, r2);
-                svfloat32_t t1l = svzip1_f32(r1, r3);
-                svfloat32_t t1h = svzip2_f32(r1, r3);
-                svfloat32_t d00 = svzip1_f32(t0l, t1l);
-                svfloat32_t d01 = svzip2_f32(t0l, t1l);
-                svfloat32_t d10 = svzip1_f32(t0h, t1h);
-                svfloat32_t d11 = svzip2_f32(t0h, t1h);
+                svfloat32_t d00, d01, d10, d11;
+                Transpose4x4(r0, r1, r2, r3, d00, d01, d10, d11);
 
                 r0 = svld1_f32(m4, src + 0 * srcStride + 4);
                 r1 = svld1_f32(m4, src + 1 * srcStride + 4);
                 r2 = svld1_f32(m4, src + 2 * srcStride + 4);
                 r3 = svld1_f32(m4, src + 3 * srcStride + 4);
-                t0l = svzip1_f32(r0, r2);
-                t0h = svzip2_f32(r0, r2);
-                t1l = svzip1_f32(r1, r3);
-                t1h = svzip2_f32(r1, r3);
-                svfloat32_t d20 = svzip1_f32(t0l, t1l);
-                svfloat32_t d21 = svzip2_f32(t0l, t1l);
-                svfloat32_t d30 = svzip1_f32(t0h, t1h);
-                svfloat32_t d31 = svzip2_f32(t0h, t1h);
+                svfloat32_t d20, d21, d30, d31;
+                Transpose4x4(r0, r1, r2, r3, d20, d21, d30, d31);
                 src += 4 * srcStride;
 
-                svfloat32_t t00 = svadd_f32_x(m4, d00, d31);
-                svfloat32_t t01 = svadd_f32_x(m4, d01, d30);
-                svfloat32_t t10 = svadd_f32_x(m4, d10, d21);
-                svfloat32_t t11 = svadd_f32_x(m4, d11, d20);
-                svfloat32_t tmp7 = svsub_f32_x(m4, d00, d31);
-                svfloat32_t tmp6 = svsub_f32_x(m4, d01, d30);
-                svfloat32_t tmp5 = svsub_f32_x(m4, d10, d21);
-                svfloat32_t tmp4 = svsub_f32_x(m4, d11, d20);
-
-                svfloat32_t tmp10 = svadd_f32_x(m4, t00, t11);
-                svfloat32_t tmp13 = svsub_f32_x(m4, t00, t11);
-                svfloat32_t tmp11 = svadd_f32_x(m4, t01, t10);
-                svfloat32_t tmp12 = svsub_f32_x(m4, t01, t10);
-
-                d00 = svadd_f32_x(m4, tmp10, tmp11);
-                d20 = svsub_f32_x(m4, tmp10, tmp11);
-
-                const svfloat32_t c0707 = svdup_n_f32(0.707106781f);
-                const svfloat32_t c0383 = svdup_n_f32(0.382683433f);
-                const svfloat32_t c0541 = svdup_n_f32(0.541196100f);
-                const svfloat32_t c1307 = svdup_n_f32(1.306562965f);
-
-                svfloat32_t z1 = svmul_f32_x(m4, svadd_f32_x(m4, tmp12, tmp13), c0707);
-                d10 = svadd_f32_x(m4, tmp13, z1);
-                d30 = svsub_f32_x(m4, tmp13, z1);
-
-                tmp10 = svadd_f32_x(m4, tmp4, tmp5);
-                tmp11 = svadd_f32_x(m4, tmp5, tmp6);
-                tmp12 = svadd_f32_x(m4, tmp6, tmp7);
-
-                svfloat32_t z5 = svmul_f32_x(m4, svsub_f32_x(m4, tmp10, tmp12), c0383);
-                svfloat32_t z2 = svmla_f32_x(m4, z5, tmp10, c0541);
-                svfloat32_t z4 = svmla_f32_x(m4, z5, tmp12, c1307);
-                svfloat32_t z3 = svmul_f32_x(m4, tmp11, c0707);
-
-                svfloat32_t z11 = svadd_f32_x(m4, tmp7, z3);
-                svfloat32_t z13 = svsub_f32_x(m4, tmp7, z3);
-
-                d01 = svadd_f32_x(m4, z11, z4);
-                d11 = svsub_f32_x(m4, z13, z2);
-                d21 = svadd_f32_x(m4, z13, z2);
-                d31 = svsub_f32_x(m4, z11, z4);
+                JpegDct1D(m4, d00, d01, d10, d11, d20, d21, d30, d31);
 
                 svst1_s32(m4, dst + 0x00, Round(m4, svmul_f32_x(m4, svld1_f32(m4, fdt + 8 * 0), d00)));
                 svst1_s32(m4, dst + 0x08, Round(m4, svmul_f32_x(m4, svld1_f32(m4, fdt + 8 * 1), d01)));
@@ -215,26 +227,7 @@ namespace Simd
             svfloat32_t d6 = svld1_f32(m8, src + 6 * stride);
             svfloat32_t d7 = svld1_f32(m8, src + 7 * stride);
             JpegDct1D(m8, d0, d1, d2, d3, d4, d5, d6, d7);
-
-            SIMD_ALIGNED(64) float buf[64];
-            svst1_f32(m8, buf + 0 * 8, d0);
-            svst1_f32(m8, buf + 1 * 8, d1);
-            svst1_f32(m8, buf + 2 * 8, d2);
-            svst1_f32(m8, buf + 3 * 8, d3);
-            svst1_f32(m8, buf + 4 * 8, d4);
-            svst1_f32(m8, buf + 5 * 8, d5);
-            svst1_f32(m8, buf + 6 * 8, d6);
-            svst1_f32(m8, buf + 7 * 8, d7);
-
-            svuint32_t idx = svlsl_n_u32_x(m8, svindex_u32(0, 1), 3);
-            d0 = svld1_gather_u32index_f32(m8, buf + 0, idx);
-            d1 = svld1_gather_u32index_f32(m8, buf + 1, idx);
-            d2 = svld1_gather_u32index_f32(m8, buf + 2, idx);
-            d3 = svld1_gather_u32index_f32(m8, buf + 3, idx);
-            d4 = svld1_gather_u32index_f32(m8, buf + 4, idx);
-            d5 = svld1_gather_u32index_f32(m8, buf + 5, idx);
-            d6 = svld1_gather_u32index_f32(m8, buf + 6, idx);
-            d7 = svld1_gather_u32index_f32(m8, buf + 7, idx);
+            Transpose8x8(d0, d1, d2, d3, d4, d5, d6, d7);
             JpegDct1D(m8, d0, d1, d2, d3, d4, d5, d6, d7);
 
             svst1_s32(m8, dst + 8 * 0, Round(m8, svmul_f32_x(m8, svld1_f32(m8, fdt + 8 * 0), d0)));
@@ -250,7 +243,7 @@ namespace Simd
         static int JpegProcessDu(Base::BitBuf& bitBuf, float* CDU, int stride, const float* fdtbl, int DC, const uint16_t HTDC[256][2], const uint16_t HTAC[256][2])
         {
             SIMD_ALIGNED(64) int DUO[64], DU[64];
-            if (svcntw() >= 8)
+            if (svcntw() == 8)
                 JpegDct8(CDU, stride, fdtbl, DUO);
             else
             {
@@ -307,16 +300,16 @@ namespace Simd
         SIMD_INLINE void RgbToYuv(const uint8_t* r, const uint8_t* g, const uint8_t* b, int stride, int height,
             float* y, float* u, float* v, int size)
         {
-            const svfloat32_t k0 = svdup_n_f32(+0.29900f);
-            const svfloat32_t k1 = svdup_n_f32(+0.58700f);
-            const svfloat32_t k2 = svdup_n_f32(+0.11400f);
-            const svfloat32_t k3 = svdup_n_f32(-128.000f);
-            const svfloat32_t k4 = svdup_n_f32(-0.16874f);
-            const svfloat32_t k5 = svdup_n_f32(-0.33126f);
-            const svfloat32_t k6 = svdup_n_f32(+0.50000f);
-            const svfloat32_t k7 = svdup_n_f32(+0.50000f);
-            const svfloat32_t k8 = svdup_n_f32(-0.41869f);
-            const svfloat32_t k9 = svdup_n_f32(-0.08131f);
+            const svfloat32_t kY0 = svdup_n_f32(+0.29900f);
+            const svfloat32_t kY1 = svdup_n_f32(+0.58700f);
+            const svfloat32_t kY2 = svdup_n_f32(+0.11400f);
+            const svfloat32_t kY3 = svdup_n_f32(-128.000f);
+            const svfloat32_t kU0 = svdup_n_f32(+0.16874f);
+            const svfloat32_t kU1 = svdup_n_f32(+0.33126f);
+            const svfloat32_t kU2 = svdup_n_f32(+0.50000f);
+            const svfloat32_t kV0 = svdup_n_f32(+0.50000f);
+            const svfloat32_t kV1 = svdup_n_f32(+0.41869f);
+            const svfloat32_t kV2 = svdup_n_f32(+0.08131f);
             const size_t F = svcntw();
             for (int row = 0; row < size;)
             {
@@ -326,12 +319,18 @@ namespace Simd
                     svfloat32_t _r = LoadU8AsF32(mask, r + col);
                     svfloat32_t _g = LoadU8AsF32(mask, g + col);
                     svfloat32_t _b = LoadU8AsF32(mask, b + col);
-                    svst1_f32(mask, y + col, svadd_f32_x(mask, svadd_f32_x(mask, svadd_f32_x(mask,
-                        svmul_f32_x(mask, _r, k0), svmul_f32_x(mask, _g, k1)), svmul_f32_x(mask, _b, k2)), k3));
-                    svst1_f32(mask, u + col, svadd_f32_x(mask, svadd_f32_x(mask,
-                        svmul_f32_x(mask, _r, k4), svmul_f32_x(mask, _g, k5)), svmul_f32_x(mask, _b, k6)));
-                    svst1_f32(mask, v + col, svadd_f32_x(mask, svadd_f32_x(mask,
-                        svmul_f32_x(mask, _r, k7), svmul_f32_x(mask, _g, k8)), svmul_f32_x(mask, _b, k9)));
+                    svfloat32_t _y = svmla_f32_x(mask, kY3, _r, kY0);
+                    _y = svmla_f32_x(mask, _y, _g, kY1);
+                    _y = svmla_f32_x(mask, _y, _b, kY2);
+                    svfloat32_t _u = svmul_f32_x(mask, _b, kU2);
+                    _u = svmls_f32_x(mask, _u, _r, kU0);
+                    _u = svmls_f32_x(mask, _u, _g, kU1);
+                    svfloat32_t _v = svmul_f32_x(mask, _r, kV0);
+                    _v = svmls_f32_x(mask, _v, _g, kV1);
+                    _v = svmls_f32_x(mask, _v, _b, kV2);
+                    svst1_f32(mask, y + col, _y);
+                    svst1_f32(mask, u + col, _u);
+                    svst1_f32(mask, v + col, _v);
                 }
                 if (++row < height)
                     r += stride, g += stride, b += stride;
@@ -399,16 +398,20 @@ namespace Simd
 
         SIMD_INLINE void Nv12ToUv(const uint8_t* uvSrc, int uvStride, int height, float* u, float* v)
         {
-            const size_t F = svcntw();
             const svfloat32_t k = svdup_n_f32(-128.000f);
+            const svbool_t m4 = svwhilelt_b32((uint64_t)0, (uint64_t)4);
+            const svbool_t m8b = svwhilelt_b8((uint64_t)0, (uint64_t)8);
             for (int row = 0; row < 8;)
             {
-                for (size_t col = 0; col < 8; col += F)
+                for (int col = 0; col < 8; col += 4)
                 {
-                    svbool_t mask = svwhilelt_b32(col, (size_t)8);
-                    svuint32_t off = svindex_u32((uint32_t)(col * 2), 2);
-                    svst1_f32(mask, u + col, svadd_f32_x(mask, svcvt_f32_u32_x(mask, svld1ub_gather_u32offset_u32(mask, uvSrc, off)), k));
-                    svst1_f32(mask, v + col, svadd_f32_x(mask, svcvt_f32_u32_x(mask, svld1ub_gather_u32offset_u32(mask, uvSrc + 1, off)), k));
+                    svuint8_t uv = svld1_u8(m8b, uvSrc + col * 2);
+                    svuint8_t u8 = svuzp1_u8(uv, uv);
+                    svuint8_t v8 = svuzp2_u8(uv, uv);
+                    svuint32_t u32 = svunpklo_u32(svunpklo_u16(u8));
+                    svuint32_t v32 = svunpklo_u32(svunpklo_u16(v8));
+                    svst1_f32(m4, u + col, svadd_f32_x(m4, svcvt_f32_u32_x(m4, u32), k));
+                    svst1_f32(m4, v + col, svadd_f32_x(m4, svcvt_f32_u32_x(m4, v32), k));
                 }
                 if (++row < height)
                     uvSrc += uvStride;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improve SVE2 optimizations of `ImageJpegSaver` for ARM/ARM64, used by `ImageSaveToMemory` and checked by `Test::ImageSaveToMemoryAutoTest`.

## Changes
- DCT quantization rounding matches `Base::Round` / `Neon::Round`: add ±0.5 then convert toward zero. `svrintn_f32_x` (ties to even) fails `Gray8-Jpeg-10`.
- RGB-to-YUV uses the same mul-then-add association as Base/NEON. FMA in `RgbToYuv` failed `Bgr24-Jpeg-10` on Neoverse-N2 (decoded channel error ~14, limit 9).
- `d2`/`d6` DCT terms use mul then add/sub (same as NEON). `z2`/`z4` keep `svmla`.
- 4x4 horizontal DCT transpose uses `svzip1`/`svzip2`; 8-wide DCT (VL = 256-bit) transposes in registers with zip plus 128-bit combine instead of store/gather. GCC 13 `armv9-a+sve2` does not provide SVE2.1 `svzipq`/`svuzpq`.
- NV12 UV split uses `svuzp1`/`svuzp2` instead of gather loads.
- Horizontal 8-point DCT shares `JpegDct1D` with the vertical path.
- No new macros.
- Documented under release 7.2.165 Improving.

## Test plan
- Host simulation of rounding (`Base::Round` vs `rintn`) and RGB-to-YUV FMA vs mul+add.
- aarch64 cross-compile of `SimdSve2ImageSaveJpeg.cpp`.
- GitHub `Test` workflow on `ubuntu-24.04-arm` (`build_and_test_arm64`): **passed** for `579f405f1` (Test C++ All, Test C++ Custom `-fi=ToMemory`, Test Python).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8444fd4b-c150-412d-a90e-3ba35ec52f40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8444fd4b-c150-412d-a90e-3ba35ec52f40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

