### PR TITLE
Refactor Avx2::ActivateNchw to take vectorized _params

### DIFF
--- a/src/Simd/SimdAvx2SynetConvolution16bNchwGemm.cpp
+++ b/src/Simd/SimdAvx2SynetConvolution16bNchwGemm.cpp
@@ -215,6 +215,9 @@ namespace Simd
             const uint16_t* weight2 = weight0 + 2 * K;
             const uint16_t* weight3 = weight0 + 3 * K;
             const uint16_t* weight4 = weight0 + 4 * K;
+            __m256 _params[2];
+            if (type != SimdConvolutionActivationIdentity && type != SimdConvolutionActivationPrelu)
+                _params[0] = _mm256_set1_ps(params[0]), _params[1] = _mm256_set1_ps(params[1]);
             if (dstS > F)
             {
                 if (zero)
@@ -291,20 +294,20 @@ namespace Simd
                 }
                 if (dstS == DF)
                 {
-                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, 0), dst += dD, buf += dB;
-                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, 1), dst += dD, buf += dB;
-                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, 2), dst += dD, buf += dB;
-                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, 3), dst += dD, buf += dB;
-                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, 4), dst += dD, buf += dB;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, _params, params, 0), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, _params, params, 1), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, _params, params, 2), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, _params, params, 3), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, _params, params, 4), dst += dD, buf += dB;
                 }
                 else
                 {
                     dstS -= F;
-                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, params, 0, dstS), dst += dD, buf += dB;
-                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, params, 1, dstS), dst += dD, buf += dB;
-                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, params, 2, dstS), dst += dD, buf += dB;
-                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, params, 3, dstS), dst += dD, buf += dB;
-                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, params, 4, dstS), dst += dD, buf += dB;
+                    if (M > 0) Save2<term, type>(dst, buf, d00, d01, bias, _params, params, 0, dstS), dst += dD, buf += dB;
+                    if (M > 1) Save2<term, type>(dst, buf, d10, d11, bias, _params, params, 1, dstS), dst += dD, buf += dB;
+                    if (M > 2) Save2<term, type>(dst, buf, d20, d21, bias, _params, params, 2, dstS), dst += dD, buf += dB;
+                    if (M > 3) Save2<term, type>(dst, buf, d30, d31, bias, _params, params, 3, dstS), dst += dD, buf += dB;
+                    if (M > 4) Save2<term, type>(dst, buf, d40, d41, bias, _params, params, 4, dstS), dst += dD, buf += dB;
                 }
             }
             else
@@ -369,19 +372,19 @@ namespace Simd
                 }
                 if (dstS == F)
                 {
-                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, 0), dst += dD, buf += dB;
-                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, 1), dst += dD, buf += dB;
-                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, 2), dst += dD, buf += dB;
-                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, 3), dst += dD, buf += dB;
-                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, 4), dst += dD, buf += dB;
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, _params, params, 0), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, _params, params, 1), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, _params, params, 2), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, _params, params, 3), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, _params, params, 4), dst += dD, buf += dB;
                 }
                 else
                 {
-                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, params, 0, dstS), dst += dD, buf += dB;
-                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, params, 1, dstS), dst += dD, buf += dB;
-                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, params, 2, dstS), dst += dD, buf += dB;
-                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, params, 3, dstS), dst += dD, buf += dB;
-                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, params, 4, dstS), dst += dD, buf += dB;
+                    if (M > 0) Save1<term, type>(dst, buf, d00, bias, _params, params, 0, dstS), dst += dD, buf += dB;
+                    if (M > 1) Save1<term, type>(dst, buf, d10, bias, _params, params, 1, dstS), dst += dD, buf += dB;
+                    if (M > 2) Save1<term, type>(dst, buf, d20, bias, _params, params, 2, dstS), dst += dD, buf += dB;
+                    if (M > 3) Save1<term, type>(dst, buf, d30, bias, _params, params, 3, dstS), dst += dD, buf += dB;
+                    if (M > 4) Save1<term, type>(dst, buf, d40, bias, _params, params, 4, dstS), dst += dD, buf += dB;
                 }
             }
         }

--- a/src/Simd/SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp
+++ b/src/Simd/SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp
@@ -43,7 +43,7 @@ namespace Simd
  
         template<Term8iType term, SimdConvolutionActivationType type, int N> void SynetQuantizedConvolutionNchwGemm_Gemm2xN(const int8_t* weight0, const ConvParam& p, 
             const AlgParam& a, size_t K, size_t M, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, 
-            const __m256& iScale, const float* params, const __m256& dNorm, const __m256i& dZero, int32_t* buf, uint8_t* dst)
+            const __m256& iScale, const float* params, const __m256* _params, const __m256& dNorm, const __m256i& dZero, int32_t* buf, uint8_t* dst)
         {
             __m256i d00, d01, d10, d11, d20, d21, d30, d31, d40, d41, w0, s0, s1;
             size_t dB = a.bufN, dD = a.N * a.elem;
@@ -83,20 +83,20 @@ namespace Simd
                 }
                 if (M == DF)
                 {
-                    if (N > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, _params, params, 0, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, _params, params, 1, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, _params, params, 2, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, _params, params, 3, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, _params, params, 4, dNorm, dZero), dst += dD, buf += dB;
                 }
                 else
                 {
                     M -= F;
-                    if (N > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 0) Save2<term, type>(dst, buf, d00, d01, sBias, sNorm, iLo, iHi, iScale, _params, params, 0, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 1) Save2<term, type>(dst, buf, d10, d11, sBias, sNorm, iLo, iHi, iScale, _params, params, 1, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 2) Save2<term, type>(dst, buf, d20, d21, sBias, sNorm, iLo, iHi, iScale, _params, params, 2, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 3) Save2<term, type>(dst, buf, d30, d31, sBias, sNorm, iLo, iHi, iScale, _params, params, 3, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 4) Save2<term, type>(dst, buf, d40, d41, sBias, sNorm, iLo, iHi, iScale, _params, params, 4, dNorm, dZero, M), dst += dD, buf += dB;
                 }
             }
             else
@@ -129,19 +129,19 @@ namespace Simd
                 }
                 if (M == F)
                 {
-                    if (N > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero), dst += dD, buf += dB;
-                    if (N > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, _params, params, 0, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, _params, params, 1, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, _params, params, 2, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, _params, params, 3, dNorm, dZero), dst += dD, buf += dB;
+                    if (N > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, _params, params, 4, dNorm, dZero), dst += dD, buf += dB;
                 }
                 else
                 {
-                    if (N > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, params, 0, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, params, 1, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, params, 2, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, params, 3, dNorm, dZero, M), dst += dD, buf += dB;
-                    if (N > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, params, 4, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 0) Save1<term, type>(dst, buf, d00, sBias, sNorm, iLo, iHi, iScale, _params, params, 0, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 1) Save1<term, type>(dst, buf, d10, sBias, sNorm, iLo, iHi, iScale, _params, params, 1, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 2) Save1<term, type>(dst, buf, d20, sBias, sNorm, iLo, iHi, iScale, _params, params, 2, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 3) Save1<term, type>(dst, buf, d30, sBias, sNorm, iLo, iHi, iScale, _params, params, 3, dNorm, dZero, M), dst += dD, buf += dB;
+                    if (N > 4) Save1<term, type>(dst, buf, d40, sBias, sNorm, iLo, iHi, iScale, _params, params, 4, dNorm, dZero, M), dst += dD, buf += dB;
                 }
             }
         }
@@ -150,7 +150,7 @@ namespace Simd
 
         typedef void(*SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr)(const int8_t* weight0, const ConvParam& p, const AlgParam& a, size_t K, size_t M, int update, 
             const uint8_t* src, const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, 
-            const float* params, const __m256& dNorm, const __m256i& dZero, int32_t* buf, uint8_t* dst);
+            const float* params, const __m256* _params, const __m256& dNorm, const __m256i& dZero, int32_t* buf, uint8_t* dst);
 
         template<Term8iType term, SimdConvolutionActivationType type> SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr GetSynetQuantizedConvolutionNchwGemm_Gemm2xN(size_t N)
         {
@@ -176,7 +176,7 @@ namespace Simd
             SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr gemm_2xN = GetSynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type>(n);
             SynetQuantizedConvolutionNchwGemm_Gemm2xN_Ptr gemm_2xM = GetSynetQuantizedConvolutionNchwGemm_Gemm2xN<term, type>(m);
 
-            __m256 _iScale, _dNorm;
+            __m256 _iScale, _params[2], _dNorm;
             __m256i _dZero = _mm256_set1_epi32(dZero), _iLo, _iHi;
             if (type != SimdConvolutionActivationIdentity)
             {
@@ -184,6 +184,8 @@ namespace Simd
                 _iHi = _mm256_set1_epi32(255 - iZero);
                 _iScale = _mm256_set1_ps(iScale);
                 _dNorm = _mm256_set1_ps(dNorm);
+                _params[0] = _mm256_set1_ps(params[0]);
+                _params[1] = _mm256_set1_ps(params[1]);
             }
             for (size_t ds = 0; ds < dstS; ds += DF)
             {
@@ -193,9 +195,9 @@ namespace Simd
                 uint8_t* d = dst + ds * a.elem;
                 size_t i = 0;
                 for (; i < nn; i += n, w += n * dW, b += n * dB, d += n * dD)
-                    gemm_2xN(w, p, a, K, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _dNorm, _dZero, b, d);
+                    gemm_2xN(w, p, a, K, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _params, _dNorm, _dZero, b, d);
                 for (; i < n1; i += m, w += m * dW, b += m * dB, d += m * dD)
-                    gemm_2xM(w, p, a, K, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _dNorm, _dZero, b, d);
+                    gemm_2xM(w, p, a, K, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _params, _dNorm, _dZero, b, d);
                 src += K * DF;
             }
         }

--- a/src/Simd/SimdSynetActivation.h
+++ b/src/Simd/SimdSynetActivation.h
@@ -346,12 +346,12 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        template<::SimdConvolutionActivationType type> SIMD_INLINE __m256 ActivateNchw(__m256 value, const float* params, size_t offset)
+        template<::SimdConvolutionActivationType type> SIMD_INLINE __m256 ActivateNchw(__m256 value, const __m256* _params, const float* params, size_t offset)
         {
-            return Activate<type>(value, params, offset);
+            return Activate<type>(value, _params, offset);
         }
 
-        template<> SIMD_INLINE __m256 ActivateNchw<::SimdConvolutionActivationPrelu>(__m256 value, const float* params, size_t offset)
+        template<> SIMD_INLINE __m256 ActivateNchw<::SimdConvolutionActivationPrelu>(__m256 value, const __m256* _params, const float* params, size_t offset)
         {
             return _mm256_add_ps(_mm256_max_ps(_mm256_setzero_ps(), value), _mm256_mul_ps(_mm256_set1_ps(params[offset]), _mm256_min_ps(_mm256_setzero_ps(), value)));
         }

--- a/src/Simd/SimdSynetConvolution16bCommon.h
+++ b/src/Simd/SimdSynetConvolution16bCommon.h
@@ -404,8 +404,8 @@ namespace Simd
             template<SimdConvolutionActivationType type> static SIMD_INLINE void Postprocess(const float* src, const float* bias, const float* params, size_t offset, uint8_t* dst);
             template<SimdConvolutionActivationType type> static SIMD_INLINE void Postprocess(const float* src, const float* bias, const float* params, size_t offset, uint8_t* dst, size_t tail);
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset);
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset, size_t tail);
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset);
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset, size_t tail);
         };
 
         template <> struct Term16b<Term16bLast16b>
@@ -461,16 +461,16 @@ namespace Simd
                     ((uint16_t*)dst)[offset + i] = tmp[i];
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset)
             {
-                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), params, offset);
+                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), _params, params, offset);
                 __m256i b16 = _mm256_permute4x64_epi64(_mm256_packus_epi32(Float32ToBFloat16(f32), Avx2::K_ZERO), 0xD8);
                 _mm_storeu_si128((__m128i*)(ptr + index * DF), _mm256_castsi256_si128(b16));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset, size_t tail)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset, size_t tail)
             {
-                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), params, offset);
+                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), _params, params, offset);
                 __m256i b16 = _mm256_permute4x64_epi64(_mm256_packus_epi32(Float32ToBFloat16(f32), Avx2::K_ZERO), 0xD8);
                 uint16_t tmp[F];
                 _mm_storeu_si128((__m128i*)tmp, _mm256_castsi256_si128(b16));
@@ -522,15 +522,15 @@ namespace Simd
                     ((float*)dst)[offset + i] = tmp[i];
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset)
             {
-                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), params, offset);
+                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), _params, params, offset);
                 _mm256_storeu_ps((float*)ptr + index * F, f32);
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset, size_t tail)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset, size_t tail)
             {
-                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), params, offset);
+                __m256 f32 = ActivateNchw<type>(_mm256_add_ps(value, _mm256_set1_ps(bias[offset])), _params, params, offset);
                 float tmp[F];
                 _mm256_storeu_ps(tmp, f32);
                 for (size_t i = 0; i < tail; ++i)
@@ -574,12 +574,12 @@ namespace Simd
             {
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset)
             {
                 _mm256_storeu_ps(buf + index * F, value);
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const float* params, size_t offset, size_t tail)
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m256 value, const float* bias, const __m256* _params, const float* params, size_t offset, size_t tail)
             {
                 float tmp[F];
                 _mm256_storeu_ps(tmp, value);
@@ -670,26 +670,26 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, __m256 val0, const float* bias, const float* params, size_t offset)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, __m256 val0, const float* bias, const __m256* _params, const float* params, size_t offset)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, offset);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, _params, params, offset);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, __m256 val0, const float* bias, const float* params, size_t offset, size_t tail)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, __m256 val0, const float* bias, const __m256* _params, const float* params, size_t offset, size_t tail)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, offset, tail);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, _params, params, offset, tail);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, __m256 val0, __m256 val1, const float* bias, const float* params, size_t offset)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, __m256 val0, __m256 val1, const float* bias, const __m256* _params, const float* params, size_t offset)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, offset);
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, offset);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, _params, params, offset);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, _params, params, offset);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, __m256 val0, __m256 val1, const float* bias, const float* params, size_t offset, size_t tail)
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, __m256 val0, __m256 val1, const float* bias, const __m256* _params, const float* params, size_t offset, size_t tail)
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, offset);
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, offset, tail);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, _params, params, offset);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, _params, params, offset, tail);
         }
     }
 #endif

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -576,7 +576,7 @@ namespace Simd
         //--------------------------------------------------------------------------------------------------
 
         template<SimdConvolutionActivationType type> SIMD_INLINE __m256i ToSave32i(__m256i sum, const __m256i& sBias, const __m256& sNorm,
-            const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+            const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
         {
             if (type == SimdConvolutionActivationIdentity)
             {
@@ -586,12 +586,12 @@ namespace Simd
             {
                 __m256i i32 = _mm256_cvtps_epi32(_mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_add_epi32(sum, sBias)), sNorm));
                 __m256 f32 = _mm256_mul_ps(_mm256_cvtepi32_ps(_mm256_min_epi32(_mm256_max_epi32(iLo, i32), iHi)), iScale);
-                return QuantizeLinear(ActivateNchw<type>(f32, params, offset), dNorm, dZero);
+                return QuantizeLinear(ActivateNchw<type>(f32, _params, params, offset), dNorm, dZero);
             }
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, __m256i sum, const __m256i& sBias,
-            const __m256& sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+            const __m256& sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
         {
             if (term == Term8iInterim)
             {
@@ -599,7 +599,7 @@ namespace Simd
             }
             else if (term == Term8iLast8u)
             {
-                __m256i d0 = ToSave32i<type>(sum, sBias, sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                __m256i d0 = ToSave32i<type>(sum, sBias, sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
                 _mm_storel_epi64((__m128i*)dst, _mm256_castsi256_si128(PackI16ToU8(PackI32ToI16(d0, K_ZERO), K_ZERO)));
             }
             else
@@ -609,7 +609,7 @@ namespace Simd
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> static SIMD_INLINE void Save(uint8_t* dst, int32_t* buf, __m256i sum, const __m256i& sBias,
-            const __m256& sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
+            const __m256& sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
         {
             if (term == Term8iInterim)
             {
@@ -621,7 +621,7 @@ namespace Simd
             else if (term == Term8iLast8u)
             {
                 uint8_t tmp[F];
-                Save<term, type>(tmp, buf, sum, sBias, sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                Save<term, type>(tmp, buf, sum, sBias, sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
                 for (size_t i = 0; i < tail; ++i)
                     dst[i] = tmp[i];
             }
@@ -632,7 +632,7 @@ namespace Simd
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> static SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, __m256i sum0, __m256i sum1,
-            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
         {
             if (term == Term8iInterim)
             {
@@ -643,8 +643,8 @@ namespace Simd
             {
                 __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
                 __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
-                __m256i d0 = ToSave32i<type>(sum0, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
-                __m256i d1 = ToSave32i<type>(sum1, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+                __m256i d0 = ToSave32i<type>(sum0, _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
+                __m256i d1 = ToSave32i<type>(sum1, _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
                 _mm_storeu_si128((__m128i*)dst, _mm256_castsi256_si128(PackI16ToU8(PackI32ToI16(d0, d1), K_ZERO)));
             }
             else
@@ -654,28 +654,28 @@ namespace Simd
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* dst, int32_t* buf, __m256i sum0, __m256i sum1,
-            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
         {
             __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
             __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
-            Save<term, type>(dst + 0, buf + 0, sum0, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
-            Save<term, type>(dst + F, buf + F, sum1, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero, tail);
+            Save<term, type>(dst + 0, buf + 0, sum0, _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
+            Save<term, type>(dst + F, buf + F, sum1, _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero, tail);
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, __m256i sum,
-            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero)
         {
             __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
             __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
-            Save<term, type>(dst, buf, sum, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero);
+            Save<term, type>(dst, buf, sum, _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
         }
 
         template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* dst, int32_t* buf, __m256i sum,
-            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
+            const int32_t* sBias, const float* sNorm, const __m256i& iLo, const __m256i& iHi, const __m256& iScale, const __m256* _params, const float* params, size_t offset, const __m256& dNorm, const __m256i& dZero, size_t tail)
         {
             __m256i _sBias = _mm256_set1_epi32(sBias[offset]);
             __m256 _sNorm = _mm256_set1_ps(sNorm[offset]);
-            Save<term, type>(dst, buf, sum, _sBias, _sNorm, iLo, iHi, iScale, params, offset, dNorm, dZero, tail);
+            Save<term, type>(dst, buf, sum, _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero, tail);
         }
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `const __m256* _params` to `Avx2::ActivateNchw` so it matches `Sse41::ActivateNchw`.

Non-PReLU activations now use the broadcast `__m256` parameters (same as `Activate`), while the PReLU specialization still reads the per-channel slope from `params[offset]`.

AVX2 NCHW GEMM callers are updated the same way as the SSE4.1 versions:

- `Avx2::Term16b` NCHW `Save` / `Save1` / `Save2` in `SimdSynetConvolution16bCommon.h`
- NCHW `ToSave32i` / `Save` / `Save1` / `Save2` in `SimdSynetQuantizedActivation.h`
- `SimdAvx2SynetConvolution16bNchwGemm.cpp`
- `SimdAvx2SynetQuantizedConvolutionNchwGemm.cpp`

## Testing

Local Release build (`g++`, `-march=native`, `SIMD_SHARED=ON`) and:

```
./Test "-r=.." -m=a -tt=1 -ts=1 -mt=1 \
  -fi=SynetConvolution16bForward \
  -fi=SynetQuantizedConvolutionForward
```

All tests finished successfully, including NCHW Identity / Relu / Prelu cases that go through `Avx2::ActivateNchw`. GitHub CI `build_and_test_arm64` and `build_and_test_gcc_new` also passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30d0a467-44f9-4b6f-b401-48338cb6f7e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30d0a467-44f9-4b6f-b401-48338cb6f7e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

