### PR TITLE
Mention Simd::SynetInnerProduct16b in Doxygen cpp_synet group

### DIFF
--- a/prj/txt/DoxygenGroups.txt
+++ b/prj/txt/DoxygenGroups.txt
@@ -93,7 +93,7 @@
 
 /*! @ingroup cpp_types
     @defgroup cpp_synet Synet Wrappers
-    \short Simd::SynetAdd16b, Simd::SynetQuantizedAdd, Simd::SynetQuantizedMul, Simd::SynetGatherElements, Simd::SynetPermute and Simd::SynetInnerProduct32f classes (C++ wrappers of Synet operations).
+    \short Simd::SynetAdd16b, Simd::SynetQuantizedAdd, Simd::SynetQuantizedMul, Simd::SynetGatherElements, Simd::SynetPermute, Simd::SynetInnerProduct32f and Simd::SynetInnerProduct16b classes (C++ wrappers of Synet operations).
 */
 
 /*! @ingroup cpp_types


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #920: mention `Simd::SynetInnerProduct16b` in the Doxygen `cpp_synet` group description in `prj/txt/DoxygenGroups.txt`, matching the `Simd::SynetInnerProduct32f` update from #919.

The C++ wrapper, `TestSynetInnerProduct16b()`, and the 7.2.165 release note are already on `dev` via #920.

## Testing

- ARM64 CI `build_and_test_arm64 (13, Release)` passed on this PR.
- Local x86_64 Release build: `./Test "-r=.." -cc=1 -fi=SynetInnerProduct16b -tt=1 -ts=1` finished successfully (wrapper vs C API, 0 mismatches).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f5d2004-07a5-4fba-84db-30caf6e7f139?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f5d2004-07a5-4fba-84db-30caf6e7f139&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

