### PR TITLE
Keep scalar PNG Avg/Paeth unfilters for 1-byte pixels

### DIFF
--- a/src/Simd/SimdSse41ImageLoadPng.cpp
+++ b/src/Simd/SimdSse41ImageLoadPng.cpp
@@ -404,7 +404,6 @@ namespace Simd
             {
                 switch (srcN)
                 {
-                case 1: DecodeAvgEq<1, 16>(curr, prev, width, dst); break;
                 case 2: DecodeAvgEq<2, 16>(curr, prev, width, dst); break;
                 case 3: DecodeAvgEq<3, 15>(curr, prev, width, dst); break;
                 case 4: DecodeAvgEq<4, 16>(curr, prev, width, dst); break;
@@ -446,7 +445,6 @@ namespace Simd
             {
                 switch (srcN)
                 {
-                case 1: DecodePaethEq<1, 16>(curr, prev, width, dst); break;
                 case 2: DecodePaethEq<2, 16>(curr, prev, width, dst); break;
                 case 3: DecodePaethEq<3, 15>(curr, prev, width, dst); break;
                 case 4: DecodePaethEq<4, 16>(curr, prev, width, dst); break;
@@ -488,7 +486,6 @@ namespace Simd
             {
                 switch (srcN)
                 {
-                case 1: DecodeAvgFirstEq<1, 16>(curr, width, dst); break;
                 case 2: DecodeAvgFirstEq<2, 16>(curr, width, dst); break;
                 case 3: DecodeAvgFirstEq<3, 15>(curr, width, dst); break;
                 case 4: DecodeAvgFirstEq<4, 16>(curr, width, dst); break;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #949.

Whole-vector Avg/Paeth unfilters are serial for `srcN == 1`, so the SIMD path was slower than Base on Gray8 (`~7.5 ms` vs `~4.3 ms` in `ImageLoadFromMemoryAutoTest`).

This drops the `n=1` Avg/Paeth/AvgFirst cases so grayscale uses the scalar fallback. Vector paths for `n>=2` (RGB/RGBA and 16-bit) stay as in #949.

After this change, AutoTest Gray8 is `4.182 ms` (Sse41) vs `4.278 ms` (Base). Color-format speedups from #949 are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f7a186c-def2-4fb0-aedc-76b96073b4b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f7a186c-def2-4fb0-aedc-76b96073b4b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

