### PR TITLE
Remove ForceAvxStack and SIMD_DESCR_INT_SIMD_PAD

### DIFF
--- a/src/Simd/SimdAvx2DescrIntCdd.cpp
+++ b/src/Simd/SimdAvx2DescrIntCdd.cpp
@@ -158,7 +158,6 @@ namespace Simd
 
         template<int bits> void CosineDistance(const uint8_t* a, const uint8_t* b, size_t size, float* distance)
         {
-            ForceAvxStack();
             float abSum = (float)Correlation<bits>(a + 16, b + 16, size);
             Base::DecodeCosineDistance(a, b, abSum, distance);
         }
@@ -169,7 +168,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect2x4<4>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size64 = AlignLo(size, 64), o = 16;
             __m256i a0, a1, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -247,7 +245,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect2x4<5>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), size16a = AlignLo(size - 1, 16), o = 16;
             __m256i a0, a1, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -327,7 +324,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect2x4<6>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), size16a = AlignLo(size - 1, 16), o = 16;
             __m256i a0, a1, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -407,7 +403,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect2x4<7>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), size16a = AlignLo(size - 1, 16), o = 16;
             __m256i a0, a1, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -487,7 +482,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect2x4<8>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), o = 16;
             __m256i a0, a1, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -548,7 +542,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect1x4<4>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size64 = AlignLo(size, 64), o = 16;
             __m256i a0, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -607,7 +600,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect1x4<5>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), size16a = AlignLo(size - 1, 16), o = 16;
             __m256i a0, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -668,7 +660,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect1x4<6>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), size16a = AlignLo(size - 1, 16), o = 16;
             __m256i a0, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -729,7 +720,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect1x4<7>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), size16a = AlignLo(size - 1, 16), o = 16;
             __m256i a0, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -790,7 +780,6 @@ namespace Simd
 
         template<> void MicroCosineDistancesDirect1x4<8>(const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t i = 0, size16 = AlignLo(size, 16), o = 16;
             __m256i a0, b0;
             __m256i ab00 = _mm256_setzero_si256();
@@ -835,7 +824,6 @@ namespace Simd
 
         template<int bits> void MacroCosineDistancesDirect(size_t M, size_t N, const uint8_t* const* A, const uint8_t* const* B, size_t size, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t M2 = AlignLoAny(M, 2);
             size_t N4 = AlignLoAny(N, 4);
             size_t i = 0;

--- a/src/Simd/SimdAvx2DescrIntCdu.cpp
+++ b/src/Simd/SimdAvx2DescrIntCdu.cpp
@@ -103,7 +103,6 @@ namespace Simd
 
         template<int bits> void UnpackDataA(size_t count, const uint8_t* const* src, size_t size, uint8_t* dst, size_t stride)
         {
-            ForceAvxStack();
             size_t size16 = AlignLo(size, 16), size32 = AlignLo(size - 1, 32);
             for (size_t i = 0; i < count; i++)
             {
@@ -167,7 +166,6 @@ namespace Simd
 
         template<int bits> void UnpackDataB(size_t count, const uint8_t* const* src, size_t size, uint8_t* dst, size_t stride)
         {
-            ForceAvxStack();
             size_t countDF = AlignLo(count, DF), size16 = AlignLo(size, 16), size32 = AlignLo(size - 1, 32), i, j, o;
             for (i = 0; i < countDF; i += DF, src += DF)
             {
@@ -226,7 +224,6 @@ namespace Simd
 
         template<int M> void Correlation8_2xM(size_t N, size_t K, const uint8_t* ad0, const uint8_t* bd, const float* an, const float* bn, size_t bnStride, float* distances, size_t stride)
         {
-            ForceAvxStack();
             __m256i ab00, ab01, ab10, ab11, ab20, ab21, ab30, ab31, ab40, ab41, a0, b0, b1;
             const uint8_t* ad1 = ad0 + 1 * K;
             const uint8_t* ad2 = ad0 + 2 * K;
@@ -322,7 +319,6 @@ namespace Simd
 
         void MacroCorrelation8(size_t M, size_t N, size_t K, const uint8_t* ad, const float* an, const uint8_t* bd, const float* bn, float* distances, size_t stride)
         {
-            ForceAvxStack();
             size_t M5 = AlignLoAny(M, 5);
             Correlation8_2xM_Ptr correlation_2x5 = GetCorrelation8_2xM(5);
             Correlation8_2xM_Ptr correlation_2xT = GetCorrelation8_2xM(M - M5);

--- a/src/Simd/SimdAvx2DescrIntEnc.cpp
+++ b/src/Simd/SimdAvx2DescrIntEnc.cpp
@@ -69,7 +69,6 @@ namespace Simd
 
         static void Encode32f4(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, size32 = AlignLo(size, 32);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -102,7 +101,6 @@ namespace Simd
 
         static void Encode32f5(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, main = size - 8, main16 = AlignLo(main, 16);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -141,7 +139,6 @@ namespace Simd
 
         static void Encode32f6(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, main = size - 8, main16 = AlignLo(main, 16);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -180,7 +177,6 @@ namespace Simd
 
         static void Encode32f7(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, main = size - 8, main16 = AlignLo(main, 16);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -204,7 +200,6 @@ namespace Simd
 
         static void Encode32f8(const float* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t sizeA = AlignLo(size, A), i = 0;
             __m256 _scale = _mm256_set1_ps(scale);
@@ -251,7 +246,6 @@ namespace Simd
 
         static void Encode16f4(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, size32 = AlignLo(size, 32);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -284,7 +278,6 @@ namespace Simd
 
         static void Encode16f5(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, main = size - 8, main16 = AlignLo(main, 16);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -323,7 +316,6 @@ namespace Simd
 
         static void Encode16f6(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, main = size - 8, main16 = AlignLo(main, 16);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -362,7 +354,6 @@ namespace Simd
 
         static void Encode16f7(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t i = 0, main = size - 8, main16 = AlignLo(main, 16);
             __m256 _scale = _mm256_set1_ps(scale);
@@ -386,7 +377,6 @@ namespace Simd
 
         static void Encode16f8(const uint16_t* src, float scale, float min, size_t size, int32_t& sum, int32_t& sqsum, uint8_t* dst)
         {
-            ForceAvxStack();
             assert(size % 8 == 0);
             size_t sizeA = AlignLo(size, A), i = 0;
             __m256 _scale = _mm256_set1_ps(scale);

--- a/src/Simd/SimdBaseDescrInt.cpp
+++ b/src/Simd/SimdBaseDescrInt.cpp
@@ -647,7 +647,7 @@ namespace Simd
             : _size(size)
             , _depth(depth)
         {
-            _encSize = 16 + DivHi(size * depth, 8) + SIMD_DESCR_INT_SIMD_PAD;
+            _encSize = 16 + DivHi(size * depth, 8);
             _range = float((1 << _depth) - 1);
             _minMax32f = MinMax32f;
             _minMax16f = MinMax16f;
@@ -676,7 +676,6 @@ namespace Simd
 
         void DescrInt::Encode32f(const float* src, uint8_t* dst) const
         {
-            ForceAvxStack();
             float min, max;
             _minMax32f(src, _size, min, max);
             max = min + Simd::Max(max - min, SIMD_DESCR_INT_EPS);
@@ -687,12 +686,10 @@ namespace Simd
             _encode32f(src, scale, min, _size, sum, sqsum, dst + 16);
             ((float*)dst)[2] = float(sum) * invScale + 0.5f * float(_size) * min;
             ((float*)dst)[3] = ::sqrt(float(sqsum) * invScale * invScale + 2.0f * sum * invScale * min + float(_size) * min * min);
-            memset(dst + 16 + DivHi(_size * _depth, 8), 0, SIMD_DESCR_INT_SIMD_PAD);
         }
 
         void DescrInt::Encode16f(const uint16_t* src, uint8_t* dst) const
         {
-            ForceAvxStack();
             float min, max;
             _minMax16f(src, _size, min, max);
             max = min + Simd::Max(max - min, SIMD_DESCR_INT_EPS);
@@ -703,7 +700,6 @@ namespace Simd
             _encode16f(src, scale, min, _size, sum, sqsum, dst + 16);
             ((float*)dst)[2] = float(sum) * invScale + 0.5f * float(_size) * min;
             ((float*)dst)[3] = ::sqrt(float(sqsum) * invScale * invScale + 2.0f * sum * invScale * min + float(_size) * min * min);
-            memset(dst + 16 + DivHi(_size * _depth, 8), 0, SIMD_DESCR_INT_SIMD_PAD);
         }
 
         void DescrInt::Decode32f(const uint8_t* src, float* dst) const
@@ -723,7 +719,6 @@ namespace Simd
 
         void DescrInt::CosineDistancesMxNa(size_t M, size_t N, const uint8_t* const* A, const uint8_t* const* B, float* distances) const
         {
-            ForceAvxStack();
             if (_macroCosineDistancesDirect)
             {
                 if (_unpSize * _microNu > Base::AlgCacheL1() || N * 2 < _microNu || M * 2 < _microMu  || _macroCosineDistancesUnpack == NULL)
@@ -747,7 +742,6 @@ namespace Simd
 
         void DescrInt::CosineDistancesMxNp(size_t M, size_t N, const uint8_t* A, const uint8_t* B, float* distances) const
         {
-            ForceAvxStack();
             Array8ucp a(M);
             for (size_t i = 0; i < M; ++i)
                 a[i] = A + i * _encSize;
@@ -783,7 +777,6 @@ namespace Simd
 
         void DescrInt::CosineDistancesDirect(size_t M, size_t N, const uint8_t* const* A, const uint8_t* const* B, float* distances) const
         {
-            ForceAvxStack();
             const size_t L2 = Base::AlgCacheL2();
             size_t mN = AlignLoAny(L2 / _encSize, _microNd);
             size_t mM = AlignLoAny(L2 / _encSize, _microMd);
@@ -800,7 +793,6 @@ namespace Simd
 
         void DescrInt::CosineDistancesUnpack(size_t M, size_t N, const uint8_t* const* A, const uint8_t* const* B, float* distances) const
         {
-            ForceAvxStack();
             size_t macroM = AlignLoAny(Base::AlgCacheL2() / _unpSize, _microMu);
             size_t macroN = AlignLoAny(Base::AlgCacheL3() / _unpSize, _microNu);
             size_t sizeA = Simd::Min(macroM, M), sizeB = AlignHi(Simd::Min(macroN, N), _microNu);

--- a/src/Simd/SimdDescrInt.h
+++ b/src/Simd/SimdDescrInt.h
@@ -28,25 +28,8 @@
 
 #define SIMD_DESCR_INT_EPS 0.000001f
 
-// Unused bytes after the packed payload so SIMD loads/stores of 16-byte
-// registers cannot run off a tight EncodedSize * count allocation.
-#define SIMD_DESCR_INT_SIMD_PAD 0
-
 namespace Simd
 {
-    // MinGW x64 only guarantees 16-byte incoming stack alignment. Functions
-    // compiled with -mavx2 may spill YMM with vmovaps (32-byte). An always-
-    // inlined 32-byte local forces GCC to realign the caller's frame.
-    SIMD_INLINE void ForceAvxStack()
-    {
-//        SIMD_ALIGNED(32) uint8_t align[32];
-//#if defined(__GNUC__)
-//        __asm__ __volatile__("" : : "r"(align) : "memory");
-//#else
-//        align[0] = 0;
-//#endif
-    }
-
     namespace Base
     {
         class DescrInt : public Deletable


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes unused `ForceAvxStack` and `SIMD_DESCR_INT_SIMD_PAD` from `SimdDescrInt.h` and all call sites.

On `dev` the helper was already an empty stub and the pad was already `0`. This change deletes both symbols and updates the remaining uses:

- `DescrInt` encoded size is again `16 + DivHi(size * depth, 8)` (no pad term).
- Encode no longer calls a zero-length `memset` of the pad.
- All `ForceAvxStack()` calls in Base and AVX2 DescrInt kernels are removed.

The existing `CosineDistancesMxNp` tail-copy scratch pad is unchanged, so packed `EncodedSize * count` buffers still do not over-read.

## Verification

Release CMake build (`g++`, `SIMD_SHARED=ON`) and:

```
./Test "-r=.." -fi=DescrInt -tt=1 -ts=1
```

Result: `ALL TESTS ARE FINISHED SUCCESSFULLY` (encode/decode 16f/32f, CosineDistance, CosineDistancesMxNa, CosineDistancesMxNp).

GitHub CI on this PR: `build_and_test_arm64` and `build_and_test_mingw` both succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f867b5ea-f270-48d9-9863-d147b81290c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f867b5ea-f270-48d9-9863-d147b81290c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

