### PR TITLE
Move Test::ROOT_PATH and Test::REAL_IMAGE into Test::Options

### DIFF
--- a/src/Test/Test.cpp
+++ b/src/Test/Test.cpp
@@ -928,12 +928,8 @@ namespace Test
         return 0;
     }
 
-#if defined(_MSC_VER)
-    String ROOT_PATH = "../..";
-#else
-    String ROOT_PATH = "..";
-#endif
-    String REAL_IMAGE = "";
+    //String ROOT_PATH = "..";
+    //String REAL_IMAGE = "";
 
 #ifdef TEST_PERFORMANCE_TEST_ENABLE
     int C = 512;

--- a/src/Test/TestConfig.h
+++ b/src/Test/TestConfig.h
@@ -115,8 +115,8 @@ namespace Test
 
     //extern uint32_t DISABLED_EXTENSIONS;
 
-    extern String ROOT_PATH;
-    extern String REAL_IMAGE;
+    //extern String ROOT_PATH;
+    //extern String REAL_IMAGE;
 
     extern int LITTER_CPU_CACHE;
 

--- a/src/Test/TestContour.cpp
+++ b/src/Test/TestContour.cpp
@@ -225,7 +225,7 @@ namespace Test
     {
         ContourDetector::View image;
 
-        String path = ROOT_PATH + "/data/image/face/lena.pgm";
+        String path = options.rootPath + "/data/image/face/lena.pgm";
         if (!image.Load(path))
         {
             TEST_LOG_SS(Error, "Can't load test image '" << path << "' !");

--- a/src/Test/TestDetection.cpp
+++ b/src/Test/TestDetection.cpp
@@ -35,7 +35,7 @@ namespace Test
     std::recursive_mutex g_mutex;
     Samples g_samples;
 
-    View GetSample(const Size & size, bool large)
+    View GetSample(const Size & size, bool large, const Options & options)
     {
         std::lock_guard<std::recursive_mutex> lock(g_mutex);
 
@@ -45,7 +45,7 @@ namespace Test
         if (dst.format == View::Gray8)
             return dst;
 
-        String path = ROOT_PATH + "/data/image/face/lena.pgm";
+        String path = options.rootPath + "/data/image/face/lena.pgm";
         View obj;
         if (!obj.Load(path))
         {
@@ -150,13 +150,13 @@ namespace Test
     FuncD(function1.func, function1.description + (tilted ? "[1]" : "[0]")), \
     FuncD(function2.func, function2.description + (tilted ? "[1]" : "[0]"))
 
-    bool DetectionDetectAutoTest(const void * data, int width, int height, int throughColumn, int int16, const FuncD & f1, const FuncD & f2)
+    bool DetectionDetectAutoTest(const void * data, int width, int height, int throughColumn, int int16, const FuncD & f1, const FuncD & f2, const Options & options)
     {
         bool result = true;
 
         TEST_LOG_SS(Info, "Test " << f1.description << " & " << f2.description << " for size [" << width << "," << height << "].");
 
-        View src = GetSample(Size(width, height), false);
+        View src = GetSample(Size(width, height), false, options);
         if (src.format == View::None)
             return false;
 
@@ -210,7 +210,7 @@ namespace Test
         return result;
     }
 
-    bool DetectionDetectAutoTest(const String & path, int throughColumn, int int16, const FuncD & f1, const FuncD & f2)
+    bool DetectionDetectAutoTest(const String & path, int throughColumn, int int16, const FuncD & f1, const FuncD & f2, const Options & options)
     {
         bool result = true;
 
@@ -230,24 +230,24 @@ namespace Test
             return false;
         }
 
-        result = result && DetectionDetectAutoTest(data, W, H, throughColumn, int16, f1, f2);
-        result = result && DetectionDetectAutoTest(data, W + O, H - O, throughColumn, int16, f1, f2);
+        result = result && DetectionDetectAutoTest(data, W, H, throughColumn, int16, f1, f2, options);
+        result = result && DetectionDetectAutoTest(data, W + O, H - O, throughColumn, int16, f1, f2, options);
 
         SimdRelease(data);
 
         return result;
     }
 
-    bool DetectionDetectAutoTest(int lbp, int throughColumn, int int16, const FuncD & f1, const FuncD & f2)
+    bool DetectionDetectAutoTest(int lbp, int throughColumn, int int16, const FuncD & f1, const FuncD & f2, const Options & options)
     {
         bool result = true;
 
         if (lbp)
-            result = result && DetectionDetectAutoTest(ROOT_PATH + "/data/cascade/lbp_face.xml", throughColumn, int16, f1, f2);
+            result = result && DetectionDetectAutoTest(options.rootPath + "/data/cascade/lbp_face.xml", throughColumn, int16, f1, f2, options);
         else
         {
-            result = result && DetectionDetectAutoTest(ROOT_PATH + "/data/cascade/haar_face_0.xml", throughColumn, int16, ARGS_D(0, f1, f2));
-            result = result && DetectionDetectAutoTest(ROOT_PATH + "/data/cascade/haar_face_1.xml", throughColumn, int16, ARGS_D(1, f1, f2));
+            result = result && DetectionDetectAutoTest(options.rootPath + "/data/cascade/haar_face_0.xml", throughColumn, int16, ARGS_D(0, f1, f2), options);
+            result = result && DetectionDetectAutoTest(options.rootPath + "/data/cascade/haar_face_1.xml", throughColumn, int16, ARGS_D(1, f1, f2), options);
         }
 
         return result;
@@ -258,31 +258,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Base::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Base::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Sse41::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Sse41::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp), options);
 #endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Avx2::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Avx2::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp), options);
 #endif
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Avx512bw::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Avx512bw::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Neon::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Neon::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Sve2::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp));
+            result = result && DetectionDetectAutoTest(0, 0, 0, FUNC_D(Simd::Sve2::DetectionHaarDetect32fp), FUNC_D(SimdDetectionHaarDetect32fp), options);
 #endif
 
         return result;
@@ -293,31 +293,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Base::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi));
+            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Base::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Sse41::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi));
+            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Sse41::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi), options);
 #endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Avx2::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi));
+            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Avx2::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi), options);
 #endif
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Avx512bw::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi));
+            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Avx512bw::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Neon::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi));
+            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Neon::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Sve2::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi));
+            result = result && DetectionDetectAutoTest(0, 1, 0, FUNC_D(Simd::Sve2::DetectionHaarDetect32fi), FUNC_D(SimdDetectionHaarDetect32fi), options);
 #endif
 
         return result;
@@ -328,31 +328,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Base::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp));
+            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Base::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Sse41::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp));
+            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Sse41::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp), options);
 #endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Avx2::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp));
+            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Avx2::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp), options);
 #endif
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Avx512bw::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp));
+            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Avx512bw::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Neon::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp));
+            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Neon::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Sve2::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp));
+            result = result && DetectionDetectAutoTest(1, 0, 0, FUNC_D(Simd::Sve2::DetectionLbpDetect32fp), FUNC_D(SimdDetectionLbpDetect32fp), options);
 #endif
 
         return result;
@@ -363,31 +363,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Base::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Base::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Sse41::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Sse41::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi), options);
 #endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Avx2::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Avx2::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi), options);
 #endif
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Avx512bw::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Avx512bw::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Neon::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Neon::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Sve2::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi));
+            result = result && DetectionDetectAutoTest(1, 1, 0, FUNC_D(Simd::Sve2::DetectionLbpDetect32fi), FUNC_D(SimdDetectionLbpDetect32fi), options);
 #endif
 
         return result;
@@ -398,31 +398,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Base::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Base::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Sse41::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Sse41::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip), options);
 #endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Avx2::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Avx2::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip), options);
 #endif
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Avx512bw::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Avx512bw::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Neon::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Neon::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Sve2::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip));
+            result = result && DetectionDetectAutoTest(1, 0, 1, FUNC_D(Simd::Sve2::DetectionLbpDetect16ip), FUNC_D(SimdDetectionLbpDetect16ip), options);
 #endif
 
         return result;
@@ -433,31 +433,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Base::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Base::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Sse41::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Sse41::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii), options);
 #endif
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Avx2::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Avx2::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii), options);
 #endif
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Avx512bw::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Avx512bw::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Neon::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Neon::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Sve2::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii));
+            result = result && DetectionDetectAutoTest(1, 1, 1, FUNC_D(Simd::Sve2::DetectionLbpDetect16ii), FUNC_D(SimdDetectionLbpDetect16ii), options);
 #endif
 
         return result;
@@ -477,9 +477,9 @@ namespace Test
     typedef Simd::Detection<Simd::Allocator> Detection;
     typedef Detection::Objects Objects;
 
-    static void DetectionSpecialTest(Detection & detection, Objects & objects, int threadNumber)
+    static void DetectionSpecialTest(Detection & detection, Objects & objects, int threadNumber, const Options & options)
     {
-        View src = GetSample(Size(W, H), true);
+        View src = GetSample(Size(W, H), true, options);
 
         View roi(src.Size(), View::Gray8);
         Simd::Fill(roi, 255);
@@ -518,23 +518,23 @@ namespace Test
         Detection detection;
 
         double time = GetTime();
-        detection.Load(ROOT_PATH + "/data/cascade/haar_face_0.xml", 0);
-        detection.Load(ROOT_PATH + "/data/cascade/haar_face_1.xml", 1);
-        detection.Load(ROOT_PATH + "/data/cascade/lbp_face.xml", 2);
+        detection.Load(options.rootPath + "/data/cascade/haar_face_0.xml", 0);
+        detection.Load(options.rootPath + "/data/cascade/haar_face_1.xml", 1);
+        detection.Load(options.rootPath + "/data/cascade/lbp_face.xml", 2);
         TEST_LOG_SS(Info, "Load: " << (GetTime() - time) * 1000 << " ms " << std::endl);
 
         Objects os, om;
 
-        DetectionSpecialTest(detection, os, 1);
+        DetectionSpecialTest(detection, os, 1, options);
 
         if (std::thread::hardware_concurrency() >= 2)
-            DetectionSpecialTest(detection, om, 2);
+            DetectionSpecialTest(detection, om, 2, options);
 
         if(std::thread::hardware_concurrency() >= 4)
-            DetectionSpecialTest(detection, om, 4);
+            DetectionSpecialTest(detection, om, 4, options);
 
         if (std::thread::hardware_concurrency() >= 8)
-            DetectionSpecialTest(detection, om, 8);
+            DetectionSpecialTest(detection, om, 8, options);
 
         bool result = true;
         if (os.size() != om.size())

--- a/src/Test/TestFilter.cpp
+++ b/src/Test/TestFilter.cpp
@@ -37,7 +37,7 @@ namespace Test
 {
     const bool NOISE_IMAGE = true;
 
-    static bool GetTestImage(View& image, size_t width, size_t height, size_t channels, const String& desc1, const String& desc2)
+    static bool GetTestImage(View& image, size_t width, size_t height, size_t channels, const String& desc1, const String& desc2, const Options & options)
     {
         bool result = true;
         View::Format format;
@@ -50,7 +50,7 @@ namespace Test
         default:
             assert(0);
         }
-        if (REAL_IMAGE.empty())
+        if (options.realImage.empty())
         {
             TEST_LOG_SS(Info, "Test " << desc1 << " & " << desc2 << " [" << width << ", " << height << "].");
             image.Recreate(width, height, format, NULL, TEST_ALIGN(width));
@@ -67,7 +67,7 @@ namespace Test
         }
         else
         {
-            String path = ROOT_PATH + "/data/image/" + REAL_IMAGE;
+            String path = options.rootPath + "/data/image/" + options.realImage;
             if (!FileExists(path))
             {
                 TEST_LOG_SS(Error, "File '" << path << "' is not exist!");
@@ -78,7 +78,7 @@ namespace Test
                 TEST_LOG_SS(Error, "Can't load image from '" << path << "'!");
                 return false;
             }
-            TEST_LOG_SS(Info, "Test " << desc1 << " & " << desc2 << " at " << REAL_IMAGE << " [" << image.width << "x" << image.height << "].");
+            TEST_LOG_SS(Info, "Test " << desc1 << " & " << desc2 << " at " << options.realImage << " [" << image.width << "x" << image.height << "].");
         }
         TEST_ALIGN(SIMD_ALIGN);
         return result;
@@ -1095,7 +1095,7 @@ namespace
 #define FUNC_GB(function) \
     FuncGB(function, std::string(#function))
 
-    bool GaussianBlurAutoTest(size_t width, size_t height, size_t channels, float sigma, FuncGB f1, FuncGB f2)
+    bool GaussianBlurAutoTest(size_t width, size_t height, size_t channels, float sigma, FuncGB f1, FuncGB f2, const Options & options)
     {
         bool result = true;
 
@@ -1103,7 +1103,7 @@ namespace
         f2.Update(channels, sigma);
 
         View src;
-        if (!GetTestImage(src, width, height, channels, f1.description, f2.description))
+        if (!GetTestImage(src, width, height, channels, f1.description, f2.description, options))
             return false;
 
         View dst1(src.width, src.height, src.format, NULL, TEST_ALIGN(width));
@@ -1128,17 +1128,17 @@ namespace
         return result;
     }
 
-    bool GaussianBlurAutoTest(int channels, float sigma, const FuncGB& f1, const FuncGB& f2)
+    bool GaussianBlurAutoTest(int channels, float sigma, const FuncGB& f1, const FuncGB& f2, const Options & options)
     {
         bool result = true;
 
-        result = result && GaussianBlurAutoTest(W, H, channels, sigma, f1, f2);
-        result = result && GaussianBlurAutoTest(W + O, H - O, channels, sigma, f1, f2);
+        result = result && GaussianBlurAutoTest(W, H, channels, sigma, f1, f2, options);
+        result = result && GaussianBlurAutoTest(W + O, H - O, channels, sigma, f1, f2, options);
 
         return result;
     }
 
-    bool GaussianBlurAutoTest(const FuncGB& f1, const FuncGB& f2)
+    bool GaussianBlurAutoTest(const FuncGB& f1, const FuncGB& f2, const Options & options)
     {
         bool result = true;
 
@@ -1146,9 +1146,9 @@ namespace
 
         for (int channels = 1; channels <= 4; channels++)
         {
-            result = result && GaussianBlurAutoTest(channels, 0.3f, f1, f2);
-            result = result && GaussianBlurAutoTest(channels, 1.0f, f1, f2);
-            result = result && GaussianBlurAutoTest(channels, 3.0f, f1, f2);
+            result = result && GaussianBlurAutoTest(channels, 0.3f, f1, f2, options);
+            result = result && GaussianBlurAutoTest(channels, 1.0f, f1, f2, options);
+            result = result && GaussianBlurAutoTest(channels, 3.0f, f1, f2, options);
         }
 
         return result;
@@ -1159,31 +1159,31 @@ namespace
         bool result = true;
 
         if (TestBase(options))
-            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Base::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Base::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Sse41::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Sse41::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit), options);
 #endif 
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Avx2::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Avx2::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit), options);
 #endif 
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Avx512bw::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Avx512bw::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit), options);
 #endif 
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Sve2::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Sve2::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Neon::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit));
+            result = result && GaussianBlurAutoTest(FUNC_GB(Simd::Neon::GaussianBlurInit), FUNC_GB(SimdGaussianBlurInit), options);
 #endif
 
         return result;
@@ -1243,7 +1243,7 @@ namespace
     }
 
     bool RecursiveBilateralFilterAutoTest(size_t width, size_t height, size_t channels, 
-        float spatial, float range, SimdRecursiveBilateralFilterFlags flags, FuncRBF f1, FuncRBF f2)
+        float spatial, float range, SimdRecursiveBilateralFilterFlags flags, FuncRBF f1, FuncRBF f2, const Options & options)
     {
         bool result = true;
 
@@ -1251,7 +1251,7 @@ namespace
         f2.Update(channels, spatial, range, flags);
 
         View src;
-        if (!GetTestImage(src, width, height, channels, f1.description, f2.description))
+        if (!GetTestImage(src, width, height, channels, f1.description, f2.description, options))
             return false;
 
         View dst1(src.width, src.height, src.format, NULL, TEST_ALIGN(width));
@@ -1275,7 +1275,7 @@ namespace
 
         result = result && Compare(dst1, dst2, maxDifference, true, 64);
 
-        if (!REAL_IMAGE.empty() || NOISE_IMAGE == false || result == false)
+        if (!options.realImage.empty() || NOISE_IMAGE == false || result == false)
         {
             SaveRbf(src, "src", width, height, channels, spatial, range, flags);
             SaveRbf(dst1, "dst1", width, height, channels, spatial, range, flags);
@@ -1285,17 +1285,17 @@ namespace
         return result;
     }
 
-    bool RecursiveBilateralFilterAutoTest(size_t channels, float spatial, float range, SimdRecursiveBilateralFilterFlags flags, const FuncRBF& f1, const FuncRBF& f2)
+    bool RecursiveBilateralFilterAutoTest(size_t channels, float spatial, float range, SimdRecursiveBilateralFilterFlags flags, const FuncRBF& f1, const FuncRBF& f2, const Options & options)
     {
         bool result = true;
 
-        result = result && RecursiveBilateralFilterAutoTest(W, H, channels, spatial, range, flags, f1, f2);
-        result = result && RecursiveBilateralFilterAutoTest(W + O, H - O, channels, spatial, range, flags, f1, f2);
+        result = result && RecursiveBilateralFilterAutoTest(W, H, channels, spatial, range, flags, f1, f2, options);
+        result = result && RecursiveBilateralFilterAutoTest(W + O, H - O, channels, spatial, range, flags, f1, f2, options);
 
         return result;
     }
 
-    bool RecursiveBilateralFilterAutoTest(const FuncRBF& f1, const FuncRBF& f2)
+    bool RecursiveBilateralFilterAutoTest(const FuncRBF& f1, const FuncRBF& f2, const Options & options)
     {
         bool result = true;
 
@@ -1312,12 +1312,12 @@ namespace
 
         for (int channels = 1; channels <= 4; channels++)
         {
-            if (channels == 2 && (!REAL_IMAGE.empty() || NOISE_IMAGE == false))
+            if (channels == 2 && (!options.realImage.empty() || NOISE_IMAGE == false))
                 continue;
-            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)fa, f1, f2);
-            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)fm, f1, f2);
-            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)fs, f1, f2);
-            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)pa, f1, f2);
+            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)fa, f1, f2, options);
+            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)fm, f1, f2, options);
+            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)fs, f1, f2, options);
+            result = result && RecursiveBilateralFilterAutoTest(channels, 0.12f, 0.09f, (SimdRecursiveBilateralFilterFlags)pa, f1, f2, options);
         }
 
         return result;
@@ -1328,26 +1328,26 @@ namespace
         bool result = true;
 
         if (TestBase(options))
-            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Base::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Base::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Sse41::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Sse41::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit), options);
 #endif 
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Avx2::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Avx2::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit), options);
 #endif
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Base::RecursiveBilateralFilterInit), FUNC_RBF(Simd::Sve2::RecursiveBilateralFilterInit));
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Base::RecursiveBilateralFilterInit), FUNC_RBF(Simd::Sve2::RecursiveBilateralFilterInit), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Neon::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit));
+            result = result && RecursiveBilateralFilterAutoTest(FUNC_RBF(Simd::Neon::RecursiveBilateralFilterInit), FUNC_RBF(SimdRecursiveBilateralFilterInit), options);
 #endif
 
         return result;

--- a/src/Test/TestImageIO.cpp
+++ b/src/Test/TestImageIO.cpp
@@ -38,9 +38,9 @@ namespace Test
 {
     const int DebugImageSave = 1;
 
-    SIMD_INLINE int GetMaxJpegError(int quality)
+    SIMD_INLINE int GetMaxJpegError(int quality, const Options & options)
     {
-        if (!REAL_IMAGE.empty())
+        if (!options.realImage.empty())
             return 4;
 #if defined(_WIN32)
 #if !defined(NDEBUG)
@@ -56,11 +56,11 @@ namespace Test
     //-------------------------------------------------------------------------------------------------
 
     bool GetTestImage(View& image, size_t width, size_t height, View::Format format, 
-        const String& desc1, const String& desc2, SimdImageFileType file, int quality, uint8_t ** data, size_t *size)
+        const String& desc1, const String& desc2, SimdImageFileType file, int quality, uint8_t ** data, size_t *size, const Options & options)
     {
         bool result = true;
         String path;
-        if (REAL_IMAGE.empty())
+        if (options.realImage.empty())
         {
             TEST_LOG_SS(Info, "Test " << desc1 << " & " << desc2 << " [" << width << ", " << height << "].");
             image.Recreate(width, height, format, NULL, TEST_ALIGN(width));
@@ -75,13 +75,13 @@ namespace Test
         }
         else
         {
-            path = ROOT_PATH + "/data/image/" + REAL_IMAGE;
+            path = options.rootPath + "/data/image/" + options.realImage;
             if (!image.Load(path, format))
             {
                 TEST_LOG_SS(Error, "Can't load image from '" << path << "'!");
                 return false;
             }
-            TEST_LOG_SS(Info, "Test " << desc1 << " & " << desc2 << " at " << REAL_IMAGE << " [" << image.width << "x" << image.height << "].");
+            TEST_LOG_SS(Info, "Test " << desc1 << " & " << desc2 << " at " << options.realImage << " [" << image.width << "x" << image.height << "].");
         }
         if (data && size)
         {
@@ -146,7 +146,7 @@ namespace Test
 #define FUNC_SM(func) \
     FuncSM(func, std::string(#func))
 
-    bool ImageSaveToMemoryAutoTest(size_t width, size_t height, View::Format format, SimdImageFileType file, int quality, FuncSM f1, FuncSM f2)
+    bool ImageSaveToMemoryAutoTest(size_t width, size_t height, View::Format format, SimdImageFileType file, int quality, FuncSM f1, FuncSM f2, const Options & options)
     {
         bool result = true;
 
@@ -154,7 +154,7 @@ namespace Test
         f2.Update(format, file, quality);
 
         View src;
-        if (!GetTestImage(src, width, height, format, f1.desc, f2.desc, file, quality, NULL, NULL))
+        if (!GetTestImage(src, width, height, format, f1.desc, f2.desc, file, quality, NULL, NULL, options))
             return false;
 
         uint8_t* data1 = NULL, * data2 = NULL;
@@ -169,7 +169,7 @@ namespace Test
             View dst1, dst2;
             if (dst1.Load(data1, size1, format) && dst2.Load(data2, size2, format))
             {
-                int differenceMax = GetMaxJpegError(quality);
+                int differenceMax = GetMaxJpegError(quality, options);
                 result = result && Compare(dst1, dst2, differenceMax, true, 64, 0, "dst1 & dst2");
                 if (!result)
                 {
@@ -198,18 +198,18 @@ namespace Test
         return result;
     }
 
-    bool ImageSaveToMemoryAutoTest(View::Format format, SimdImageFileType file, int quality, const FuncSM& f1, const FuncSM& f2)
+    bool ImageSaveToMemoryAutoTest(View::Format format, SimdImageFileType file, int quality, const FuncSM& f1, const FuncSM& f2, const Options & options)
     {
         bool result = true;
 
-        result = result && ImageSaveToMemoryAutoTest(W, H, format, file, quality, f1, f2);
+        result = result && ImageSaveToMemoryAutoTest(W, H, format, file, quality, f1, f2, options);
 #if !defined(TEST_REAL_IMAGE)
-        result = result && ImageSaveToMemoryAutoTest(W + O, H - O, format, file, quality, f1, f2);
+        result = result && ImageSaveToMemoryAutoTest(W + O, H - O, format, file, quality, f1, f2, options);
 #endif
         return result;
     }
 
-    bool ImageSaveToMemoryAutoTest(const FuncSM & f1, const FuncSM& f2)
+    bool ImageSaveToMemoryAutoTest(const FuncSM & f1, const FuncSM& f2, const Options & options)
     {
         bool result = true;
 
@@ -220,12 +220,12 @@ namespace Test
             {
                 if (file == SimdImageFileJpeg)
                 {
-                    result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 100, f1, f2);
+                    result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 100, f1, f2, options);
                     //result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 95, f1, f2);
                     //result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 85, f1, f2);
-                    result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 10, f1, f2);
+                    result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 10, f1, f2, options);
                 }
-                result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 65, f1, f2);
+                result = result && ImageSaveToMemoryAutoTest(formats[format], (SimdImageFileType)file, 65, f1, f2, options);
             }
         }
 
@@ -237,31 +237,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Base::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory));
+            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Base::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Sse41::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory));
+            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Sse41::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory), options);
 #endif 
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Avx2::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory));
+            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Avx2::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory), options);
 #endif 
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Avx512bw::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory));
+            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Avx512bw::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory), options);
 #endif 
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Sve2::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory));
+            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Sve2::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Neon::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory));
+            result = result && ImageSaveToMemoryAutoTest(FUNC_SM(Simd::Neon::ImageSaveToMemory), FUNC_SM(SimdImageSaveToMemory), options);
 #endif 
 
         return result;
@@ -297,7 +297,7 @@ namespace Test
 #define FUNC_SNJM(func) \
     FuncSNJM(func, std::string(#func))
 
-    bool Nv12SaveAsJpegToMemoryAutoTest(size_t width, size_t height, SimdYuvType yuvType, int quality, FuncSNJM f1, FuncSNJM f2)
+    bool Nv12SaveAsJpegToMemoryAutoTest(size_t width, size_t height, SimdYuvType yuvType, int quality, FuncSNJM f1, FuncSNJM f2, const Options & options)
     {
         bool result = true;
 
@@ -305,7 +305,7 @@ namespace Test
         f2.Update(quality, yuvType);
 
         View bgra;
-        if (!GetTestImage(bgra, width, height, View::Bgra32, f1.desc, f2.desc, SimdImageFileJpeg, quality, NULL, NULL))
+        if (!GetTestImage(bgra, width, height, View::Bgra32, f1.desc, f2.desc, SimdImageFileJpeg, quality, NULL, NULL, options))
             return false;
 
         View y(width, height, View::Gray8);
@@ -326,7 +326,7 @@ namespace Test
         View dst1, dst2;
         if (dst1.Load(data1, size1, View::Bgra32) && dst2.Load(data2, size2, View::Bgra32))
         {
-            int differenceMax = GetMaxJpegError(quality);
+            int differenceMax = GetMaxJpegError(quality, options);
             result = result && Compare(dst1, dst2, differenceMax, true, 64, 0, "dst1 & dst2");
             if (!result)
             {
@@ -369,7 +369,7 @@ namespace Test
         return result;
     }
 
-    bool Nv12SaveAsJpegToMemoryAutoTest(const FuncSNJM& f1, const FuncSNJM& f2)
+    bool Nv12SaveAsJpegToMemoryAutoTest(const FuncSNJM& f1, const FuncSNJM& f2, const Options & options)
     {
         bool result = true;
 
@@ -380,9 +380,9 @@ namespace Test
         {
             for (size_t q = 0; q < qualities.size() && result; ++q)
             {
-                result = result && Nv12SaveAsJpegToMemoryAutoTest(W, H, yuvTypes[t], qualities[q], f1, f2);
+                result = result && Nv12SaveAsJpegToMemoryAutoTest(W, H, yuvTypes[t], qualities[q], f1, f2, options);
 #if !defined(TEST_REAL_IMAGE)
-                result = result && Nv12SaveAsJpegToMemoryAutoTest(W + E, H - E, yuvTypes[t], qualities[q], f1, f2);
+                result = result && Nv12SaveAsJpegToMemoryAutoTest(W + E, H - E, yuvTypes[t], qualities[q], f1, f2, options);
 #endif
             }
         }
@@ -395,31 +395,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Base::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory));
+            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Base::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Sse41::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory));
+            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Sse41::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory), options);
 #endif 
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Avx2::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory));
+            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Avx2::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory), options);
 #endif 
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Avx512bw::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory));
+            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Avx512bw::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory), options);
 #endif 
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Sve2::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory));
+            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Sve2::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Neon::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory));
+            result = result && Nv12SaveAsJpegToMemoryAutoTest(FUNC_SNJM(Simd::Neon::Nv12SaveAsJpegToMemory), FUNC_SNJM(SimdNv12SaveAsJpegToMemory), options);
 #endif 
 
         return result;
@@ -455,7 +455,7 @@ namespace Test
 #define FUNC_SYJM(func) \
     FuncSYJM(func, std::string(#func))
 
-    bool Yuv420pSaveAsJpegToMemoryAutoTest(size_t width, size_t height, SimdYuvType yuvType, int quality, FuncSYJM f1, FuncSYJM f2)
+    bool Yuv420pSaveAsJpegToMemoryAutoTest(size_t width, size_t height, SimdYuvType yuvType, int quality, FuncSYJM f1, FuncSYJM f2, const Options & options)
     {
         bool result = true;
 
@@ -465,7 +465,7 @@ namespace Test
         f2.Update(quality, yuvType);
 
         View bgra;
-        if (!GetTestImage(bgra, width, height, View::Bgra32, f1.desc, f2.desc, SimdImageFileJpeg, quality, NULL, NULL))
+        if (!GetTestImage(bgra, width, height, View::Bgra32, f1.desc, f2.desc, SimdImageFileJpeg, quality, NULL, NULL, options))
             return false;
 
         View y(width, height, View::Gray8);
@@ -483,7 +483,7 @@ namespace Test
         View dst1, dst2;
         if (dst1.Load(data1, size1, View::Bgra32) && dst2.Load(data2, size2, View::Bgra32))
         {
-            int differenceMax = GetMaxJpegError(quality);
+            int differenceMax = GetMaxJpegError(quality, options);
             result = result && Compare(dst1, dst2, differenceMax, true, 64, 0, "dst1 & dst2");
             if (!result)
             {
@@ -520,7 +520,7 @@ namespace Test
         return result;
     }
 
-    bool Yuv420pSaveAsJpegToMemoryAutoTest(const FuncSYJM& f1, const FuncSYJM& f2)
+    bool Yuv420pSaveAsJpegToMemoryAutoTest(const FuncSYJM& f1, const FuncSYJM& f2, const Options & options)
     {
         bool result = true;
 
@@ -531,9 +531,9 @@ namespace Test
         {
             for (size_t q = 0; q < qualities.size() && result; ++q)
             {
-                result = result && Yuv420pSaveAsJpegToMemoryAutoTest(W, H, yuvTypes[t], qualities[q], f1, f2);
+                result = result && Yuv420pSaveAsJpegToMemoryAutoTest(W, H, yuvTypes[t], qualities[q], f1, f2, options);
 #if !defined(TEST_REAL_IMAGE)
-                result = result && Yuv420pSaveAsJpegToMemoryAutoTest(W + E, H - E, yuvTypes[t], qualities[q], f1, f2);
+                result = result && Yuv420pSaveAsJpegToMemoryAutoTest(W + E, H - E, yuvTypes[t], qualities[q], f1, f2, options);
 #endif
             }
         }
@@ -546,31 +546,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Base::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory));
+            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Base::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Sse41::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory));
+            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Sse41::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory), options);
 #endif 
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Avx2::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory));
+            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Avx2::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory), options);
 #endif 
 
 #ifdef SIMD_AVX512BW_ENABLE
         if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Avx512bw::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory));
+            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Avx512bw::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory), options);
 #endif 
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Sve2::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory));
+            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Sve2::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Neon::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory));
+            result = result && Yuv420pSaveAsJpegToMemoryAutoTest(FUNC_SYJM(Simd::Neon::Yuv420pSaveAsJpegToMemory), FUNC_SYJM(SimdYuv420pSaveAsJpegToMemory), options);
 #endif 
 
         return result;
@@ -618,7 +618,7 @@ namespace Test
         return false;
     }
 
-    bool ImageLoadFromMemoryAutoTest(size_t width, size_t height, View::Format format, SimdImageFileType file, int quality, FuncLM f1, FuncLM f2)
+    bool ImageLoadFromMemoryAutoTest(size_t width, size_t height, View::Format format, SimdImageFileType file, int quality, FuncLM f1, FuncLM f2, const Options & options)
     {
         bool result = true;
 
@@ -628,7 +628,7 @@ namespace Test
         View src;
         size_t size = 0;
         uint8_t* data = NULL;
-        if (!GetTestImage(src, width, height, format, f1.desc, f2.desc, file, quality, &data, &size))
+        if (!GetTestImage(src, width, height, format, f1.desc, f2.desc, file, quality, &data, &size, options))
             return false;
 
         View dst1, dst2;
@@ -639,7 +639,7 @@ namespace Test
 
         if (file == SimdImageFileJpeg)
         {
-            int differenceMax = GetMaxJpegError(quality);
+            int differenceMax = GetMaxJpegError(quality, options);
             result = result && Compare(dst1, dst2, differenceMax, true, 64, 0, "dst1 & dst2");
             if (!result)
             {
@@ -671,21 +671,21 @@ namespace Test
         return result;
     }
 
-    bool ImageLoadFromMemoryAutoTest(View::Format format, SimdImageFileType file, int quality, FuncLM f1, FuncLM f2)
+    bool ImageLoadFromMemoryAutoTest(View::Format format, SimdImageFileType file, int quality, FuncLM f1, FuncLM f2, const Options & options)
     {
         bool result = true;
 
         //result = result && ImageLoadFromMemoryAutoTest(W, H, format, file, quality, f1, f2);
-        result = result && ImageLoadFromMemoryAutoTest(W + O, H - O, format, file, quality, f1, f2);
+        result = result && ImageLoadFromMemoryAutoTest(W + O, H - O, format, file, quality, f1, f2, options);
 
         return result;
     }
 
-    bool ImageLoadFromMemoryAutoTest(const FuncLM& f1, const FuncLM& f2)
+    bool ImageLoadFromMemoryAutoTest(const FuncLM& f1, const FuncLM& f2, const Options & options)
     {
         bool result = true;
 
-        result = result && ImageLoadFromMemoryAutoTest(W, H, View::Rgb24, SimdImageFileJpeg, 100, f1, f2);
+        result = result && ImageLoadFromMemoryAutoTest(W, H, View::Rgb24, SimdImageFileJpeg, 100, f1, f2, options);
 
         std::vector<View::Format> formats = { View::Gray8, View::Bgr24, View::Bgra32, View::Rgb24, View::Rgba32 };
         for (size_t format = 0; format < formats.size(); format++)
@@ -694,11 +694,11 @@ namespace Test
             {
                 if (file == SimdImageFileJpeg)
                 {
-                    result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 100, f1, f2);
-                    result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 95, f1, f2);
-                    result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 10, f1, f2);
+                    result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 100, f1, f2, options);
+                    result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 95, f1, f2, options);
+                    result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 10, f1, f2, options);
                 }
-                result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 65, f1, f2);
+                result = result && ImageLoadFromMemoryAutoTest(formats[format], (SimdImageFileType)file, 65, f1, f2, options);
             }
         }
 
@@ -710,31 +710,31 @@ namespace Test
         bool result = true;
 
         if (TestBase(options))
-            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Base::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Base::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 
 #ifdef SIMD_SSE41_ENABLE
         if (Simd::Sse41::Enable && TestSse41(options))
-            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Sse41::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Sse41::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 #endif 
 
 #ifdef SIMD_AVX2_ENABLE
         if (Simd::Avx2::Enable && TestAvx2(options))
-            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Avx2::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Avx2::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 #endif 
 
 //#ifdef SIMD_AVX512BW_ENABLE
 //        if (Simd::Avx512bw::Enable && TestAvx512bw(options))
-//            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Avx512bw::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+//            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Avx512bw::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 //#endif 
 
 #ifdef SIMD_SVE2_ENABLE
         if (Simd::Sve2::Enable && TestSve2(options))
-            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Sve2::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Sve2::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 #endif
 
 #ifdef SIMD_NEON_ENABLE
         if (Simd::Neon::Enable && TestNeon(options))
-            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Neon::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+            result = result && ImageLoadFromMemoryAutoTest(FUNC_LM(Simd::Neon::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 #endif 
 
         return result;
@@ -742,11 +742,11 @@ namespace Test
 
     //-------------------------------------------------------------------------------------------------
 
-    bool ImageLoadFromMemorySpecialTest(const String & name, View::Format format, const FuncLM& f1, const FuncLM& f2)
+    bool ImageLoadFromMemorySpecialTest(const String & name, View::Format format, const FuncLM& f1, const FuncLM& f2, const Options & options)
     {
         bool result = true;
 
-        String path = ROOT_PATH + "/data/image/" + name;
+        String path = options.rootPath + "/data/image/" + name;
         TEST_LOG_SS(Info, "Test " << f1.desc << " & " << f2.desc << " at " << path << " for " << ToString(format) << ".");
 
         size_t size = 0;
@@ -780,13 +780,13 @@ namespace Test
         return result;
     }
 
-    bool ImageLoadFromMemorySpecialTest(const String& name, const FuncLM& f1, const FuncLM& f2)
+    bool ImageLoadFromMemorySpecialTest(const String& name, const FuncLM& f1, const FuncLM& f2, const Options & options)
     {
         bool result = true;
 
         std::vector<View::Format> formats = { View::Gray8, View::Bgr24, View::Bgra32, View::Rgb24, View::Rgba32 };
         for (size_t format = 0; format < formats.size(); format++)
-            result = result && ImageLoadFromMemorySpecialTest(name, formats[format], f1, f2);
+            result = result && ImageLoadFromMemorySpecialTest(name, formats[format], f1, f2, options);
 
         return result;
     }
@@ -794,128 +794,128 @@ namespace Test
 #define SIMD_PNG_TEST
 //#define SIMD_JPEG_TEST
 
-    bool ImageLoadFromMemorySpecialTest(const FuncLM& f1, const FuncLM& f2)
+    bool ImageLoadFromMemorySpecialTest(const FuncLM& f1, const FuncLM& f2, const Options & options)
     {
         bool result = true;
 
 #if defined(SIMD_PNG_TEST) && 1
-        result = result && ImageLoadFromMemorySpecialTest("png/basn0g01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn0g02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn0g04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn0g08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn0g16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn0g01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn0g02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn0g04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn0g08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn0g16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basn2c08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn2c16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn2c08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn2c16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basn3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn3p08.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn3p08.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basn4a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn4a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn4a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn4a16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basn6a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basn6a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn6a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basn6a16.png", f1, f2, options);
 #endif
 #if defined(SIMD_PNG_TEST) && 1
-        result = result && ImageLoadFromMemorySpecialTest("png/basi0g01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi0g02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi0g04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi0g08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi0g16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi0g01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi0g02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi0g04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi0g08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi0g16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basi2c08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi2c16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi2c08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi2c16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basi3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi3p08.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi3p08.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basi4a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi4a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi4a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi4a16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/basi6a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/basi6a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi6a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/basi6a16.png", f1, f2, options);
 #endif
 #if defined(SIMD_PNG_TEST) && 1
-        result = result && ImageLoadFromMemorySpecialTest("png/s01i3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s01n3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s02i3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s02n3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s03i3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s03n3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s04i3p01.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s04n3p01.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/s01i3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s01n3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s02i3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s02n3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s03i3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s03n3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s04i3p01.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s04n3p01.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/s05i3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s05n3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s06i3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s06n3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s07i3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s07n3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s08i3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s08n3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s09i3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s09n3p02.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/s05i3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s05n3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s06i3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s06n3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s07i3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s07n3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s08i3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s08n3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s09i3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s09n3p02.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/s32i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s32n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s33i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s33n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s34i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s34n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s35i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s35n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s36i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s36n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s37i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s37n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s38i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s38n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s39i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s39n3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s40i3p04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/s40n3p04.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/s32i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s32n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s33i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s33n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s34i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s34n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s35i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s35n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s36i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s36n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s37i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s37n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s38i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s38n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s39i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s39n3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s40i3p04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/s40n3p04.png", f1, f2, options);
 #endif
 #if defined(SIMD_PNG_TEST) && 1
-        result = result && ImageLoadFromMemorySpecialTest("png/bgai4a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/bgai4a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgai4a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgai4a16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/bgan6a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/bgan6a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgan6a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgan6a16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/bgbn4a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/bggn4a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgbn4a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/bggn4a16.png", f1, f2, options);
 
-        result = result && ImageLoadFromMemorySpecialTest("png/bgwn6a08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/bgyn6a16.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgwn6a08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/bgyn6a16.png", f1, f2, options);
 #endif
 #if defined(SIMD_PNG_TEST) && 1
-        result = result && ImageLoadFromMemorySpecialTest("png/tbbn0g04.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbbn2c16.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbbn3p08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbgn2c16.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbgn3p08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbrn2c08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbwn0g16.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbwn3p08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tbyn3p08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tm3n3p02.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tp0n0g08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tp0n2c08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tp0n3p08.png", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("png/tp1n3p08.png", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbbn0g04.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbbn2c16.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbbn3p08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbgn2c16.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbgn3p08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbrn2c08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbwn0g16.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbwn3p08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tbyn3p08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tm3n3p02.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tp0n0g08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tp0n2c08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tp0n3p08.png", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("png/tp1n3p08.png", f1, f2, options);
 #endif
 
 #if defined(SIMD_JPEG_TEST) && 1
-        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg_progress.jpg", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg400jfif.jpg", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg420exif.jpg", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg422jfif.jpg", f1, f2);
-        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg444.jpg", f1, f2);
+        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg_progress.jpg", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg400jfif.jpg", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg420exif.jpg", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg422jfif.jpg", f1, f2, options);
+        result = result && ImageLoadFromMemorySpecialTest("jpeg/jpeg444.jpg", f1, f2, options);
 #endif
 
         return result;
@@ -925,7 +925,7 @@ namespace Test
     {
         bool result = true;
 
-        result = result && ImageLoadFromMemorySpecialTest(FUNC_LM(Simd::Base::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory));
+        result = result && ImageLoadFromMemorySpecialTest(FUNC_LM(Simd::Base::ImageLoadFromMemory), FUNC_LM(SimdImageLoadFromMemory), options);
 
         return result;
     }

--- a/src/Test/TestImageMatcher.cpp
+++ b/src/Test/TestImageMatcher.cpp
@@ -78,12 +78,12 @@ namespace Test
         }
     }
 
-    bool CreateSamples(const Size & size, size_t factor, bool normalized, ViewPtrs & dst)
+    bool CreateSamples(const Size & size, size_t factor, bool normalized, ViewPtrs & dst, const Options & options)
     {
         dst.clear();
         for (size_t i = 0, n = 10, current = 0, total = 0; i < n; ++i)
         {
-            String path = ROOT_PATH + "/data/image/digit/" + char('0' + i) + ".pgm";
+            String path = options.rootPath + "/data/image/digit/" + char('0' + i) + ".pgm";
             View pooled;
             if (!pooled.Load(path))
             {
@@ -138,7 +138,7 @@ namespace Test
         bool normalized = false;
 
         ViewPtrs samples;
-        if (!CreateSamples(size, factor, normalized, samples))
+        if (!CreateSamples(size, factor, normalized, samples, options))
             return false;
 
         Indexes is0;

--- a/src/Test/TestNeural.cpp
+++ b/src/Test/TestNeural.cpp
@@ -1169,13 +1169,13 @@ namespace Test
         TrainData *_data;
     };
 
-    bool LoadDigits(const Network & net, bool error, TrainSample & dst)
+    bool LoadDigits(const Network & net, bool error, TrainSample & dst, const Options & options)
     {
         Size size = net.InputIndex().Size();
         dst.Resize(0);
         for (size_t i = 0, n = 10, current = 0, total = 0; (error ? i <= n : i < n); ++i)
         {
-            String path = (i < n ? ROOT_PATH + "/data/image/digit/" + char('0' + i) + ".pgm" : ROOT_PATH + "/data/image/face/lena.pgm");
+            String path = (i < n ? options.rootPath + "/data/image/digit/" + char('0' + i) + ".pgm" : options.rootPath + "/data/image/face/lena.pgm");
             View pooled;
             if (!pooled.Load(path))
             {
@@ -1283,7 +1283,7 @@ namespace Test
             return false;
         }
 
-        String path = ROOT_PATH + "/data/network/digit.txt";
+        String path = options.rootPath + "/data/network/digit.txt";
         if (!net.Load(path))
         {
             TEST_LOG_SS(Error, "Can't load Simd::Neural::Network from file '" << path << "'!");
@@ -1291,7 +1291,7 @@ namespace Test
         }
 
         TrainSample sample;
-        if (!LoadDigits(net, true, sample))
+        if (!LoadDigits(net, true, sample, options))
             return false;
 
         Error error;
@@ -1349,7 +1349,7 @@ namespace Test
         }
 
         TrainSample sample;
-        if (!LoadDigits(net, true, sample))
+        if (!LoadDigits(net, true, sample, options))
             return false;
 
         TrainData data;

--- a/src/Test/TestOptions.h
+++ b/src/Test/TestOptions.h
@@ -78,6 +78,8 @@ namespace Test
                         {
                             if (arg.substr(name.size(), 1) == "=")
                                 value = arg.substr(name.size() + 1);
+                            else
+                                continue;
                         }
                         else
                         {
@@ -174,7 +176,7 @@ namespace Test
 
         Strings include, exclude;
 
-        String text, html, source, output;
+        String text, html, source, output, rootPath, realImage;
 
         size_t workThreads, testRepeats, testStatistics, testThreads;
 
@@ -219,6 +221,12 @@ namespace Test
             output = GetArg("-o", "", false);
             warmUpTime = FromString<int>(GetArg("-wu", "0", false)) * 0.001;
             disabledExtensions = FromString<uint32_t>(GetArg("-de", "0", false));
+#if defined(_MSC_VER)
+            rootPath = GetArg("-r", "../..", false);
+#else
+            rootPath = GetArg("-r", "..", false);
+#endif
+            realImage = GetArg("-ri", "", false);
 
             for (int i = 1; i < argc; ++i)
             {
@@ -269,7 +277,7 @@ namespace Test
                 }
                 else if (arg.find("-r=") == 0)
                 {
-                    ROOT_PATH = arg.substr(3, arg.size() - 3);
+                    //rootPath = arg.substr(3, arg.size() - 3);
                 }
                 else if (arg.find("-s=") == 0)
                 {
@@ -313,7 +321,7 @@ namespace Test
                 }
                 else if (arg.find("-ri=") == 0)
                 {
-                    REAL_IMAGE = arg.substr(4, arg.size() - 4);
+                    //realImage = arg.substr(4, arg.size() - 4);
                 }
                 else if (arg.find("-cc=") == 0)
                 {

--- a/src/Test/TestShift.cpp
+++ b/src/Test/TestShift.cpp
@@ -241,7 +241,7 @@ namespace Test
         ShiftDetector shiftDetector;
 
         ShiftDetector::View background;
-        String path = ROOT_PATH + "/data/image/face/lena.pgm";
+        String path = options.rootPath + "/data/image/face/lena.pgm";
         if (!background.Load(path))
         {
             TEST_LOG_SS(Error, "Can't load test image '" << path << "' !");

--- a/src/Test/TestYuvToAny.cpp
+++ b/src/Test/TestYuvToAny.cpp
@@ -553,7 +553,7 @@ namespace Test
     {
         bool result = true;
 
-        String path = ROOT_PATH + "/data/image/city.jpg";
+        String path = options.rootPath + "/data/image/city.jpg";
         View orig;
         if (!orig.Load(path, View::Bgr24))
             return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move the remaining test path globals into `Test::Options`, continuing the Options refactoring on `dev`.

## Changes

- Add `Options::rootPath` (`-r`, default `..` on non-MSVC / `../..` on MSVC) and `Options::realImage` (`-ri`, default empty).
- Remove the `Test::ROOT_PATH` and `Test::REAL_IMAGE` globals from `TestConfig.h` / `Test.cpp`.
- Thread `const Options &` through helpers that load images, cascades, and networks (`GetTestImage`, `GetSample`, `LoadDigits`, `CreateSamples`, Detection/ImageIO/Filter overloads).
- In `ArgsParser::GetArgs`, require `=` after the option name in alt mode so `-r` does not match `-ri` (and `-o` does not match `-ot` / `-oh`).

## Testing

Release build with g++ (`SIMD_SHARED=ON`), then:

- `./Test "-r=.." -fi=Sobel -tt=1 -ts=1` — passed
- `./Test "-r=.." -fi=DetectionHaar -fe=Special -tt=1 -ts=1` — passed (cascades + `lena.pgm` via `rootPath`)
- `./Test "-r=.." -ri=city.jpg -fi=ImageSaveToMemory -tt=1 -ts=1` — passed (`-r` / `-ri` together)
- `./Test "-r=.." -m=s -fi=ContourDetector -tt=1 -ts=1` — passed
- `./Test "-r=.." -m=s -fi=ShiftDetectorFile -tt=1 -ts=1` — passed
- `./Test "-r=.." -m=s -fi=ImageLoadFromMemory -tt=1 -ts=1` — passed (paths logged as `../data/image/png/...`)
- `./Test "-r=.." -ri=city.jpg -fi=RecursiveBilateralFilter -tt=1 -ts=1` — passed (channel-2 cases skipped when `realImage` is set)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f36f10f-57c1-4901-b70f-8dfefbeb5abc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f36f10f-57c1-4901-b70f-8dfefbeb5abc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

