### PR TITLE
Add C++ wrapper Simd::SynetScale8i

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -38,11 +38,22 @@
 <a href="#HOME">Home</a>
 <hr/>
 <h3 id="R166">September 3, 2026 (version 7.2.166)</h3> 
+<h4>Algorithms</h4>
+<h5>New features</h5>
+<ul>
+ <li>C++ wrapper Simd::SynetScale8i.</li>
+</ul>
+<h4>Test framework</h4>
+<h5>New features</h5>
+<ul>
+ <li>Tests for verifying functionality of C++ wrapper Simd::SynetScale8i.</li>
+</ul>
 <h4>Documentation</h4>
 <h5>Improving</h5>
 <ul>
  <li>Improved description of structure Simd::Font.</li>
  <li>Improved description of structure Simd::Frame.</li>
+ <li>Added description of class Simd::SynetScale8i.</li>
 </ul>
 
 <a href="#HOME">Home</a>

--- a/src/Simd/SimdSynet.hpp
+++ b/src/Simd/SimdSynet.hpp
@@ -4300,6 +4300,209 @@ namespace Simd
         int _add;
         SimdConvolutionParameters _convs[3];
     };
+
+    //-------------------------------------------------------------------------------------------------
+
+    /*! @ingroup cpp_synet
+
+        \short The SynetScale8i class is a C++ wrapper of FP32/UINT8 scale and bias.
+
+        The class wraps C API functions ::SimdSynetScale8iInit, ::SimdSynetScale8iInternalBufferSize,
+        ::SimdSynetScale8iSetParams and ::SimdSynetScale8iForward. It performs per-channel affine
+        transformation of FP32 or UINT8 tensors. When UINT8 is used, conversion parameters are derived
+        from statistics passed to SetParams():
+        \verbatim
+        dst = Convert(src*internalScale[c] + internalShift[c]);
+        \endverbatim
+        Algorithm's details after SetParams() prepares internal coefficients (example for NCHW format):
+        \verbatim
+        for(b = 0; b < batch; ++b)
+            for(c = 0; c < channels; ++c)
+                for(s = 0; s < spatial; ++s)
+                    dst[(b*channels + c)*spatial + s] = Convert(src[(b*channels + c)*spatial + s]*internalScale[c] + internalShift[c]);
+        \endverbatim
+
+        The current implementation creates a context for FP32 or UINT8 input and output tensor types
+        and ::SimdTensorFormatNchw or ::SimdTensorFormatNhwc tensor format. Compatibility flags select
+        precise or narrowed UINT8 calculation mode. Narrowed mode uses unsigned range [0, 180]; otherwise
+        the range is [0, 255]. Call Init() and SetParams() before Forward(). Use Enable() to check that
+        a context was created. The context is released by Clear() or by the destructor.
+
+        Using example:
+        \verbatim
+        #include "Simd/SimdSynet.hpp"
+
+        int main()
+        {
+            const size_t batch = 1, channels = 4, spatial = 16;
+            const SimdSynetCompatibilityType compatibility = (SimdSynetCompatibilityType)(SimdSynetCompatibility8iNarrowed | SimdSynetCompatibilityFmaUse);
+            std::vector<uint8_t> src(batch * channels * spatial, 80), dst(batch * channels * spatial, 0);
+            std::vector<float> scale(channels, 0.5f), bias(channels, 0.1f);
+            std::vector<float> srcMin(channels, 0.0f), srcMax(channels, 1.0f);
+            std::vector<float> dstMin(channels, 0.0f), dstMax(channels, 1.0f);
+            const float * stats[4] = { srcMin.data(), srcMax.data(), dstMin.data(), dstMax.data() };
+
+            Simd::SynetScale8i scale8i;
+            scale8i.Init(batch, channels, spatial, SimdTensorData8u, SimdTensorData8u, SimdTensorFormatNhwc, compatibility);
+            if (scale8i.Enable())
+            {
+                scale8i.SetParams(scale.data(), bias.data(), stats);
+                scale8i.Forward(src.data(), dst.data());
+            }
+
+            return 0;
+        }
+        \endverbatim
+    */
+    class SynetScale8i
+    {
+    public:
+        /*!
+            Creates a new empty SynetScale8i class.
+        */
+        SynetScale8i()
+            : _context(NULL)
+            , _batch(0)
+            , _channels(0)
+            , _spatial(0)
+            , _srcType(SimdTensorData32f)
+            , _dstType(SimdTensorData32f)
+            , _format(SimdTensorFormatUnknown)
+            , _compatibility(SimdSynetCompatibilityDefault)
+        {
+        }
+
+        /*!
+            SynetScale8i class destructor. Releases internal context.
+        */
+        virtual ~SynetScale8i()
+        {
+            Clear();
+        }
+
+        /*!
+            Initializes (or re-initializes) an FP32/UINT8 scale and bias context.
+
+            Creates an internal context with using of function ::SimdSynetScale8iInit.
+            The context is recreated only if batch size, channel count, spatial size, tensor types,
+            tensor format or compatibility flags were changed.
+
+            \note This function is a C++ wrapper for function ::SimdSynetScale8iInit.
+
+            \param [in] batch - a batch size.
+            \param [in] channels - a number of channels in input and output tensors.
+            \param [in] spatial - a spatial size (height*width) of input and output tensors.
+            \param [in] srcType - an input data type. It can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] dstType - an output data type. It can be ::SimdTensorData32f or ::SimdTensorData8u.
+            \param [in] format - a format of input and output tensors. It can be ::SimdTensorFormatNchw or ::SimdTensorFormatNhwc.
+            \param [in] compatibility - calculation compatibility flags. They select precise or narrowed UINT8
+                calculation mode. Narrowed mode uses unsigned range [0, 180]; otherwise the range is [0, 255].
+        */
+        SIMD_INLINE void Init(size_t batch, size_t channels, size_t spatial, SimdTensorDataType srcType, SimdTensorDataType dstType, SimdTensorFormatType format, SimdSynetCompatibilityType compatibility)
+        {
+            if (_batch != batch || _channels != channels || _spatial != spatial ||
+                _srcType != srcType || _dstType != dstType || _format != format || _compatibility != compatibility)
+            {
+                Clear();
+                _batch = batch;
+                _channels = channels;
+                _spatial = spatial;
+                _srcType = srcType;
+                _dstType = dstType;
+                _format = format;
+                _compatibility = compatibility;
+                _context = SimdSynetScale8iInit(_batch, _channels, _spatial, _srcType, _dstType, _format, _compatibility);
+            }
+        }
+
+        /*!
+            Checks that the internal scale context was created.
+
+            \return true if the context exists and Forward() can be called.
+        */
+        SIMD_INLINE bool Enable() const
+        {
+            return _context != NULL;
+        }
+
+        /*!
+            Gets the size in bytes of internal storage used by the scale context.
+
+            The returned value reports internal storage used to store conversion parameters,
+            scale and shift arrays.
+
+            \note This function is a C++ wrapper for function ::SimdSynetScale8iInternalBufferSize.
+
+            \return a number of bytes used by internal buffers.
+        */
+        SIMD_INLINE size_t InternalBufferSize() const
+        {
+            return _context ? SimdSynetScale8iInternalBufferSize(_context) : 0;
+        }
+
+        /*!
+            Sets per-channel scale, bias and tensor statistics for FP32/UINT8 scale algorithm.
+
+            This function must be called before Forward(). The \a scale array contains FP32 per-channel
+            scale coefficients with \a channels elements. Source statistics (\a stats[0], \a stats[1],
+            each with \a channels elements) define per-channel source quantization parameters;
+            destination statistics (\a stats[2], \a stats[3], each with \a channels elements) define
+            per-channel output quantization parameters. After the first call \a stats can be NULL.
+
+            \note This function is a C++ wrapper for function ::SimdSynetScale8iSetParams.
+
+            \param [in] scale - a pointer to original FP32 per-channel scale coefficients.
+            \param [in] bias - a pointer to original FP32 per-channel bias coefficients. Can be NULL.
+            \param [in] stats - a pointer to pointers with input and output statistics:
+                input min (stats[0]), input max (stats[1]), output min (stats[2]) and output max (stats[3]).
+                Can be NULL for subsequent calls after statistics were initialized.
+        */
+        SIMD_INLINE void SetParams(const float * scale, const float * bias, const float * const * stats)
+        {
+            if (_context)
+                SimdSynetScale8iSetParams(_context, scale, bias, stats);
+        }
+
+        /*!
+            Performs forward propagation of FP32/UINT8 scale algorithm.
+
+            The function applies per-channel scale and bias prepared by SetParams() and converts
+            between FP32 and UINT8 according to the types stored in the context created by Init().
+
+            \note This function is a C++ wrapper for function ::SimdSynetScale8iForward.
+
+            \param [in] src - a pointer to input tensor data. Its type is defined by parameter srcType of Init().
+            \param [out] dst - a pointer to output tensor data. Its type is defined by parameter dstType of Init().
+        */
+        SIMD_INLINE void Forward(const uint8_t * src, uint8_t * dst)
+        {
+            if (_context)
+                SimdSynetScale8iForward(_context, src, dst);
+        }
+
+        /*!
+            Releases internal context and clears stored scale parameters.
+        */
+        SIMD_INLINE void Clear()
+        {
+            if (_context)
+                SimdRelease(_context), _context = NULL;
+            _batch = 0;
+            _channels = 0;
+            _spatial = 0;
+            _srcType = SimdTensorData32f;
+            _dstType = SimdTensorData32f;
+            _format = SimdTensorFormatUnknown;
+            _compatibility = SimdSynetCompatibilityDefault;
+        }
+
+    private:
+        void * _context;
+        size_t _batch, _channels, _spatial;
+        SimdTensorDataType _srcType, _dstType;
+        SimdTensorFormatType _format;
+        SimdSynetCompatibilityType _compatibility;
+    };
 }
 
 #endif

--- a/src/Test/TestCheckCpp.cpp
+++ b/src/Test/TestCheckCpp.cpp
@@ -1312,6 +1312,49 @@ namespace Test
                 std::cout << "TestSynetQuantizedMergedConvolution is failed at " << i << " : " << (int)dst1[i] << " != " << (int)dst2[i] << std::endl;
         }
     }
+
+    static void TestSynetScale8i()
+    {
+        const size_t batch = 1, channels = 4, spatial = 16;
+        const SimdSynetCompatibilityType compatibility = (SimdSynetCompatibilityType)(SimdSynetCompatibility8iNarrowed | SimdSynetCompatibilityFmaUse);
+        const size_t size = batch * channels * spatial;
+        std::vector<uint8_t> src(size), dst1(size, 0), dst2(size, 0);
+        std::vector<float> scale(channels), bias(channels);
+        std::vector<float> srcMin(channels, 0.0f), srcMax(channels, 1.0f);
+        std::vector<float> dstMin(channels, 0.0f), dstMax(channels, 1.0f);
+        const float* stats[4] = { srcMin.data(), srcMax.data(), dstMin.data(), dstMax.data() };
+        for (size_t i = 0; i < src.size(); ++i)
+            src[i] = uint8_t(40 + i % 80);
+        for (size_t i = 0; i < channels; ++i)
+        {
+            scale[i] = 0.5f + 0.1f * float(i);
+            bias[i] = 0.1f * float(i);
+        }
+
+        Simd::SynetScale8i scale8i;
+        scale8i.Init(batch, channels, spatial, SimdTensorData8u, SimdTensorData8u, SimdTensorFormatNhwc, compatibility);
+        if (scale8i.Enable())
+        {
+            scale8i.SetParams(scale.data(), bias.data(), stats);
+            scale8i.Forward(src.data(), dst1.data());
+        }
+
+        void* context = SimdSynetScale8iInit(batch, channels, spatial, SimdTensorData8u, SimdTensorData8u, SimdTensorFormatNhwc, compatibility);
+        if (context)
+        {
+            SimdSynetScale8iSetParams(context, scale.data(), bias.data(), stats);
+            SimdSynetScale8iForward(context, src.data(), dst2.data());
+            if (scale8i.InternalBufferSize() != SimdSynetScale8iInternalBufferSize(context))
+                std::cout << "TestSynetScale8i is failed : InternalBufferSize mismatch" << std::endl;
+            SimdRelease(context);
+        }
+
+        for (size_t i = 0; i < dst1.size(); ++i)
+        {
+            if (dst1[i] != dst2[i])
+                std::cout << "TestSynetScale8i is failed at " << i << " : " << (int)dst1[i] << " != " << (int)dst2[i] << std::endl;
+        }
+    }
 #endif
 
     void CheckCpp()
@@ -1363,6 +1406,7 @@ namespace Test
         TestSynetMergedConvolution16b();
         TestSynetMergedConvolution8i();
         TestSynetQuantizedMergedConvolution();
+        TestSynetScale8i();
 #endif
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a C++ analogue of Synet's `Synet::Scale8i` (`src/Synet/Utils/Scale.h` on the Synet `dev` branch) as `Simd::SynetScale8i` in `SimdSynet.hpp`.

The wrapper covers the existing C API:

- `SimdSynetScale8iInit`
- `SimdSynetScale8iInternalBufferSize`
- `SimdSynetScale8iSetParams`
- `SimdSynetScale8iForward`

It follows the same pattern as the other Synet C++ wrappers: `Init` / `Enable` / `InternalBufferSize` / `SetParams` / `Forward` / `Clear`, with Doxygen documentation and a usage example.

`TestSynetScale8i()` in `src/Test/TestCheckCpp.cpp` compares the wrapper against the C API (UINT8 NHWC forward path and internal buffer size).

Release notes for **7.2.166** in `docs/2026.html` list the wrapper, the CheckCpp test, and the class description.

`SimdSynet.hpp` is already listed in `prj/vs2022/Simd.vcxproj` and `prj/vs2022/Simd.vcxproj.filters`. `TestCheckCpp.cpp` is already listed in `prj/vs2022/Test.vcxproj` and `prj/vs2022/Test.vcxproj.filters`. No new source files were added.

## Test plan

- [x] CMake Release build with g++ (`SIMD_SHARED=ON`) completed successfully.
- [x] `./Test "-r=.." -cc=1 -fi=SynetScale8i -tt=1 -ts=1` from `build/`: CheckCpp (including `TestSynetScale8i`) produced no mismatch messages; SynetScale8iForward reported **ALL TESTS ARE FINISHED SUCCESSFULLY**.
- [x] GitHub CI: `build_and_test_arm64` and `build_and_test_mingw` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8325dca-8f17-434d-93ab-44a7710a3b7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8325dca-8f17-434d-93ab-44a7710a3b7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

