### PR TITLE
Add SVE2 optimizations of PGM/PPM/BMP image loaders

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -80,6 +80,11 @@
  <li>SVE2 optimizations of class ImageBmpSaver.</li>
  <li>SVE2 optimizations of class ImagePngSaver.</li>
  <li>SVE2 optimizations of class ImageJpegSaver.</li>
+ <li>SVE2 optimizations of class ImagePgmTxtLoader.</li>
+ <li>SVE2 optimizations of class ImagePgmBinLoader.</li>
+ <li>SVE2 optimizations of class ImagePpmTxtLoader.</li>
+ <li>SVE2 optimizations of class ImagePpmBinLoader.</li>
+ <li>SVE2 optimizations of class ImageBmpLoader.</li>
  <li>C++ wrapper Simd::SynetAdd16b.</li>
  <li>C++ wrapper Simd::SynetQuantizedAdd.</li>
  <li>C++ wrapper Simd::SynetQuantizedMul.</li>
@@ -156,6 +161,11 @@
  <li>Tests for verifying functionality of SVE2 optimizations of class ImagePpmBinSaver.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of class ImagePngSaver.</li>
  <li>Tests for verifying functionality of SVE2 optimizations of class ImageJpegSaver.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of class ImagePgmTxtLoader.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of class ImagePgmBinLoader.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of class ImagePpmTxtLoader.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of class ImagePpmBinLoader.</li>
+ <li>Tests for verifying functionality of SVE2 optimizations of class ImageBmpLoader.</li>
 </ul>
 <h5>Removing</h5>
 <ul>

--- a/prj/vs2022/Sve2.vcxproj
+++ b/prj/vs2022/Sve2.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2InterleaveUv.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Histogram.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdSve2ImageLoad.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ImageSave.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ImageSaveJpeg.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdSve2ImageSavePng.cpp" />

--- a/prj/vs2022/Sve2.vcxproj.filters
+++ b/prj/vs2022/Sve2.vcxproj.filters
@@ -314,6 +314,9 @@
     <ClCompile Include="..\..\src\Simd\SimdSve2Hog.cpp">
       <Filter>Sve2\Legacy</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdSve2ImageLoad.cpp">
+      <Filter>Sve2\Image</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdSve2ImageSave.cpp">
       <Filter>Sve2\Image</Filter>
     </ClCompile>

--- a/src/Simd/SimdImageLoad.h
+++ b/src/Simd/SimdImageLoad.h
@@ -480,6 +480,60 @@ namespace Simd
         uint8_t* ImageLoadFromMemory(const uint8_t* data, size_t size, size_t* stride, size_t* width, size_t* height, SimdPixelFormatType* format);
     }
 #endif
+
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        class ImagePgmTxtLoader : public Neon::ImagePgmTxtLoader
+        {
+        public:
+            ImagePgmTxtLoader(const ImageLoaderParam& param);
+
+        protected:
+            virtual void SetConverters();
+        };
+
+        class ImagePgmBinLoader : public Neon::ImagePgmBinLoader
+        {
+        public:
+            ImagePgmBinLoader(const ImageLoaderParam& param);
+
+        protected:
+            virtual void SetConverters();
+        };
+
+        class ImagePpmTxtLoader : public Neon::ImagePpmTxtLoader
+        {
+        public:
+            ImagePpmTxtLoader(const ImageLoaderParam& param);
+
+        protected:
+            virtual void SetConverters();
+        };
+
+        class ImagePpmBinLoader : public Neon::ImagePpmBinLoader
+        {
+        public:
+            ImagePpmBinLoader(const ImageLoaderParam& param);
+
+        protected:
+            virtual void SetConverters();
+        };
+
+        class ImageBmpLoader : public Neon::ImageBmpLoader
+        {
+        public:
+            ImageBmpLoader(const ImageLoaderParam& param);
+
+        protected:
+            virtual void SetConverters();
+        };
+
+        //-------------------------------------------------------------------------------------------------
+
+        uint8_t* ImageLoadFromMemory(const uint8_t* data, size_t size, size_t* stride, size_t* width, size_t* height, SimdPixelFormatType* format);
+    }
+#endif
 }
 
 #endif

--- a/src/Simd/SimdLib.cpp
+++ b/src/Simd/SimdLib.cpp
@@ -3463,7 +3463,7 @@ SIMD_API uint8_t* SimdYuv420pSaveAsJpegToMemory(const uint8_t* y, size_t yStride
 SIMD_API uint8_t* SimdImageLoadFromMemory(const uint8_t* data, size_t size, size_t* stride, size_t* width, size_t* height, SimdPixelFormatType* format)
 {
     SIMD_EMPTY();
-    const static Simd::ImageLoadFromMemoryPtr imageLoadFromMemory = SIMD_FUNC4(ImageLoadFromMemory, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static Simd::ImageLoadFromMemoryPtr imageLoadFromMemory = SIMD_FUNC5(ImageLoadFromMemory, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return imageLoadFromMemory(data, size, stride, width, height, format);
 }
@@ -3471,7 +3471,7 @@ SIMD_API uint8_t* SimdImageLoadFromMemory(const uint8_t* data, size_t size, size
 SIMD_API uint8_t* SimdImageLoadFromFile(const char* path, size_t* stride, size_t* width, size_t* height, SimdPixelFormatType* format)
 {
     SIMD_EMPTY();
-    const static Simd::ImageLoadFromMemoryPtr imageLoadFromMemory = SIMD_FUNC4(ImageLoadFromMemory, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_NEON_FUNC);
+    const static Simd::ImageLoadFromMemoryPtr imageLoadFromMemory = SIMD_FUNC5(ImageLoadFromMemory, SIMD_AVX512BW_FUNC, SIMD_AVX2_FUNC, SIMD_SSE41_FUNC, SIMD_SVE2_FUNC, SIMD_NEON_FUNC);
 
     return ImageLoadFromFile(imageLoadFromMemory, path, stride, width, height, format);
 }

--- a/src/Simd/SimdSve2ImageLoad.cpp
+++ b/src/Simd/SimdSve2ImageLoad.cpp
@@ -1,0 +1,195 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdImageLoad.h"
+#include "Simd/SimdSve2.h"
+
+#include <memory>
+
+namespace Simd
+{
+#ifdef SIMD_SVE2_ENABLE    
+    namespace Sve2
+    {
+        ImagePgmTxtLoader::ImagePgmTxtLoader(const ImageLoaderParam& param)
+            : Neon::ImagePgmTxtLoader(param)
+        {
+        }
+
+        void ImagePgmTxtLoader::SetConverters()
+        {
+            Neon::ImagePgmTxtLoader::SetConverters();
+            if (_image.width >= svcntb())
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Sve2::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Sve2::GrayToBgra; break;
+                case SimdPixelFormatRgb24: _toAny = Sve2::GrayToBgr; break;
+                case SimdPixelFormatRgba32: _toBgra = Sve2::GrayToBgra; break;
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        ImagePgmBinLoader::ImagePgmBinLoader(const ImageLoaderParam& param)
+            : Neon::ImagePgmBinLoader(param)
+        {
+        }
+
+        void ImagePgmBinLoader::SetConverters()
+        {
+            Neon::ImagePgmBinLoader::SetConverters();
+            if (_image.width >= svcntb())
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Sve2::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Sve2::GrayToBgra; break;
+                case SimdPixelFormatRgb24: _toAny = Sve2::GrayToBgr; break;
+                case SimdPixelFormatRgba32: _toBgra = Sve2::GrayToBgra; break;
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        ImagePpmTxtLoader::ImagePpmTxtLoader(const ImageLoaderParam& param)
+            : Neon::ImagePpmTxtLoader(param)
+        {
+        }
+
+        void ImagePpmTxtLoader::SetConverters()
+        {
+            Neon::ImagePpmTxtLoader::SetConverters();
+            if (_image.width >= svcntb())
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatGray8: _toAny = Sve2::RgbToGray; break;
+                case SimdPixelFormatBgr24: _toAny = Sve2::BgrToRgb; break;
+                case SimdPixelFormatBgra32: _toBgra = Sve2::RgbToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Sve2::BgrToBgra; break;
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        ImagePpmBinLoader::ImagePpmBinLoader(const ImageLoaderParam& param)
+            : Neon::ImagePpmBinLoader(param)
+        {
+        }
+
+        void ImagePpmBinLoader::SetConverters()
+        {
+            Neon::ImagePpmBinLoader::SetConverters();
+            if (_image.width >= svcntb())
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatGray8: _toAny = Sve2::RgbToGray; break;
+                case SimdPixelFormatBgr24: _toAny = Sve2::BgrToRgb; break;
+                case SimdPixelFormatBgra32: _toBgra = Sve2::RgbToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Sve2::BgrToBgra; break;
+                }
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        ImageBmpLoader::ImageBmpLoader(const ImageLoaderParam& param)
+            : Neon::ImageBmpLoader(param)
+        {
+        }
+
+        void ImageBmpLoader::SetConverters()
+        {
+            Neon::ImageBmpLoader::SetConverters();
+            if (_width < svcntb())
+                return;
+            if (_bpp == 8)
+            {
+                switch (_param.format)
+                {
+                case SimdPixelFormatBgr24: _toAny = Sve2::GrayToBgr; break;
+                case SimdPixelFormatRgb24: _toAny = Sve2::GrayToBgr; break;
+                case SimdPixelFormatBgra32: _toBgra = Sve2::GrayToBgra; break;
+                case SimdPixelFormatRgba32: _toBgra = Sve2::GrayToBgra; break;
+                default: break;
+                }
+                return;
+            }
+            switch (_param.format)
+            {
+            case SimdPixelFormatGray8: _toAny = (_bpp == 32 ? Sve2::BgraToGray : (_bpp == 24 ? Sve2::BgrToGray : NULL)); break;
+            case SimdPixelFormatBgr24: _toAny = (_bpp == 32 ? (ToAnyPtr)Sve2::BgraToBgr : NULL); break;
+            case SimdPixelFormatRgb24: _toAny = (_bpp == 32 ? Sve2::BgraToRgb : Sve2::BgrToRgb); break;
+            case SimdPixelFormatBgra32: _toBgra = (_bpp == 32 ? NULL : (ToBgraPtr)Sve2::BgrToBgra); break;
+            case SimdPixelFormatRgba32:
+                if (_bpp == 32)
+                    _toAny = Sve2::BgraToRgba;
+                else
+                    _toBgra = (ToBgraPtr)Sve2::RgbToBgra;
+                break;
+            default: break;
+            }
+        }
+
+        //-------------------------------------------------------------------------------------------------
+
+        ImageLoader* CreateImageLoader(const ImageLoaderParam& param)
+        {
+            switch (param.file)
+            {
+            case SimdImageFilePgmTxt: return new ImagePgmTxtLoader(param);
+            case SimdImageFilePgmBin: return new ImagePgmBinLoader(param);
+            case SimdImageFilePpmTxt: return new ImagePpmTxtLoader(param);
+            case SimdImageFilePpmBin: return new ImagePpmBinLoader(param);
+            case SimdImageFilePng: return new Base::ImagePngLoader(param);
+            case SimdImageFileJpeg: return new Base::ImageJpegLoader(param);
+            case SimdImageFileBmp: return new ImageBmpLoader(param);
+            default:
+                return NULL;
+            }
+        }
+
+        uint8_t* ImageLoadFromMemory(const uint8_t* data, size_t size, size_t* stride, size_t* width, size_t* height, SimdPixelFormatType* format)
+        {
+            ImageLoaderParam param(data, size, *format);
+            if (param.Validate())
+            {
+                Holder<ImageLoader> loader(CreateImageLoader(param));
+                if (loader)
+                {
+                    if (loader->FromStream())
+                        return loader->Release(stride, width, height, format);
+                }
+            }
+            return NULL;
+        }
+    }
+#endif
+}

--- a/src/Test/TestImageIO.cpp
+++ b/src/Test/TestImageIO.cpp
@@ -690,7 +690,7 @@ namespace Test
         std::vector<View::Format> formats = { View::Gray8, View::Bgr24, View::Bgra32, View::Rgb24, View::Rgba32 };
         for (size_t format = 0; format < formats.size(); format++)
         {
-            for (int file = (int)SimdImageFilePng; file <= (int)SimdImageFileBmp; file++)
+            for (int file = (int)SimdImageFilePgmTxt; file <= (int)SimdImageFileBmp; file++)
             {
                 if (file == SimdImageFileJpeg)
                 {

--- a/src/Test/TestImageIO.cpp
+++ b/src/Test/TestImageIO.cpp
@@ -727,6 +727,11 @@ namespace Test
 //            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Avx512bw::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
 //#endif 
 
+#ifdef SIMD_SVE2_ENABLE
+        if (Simd::Sve2::Enable && TestSve2(options))
+            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Sve2::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+#endif
+
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
             result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Neon::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds SVE2 implementations of the PGM/PPM/BMP image loader classes used by `ImageLoadFromMemory`:

- `Sve2::ImagePgmTxtLoader`
- `Sve2::ImagePgmBinLoader`
- `Sve2::ImagePpmTxtLoader`
- `Sve2::ImagePpmBinLoader`
- `Sve2::ImageBmpLoader`

These follow the existing NEON/SSE/AVX and SVE2 saver pattern: the SVE2 loaders inherit from the NEON classes and replace color-conversion callbacks with SVE2 kernels (`GrayToBgr`, `GrayToBgra`, `RgbToGray`, `BgrToRgb`, `RgbToBgra`, `BgrToBgra`, `BgraToGray`, `BgrToGray`, `BgraToBgr`, `BgraToRgb`, `BgraToRgba`) when width is at least one SVE vector.

`Sve2::ImageLoadFromMemory` is wired into `SimdImageLoadFromMemory` / `SimdImageLoadFromFile` (preferred over NEON). PNG/JPEG loads still use the Base loaders until those formats have SVE2 implementations.

`ImageLoadFromMemoryAutoTest` now also covers PGM/PPM (it previously started at PNG).

## Test plan

- Native x86_64 Release build (`g++`, `SIMD_SHARED=ON`): `./Test "-r=.." -fi=ImageLoadFromMemory -tt=1 -ts=1` — **ALL TESTS ARE FINISHED SUCCESSFULLY** (34.3 s). Includes PGM/PPM/BMP/PNG/JPEG for Gray8, Bgr24, Bgra32, Rgb24, Rgba32.
- aarch64 cross-compile with `-march=armv9-a+sve+sve2+i8mm+bf16 -msve-vector-bits=scalable`: `SimdSve2ImageLoad.cpp`, `SimdLib.cpp`, and `TestImageIO.cpp` compiled successfully. Object symbols include `Sve2::ImageLoadFromMemory` and the five loader constructors; `SimdImageLoadFromMemory` references `Sve2::ImageLoadFromMemory`.

## Notes

- New file: `src/Simd/SimdSve2ImageLoad.cpp`
- VS2022: `prj/vs2022/Sve2.vcxproj` and `Sve2.vcxproj.filters`
- Release notes: `docs/2026.html` (7.2.165)
- Runtime SVE2 vs Base comparison needs an ARM host with SVE2; this environment is x86_64.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fef80ad-1447-4c9a-979b-1339e86ddb92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fef80ad-1447-4c9a-979b-1339e86ddb92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

