### PR TITLE
Add AVX2 optimizations of SynetQuantizedConvolutionNchwGemm

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -49,7 +49,7 @@
 <ul>
  <li>AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcSpecV1.</li>
  <li>SSE4.1 optimizations of class ImagePngLoader.</li>
- <li>Base implementation, SSE4.1 optimizations of class SynetQuantizedConvolutionNchwGemm.</li>
+ <li>Base implementation, SSE4.1, AVX2 optimizations of class SynetQuantizedConvolutionNchwGemm.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/Avx2.vcxproj
+++ b/prj/vs2022/Avx2.vcxproj
@@ -144,6 +144,7 @@
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedAdd.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConcat.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolutionNhwcDepthwise.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolutionNhwcDepthwiseV2.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolutionNhwcGemmV0.cpp" />

--- a/prj/vs2022/Avx2.vcxproj.filters
+++ b/prj/vs2022/Avx2.vcxproj.filters
@@ -505,6 +505,9 @@
     <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolutionNhwcGemmV0.cpp">
       <Filter>Avx2\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp">
+      <Filter>Avx2\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdAvx2ImageLoadPng.cpp">
       <Filter>Avx2\Image</Filter>
     </ClCompile>

--- a/src/Simd/SimdAvx2SynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdAvx2SynetQuantizedConvolution.cpp
@@ -50,6 +50,8 @@ namespace Simd
                 return new SynetQuantizedConvolutionNhwcSpecV0(param);
             else if(SynetQuantizedConvolutionNhwcGemmV0::Preferable(param))
                 return new SynetQuantizedConvolutionNhwcGemmV0(param);
+            else if (SynetQuantizedConvolutionNchwGemm::Preferable(param))
+                return new SynetQuantizedConvolutionNchwGemm(param);
             else
                 return Sse41::SynetQuantizedConvolutionInit(batch, conv);
         }

--- a/src/Simd/SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp
+++ b/src/Simd/SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp
@@ -1,0 +1,236 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+
+namespace Simd
+{
+#if defined(SIMD_AVX2_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace Avx2
+    {
+        typedef Base::SynetQuantizedConvolutionNchwGemm::AlgParam AlgParam;
+        typedef Base::SynetQuantizedConvolutionNchwGemm::GemmPtr GemmPtr;
+
+        //-----------------------------------------------------------------------------------------
+ 
+        template<Term8iType term, SimdConvolutionActivationType type, int N> void SynetQuantizedConvolutionNchwGemm_Gemm2xN(const int8_t* weight0, const ConvParam& p, 
+            const AlgParam& a, size_t K, size_t M, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, 
+            const __m256& iScale, const float* params, const __m256& dNorm, const __m256i& dZero, int32_t* buf, uint8_t* dst)
+        {
+            __m256i d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, w0, s0, s1;
+            size_t dB = a.bufN, dD = a.N * a.elem;
+            const uint8_t* src1 = src0 + K * F;
+            const int8_t* weight1 = weight0 + 1 * K;
+            const int8_t* weight2 = weight0 + 2 * K;
+            const int8_t* weight3 = weight0 + 3 * K;
+            const int8_t* weight4 = weight0 + 4 * K;
+            if (M > F)
+            {
+                if (update)
+                {
+                    if (N > 0) d00 = _mm256_loadu_si256((__m256i*)(buf + 0 * dB) + 0), d01 = _mm256_loadu_si256((__m256i*)(buf + 0 * dB) + 1);
+                    if (N > 1) d10 = _mm256_loadu_si256((__m256i*)(buf + 1 * dB) + 0), d11 = _mm256_loadu_si256((__m256i*)(buf + 1 * dB) + 1);
+                    if (N > 2) d20 = _mm256_loadu_si256((__m256i*)(buf + 2 * dB) + 0), d21 = _mm256_loadu_si256((__m256i*)(buf + 2 * dB) + 1);
+                    if (N > 3) d30 = _mm256_loadu_si256((__m256i*)(buf + 3 * dB) + 0), d31 = _mm256_loadu_si256((__m256i*)(buf + 3 * dB) + 1);
+                    if (N > 4) d40 = _mm256_loadu_si256((__m256i*)(buf + 4 * dB) + 0), d41 = _mm256_loadu_si256((__m256i*)(buf + 4 * dB) + 1);
+                }
+                else
+                {
+                    if (N > 0) d00 = _mm256_setzero_si256(), d01 = _mm256_setzero_si256();
+                    if (N > 1) d10 = _mm256_setzero_si256(), d11 = _mm256_setzero_si256();
+                    if (N > 2) d20 = _mm256_setzero_si256(), d21 = _mm256_setzero_si256();
+                    if (N > 3) d30 = _mm256_setzero_si256(), d31 = _mm256_setzero_si256();
+                    if (N > 4) d40 = _mm256_setzero_si256(), d41 = _mm256_setzero_si256();
+                }
+                for (size_t k = 0; k < K; k += 4)
+                {
+                    s0 = _mm256_loadu_si256((__m256i*)src0);
+                    s1 = _mm256_loadu_si256((__m256i*)src1);
+                    if (N > 0) w0 = Set4(weight0 + k), Madd4<true>(d00, s0, w0), Madd4<true>(d01, s1, w0);
+                    if (N > 1) w0 = Set4(weight1 + k), Madd4<true>(d10, s0, w0), Madd4<true>(d11, s1, w0);
+                    if (N > 2) w0 = Set4(weight2 + k), Madd4<true>(d20, s0, w0), Madd4<true>(d21, s1, w0);
+                    if (N > 3) w0 = Set4(weight3 + k), Madd4<true>(d30, s0, w0), Madd4<true>(d31, s1, w0);
+                    if (N > 4) w0 = Set4(weight4 + k), Madd4<true>(d40, s0, w0), Madd4<true>(d41, s1, w0);
+                    src0 += A, src1 += A;
+                }
+                if (M == DF)
+                {
+                    if (N > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero), dst += dD, buf += dB;
+                }
+                else
+                {
+                    M -= F;
+                    if (N > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero, M), dst += dD, buf += dB;
+                }
+            }
+            else
+            {
+                if (update)
+                {
+                    if (N > 0) d00 = _mm256_loadu_si256((__m256i*)(buf + 0 * dB) + 0);
+                    if (N > 1) d10 = _mm256_loadu_si256((__m256i*)(buf + 1 * dB) + 0);
+                    if (N > 2) d20 = _mm256_loadu_si256((__m256i*)(buf + 2 * dB) + 0);
+                    if (N > 3) d30 = _mm256_loadu_si256((__m256i*)(buf + 3 * dB) + 0);
+                    if (N > 4) d40 = _mm256_loadu_si256((__m256i*)(buf + 4 * dB) + 0);
+                }
+                else
+                {
+                    if (N > 0) d00 = _mm256_setzero_si256();
+                    if (N > 1) d10 = _mm256_setzero_si256();
+                    if (N > 2) d20 = _mm256_setzero_si256();
+                    if (N > 3) d30 = _mm256_setzero_si256();
+                    if (N > 4) d40 = _mm256_setzero_si256();
+                }
+                for (size_t k = 0; k < K; k += 4)
+                {
+                    s0 = _mm256_loadu_si256((__m256i*)src0);
+                    if (N > 0) w0 = Set4(weight0 + k), Madd4<true>(d00, s0, w0);
+                    if (N > 1) w0 = Set4(weight1 + k), Madd4<true>(d10, s0, w0);
+                    if (N > 2) w0 = Set4(weight2 + k), Madd4<true>(d20, s0, w0);
+                    if (N > 3) w0 = Set4(weight3 + k), Madd4<true>(d30, s0, w0);
+                    if (N > 4) w0 = Set4(weight4 + k), Madd4<true>(d40, s0, w0);
+                    src0 += A;
+                }
+                if (M == F)
+                {
+                    if (N > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero), dst += dD, buf += dB;
+                }
+                else
+                {
+                    if (N > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero, M), dst += dD, buf += dB;
+                }
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        typedef void(*SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr)(const int8_t* weight0, const ConvParam& p, const AlgParam& a, size_t K, size_t M, int update, 
+            const uint8_t* src, const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, 
+            const float* params, const __m256& dNorm, const __m256i& dZero, int32_t* buf, uint8_t* dst);
+
+        template<Term8iType term, SimdConvolutionActivationType type> SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr GetSynetQuantizedConvolutionNchwGemm_Gemm2xN(size_t N)
+        {
+            switch (N)
+            {
+            case 0: return NULL;
+            case 1: return SynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type, 1>;
+            case 2: return SynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type, 2>;
+            case 3: return SynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type, 3>;
+            case 4: return SynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type, 4>;
+            case 5: return SynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type, 5>;
+            default: assert(0);  return NULL;
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> static void SynetQuantizedConvolutionNchwGemm_Gemm(const int8_t* weight, 
+            const ConvParam& p, const AlgParam& a, size_t dstC, size_t dstH, size_t K, int update, const uint8_t* src, const int32_t* sBias,
+            const float* sNorm, int32_t iZero, float iScale, const float* params, float dNorm, int32_t dZero, int32_t* sum, int32_t* buf, uint8_t* dst)
+        {
+            size_t dstS = dstH * p.dstW, n1 = dstC, n = 5;
+            size_t nn = AlignLoAny(n1, n), m = n1 - nn;
+            size_t dB = a.bufN, dD = a.N * a.elem, dW = K, dp = type == ::SimdConvolutionActivationPrelu ? 1 : 0;
+            SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr gemm_2xN = GetSynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type>(n);
+            SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr gemm_2xM = GetSynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type>(m);
+
+            __m256 _iScale, _dNorm;
+            __m256i _dZero = _mm256_set1_epi32(dZero), _iLo, _iHi;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = _mm256_set1_epi32(-iZero);
+                _iHi = _mm256_set1_epi32(255 - iZero);
+                _iScale = _mm256_set1_ps(iScale);
+                _dNorm = _mm256_set1_ps(dNorm);
+            }
+            for (size_t ds = 0; ds < dstS; ds += DF)
+            {
+                size_t dS = Simd::Min(DF, dstS - ds);
+                const int8_t* w = weight;
+                int32_t* b = sum + ds;
+                uint8_t* d = dst + ds * a.elem;
+                size_t i = 0;
+                for (; i < nn; i += n, w += n * dW, b += n * dB, d += n * dD)
+                    gemm_2xN(w, p, a, K, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _dNorm, _dZero, b, d);
+                for (; i < n1; i += m, w += m * dW, b += m * dB, d += m * dD)
+                    gemm_2xM(w, p, a, K, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _dNorm, _dZero, b, d);
+                src += K * DF;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE void SetGemm(const ConvParam& p, const AlgParam& a, GemmPtr* gemm)
+        {
+            gemm[0] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iInterim, SimdConvolutionActivationIdentity>;
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationIdentity>; break;
+            case SimdConvolutionActivationRelu: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationRelu>; break;
+            case SimdConvolutionActivationLeakyRelu: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationLeakyRelu>; break;
+            case SimdConvolutionActivationRestrictRange: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationRestrictRange>; break;
+            case SimdConvolutionActivationPrelu: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationPrelu>; break;
+            case SimdConvolutionActivationElu: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationElu>; break;
+            case SimdConvolutionActivationHswish: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationHswish>; break;
+            case SimdConvolutionActivationMish: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationMish>; break;
+            case SimdConvolutionActivationHardSigmoid: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationHardSigmoid>; break;
+            case SimdConvolutionActivationSwish: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationSwish>; break;
+            case SimdConvolutionActivationGelu: gemm[1] = SynetQuantizedConvolutionNchwGemm_Gemm<Term8iLast8u, SimdConvolutionActivationGelu>; break;
+            default:
+                gemm[1] = NULL;
+            }
+        }
+
+         //-----------------------------------------------------------------------------------------
+
+        SynetQuantizedConvolutionNchwGemm::SynetQuantizedConvolutionNchwGemm(const ConvParam& p)
+            : Sse41::SynetQuantizedConvolutionNchwGemm(p)
+        {
+            SetAlgParam(F, F * 2, 5, 4);
+            SetGemm(p, _alg, _gemm);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynet.h
+++ b/src/Simd/SimdSynet.h
@@ -423,6 +423,11 @@ namespace Simd
             return _mm256_set1_epi32(*(int32_t*)src);
         }
 
+        SIMD_INLINE __m256i Set4(const int8_t* src)
+        {
+            return _mm256_set1_epi32(*(int32_t*)src);
+        }
+
         template<bool overflow> void Madd4(__m256i& i32, __m256i u8, __m256i i8);
 
         template<> SIMD_INLINE void Madd4<true>(__m256i& i32, __m256i u8, __m256i i8)

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -572,6 +572,111 @@ namespace Simd
         {
             Save<term, type, 0>(dst, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template<SimdConvolutionActivationType type> SIMD_INLINE __m256i ToSave32i(__m256i sum, const __m256i& sBias, const __m256& sNorm,
+            const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+        {
+            if (type == SimdConvolutionActivationIdentity)
+            {
+                return _mm256_add_epi32(_mm256_cvtps_epi32(_mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_add_epi32(sum, sBias)), sNorm)), dZero);
+            }
+            else
+            {
+                __m256i i32 = _mm256_cvtps_epi32(_mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_add_epi32(sum, sBias)), sNorm));
+                __m256 f32 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_min_epi32(_mm256_max_epi32(iLo, i32), iHi)), iScale);
+                return QuantizeLinear(ActivateNchw<type>(f32, params, offset), dNorm, dZero);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, __m256i sum, const __m256i& sBias,
+            const __m256& sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+        {
+            if (term == Term8iInterim)
+            {
+                _mm256_storeu_si256((__m256i*)buf, sum);
+            }
+            else if (term == Term8iLast8u)
+            {
+                __m256i d0 = ToSave32i<type>(sum, sBias, sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                _mm_storel_epi64((__m128i*)dst, _mm256_castsi256_si128(PackI16ToU8(PackI32ToI16(d0, K_ZERO), K_ZERO)));
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, __m256i sum, const __m256i& sBias,
+            const __m256& sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
+        {
+            if (term == Term8iInterim)
+            {
+                int32_t tmp[F];
+                _mm256_storeu_si256((__m256i*)tmp, sum);
+                for (size_t i = 0; i < tail; ++i)
+                    buf[i] = tmp[i];
+            }
+            else if (term == Term8iLast8u)
+            {
+                uint8_t tmp[F];
+                Save<term, type>(tmp, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                for (size_t i = 0; i < tail; ++i)
+                    dst[i] = tmp[i];
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> static SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, __m256i sum0, __m256i sum1,
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+        {
+            if (term == Term8iInterim)
+            {
+                _mm256_storeu_si256((__m256i*)buf + 0, sum0);
+                _mm256_storeu_si256((__m256i*)buf + 1, sum1);
+            }
+            else if (term == Term8iLast8u)
+            {
+                __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
+                __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
+                __m256i d0 = ToSave32i<type>(sum0, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                __m256i d1 = ToSave32i<type>(sum1, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                _mm_storeu_si128((__m128i*)dst, _mm256_castsi256_si128(PackI16ToU8(PackI32ToI16(d0, d1), K_ZERO)));
+            }
+            else
+            {
+                assert(0);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, __m256i sum0, __m256i sum1,
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
+        {
+            __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
+            __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
+            Save<term, type>(dst + 0, buf + 0, sum0, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+            Save<term, type>(dst + F, buf + F, sum1, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero, tail);
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, __m256i sum,
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+        {
+            __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
+            __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
+            Save<term, type>(dst, buf, sum, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, __m256i sum,
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
+        {
+            __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
+            __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
+            Save<term, type>(dst, buf, sum, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero, tail);
+        }
     }
 #endif
 

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -589,6 +589,16 @@ namespace Simd
 
         //------------------------------------------------------------------------------------------------
 
+        class SynetQuantizedConvolutionNchwGemm : public Sse41::SynetQuantizedConvolutionNchwGemm
+        {
+        public:
+            SynetQuantizedConvolutionNchwGemm(const ConvParam& p);
+
+            virtual String Ext() const { return "Avx2"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
         void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv);
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add AVX2 SIMD optimizations of `SynetQuantizedConvolutionNchwGemm` for the SynetQuantizedConvolution API (NCHW tensor format), based on the existing SSE4.1 implementation.

## Changes
- New `SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp` with AVX2 GEMM kernels (`F=8`, `microN=5`, `microK=4`), using templates instead of macros.
- AVX2 NCHW `Save1`/`Save2` helpers and `Set4(const int8_t*)` for int8 weight broadcast.
- Register the AVX2 class from `Avx2::SynetQuantizedConvolutionInit`.
- VS2022 `Avx2` project files.
- Release notes for 7.2.166.

Correctness is covered by `Test::SynetQuantizedConvolutionForwardAutoTest` (NCHW cases).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9c4645f-325f-4282-aed1-f645e88956f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9c4645f-325f-4282-aed1-f645e88956f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

