### PR TITLE
Refactor Avx512bw::ActivateNchw to take vectorized _params

### DIFF
--- a/src/Simd/SimdAmxBf16SynetConvolution16bNchwGemm.cpp
+++ b/src/Simd/SimdAmxBf16SynetConvolution16bNchwGemm.cpp
@@ -48,6 +48,9 @@ namespace Simd
             int stepW = a.reorderType ? 512 : 32, strideW = a.reorderType ? 64 : (int)K * 2;
             const uint16_t* weight1 = weight0 + K * F;
             const uint16_t* src1 = src0 + K * F;
+            __m512 _params[2];
+            if (type != SimdConvolutionActivationIdentity && type != SimdConvolutionActivationPrelu)
+                _params[0] = _mm512_set1_ps(params[0]), _params[1] = _mm512_set1_ps(params[1]);
             if (cfg)
                 SetTileConf2x2(dstC, dstS);
             if (zero)
@@ -97,9 +100,9 @@ namespace Simd
                 __mmask16 tailD = TailMask16(dstS - F);
                 size_t dstC8 = AlignLo(dstC, 8), dc = 0;
                 for (; dc < dstC8; dc += 8)
-                    Apply2x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, params, dc, tailD);
+                    Apply2x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, _params, params, dc, tailD);
                 for (; dc < dstC; ++dc)
-                    Apply2<term, type>(dst + dc * dD, buf + dc * dB, bias, params, dc, tailD);
+                    Apply2<term, type>(dst + dc * dD, buf + dc * dB, bias, _params, params, dc, tailD);
             }
             else
             {
@@ -116,6 +119,9 @@ namespace Simd
             int dB = int(a.sumBuf ? a.bufN : a.N), dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
             int stepW = a.reorderType ? 512 : 32, strideW = a.reorderType ? 64 : (int)K * 2;
             const uint16_t* weight1 = weight0 + K * F;
+            __m512 _params[2];
+            if (type != SimdConvolutionActivationIdentity && type != SimdConvolutionActivationPrelu)
+                _params[0] = _mm512_set1_ps(params[0]), _params[1] = _mm512_set1_ps(params[1]);
             if (cfg)
                 SetTileConf2x1(dstC, dstS);
             if (zero)
@@ -152,9 +158,9 @@ namespace Simd
                 __mmask16 tailD = TailMask16(dstS);
                 size_t dstC8 = AlignLo(dstC, 8), dc = 0;
                 for (; dc < dstC8; dc += 8)
-                    Apply1x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, params, dc, tailD);
+                    Apply1x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, _params, params, dc, tailD);
                 for (; dc < dstC; ++dc)
-                    Apply1<term, type>(dst + dc * dD, buf + dc * dB, bias, params, dc, tailD);
+                    Apply1<term, type>(dst + dc * dD, buf + dc * dB, bias, _params, params, dc, tailD);
             }
             else
             {
@@ -169,6 +175,9 @@ namespace Simd
             int dB = int(a.sumBuf ? a.bufN : a.N), dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
             int stepW = a.reorderType ? 512 : 32, strideW = a.reorderType ? 64 : (int)K * 2;
             const uint16_t* src1 = src0 + K * F;
+            __m512 _params[2];
+            if (type != SimdConvolutionActivationIdentity && type != SimdConvolutionActivationPrelu)
+                _params[0] = _mm512_set1_ps(params[0]), _params[1] = _mm512_set1_ps(params[1]);
 
             if (cfg)
                 SetTileConf1x2(dstC, dstS);
@@ -206,9 +215,9 @@ namespace Simd
                 __mmask16 tailD = TailMask16(dstS - F);
                 size_t dstC8 = AlignLo(dstC, 8), dc = 0;
                 for (; dc < dstC8; dc += 8)
-                    Apply2x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, params, dc, tailD);
+                    Apply2x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, _params, params, dc, tailD);
                 for (; dc < dstC; ++dc)
-                    Apply2<term, type>(dst + dc * dD, buf + dc * dB, bias, params, dc, tailD);
+                    Apply2<term, type>(dst + dc * dD, buf + dc * dB, bias, _params, params, dc, tailD);
             }
             else
             {
@@ -222,6 +231,9 @@ namespace Simd
         {
             int dB = int(a.sumBuf ? a.bufN : a.N), dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
             int stepW = a.reorderType ? 512 : 32, strideW = a.reorderType ? 64 : (int)K * 2;
+            __m512 _params[2];
+            if (type != SimdConvolutionActivationIdentity && type != SimdConvolutionActivationPrelu)
+                _params[0] = _mm512_set1_ps(params[0]), _params[1] = _mm512_set1_ps(params[1]);
 
             if (cfg)
                 SetTileConf1x1(dstC, dstS);
@@ -245,9 +257,9 @@ namespace Simd
                 __mmask16 tailD = TailMask16(dstS);
                 size_t dstC8 = AlignLo(dstC, 8), dc = 0;
                 for (; dc < dstC8; dc += 8)
-                    Apply1x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, params, dc, tailD);
+                    Apply1x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, bias, _params, params, dc, tailD);
                 for (; dc < dstC; ++dc)
-                    Apply1<term, type>(dst + dc * dD, buf + dc * dB, bias, params, dc, tailD);
+                    Apply1<term, type>(dst + dc * dD, buf + dc * dB, bias, _params, params, dc, tailD);
             }
             else
             {

--- a/src/Simd/SimdAvx512bwSynetConvolution16bNchwGemm.cpp
+++ b/src/Simd/SimdAvx512bwSynetConvolution16bNchwGemm.cpp
@@ -116,6 +116,9 @@ namespace Simd
             const uint16_t* weight3 = weight0 + 3 * K;
             const uint16_t* weight4 = weight0 + 4 * K;
             const uint16_t* weight5 = weight0 + 5 * K;
+            __m512 _params[2];
+            if (type != SimdConvolutionActivationIdentity && type != SimdConvolutionActivationPrelu)
+                _params[0] = _mm512_set1_ps(params[0]), _params[1] = _mm512_set1_ps(params[1]);
             if (tails[1])
             {
                 if (zero)
@@ -267,18 +270,18 @@ namespace Simd
                     src0 += DF;
                     src1 += DF;
                 }
-                if (M > 0x0) Save2<term, type>(dst, buf, d00, d01, bias, params, 0x0, tails[1]), dst += dD, buf += dB;
-                if (M > 0x1) Save2<term, type>(dst, buf, d10, d11, bias, params, 0x1, tails[1]), dst += dD, buf += dB;
-                if (M > 0x2) Save2<term, type>(dst, buf, d20, d21, bias, params, 0x2, tails[1]), dst += dD, buf += dB;
-                if (M > 0x3) Save2<term, type>(dst, buf, d30, d31, bias, params, 0x3, tails[1]), dst += dD, buf += dB;
-                if (M > 0x4) Save2<term, type>(dst, buf, d40, d41, bias, params, 0x4, tails[1]), dst += dD, buf += dB;
-                if (M > 0x5) Save2<term, type>(dst, buf, d50, d51, bias, params, 0x5, tails[1]), dst += dD, buf += dB;
-                if (M > 0x6) Save2<term, type>(dst, buf, d60, d61, bias, params, 0x6, tails[1]), dst += dD, buf += dB;
-                if (M > 0x7) Save2<term, type>(dst, buf, d70, d71, bias, params, 0x7, tails[1]), dst += dD, buf += dB;
-                if (M > 0x8) Save2<term, type>(dst, buf, d80, d81, bias, params, 0x8, tails[1]), dst += dD, buf += dB;
-                if (M > 0x9) Save2<term, type>(dst, buf, d90, d91, bias, params, 0x9, tails[1]), dst += dD, buf += dB;
-                if (M > 0xa) Save2<term, type>(dst, buf, da0, da1, bias, params, 0xa, tails[1]), dst += dD, buf += dB;
-                if (M > 0xb) Save2<term, type>(dst, buf, db0, db1, bias, params, 0xb, tails[1]), dst += dD, buf += dB;
+                if (M > 0x0) Save2<term, type>(dst, buf, d00, d01, bias, _params, params, 0x0, tails[1]), dst += dD, buf += dB;
+                if (M > 0x1) Save2<term, type>(dst, buf, d10, d11, bias, _params, params, 0x1, tails[1]), dst += dD, buf += dB;
+                if (M > 0x2) Save2<term, type>(dst, buf, d20, d21, bias, _params, params, 0x2, tails[1]), dst += dD, buf += dB;
+                if (M > 0x3) Save2<term, type>(dst, buf, d30, d31, bias, _params, params, 0x3, tails[1]), dst += dD, buf += dB;
+                if (M > 0x4) Save2<term, type>(dst, buf, d40, d41, bias, _params, params, 0x4, tails[1]), dst += dD, buf += dB;
+                if (M > 0x5) Save2<term, type>(dst, buf, d50, d51, bias, _params, params, 0x5, tails[1]), dst += dD, buf += dB;
+                if (M > 0x6) Save2<term, type>(dst, buf, d60, d61, bias, _params, params, 0x6, tails[1]), dst += dD, buf += dB;
+                if (M > 0x7) Save2<term, type>(dst, buf, d70, d71, bias, _params, params, 0x7, tails[1]), dst += dD, buf += dB;
+                if (M > 0x8) Save2<term, type>(dst, buf, d80, d81, bias, _params, params, 0x8, tails[1]), dst += dD, buf += dB;
+                if (M > 0x9) Save2<term, type>(dst, buf, d90, d91, bias, _params, params, 0x9, tails[1]), dst += dD, buf += dB;
+                if (M > 0xa) Save2<term, type>(dst, buf, da0, da1, bias, _params, params, 0xa, tails[1]), dst += dD, buf += dB;
+                if (M > 0xb) Save2<term, type>(dst, buf, db0, db1, bias, _params, params, 0xb, tails[1]), dst += dD, buf += dB;
             }
             else
             {
@@ -403,18 +406,18 @@ namespace Simd
                     }
                     src0 += DF;
                 }
-                if (M > 0x0) Save1<term, type>(dst, buf, d00, bias, params, 0x0, tails[0]), dst += dD, buf += dB;
-                if (M > 0x1) Save1<term, type>(dst, buf, d10, bias, params, 0x1, tails[0]), dst += dD, buf += dB;
-                if (M > 0x2) Save1<term, type>(dst, buf, d20, bias, params, 0x2, tails[0]), dst += dD, buf += dB;
-                if (M > 0x3) Save1<term, type>(dst, buf, d30, bias, params, 0x3, tails[0]), dst += dD, buf += dB;
-                if (M > 0x4) Save1<term, type>(dst, buf, d40, bias, params, 0x4, tails[0]), dst += dD, buf += dB;
-                if (M > 0x5) Save1<term, type>(dst, buf, d50, bias, params, 0x5, tails[0]), dst += dD, buf += dB;
-                if (M > 0x6) Save1<term, type>(dst, buf, d60, bias, params, 0x6, tails[0]), dst += dD, buf += dB;
-                if (M > 0x7) Save1<term, type>(dst, buf, d70, bias, params, 0x7, tails[0]), dst += dD, buf += dB;
-                if (M > 0x8) Save1<term, type>(dst, buf, d80, bias, params, 0x8, tails[0]), dst += dD, buf += dB;
-                if (M > 0x9) Save1<term, type>(dst, buf, d90, bias, params, 0x9, tails[0]), dst += dD, buf += dB;
-                if (M > 0xa) Save1<term, type>(dst, buf, da0, bias, params, 0xa, tails[0]), dst += dD, buf += dB;
-                if (M > 0xb) Save1<term, type>(dst, buf, db0, bias, params, 0xb, tails[0]), dst += dD, buf += dB;
+                if (M > 0x0) Save1<term, type>(dst, buf, d00, bias, _params, params, 0x0, tails[0]), dst += dD, buf += dB;
+                if (M > 0x1) Save1<term, type>(dst, buf, d10, bias, _params, params, 0x1, tails[0]), dst += dD, buf += dB;
+                if (M > 0x2) Save1<term, type>(dst, buf, d20, bias, _params, params, 0x2, tails[0]), dst += dD, buf += dB;
+                if (M > 0x3) Save1<term, type>(dst, buf, d30, bias, _params, params, 0x3, tails[0]), dst += dD, buf += dB;
+                if (M > 0x4) Save1<term, type>(dst, buf, d40, bias, _params, params, 0x4, tails[0]), dst += dD, buf += dB;
+                if (M > 0x5) Save1<term, type>(dst, buf, d50, bias, _params, params, 0x5, tails[0]), dst += dD, buf += dB;
+                if (M > 0x6) Save1<term, type>(dst, buf, d60, bias, _params, params, 0x6, tails[0]), dst += dD, buf += dB;
+                if (M > 0x7) Save1<term, type>(dst, buf, d70, bias, _params, params, 0x7, tails[0]), dst += dD, buf += dB;
+                if (M > 0x8) Save1<term, type>(dst, buf, d80, bias, _params, params, 0x8, tails[0]), dst += dD, buf += dB;
+                if (M > 0x9) Save1<term, type>(dst, buf, d90, bias, _params, params, 0x9, tails[0]), dst += dD, buf += dB;
+                if (M > 0xa) Save1<term, type>(dst, buf, da0, bias, _params, params, 0xa, tails[0]), dst += dD, buf += dB;
+                if (M > 0xb) Save1<term, type>(dst, buf, db0, bias, _params, params, 0xb, tails[0]), dst += dD, buf += dB;
             }
         }
 

--- a/src/Simd/SimdSynetActivation.h
+++ b/src/Simd/SimdSynetActivation.h
@@ -479,16 +479,6 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        template<::SimdConvolutionActivationType type> SIMD_INLINE __m512 ActivateNchw(__m512 value, const float* params, size_t offset)
-        {
-            return Activate<type>(value, params, offset);
-        }
-
-        template<> SIMD_INLINE __m512 ActivateNchw<::SimdConvolutionActivationPrelu>(__m512 value, const float* params, size_t offset)
-        {
-            return _mm512_add_ps(_mm512_max_ps(_mm512_setzero_ps(), value), _mm512_mul_ps(_mm512_set1_ps(params[offset]), _mm512_min_ps(_mm512_setzero_ps(), value)));
-        }
-
         template<::SimdConvolutionActivationType type> SIMD_INLINE __m512 ActivateNchw(__m512 value, const __m512* _params, const float* params, size_t offset)
         {
             return Activate<type>(value, _params, offset);

--- a/src/Simd/SimdSynetConvolution16bCommon.h
+++ b/src/Simd/SimdSynetConvolution16bCommon.h
@@ -716,7 +716,7 @@ namespace Simd
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint16_t* ptr, __m512 value, const __m512* bias, const __m512* params, __mmask16 tail = __mmask16(-1));
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const __m512* bias, const __m512* params, __mmask16 tail = __mmask16(-1));
             template<SimdConvolutionActivationType type> static SIMD_INLINE void Postprocess(const float* src, const float* bias, const float* params, size_t offset, uint8_t* dst, __mmask16 tail = __mmask16(-1));
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1));
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1));
         };
 
         template <> struct Term16b<Term16bLast16b>
@@ -739,9 +739,9 @@ namespace Simd
                 _mm256_mask_storeu_epi16(dst + offset * 2, tail, _mm512_cvtepi32_epi16(Float32ToBFloat16(f32)));
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
             {
-                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), params, offset);
+                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), _params, params, offset);
                 _mm256_mask_storeu_epi16(ptr + index * DF, tail, _mm512_cvtepi32_epi16(Float32ToBFloat16(f32)));
             }
         };
@@ -764,9 +764,9 @@ namespace Simd
                 _mm512_mask_storeu_ps((float*)(dst + offset * 4), tail, f32);
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
             {
-                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), params, offset);
+                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), _params, params, offset);
                 _mm512_mask_storeu_ps((float*)ptr + index * F, tail, f32);
             }
         };
@@ -787,7 +787,7 @@ namespace Simd
             {
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
             {
                 _mm512_mask_storeu_ps(buf + index * F, tail, value);
             }
@@ -861,15 +861,15 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, __m512 val0, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save1(uint8_t* ptr, float* buf, __m512 val0, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, offset, tail);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, _params, params, offset, tail);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, __m512 val0, __m512 val1, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Save2(uint8_t* ptr, float* buf, __m512 val0, __m512 val1, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
         {
-            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, params, offset);
-            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, params, offset, tail);
+            Term16b<term>::template Save<type, 0>(ptr, buf, val0, bias, _params, params, offset);
+            Term16b<term>::template Save<type, 1>(ptr, buf, val1, bias, _params, params, offset, tail);
         }
     }
 #endif
@@ -1030,7 +1030,7 @@ namespace Simd
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Save(uint8_t* ptr, float* buf, __m512 value, const __m512* bias, const __m512* params, __mmask16 tail = __mmask16(-1));
             template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const __m512* bias, const __m512* params, __mmask16 tail = __mmask16(-1));
             template<SimdConvolutionActivationType type> static SIMD_INLINE void Postprocess(const float* src, const float* bias, const float* params, size_t offset, uint8_t* dst, __mmask16 tail = __mmask16(-1));
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1));
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1));
         };
 
         template <> struct Term16b<Term16bLast16b>
@@ -1064,10 +1064,10 @@ namespace Simd
                 //_mm_prefetch((const char*)(dst + offset * 2), _MM_HINT_NTA);
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
             {
                 __m512 value = _mm512_maskz_loadu_ps(tail, buf + index * F);
-                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), params, offset);
+                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), _params, params, offset);
                 _mm256_mask_storeu_epi16((uint16_t*)ptr + index * F, tail, (__m256i)_mm512_cvtneps_pbh(f32));
                 _mm_prefetch((const char*)(ptr + index * DF), _MM_HINT_NTA);
                 _mm_prefetch((const char*)(buf + index * F), _MM_HINT_NTA);
@@ -1102,10 +1102,10 @@ namespace Simd
                 //_mm_prefetch((const char*)(dst + offset * 4), _MM_HINT_NTA);
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
             {
                 __m512 value = _mm512_maskz_loadu_ps(tail, buf + index * F);
-                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), params, offset);
+                __m512 f32 = ActivateNchw<type>(_mm512_add_ps(value, _mm512_set1_ps(bias[offset])), _params, params, offset);
                 _mm512_mask_storeu_ps((float*)ptr + index * F, tail, f32);
                 _mm_prefetch((const char*)(ptr + index * A), _MM_HINT_NTA);
                 //_mm_prefetch((const char*)(buf + index * F), _MM_HINT_NTA);
@@ -1132,7 +1132,7 @@ namespace Simd
             {
             }
 
-            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+            template<SimdConvolutionActivationType type, int index> static SIMD_INLINE void Apply(uint8_t* ptr, float* buf, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
             {
             }
         };
@@ -1231,39 +1231,39 @@ namespace Simd
 
         //-------------------------------------------------------------------------------------------------
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply1(uint8_t* ptr, float* buf, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply1(uint8_t* ptr, float* buf, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
         {
-            Term16b<term>::template Apply<type, 0>(ptr, buf, bias, params, offset, tail);
+            Term16b<term>::template Apply<type, 0>(ptr, buf, bias, _params, params, offset, tail);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply1x8(uint8_t* ptr, int dP, float* buf, int dB, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply1x8(uint8_t* ptr, int dP, float* buf, int dB, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
         {
-            Apply1<term, type>(ptr + 0 * dP, buf + 0 * dB, bias, params, offset + 0, tail);
-            Apply1<term, type>(ptr + 1 * dP, buf + 1 * dB, bias, params, offset + 1, tail);
-            Apply1<term, type>(ptr + 2 * dP, buf + 2 * dB, bias, params, offset + 2, tail);
-            Apply1<term, type>(ptr + 3 * dP, buf + 3 * dB, bias, params, offset + 3, tail);
-            Apply1<term, type>(ptr + 4 * dP, buf + 4 * dB, bias, params, offset + 4, tail);
-            Apply1<term, type>(ptr + 5 * dP, buf + 5 * dB, bias, params, offset + 5, tail);
-            Apply1<term, type>(ptr + 6 * dP, buf + 6 * dB, bias, params, offset + 6, tail);
-            Apply1<term, type>(ptr + 7 * dP, buf + 7 * dB, bias, params, offset + 7, tail);
+            Apply1<term, type>(ptr + 0 * dP, buf + 0 * dB, bias, _params, params, offset + 0, tail);
+            Apply1<term, type>(ptr + 1 * dP, buf + 1 * dB, bias, _params, params, offset + 1, tail);
+            Apply1<term, type>(ptr + 2 * dP, buf + 2 * dB, bias, _params, params, offset + 2, tail);
+            Apply1<term, type>(ptr + 3 * dP, buf + 3 * dB, bias, _params, params, offset + 3, tail);
+            Apply1<term, type>(ptr + 4 * dP, buf + 4 * dB, bias, _params, params, offset + 4, tail);
+            Apply1<term, type>(ptr + 5 * dP, buf + 5 * dB, bias, _params, params, offset + 5, tail);
+            Apply1<term, type>(ptr + 6 * dP, buf + 6 * dB, bias, _params, params, offset + 6, tail);
+            Apply1<term, type>(ptr + 7 * dP, buf + 7 * dB, bias, _params, params, offset + 7, tail);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply2(uint8_t* ptr, float* buf, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply2(uint8_t* ptr, float* buf, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
         {
-            Term16b<term>::template Apply<type, 0>(ptr, buf, bias, params, offset);
-            Term16b<term>::template Apply<type, 1>(ptr, buf, bias, params, offset, tail);
+            Term16b<term>::template Apply<type, 0>(ptr, buf, bias, _params, params, offset);
+            Term16b<term>::template Apply<type, 1>(ptr, buf, bias, _params, params, offset, tail);
         }
 
-        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply2x8(uint8_t* ptr, int dP, float* buf, int dB, const float* bias, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
+        template<Term16bType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply2x8(uint8_t* ptr, int dP, float* buf, int dB, const float* bias, const __m512* _params, const float* params, size_t offset, __mmask16 tail = __mmask16(-1))
         {
-            Apply2<term, type>(ptr + 0 * dP, buf + 0 * dB, bias, params, offset + 0, tail);
-            Apply2<term, type>(ptr + 1 * dP, buf + 1 * dB, bias, params, offset + 1, tail);
-            Apply2<term, type>(ptr + 2 * dP, buf + 2 * dB, bias, params, offset + 2, tail);
-            Apply2<term, type>(ptr + 3 * dP, buf + 3 * dB, bias, params, offset + 3, tail);
-            Apply2<term, type>(ptr + 4 * dP, buf + 4 * dB, bias, params, offset + 4, tail);
-            Apply2<term, type>(ptr + 5 * dP, buf + 5 * dB, bias, params, offset + 5, tail);
-            Apply2<term, type>(ptr + 6 * dP, buf + 6 * dB, bias, params, offset + 6, tail);
-            Apply2<term, type>(ptr + 7 * dP, buf + 7 * dB, bias, params, offset + 7, tail);
+            Apply2<term, type>(ptr + 0 * dP, buf + 0 * dB, bias, _params, params, offset + 0, tail);
+            Apply2<term, type>(ptr + 1 * dP, buf + 1 * dB, bias, _params, params, offset + 1, tail);
+            Apply2<term, type>(ptr + 2 * dP, buf + 2 * dB, bias, _params, params, offset + 2, tail);
+            Apply2<term, type>(ptr + 3 * dP, buf + 3 * dB, bias, _params, params, offset + 3, tail);
+            Apply2<term, type>(ptr + 4 * dP, buf + 4 * dB, bias, _params, params, offset + 4, tail);
+            Apply2<term, type>(ptr + 5 * dP, buf + 5 * dB, bias, _params, params, offset + 5, tail);
+            Apply2<term, type>(ptr + 6 * dP, buf + 6 * dB, bias, _params, params, offset + 6, tail);
+            Apply2<term, type>(ptr + 7 * dP, buf + 7 * dB, bias, _params, params, offset + 7, tail);
         }
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `const __m512* _params` to `Avx512bw::ActivateNchw` so it matches `Avx2::ActivateNchw`.

Non-PReLU activations now use the broadcast `__m512` parameters (same as `Activate`), while the PReLU specialization still reads the per-channel slope from `params[offset]`. The previous 3-argument overload is removed.

AVX-512BW NCHW GEMM callers are updated the same way as the AVX2 versions:

- `Avx512bw::Term16b` NCHW `Save` / `Save1` / `Save2` in `SimdSynetConvolution16bCommon.h`
- `AmxBf16::Term16b` NCHW `Apply` / `Apply1` / `Apply2` in `SimdSynetConvolution16bCommon.h`
- `SimdAvx512bwSynetConvolution16bNchwGemm.cpp`
- `SimdAmxBf16SynetConvolution16bNchwGemm.cpp`

Quantized NCHW GEMM (`SimdAvx512bwSynetQuantizedConvolutionNchwGemm.cpp` and `SimdSynetQuantizedActivation.h`) already used the `_params` overload.

## Testing

Local Release build (`g++`, `-march=native`, `SIMD_SHARED=ON`, AVX-512BW + AMX) succeeded. Auto tests:

```
./Test "-r=.." -m=a -tt=1 -ts=1 -mt=1 \
  -fi=SynetConvolution16bForward \
  -fi=SynetQuantizedConvolutionForward
```

All tests finished successfully. Extra NCHW Identity / Relu / Prelu / LeakyRelu cases (including a tail Prelu `1x99x15x17`) were run locally against Base/Sse41/Avx2/Avx512bw/Amx; AVX-512BW (`Avx5b`) and AMX both produced matching results.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61dfdf2b-ee7b-4a5e-b0c8-92e58f3cc02c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61dfdf2b-ee7b-4a5e-b0c8-92e58f3cc02c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

