### PR TITLE
Move SVE2 Exponent, Logarithm and other math functions to SimdExp.h

### DIFF
--- a/src/Simd/SimdExp.h
+++ b/src/Simd/SimdExp.h
@@ -1,7 +1,7 @@
 /*
 * Simd Library (http://ermig1979.github.io/Simd).
 *
-* Copyright (c) 2011-2024 Yermalayeu Ihar.
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -661,6 +661,92 @@ namespace Simd
         }
     }
 #endif //SIMD_NEON_ENABLE
+
+#ifdef SIMD_SVE2_ENABLE
+    namespace Sve2
+    {
+        namespace Detail
+        {
+            SIMD_INLINE svfloat32_t Poly5(const svbool_t& mask, svfloat32_t x, float a, float b, float c, float d, float e, float f)
+            {
+                svfloat32_t p = svdup_n_f32(f);
+                p = svmla_f32_x(mask, svdup_n_f32(e), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(d), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(c), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(b), x, p);
+                p = svmla_f32_x(mask, svdup_n_f32(a), x, p);
+                return p;
+            }
+
+            SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
+            {
+                x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
+                svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
+                svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
+                svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
+                svfloat32_t expfpart = Poly5(mask, fpart, 9.9999994e-1f, 6.9315308e-1f, 2.4015361e-1f, 5.5826318e-2f, 8.9893397e-3f, 1.8775767e-3f);
+                return svmul_f32_x(mask, expipart, expfpart);
+            }
+
+            SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
+            {
+                svuint32_t i = svreinterpret_u32_f32(x);
+                svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
+                svfloat32_t e = svcvt_f32_s32_x(mask, e32);
+                svfloat32_t one = svdup_n_f32(1.0f);
+                svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
+                svfloat32_t p = Poly5(mask, m, 3.1157899f, -3.3241990f, 2.5988452f, -1.2315303f, 3.1821337e-1f, -3.4436006e-2f);
+                return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
+            }
+        }
+
+        SIMD_INLINE svfloat32_t Exponent(const svbool_t& mask, svfloat32_t value)
+        {
+            return Detail::Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
+        }
+
+        SIMD_INLINE svfloat32_t Elu(const svbool_t& mask, svfloat32_t value, svfloat32_t alpha)
+        {
+            svfloat32_t exp = Exponent(mask, value);
+            svfloat32_t neg = svmul_f32_x(mask, alpha, svsub_n_f32_x(mask, exp, 1.0f));
+            return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
+        }
+
+        SIMD_INLINE svfloat32_t Logarithm(const svbool_t& mask, svfloat32_t value)
+        {
+            return svmul_n_f32_x(mask, Detail::Log2(mask, value), 0.693147181f);
+        }
+
+        SIMD_INLINE svfloat32_t Mish(const svbool_t& mask, svfloat32_t value, svfloat32_t threshold)
+        {
+            svfloat32_t _1 = svdup_n_f32(1.0f);
+            svfloat32_t mish = svadd_n_f32_x(mask, Exponent(mask, value), 1.0f);
+            mish = svadd_n_f32_x(mask, svmul_f32_x(mask, mish, mish), 1.0f);
+            mish = svmul_f32_x(mask, value, svsub_f32_x(mask, _1, svdiv_f32_x(mask, svdup_n_f32(2.0f), mish)));
+            return svsel_f32(svcmpgt_f32(mask, threshold, value), mish, value);
+        }
+
+        SIMD_INLINE svfloat32_t Softplus(const svbool_t& mask, svfloat32_t value, svfloat32_t beta, svfloat32_t threshold)
+        {
+            svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, beta));
+            svfloat32_t log = Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f));
+            return svsel_f32(svcmpgt_f32(mask, threshold, value), svdiv_f32_x(mask, log, beta), value);
+        }
+
+        SIMD_INLINE svfloat32_t Swish(const svbool_t& mask, svfloat32_t value, svfloat32_t slope)
+        {
+            svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, slope)));
+            return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
+        }
+
+        SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t value)
+        {
+            svfloat32_t _1 = svdup_n_f32(1.0f);
+            svfloat32_t exp = Detail::Exp2(mask, svmul_n_f32_x(mask, value, 2.88539008f));
+            return svdiv_f32_x(mask, svsub_f32_x(mask, exp, _1), svadd_f32_x(mask, _1, exp));
+        }
+    }
+#endif //SIMD_SVE2_ENABLE
 }
 
 #endif//__SimdExp_h__

--- a/src/Simd/SimdSve2Synet.cpp
+++ b/src/Simd/SimdSve2Synet.cpp
@@ -26,6 +26,7 @@
 #include "Simd/SimdSve2.h"
 #include "Simd/SimdBase.h"
 #include "Simd/SimdPow.h"
+#include "Simd/SimdExp.h"
 
 namespace Simd
 {
@@ -489,31 +490,6 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        SIMD_INLINE svfloat32_t SoftmaxPoly5(const svbool_t& mask, svfloat32_t x)
-        {
-            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), x, p);
-            return p;
-        }
-
-        SIMD_INLINE svfloat32_t SoftmaxExp2(const svbool_t& mask, svfloat32_t x)
-        {
-            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-            return svmul_f32_x(mask, expipart, SoftmaxPoly5(mask, fpart));
-        }
-
-        SIMD_INLINE svfloat32_t SoftmaxExponent(const svbool_t& mask, svfloat32_t value)
-        {
-            return SoftmaxExp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-        }
-
         void SynetSoftmax32f21(const float* src, size_t outer, float* dst)
         {
             const size_t F = svcntw(), DF = 2 * F;
@@ -526,8 +502,8 @@ namespace Simd
                 svfloat32_t a = svuzp1_f32(s0, s1);
                 svfloat32_t b = svuzp2_f32(s0, s1);
                 svfloat32_t max = svmax_f32_x(body, a, b);
-                svfloat32_t exp0 = SoftmaxExponent(body, svsub_f32_x(body, a, max));
-                svfloat32_t exp1 = SoftmaxExponent(body, svsub_f32_x(body, b, max));
+                svfloat32_t exp0 = Exponent(body, svsub_f32_x(body, a, max));
+                svfloat32_t exp1 = Exponent(body, svsub_f32_x(body, b, max));
                 svfloat32_t sum = svadd_f32_x(body, exp0, exp1);
                 svfloat32_t d0 = svdiv_f32_x(body, exp0, sum);
                 svfloat32_t d1 = svdiv_f32_x(body, exp1, sum);
@@ -577,7 +553,7 @@ namespace Simd
                     for (size_t i = 0; i < inner; i += F)
                     {
                         svbool_t mask = svwhilelt_b32(i, inner);
-                        svfloat32_t _d = SoftmaxExponent(mask, svsub_f32_x(mask, svld1_f32(mask, s + i), svld1_f32(mask, max + i)));
+                        svfloat32_t _d = Exponent(mask, svsub_f32_x(mask, svld1_f32(mask, s + i), svld1_f32(mask, max + i)));
                         svst1_f32(mask, d + i, _d);
                         svst1_f32(mask, sum + i, svadd_f32_x(mask, _d, svld1_f32(mask, sum + i)));
                     }

--- a/src/Simd/SimdSve2SynetActivation.cpp
+++ b/src/Simd/SimdSve2SynetActivation.cpp
@@ -24,66 +24,13 @@
 #include "Simd/SimdMemory.h"
 #include "Simd/SimdBase.h"
 #include "Simd/SimdSynet.h"
+#include "Simd/SimdExp.h"
 
 namespace Simd
 {
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
     namespace Sve2
     {
-        SIMD_INLINE svfloat32_t Poly5(const svbool_t& mask, svfloat32_t x)
-        {
-            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), x, p);
-            return p;
-        }
-
-        SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-        {
-            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-            svfloat32_t expfpart = Poly5(mask, fpart);
-            return svmul_f32_x(mask, expipart, expfpart);
-        }
-
-        SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
-        {
-            svuint32_t i = svreinterpret_u32_f32(x);
-            svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-            svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-            svfloat32_t one = svdup_n_f32(1.0f);
-            svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-            svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-            p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-            return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-        }
-
-        SIMD_INLINE svfloat32_t Logarithm(const svbool_t& mask, svfloat32_t value)
-        {
-            return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
-        }
-
-        SIMD_INLINE svfloat32_t Exponent(const svbool_t& mask, svfloat32_t value)
-        {
-            return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-        }
-
-        SIMD_INLINE svfloat32_t Elu(const svbool_t& mask, svfloat32_t value, svfloat32_t alpha)
-        {
-            svfloat32_t exp = Exponent(mask, value);
-            svfloat32_t neg = svmul_f32_x(mask, alpha, svsub_n_f32_x(mask, exp, 1.0f));
-            return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
-        }
-
         SIMD_INLINE void SynetElu32f(const float* src, const svbool_t& mask, svfloat32_t alpha, float* dst)
         {
             svst1_f32(mask, dst, Elu(mask, svld1_f32(mask, src), alpha));
@@ -224,11 +171,7 @@ namespace Simd
 
         SIMD_INLINE svfloat32_t SynetMish32f(const svbool_t& mask, svfloat32_t value, svfloat32_t threshold)
         {
-            svfloat32_t exp = svadd_n_f32_x(mask, Exponent(mask, value), 1.0f);
-            svfloat32_t den = svadd_n_f32_x(mask, svmul_f32_x(mask, exp, exp), 1.0f);
-            svfloat32_t tanh = svsub_f32_x(mask, svdup_n_f32(1.0f), svdiv_f32_x(mask, svdup_n_f32(2.0f), den));
-            svfloat32_t mish = svmul_f32_x(mask, value, tanh);
-            return svsel_f32(svcmpgt_f32(mask, value, threshold), value, mish);
+            return Mish(mask, value, threshold);
         }
 
         SIMD_INLINE void SynetMish32f(const float* src, const svbool_t& mask, svfloat32_t threshold, float* dst)
@@ -425,9 +368,7 @@ namespace Simd
 
         SIMD_INLINE svfloat32_t SynetTanh32f(const svbool_t& mask, svfloat32_t value, svfloat32_t slope)
         {
-            const svfloat32_t _1 = svdup_n_f32(1.0f);
-            svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, slope));
-            return svdiv_f32_x(mask, svsub_f32_x(mask, exp, _1), svadd_f32_x(mask, exp, _1));
+            return Tanh(mask, svmul_f32_x(mask, value, slope));
         }
 
         SIMD_INLINE void SynetTanh32f(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)
@@ -439,7 +380,7 @@ namespace Simd
         {
             size_t F = svcntw(), QF = 4 * F, i = 0;
             const svbool_t body = svptrue_b32();
-            const svfloat32_t _slope = svdup_n_f32(2.0f * slope[0]);
+            const svfloat32_t _slope = svdup_n_f32(slope[0]);
             for (; i + QF <= size; i += QF)
             {
                 SynetTanh32f(src + i + 0 * F, body, _slope, dst + i + 0 * F);
@@ -457,10 +398,7 @@ namespace Simd
 
         SIMD_INLINE svfloat32_t SynetSoftplus32f(const svbool_t& mask, svfloat32_t value, svfloat32_t beta, svfloat32_t threshold)
         {
-            svfloat32_t exp = Exponent(mask, svmul_f32_x(mask, value, beta));
-            svfloat32_t log = Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f));
-            svfloat32_t softplus = svdiv_f32_x(mask, log, beta);
-            return svsel_f32(svcmpgt_f32(mask, value, threshold), value, softplus);
+            return Softplus(mask, value, beta, threshold);
         }
 
         SIMD_INLINE void SynetSoftplus32f(const float* src, const svbool_t& mask, svfloat32_t beta, svfloat32_t threshold, float* dst)
@@ -491,8 +429,7 @@ namespace Simd
 
         SIMD_INLINE svfloat32_t SynetSwish32f(const svbool_t& mask, svfloat32_t value, svfloat32_t slope)
         {
-            svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, slope)));
-            return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
+            return Swish(mask, value, slope);
         }
 
         SIMD_INLINE void SynetSwish32f(const float* src, const svbool_t& mask, svfloat32_t slope, float* dst)

--- a/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fDirectNchw.cpp
@@ -35,26 +35,6 @@ namespace Simd
     {
         namespace
         {
-            SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-            {
-                x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-                svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-                svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-                svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-                svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-                p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
-                return svmul_f32_x(mask, expipart, p);
-            }
-
-            SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
-            {
-                return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-            }
-
             SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
             {
                 const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -103,7 +83,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationElu>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+                svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f));
                 return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
             }
 
@@ -116,11 +96,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationMish>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                svfloat32_t _1 = svdup_n_f32(1.0f);
-                svfloat32_t mish = svadd_f32_x(mask, Exp(mask, value), _1);
-                mish = svmla_f32_x(mask, _1, mish, mish);
-                mish = svmul_f32_x(mask, value, svsub_f32_x(mask, _1, svdiv_f32_x(mask, svdup_n_f32(2.0f), mish)));
-                return svsel_f32(svcmpgt_f32(mask, param0, value), mish, value);
+                return Mish(mask, value, param0);
             }
 
             template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHardSigmoid>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
@@ -130,7 +106,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationSwish>(const svbool_t& mask, svfloat32_t value, svfloat32_t param0, svfloat32_t param1)
             {
-                svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, param0)));
+                svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, param0)));
                 return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
             }
 

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcDepthwise.cpp
@@ -35,47 +35,6 @@ namespace Simd
     {
         namespace
         {
-            SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-            {
-                x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-                svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-                svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-                svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-                svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-                p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
-                return svmul_f32_x(mask, expipart, p);
-            }
-
-            SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
-            {
-                return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-            }
-
-            SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
-            {
-                svuint32_t i = svreinterpret_u32_f32(x);
-                svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-                svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-                svfloat32_t one = svdup_n_f32(1.0f);
-                svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-                svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-                p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-                return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-            }
-
-            SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
-            {
-                return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
-            }
-
             SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
             {
                 const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -93,12 +52,6 @@ namespace Simd
                 p = svmul_f32_x(mask, p, p);
                 svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
                 return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
-            }
-
-            SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
-            {
-                svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
-                return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
             }
 
             template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask);
@@ -130,7 +83,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
             {
-                svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exp(mask, value), 1.0f), params[0]);
+                svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f), params[0]);
                 return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
             }
 
@@ -145,8 +98,8 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
             {
-                svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), svdup_n_f32(params[0]));
-                return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+                svfloat32_t exp = svmin_f32_x(mask, Exponent(mask, value), svdup_n_f32(params[0]));
+                return svmul_f32_x(mask, value, Tanh(mask, Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f))));
             }
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
@@ -156,7 +109,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
             {
-                svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
+                svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
                 return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
             }
 

--- a/src/Simd/SimdSve2SynetConvolution32fNhwcGrouped.cpp
+++ b/src/Simd/SimdSve2SynetConvolution32fNhwcGrouped.cpp
@@ -34,47 +34,6 @@ namespace Simd
     {
         namespace
         {
-            SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-            {
-                x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-                svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-                svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-                svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-                svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-                p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
-                p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
-                return svmul_f32_x(mask, expipart, p);
-            }
-
-            SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
-            {
-                return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-            }
-
-            SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
-            {
-                svuint32_t i = svreinterpret_u32_f32(x);
-                svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-                svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-                svfloat32_t one = svdup_n_f32(1.0f);
-                svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-                svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-                p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-                p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-                return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-            }
-
-            SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
-            {
-                return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
-            }
-
             SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
             {
                 const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -92,12 +51,6 @@ namespace Simd
                 p = svmul_f32_x(mask, p, p);
                 svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
                 return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
-            }
-
-            SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
-            {
-                svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
-                return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
             }
 
             template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask);
@@ -129,7 +82,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
             {
-                svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exp(mask, value), 1.0f), params[0]);
+                svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f), params[0]);
                 return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
             }
 
@@ -144,8 +97,8 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
             {
-                svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), svdup_n_f32(params[0]));
-                return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+                svfloat32_t exp = svmin_f32_x(mask, Exponent(mask, value), svdup_n_f32(params[0]));
+                return svmul_f32_x(mask, value, Tanh(mask, Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f))));
             }
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
@@ -155,7 +108,7 @@ namespace Simd
 
             template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, const float* params, size_t offset, const svbool_t& mask)
             {
-                svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
+                svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
                 return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
             }
 

--- a/src/Simd/SimdSve2SynetDeconvolution32f.cpp
+++ b/src/Simd/SimdSve2SynetDeconvolution32f.cpp
@@ -93,47 +93,6 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        SIMD_INLINE svfloat32_t DeconvExp2(const svbool_t& mask, svfloat32_t x)
-        {
-            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
-            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
-            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
-            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
-            return svmul_f32_x(mask, expipart, p);
-        }
-
-        SIMD_INLINE svfloat32_t DeconvExp(const svbool_t& mask, svfloat32_t value)
-        {
-            return DeconvExp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-        }
-
-        SIMD_INLINE svfloat32_t DeconvLog2(const svbool_t& mask, svfloat32_t x)
-        {
-            svuint32_t i = svreinterpret_u32_f32(x);
-            svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-            svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-            svfloat32_t one = svdup_n_f32(1.0f);
-            svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-            svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-            p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-            return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-        }
-
-        SIMD_INLINE svfloat32_t DeconvLog(const svbool_t& mask, svfloat32_t value)
-        {
-            return svmul_n_f32_x(mask, DeconvLog2(mask, value), 0.693147181f);
-        }
-
         SIMD_INLINE svfloat32_t DeconvErf(const svbool_t& mask, svfloat32_t x)
         {
             const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -151,12 +110,6 @@ namespace Simd
             p = svmul_f32_x(mask, p, p);
             svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
             return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
-        }
-
-        SIMD_INLINE svfloat32_t DeconvTanh(const svbool_t& mask, svfloat32_t x)
-        {
-            svfloat32_t e = DeconvExp(mask, svmul_n_f32_x(mask, x, -2.0f));
-            return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
         }
 
         template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
@@ -188,7 +141,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
         {
-            svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, DeconvExp(mask, value), 1.0f));
+            svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f));
             return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
         }
 
@@ -201,8 +154,8 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
         {
-            svfloat32_t exp = svmin_f32_x(mask, DeconvExp(mask, value), param0);
-            return svmul_f32_x(mask, value, DeconvTanh(mask, DeconvLog(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+            svfloat32_t exp = svmin_f32_x(mask, Exponent(mask, value), param0);
+            return svmul_f32_x(mask, value, Tanh(mask, Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f))));
         }
 
         template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
@@ -212,7 +165,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
         {
-            return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, DeconvExp(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
+            return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exponent(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
         }
 
         template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationGelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)

--- a/src/Simd/SimdSve2SynetMergedConvolution32fDepthwise.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32fDepthwise.cpp
@@ -32,38 +32,6 @@ namespace Simd
 #if defined(SIMD_SVE2_ENABLE) && defined(SIMD_SYNET_ENABLE)
 	namespace Sve2
 	{
-		SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
-		{
-			return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-		}
-
-		SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
-		{
-			svuint32_t i = svreinterpret_u32_f32(x);
-			svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-			svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-			svfloat32_t one = svdup_n_f32(1.0f);
-			svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-			svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-			p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-			return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-		}
-
-		SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
-		{
-			return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
-		}
-
-		SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
-		{
-			svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
-			return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
-		}
-
 		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, const float* params, const svbool_t& mask);
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationIdentity>(svfloat32_t value, const float* params, const svbool_t& mask)
@@ -93,7 +61,7 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, const float* params, const svbool_t& mask)
 		{
-			svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exp(mask, value), 1.0f), params[0]);
+			svfloat32_t neg = svmul_n_f32_x(mask, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f), params[0]);
 			return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
 		}
 
@@ -108,8 +76,8 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, const float* params, const svbool_t& mask)
 		{
-			svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), svdup_n_f32(params[0]));
-			return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+			svfloat32_t exp = svmin_f32_x(mask, Exponent(mask, value), svdup_n_f32(params[0]));
+			return svmul_f32_x(mask, value, Tanh(mask, Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f))));
 		}
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, const float* params, const svbool_t& mask)
@@ -119,7 +87,7 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, const float* params, const svbool_t& mask)
 		{
-			svfloat32_t exp = Exp(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
+			svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_n_f32_x(mask, value, params[0])));
 			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
 		}
 

--- a/src/Simd/SimdSve2SynetMergedConvolution32fInput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32fInput.cpp
@@ -35,47 +35,6 @@ namespace Simd
 		namespace
 		{
 
-		SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-		{
-			x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-			svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-			svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-			svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-			svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-			p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
-			return svmul_f32_x(mask, expipart, p);
-		}
-
-		SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
-		{
-			return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-		}
-
-		SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
-		{
-			svuint32_t i = svreinterpret_u32_f32(x);
-			svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-			svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-			svfloat32_t one = svdup_n_f32(1.0f);
-			svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-			svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-			p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-			return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-		}
-
-		SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
-		{
-			return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
-		}
-
 		SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
 		{
 			const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -93,12 +52,6 @@ namespace Simd
 			p = svmul_f32_x(mask, p, p);
 			svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
 			return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
-		}
-
-		SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
-		{
-			svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
-			return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
 		}
 
 		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
@@ -130,7 +83,7 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
 		{
-			svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+			svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f));
 			return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
 		}
 
@@ -143,8 +96,8 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
 		{
-			svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), param0);
-			return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+			svfloat32_t exp = svmin_f32_x(mask, Exponent(mask, value), param0);
+			return svmul_f32_x(mask, value, Tanh(mask, Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f))));
 		}
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
@@ -154,7 +107,7 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
 		{
-			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exp(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
+			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exponent(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
 		}
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationGelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)

--- a/src/Simd/SimdSve2SynetMergedConvolution32fOutput.cpp
+++ b/src/Simd/SimdSve2SynetMergedConvolution32fOutput.cpp
@@ -34,47 +34,6 @@ namespace Simd
 	{
 		namespace
 		{
-		SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-		{
-			x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-			svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-			svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-			svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-			svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-			p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), fpart, p);
-			p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), fpart, p);
-			return svmul_f32_x(mask, expipart, p);
-		}
-
-		SIMD_INLINE svfloat32_t Exp(const svbool_t& mask, svfloat32_t value)
-		{
-			return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-		}
-
-		SIMD_INLINE svfloat32_t Log2(const svbool_t& mask, svfloat32_t x)
-		{
-			svuint32_t i = svreinterpret_u32_f32(x);
-			svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-			svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-			svfloat32_t one = svdup_n_f32(1.0f);
-			svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-			svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-			p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-			p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-			return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-		}
-
-		SIMD_INLINE svfloat32_t Log(const svbool_t& mask, svfloat32_t value)
-		{
-			return svmul_n_f32_x(mask, Log2(mask, value), 0.693147181f);
-		}
-
 		SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
 		{
 			const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -92,12 +51,6 @@ namespace Simd
 			p = svmul_f32_x(mask, p, p);
 			svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
 			return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
-		}
-
-		SIMD_INLINE svfloat32_t Tanh(const svbool_t& mask, svfloat32_t x)
-		{
-			svfloat32_t e = Exp(mask, svmul_n_f32_x(mask, x, -2.0f));
-			return svsub_n_f32_x(mask, svdiv_f32_x(mask, svdup_n_f32(2.0f), svadd_n_f32_x(mask, e, 1.0f)), 1.0f);
 		}
 
 		template<SimdConvolutionActivationType type> SIMD_INLINE svfloat32_t Activate(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask);
@@ -129,7 +82,7 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationElu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
 		{
-			svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exp(mask, value), 1.0f));
+			svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f));
 			return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
 		}
 
@@ -142,8 +95,8 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationMish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
 		{
-			svfloat32_t exp = svmin_f32_x(mask, Exp(mask, value), param0);
-			return svmul_f32_x(mask, value, Tanh(mask, Log(mask, svadd_n_f32_x(mask, exp, 1.0f))));
+			svfloat32_t exp = svmin_f32_x(mask, Exponent(mask, value), param0);
+			return svmul_f32_x(mask, value, Tanh(mask, Logarithm(mask, svadd_n_f32_x(mask, exp, 1.0f))));
 		}
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationHardSigmoid>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
@@ -153,7 +106,7 @@ namespace Simd
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationSwish>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)
 		{
-			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exp(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
+			return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, Exponent(mask, svmul_f32_x(mask, svneg_f32_x(mask, value), param0)), 1.0f));
 		}
 
 		template<> SIMD_INLINE svfloat32_t Activate<SimdConvolutionActivationGelu>(svfloat32_t value, svfloat32_t param0, svfloat32_t param1, const svbool_t& mask)

--- a/src/Simd/SimdSve2SynetSoftmax16b.cpp
+++ b/src/Simd/SimdSve2SynetSoftmax16b.cpp
@@ -26,6 +26,7 @@
 #include "Simd/SimdSve2.h"
 #include "Simd/SimdBase.h"
 #include "Simd/SimdArray.h"
+#include "Simd/SimdExp.h"
 
 namespace Simd
 {
@@ -54,31 +55,6 @@ namespace Simd
             return svqxtnb_u32(Float32ToBFloat16(value, mask));
         }
 
-        SIMD_INLINE svfloat32_t SoftmaxPoly5(const svbool_t& mask, svfloat32_t x)
-        {
-            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), x, p);
-            return p;
-        }
-
-        SIMD_INLINE svfloat32_t SoftmaxExp2(const svbool_t& mask, svfloat32_t x)
-        {
-            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-            return svmul_f32_x(mask, expipart, SoftmaxPoly5(mask, fpart));
-        }
-
-        SIMD_INLINE svfloat32_t SoftmaxExponent(const svbool_t& mask, svfloat32_t value)
-        {
-            return SoftmaxExp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-        }
-
         void SynetSoftmax16b21(const uint16_t* src, size_t outer, uint16_t* dst)
         {
             const size_t F = svcntw();
@@ -92,8 +68,8 @@ namespace Simd
                 svfloat32_t src0 = BFloat16ToFloat32(svld1uh_gather_u32index_u32(mask, src + 0, offsets), mask);
                 svfloat32_t src1 = BFloat16ToFloat32(svld1uh_gather_u32index_u32(mask, src + 1, offsets), mask);
                 svfloat32_t max = svmax_f32_x(mask, src0, src1);
-                svfloat32_t exp0 = SoftmaxExponent(mask, svsub_f32_x(mask, src0, max));
-                svfloat32_t exp1 = SoftmaxExponent(mask, svsub_f32_x(mask, src1, max));
+                svfloat32_t exp0 = Exponent(mask, svsub_f32_x(mask, src0, max));
+                svfloat32_t exp1 = Exponent(mask, svsub_f32_x(mask, src1, max));
                 svfloat32_t sum = svadd_f32_x(mask, exp0, exp1);
                 svst1h_u32(mask, tmp0.data, Float32ToBFloat16(svdiv_f32_x(mask, exp0, sum), mask));
                 svst1h_u32(mask, tmp1.data, Float32ToBFloat16(svdiv_f32_x(mask, exp1, sum), mask));
@@ -112,9 +88,9 @@ namespace Simd
         SIMD_INLINE void SynetSoftmax16b31(const svbool_t& mask, svfloat32_t& buf0, svfloat32_t& buf1, svfloat32_t& buf2)
         {
             svfloat32_t max = svmax_f32_x(mask, buf0, svmax_f32_x(mask, buf1, buf2));
-            buf0 = SoftmaxExponent(mask, svsub_f32_x(mask, buf0, max));
-            buf1 = SoftmaxExponent(mask, svsub_f32_x(mask, buf1, max));
-            buf2 = SoftmaxExponent(mask, svsub_f32_x(mask, buf2, max));
+            buf0 = Exponent(mask, svsub_f32_x(mask, buf0, max));
+            buf1 = Exponent(mask, svsub_f32_x(mask, buf1, max));
+            buf2 = Exponent(mask, svsub_f32_x(mask, buf2, max));
             svfloat32_t sum = svadd_f32_x(mask, buf0, svadd_f32_x(mask, buf1, buf2));
             buf0 = svdiv_f32_x(mask, buf0, sum);
             buf1 = svdiv_f32_x(mask, buf1, sum);
@@ -172,7 +148,7 @@ namespace Simd
                 svfloat32_t sum = svdup_n_f32(0.0f);
                 for (size_t c = 0; c < count; ++c)
                 {
-                    svfloat32_t value = SoftmaxExponent(mask, svsub_f32_x(mask, svld1_f32(mask, buf.data + c * F), max));
+                    svfloat32_t value = Exponent(mask, svsub_f32_x(mask, svld1_f32(mask, buf.data + c * F), max));
                     sum = svadd_f32_x(mask, sum, value);
                     svst1_f32(mask, buf.data + c * F, value);
                 }
@@ -214,7 +190,7 @@ namespace Simd
                     for (size_t i = 0; i < inner; i += F)
                     {
                         svbool_t mask = svwhilelt_b32(i, inner);
-                        svfloat32_t _d = SoftmaxExponent(mask, svsub_f32_x(mask, svld1_f32(mask, b + i), svld1_f32(mask, max + i)));
+                        svfloat32_t _d = Exponent(mask, svsub_f32_x(mask, svld1_f32(mask, b + i), svld1_f32(mask, max + i)));
                         svst1_f32(mask, b + i, _d);
                         svst1_f32(mask, sum + i, svadd_f32_x(mask, _d, svld1_f32(mask, sum + i)));
                     }

--- a/src/Simd/SimdSve2SynetUnaryOperation.cpp
+++ b/src/Simd/SimdSve2SynetUnaryOperation.cpp
@@ -25,6 +25,7 @@
 #include "Simd/SimdSynet.h"
 #include "Simd/SimdBase.h"
 #include "Simd/SimdSve2.h"
+#include "Simd/SimdExp.h"
 
 namespace Simd
 {
@@ -40,53 +41,6 @@ namespace Simd
             p = svmla_f32_x(mask, svdup_n_f32(a1), x, p);
             p = svmla_f32_x(mask, svdup_n_f32(a0), x, p);
             return p;
-        }
-
-        SIMD_INLINE svfloat32_t UnaryExpPoly5(const svbool_t& mask, svfloat32_t x)
-        {
-            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), x, p);
-            return p;
-        }
-
-        SIMD_INLINE svfloat32_t UnaryExp2(const svbool_t& mask, svfloat32_t x)
-        {
-            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-            svfloat32_t expfpart = UnaryExpPoly5(mask, fpart);
-            return svmul_f32_x(mask, expipart, expfpart);
-        }
-
-        SIMD_INLINE svfloat32_t UnaryLog2(const svbool_t& mask, svfloat32_t x)
-        {
-            svuint32_t i = svreinterpret_u32_f32(x);
-            svint32_t e32 = svsub_n_s32_x(mask, svreinterpret_s32_u32(svlsr_n_u32_x(mask, svand_n_u32_x(mask, i, 0x7F800000), 23)), 127);
-            svfloat32_t e = svcvt_f32_s32_x(mask, e32);
-            svfloat32_t one = svdup_n_f32(1.0f);
-            svfloat32_t m = svreinterpret_f32_u32(svorr_u32_x(mask, svand_n_u32_x(mask, i, 0x007FFFFF), svreinterpret_u32_f32(one)));
-            svfloat32_t p = svdup_n_f32(-3.4436006e-2f);
-            p = svmla_f32_x(mask, svdup_n_f32(3.1821337e-1f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(-1.2315303f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.5988452f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(-3.3241990f), m, p);
-            p = svmla_f32_x(mask, svdup_n_f32(3.1157899f), m, p);
-            return svmla_f32_x(mask, e, p, svsub_f32_x(mask, m, one));
-        }
-
-        SIMD_INLINE svfloat32_t UnaryLogarithm(const svbool_t& mask, svfloat32_t value)
-        {
-            return svmul_n_f32_x(mask, UnaryLog2(mask, value), 0.693147181f);
-        }
-
-        SIMD_INLINE svfloat32_t UnaryExponent(const svbool_t& mask, svfloat32_t value)
-        {
-            return UnaryExp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
         }
 
         SIMD_INLINE svfloat32_t UnaryErf(const svbool_t& mask, svfloat32_t x)
@@ -106,13 +60,6 @@ namespace Simd
             p = svmul_f32_x(mask, p, p);
             svfloat32_t r = svsub_f32_x(mask, _1, svdiv_f32_x(mask, _1, p));
             return svsel_f32(svcmplt_n_f32(mask, x, 0.0f), svneg_f32_x(mask, r), r);
-        }
-
-        SIMD_INLINE svfloat32_t UnaryTanh(const svbool_t& mask, svfloat32_t value)
-        {
-            const svfloat32_t _1 = svdup_n_f32(1.0f);
-            svfloat32_t exp = UnaryExponent(mask, svmul_n_f32_x(mask, value, 2.0f));
-            return svdiv_f32_x(mask, svsub_f32_x(mask, exp, _1), svadd_f32_x(mask, exp, _1));
         }
 
         namespace UnaryDetail
@@ -163,7 +110,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t SynetUnaryOperation32f<SimdSynetUnaryOperation32fExp>(const svbool_t& mask, svfloat32_t value)
         {
-            return UnaryExponent(mask, value);
+            return Exponent(mask, value);
         }
 
         template<> SIMD_INLINE svfloat32_t SynetUnaryOperation32f<SimdSynetUnaryOperation32fFloor>(const svbool_t& mask, svfloat32_t value)
@@ -173,7 +120,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t SynetUnaryOperation32f<SimdSynetUnaryOperation32fLog>(const svbool_t& mask, svfloat32_t value)
         {
-            return UnaryLogarithm(mask, value);
+            return Logarithm(mask, value);
         }
 
         template<> SIMD_INLINE svfloat32_t SynetUnaryOperation32f<SimdSynetUnaryOperation32fNeg>(const svbool_t& mask, svfloat32_t value)
@@ -221,7 +168,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t SynetUnaryOperation32f<SimdSynetUnaryOperation32fTanh>(const svbool_t& mask, svfloat32_t value)
         {
-            return UnaryTanh(mask, value);
+            return Tanh(mask, value);
         }
 
         template<> SIMD_INLINE svfloat32_t SynetUnaryOperation32f<SimdSynetUnaryOperation32fZero>(const svbool_t& mask, svfloat32_t value)

--- a/src/Simd/SimdSynetActivation.h
+++ b/src/Simd/SimdSynetActivation.h
@@ -563,31 +563,6 @@ namespace Simd
 #ifdef SIMD_SVE2_ENABLE
     namespace Sve2
     {
-        SIMD_INLINE svfloat32_t Poly5(const svbool_t& mask, svfloat32_t x)
-        {
-            svfloat32_t p = svdup_n_f32(1.8775767e-3f);
-            p = svmla_f32_x(mask, svdup_n_f32(8.9893397e-3f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(5.5826318e-2f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(2.4015361e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(6.9315308e-1f), x, p);
-            p = svmla_f32_x(mask, svdup_n_f32(9.9999994e-1f), x, p);
-            return p;
-        }
-
-        SIMD_INLINE svfloat32_t Exp2(const svbool_t& mask, svfloat32_t x)
-        {
-            x = svmax_f32_x(mask, svmin_f32_x(mask, x, svdup_n_f32(126.99999f)), svdup_n_f32(-126.99999f));
-            svint32_t ipart = svcvt_s32_f32_x(mask, svsub_n_f32_x(mask, x, 0.5f));
-            svfloat32_t fpart = svsub_f32_x(mask, x, svcvt_f32_s32_x(mask, ipart));
-            svfloat32_t expipart = svreinterpret_f32_s32(svlsl_n_s32_x(mask, svadd_n_s32_x(mask, ipart, 127), 23));
-            return svmul_f32_x(mask, expipart, Poly5(mask, fpart));
-        }
-
-        SIMD_INLINE svfloat32_t Exponent(const svbool_t& mask, svfloat32_t value)
-        {
-            return Exp2(mask, svmul_n_f32_x(mask, value, 1.44269504f));
-        }
-
         SIMD_INLINE svfloat32_t Erf(const svbool_t& mask, svfloat32_t x)
         {
             const svfloat32_t _1 = svdup_n_f32(1.0f);
@@ -658,8 +633,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationElu>(svfloat32_t value, const svfloat32_t& param0, const svfloat32_t& param1, size_t index, const svbool_t& mask)
         {
-            svfloat32_t neg = svmul_f32_x(mask, param0, svsub_n_f32_x(mask, Exponent(mask, value), 1.0f));
-            return svsel_f32(svcmplt_n_f32(mask, value, 0.0f), neg, value);
+            return Elu(mask, value, param0);
         }
 
         template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHswish>(svfloat32_t value, const svfloat32_t& param0, const svfloat32_t& param1, size_t index, const svbool_t& mask)
@@ -669,11 +643,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationMish>(svfloat32_t value, const svfloat32_t& param0, const svfloat32_t& param1, size_t index, const svbool_t& mask)
         {
-            svfloat32_t exp = svadd_n_f32_x(mask, Exponent(mask, value), 1.0f);
-            svfloat32_t den = svadd_n_f32_x(mask, svmul_f32_x(mask, exp, exp), 1.0f);
-            svfloat32_t tanh = svsub_f32_x(mask, svdup_n_f32(1.0f), svdiv_f32_x(mask, svdup_n_f32(2.0f), den));
-            svfloat32_t mish = svmul_f32_x(mask, value, tanh);
-            return svsel_f32(svcmpgt_f32(mask, value, param0), value, mish);
+            return Mish(mask, value, param0);
         }
 
         template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationHardSigmoid>(svfloat32_t value, const svfloat32_t& param0, const svfloat32_t& param1, size_t index, const svbool_t& mask)
@@ -683,8 +653,7 @@ namespace Simd
 
         template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationSwish>(svfloat32_t value, const svfloat32_t& param0, const svfloat32_t& param1, size_t index, const svbool_t& mask)
         {
-            svfloat32_t exp = Exponent(mask, svneg_f32_x(mask, svmul_f32_x(mask, value, param0)));
-            return svdiv_f32_x(mask, value, svadd_n_f32_x(mask, exp, 1.0f));
+            return Swish(mask, value, param0);
         }
 
         template<> SIMD_INLINE svfloat32_t Activate<::SimdConvolutionActivationGelu>(svfloat32_t value, const svfloat32_t& param0, const svfloat32_t& param1, size_t index, const svbool_t& mask)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SVE2 implementations of `Exponent`, `Logarithm`, `Elu`, `Mish`, `Softplus`, `Swish`, and `Tanh` were duplicated across many files (`SimdSve2SynetActivation.cpp`, `SimdSynetActivation.h`, convolution/deconvolution/softmax/unary sources).

This change moves those functions into `SimdExp.h` next to the existing SSE4.1, AVX2, AVX-512BW, and NEON implementations, then updates the SVE2 callers to use the shared versions.

- Add `Simd::Sve2::Detail::Exp2` / `Log2` and free functions `Exponent`, `Logarithm`, `Elu`, `Mish`, `Softplus`, `Swish`, `Tanh` (SVE predicate/`svbool_t` API; no `Exp` class because SVE types are sizeless).
- Remove the local copies from activation, convolution, deconvolution, softmax, and unary sources.
- `Simd::Sve2::Pow` keeps its own private `Exp2`/`Log2`, matching the other platforms.

Net: +139 / −539 lines.

## Test plan

- [x] CMake Release build with g++ on x86_64 (SVE2 is compile-time gated by `__ARM_FEATURE_SVE2`).
- [x] C++ `Test` smoke: `./Test -r=.. -fi=Sobel -tt=1 -ts=1` — all tests finished successfully.
- [x] Synet consumers of Exp/Log: Elu, Mish, Softplus, Swish, Tanh, Sigmoid, UnaryOperation32f (including Exp/Log/Tanh), Softmax32f, Softmax16b — all tests finished successfully.
- [ ] Full SVE2 correctness on ARM hardware (not available in this environment).

[Build and test summary](https://cursor.com/agents/bc-22324131-336e-43b0-8fc9-fc483538afcb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_and_test_summary.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22324131-336e-43b0-8fc9-fc483538afcb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22324131-336e-43b0-8fc9-fc483538afcb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

