### PR TITLE
Improve description of structure Simd::Font

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -37,6 +37,15 @@
 
 <a href="#HOME">Home</a>
 <hr/>
+<h3 id="R166">September 3, 2026 (version 7.2.166)</h3> 
+<h4>Documentation</h4>
+<h5>Improving</h5>
+<ul>
+ <li>Improved description of structure Simd::Font.</li>
+</ul>
+
+<a href="#HOME">Home</a>
+<hr/>
 <h3 id="R165">September 2, 2026 (version 7.2.165)</h3> 
 <h4>Algorithms</h4>
 <h5>New features</h5>

--- a/src/Simd/SimdFont.hpp
+++ b/src/Simd/SimdFont.hpp
@@ -35,7 +35,22 @@ namespace Simd
 {
     /*! @ingroup cpp_drawing
 
-        \short The Font class provides text drawing.
+        \short The Font class is a C++ wrapper for drawing ASCII text on images.
+
+        The class wraps C API functions ::SimdFontInit, ::SimdFontResize, ::SimdFontHeight,
+        ::SimdFontMeasure and ::SimdFontDraw. It uses a built-in monospace-like font generated
+        from the generic monospace font of Gdiplus. The font supports printable ASCII glyphs.
+        The character '\n' starts a new line. Other characters are ignored.
+
+        A typical usage creates one Font, optionally resizes it to a fraction of the canvas
+        height (for example canvas.height / 32), and then draws labels at pixel coordinates
+        or at a named Simd::View::Position. Height() is used as a line step when several
+        strings are stacked, or to place a label above a rectangle. Measure() returns the
+        pixel size required to draw a string.
+
+        The canvas must have 1, 2, 3 or 4 eight-bit channels. Pixel size of canvas must be
+        equal to sizeof(Color). Text is blended into the canvas through an 8-bit glyph
+        alpha mask. Drawing is clipped to the canvas.
 
         Using example:
         \code
@@ -45,34 +60,51 @@ namespace Simd
         {
             typedef Simd::Pixel::Bgra32 Color;
             typedef Simd::Font::View View;
-
-            Simd::Font font(32);
+            typedef Simd::Font::Point Point;
+            typedef Simd::Font::String String;
 
             View image(320, 240, View::Bgra32);
 
             Simd::FillPixel(image, Color(128, 128, 0));
 
+            Simd::Font font(32);
             font.Draw(image, "Hello, Simd!", View::MiddleCenter, Color(0, 0, 255));
+
+            String text = "First_string,\nSecond-line.";
+            font.Draw(image, text, View::BottomRight, Color(0, 0, 0));
+            font.Resize(24);
+            font.Draw(image, text, View::TopLeft, Color(0, 0, 0), Color(255, 255, 255));
+
+            font.Resize(16);
+            font.Draw(image, "id=1", Point(8, 8), Color(255, 255, 255));
+            font.Draw(image, "in 1", Point(8, 8 + (ptrdiff_t)font.Height()), Color(255, 255, 0));
 
             image.Save("HelloSimd.ppm");
 
             return 0;
         }
         \endcode
+
+        \note This is a wrapper around the low-level \ref drawing API.
     */
     class Font
     {
     public:
-        typedef std::string String; /*!< String type definition. */
-        typedef Simd::Point<ptrdiff_t> Point; /*!< Point type definition. */
-        typedef Simd::View<Simd::Allocator> View; /*!< Image time definition. */
+        typedef std::string String; /*!< Text string type used by Measure and Draw. */
+        typedef Simd::Point<ptrdiff_t> Point; /*!< Point type used as a text position (x, y) and as a measured text size (width, height). */
+        typedef Simd::View<Simd::Allocator> View; /*!< Image type used as a canvas for Draw. */
 
         /*!
-            Creates a new Font class with given height.
+            Creates a new Font class with the given glyph height.
 
-            \note The font supports ASCII characters only. It was generated on the base of the generic monospace font from Gdiplus.
+            The constructor creates an internal font context by ::SimdFontInit and then calls
+            Resize with the given height. The font contains embedded ASCII glyphs (originally
+            generated from the generic monospace font of Gdiplus). Supported glyphs are
+            printable ASCII characters. The character '\n' starts a new line. Other characters
+            are ignored.
 
-            \param [in] height - initial height value. By default it is equal to 16.
+            \param [in] height - initial glyph height in pixels. By default it is equal to 16.
+                                 The value must be inside the supported range of the embedded font.
         */
         Font(size_t height = 16)
             : _context(NULL)
@@ -83,7 +115,9 @@ namespace Simd
         }
 
         /*!
-            Font class destructor.
+            Releases the internal font context.
+
+            The destructor calls ::SimdRelease for the context created by ::SimdFontInit.
         */
         ~Font()
         {
@@ -92,11 +126,15 @@ namespace Simd
         }
 
         /*!
-            Sets a new height value to font.
+            Sets a new glyph height.
 
-            \param [in] height - a new height value. 
+            The function recreates internal 8-bit alpha glyph images from embedded font data.
+            It returns false if height is outside the supported range of the embedded font.
+            Reusing the current height is a successful no-op. Typical usage scales the font
+            to the canvas, for example canvas.height / 32.
 
-            \return a result of the operation.
+            \param [in] height - a new glyph height in pixels.
+            \return true on success and false on failure.
         */
         bool Resize(size_t height)
         {
@@ -106,9 +144,12 @@ namespace Simd
         }
 
         /*!
-            Gets height of the font.
+            Gets current glyph height in pixels.
 
-            \return current height of the font.
+            The value is used as a vertical step when several text lines are drawn one under
+            another, and to place a label above a rectangle (top - Height()).
+
+            \return current glyph height in pixels. It is equal to 0 if the font context is not created.
         */
         size_t Height() const
         {
@@ -118,11 +159,19 @@ namespace Simd
         }
 
         /*!
-            Measures a size of region is need to draw given text.
+            Measures the size of the rectangle required to draw the given text.
 
-            \param [in] text - a text to draw.
+            Supported glyphs advance the current X position by the current glyph width.
+            The '\n' character starts a new line and advances Y by the current glyph height.
+            Unsupported characters are ignored. If the text contains at least one drawable
+            glyph, the returned size also includes the font indentation on all sides.
 
-            \return measured size.
+            The measured size is used by Draw overloads that take Simd::View::Position in
+            order to create a destination region with Simd::View::Region.
+
+            \param [in] text - a text to measure.
+            \return measured size (width in x, height in y). It is equal to (0, 0) if the
+                    font context is not created or the text has no drawable glyphs.
         */
         Point Measure(const String & text) const
         {
@@ -133,14 +182,24 @@ namespace Simd
         }
 
         /*!
-            Draws a text at the image.
+            Draws text at the given pixel position.
 
-            \param [out] canvas - a canvas (image where we draw text).
+            The position is the top-left corner of the measured text region; glyphs are
+            shifted by the current font indentation inside it. Drawing is clipped to the
+            canvas. Supported glyphs advance X by the current glyph width, '\n' starts a
+            new line, and unsupported characters are ignored.
+
+            The canvas must have 1, 2, 3 or 4 eight-bit channels. Pixel size of canvas must
+            be equal to sizeof(Color). Text is blended into the canvas through an 8-bit
+            glyph alpha mask.
+
+            \note This function is a C++ wrapper for function ::SimdFontDraw.
+
+            \param [out] canvas - a canvas image.
             \param [in] text - a text to draw.
-            \param [in] position - a start position to draw text.
-            \param [in] color - a color of the text.
-
-            \return a result of the operation.
+            \param [in] position - the top-left position of the measured text region.
+            \param [in] color - a color of the text. Pixel size of canvas must be equal to sizeof(Color).
+            \return true if the font context exists; otherwise false.
         */
         template <class Color> bool Draw(View & canvas, const String & text, const Point & position, const Color & color) const
         {
@@ -155,14 +214,17 @@ namespace Simd
         }
 
         /*!
-            Draws a text at the image.
+            Draws text at a named position of the canvas.
 
-            \param [out] canvas - a canvas (image where we draw text).
+            The function measures the text, takes a region of this size with Simd::View::Region
+            at the given Simd::View::Position (for example View::TopLeft, View::MiddleCenter,
+            View::BottomRight) and draws the text at the origin of this region.
+
+            \param [out] canvas - a canvas image.
             \param [in] text - a text to draw.
-            \param [in] position - a position to draw text (see Simd::View::Position).
-            \param [in] color - a color of the text.
-
-            \return a result of the operation.
+            \param [in] position - a named position of the text region (see Simd::View::Position).
+            \param [in] color - a color of the text. Pixel size of canvas must be equal to sizeof(Color).
+            \return true if the font context exists; otherwise false.
         */
         template <class Color> bool Draw(View & canvas, const String & text, const View::Position & position, const Color & color) const
         {
@@ -170,15 +232,18 @@ namespace Simd
         }
 
         /*!
-            Draws a text at the image. Fills the text background by given color.
+            Draws text at a named position and fills the text background.
 
-            \param [out] canvas - a canvas (image where we draw text).
+            The function measures the text, takes a region of this size with Simd::View::Region
+            at the given Simd::View::Position, fills this region by the background color with
+            Simd::FillPixel and then draws the text.
+
+            \param [out] canvas - a canvas image.
             \param [in] text - a text to draw.
-            \param [in] position - a position to draw text (see Simd::View::Position).
-            \param [in] color - a color of the text.
-            \param [in] background - background color.
-
-            \return a result of the operation.
+            \param [in] position - a named position of the text region (see Simd::View::Position).
+            \param [in] color - a color of the text. Pixel size of canvas must be equal to sizeof(Color).
+            \param [in] background - a background color of the text region. Pixel size of canvas must be equal to sizeof(Color).
+            \return true if the font context exists; otherwise false.
         */
         template <class Color> bool Draw(View & canvas, const String & text, const View::Position & position, const Color & color, const Color & background) const
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improved Doxygen descriptions of structure `Simd::Font` in `src/Simd/SimdFont.hpp` from real usage in tests, motion annotation, and the C font API. Added release 7.2.166 notes in `docs/2026.html`.

The comments now describe:

- Font as a C++ wrapper of `SimdFontInit`, `SimdFontResize`, `SimdFontHeight`, `SimdFontMeasure`, and `SimdFontDraw`
- Printable ASCII glyphs, `'\n'` as a line break, and ignored unsupported characters
- Typical resize to a fraction of canvas height and `Height()` as a vertical step for stacked labels
- Measure size (including indent) and how `View::Position` overloads use `View::Region`
- Pixel position as the top-left of the measured text region, clipping, 1–4 eight-bit channels, and alpha blending
- Background fill via `Simd::FillPixel` for the named-position overload
- An example that matches `TestFont.cpp` and motion-detector annotation (point, named position, background, multiline)

No executable code was changed. The test suite was not run, as requested.

## Files

- `src/Simd/SimdFont.hpp`
- `docs/2026.html` (new section for release 7.2.166)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a32a632-584b-483b-b733-c5713657353a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a32a632-584b-483b-b733-c5713657353a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

