### PR TITLE
Add AMX-INT8 optimizations of SynetQuantizedConvolutionNchwGemm

### DIFF
--- a/docs/2026.html
+++ b/docs/2026.html
@@ -49,7 +49,7 @@
 <ul>
  <li>AMX-BF16 optimizations of class SynetQuantizedConvolutionNhwcSpecV1.</li>
  <li>SSE4.1 optimizations of class ImagePngLoader.</li>
- <li>Base implementation, SSE4.1, AVX2, AVX-512BW, AVX-512VNNI, NEON, SVE2 optimizations of class SynetQuantizedConvolutionNchwGemm.</li>
+ <li>Base implementation, SSE4.1, AVX2, AVX-512BW, AVX-512VNNI, AMX-INT8, NEON, SVE2 optimizations of class SynetQuantizedConvolutionNchwGemm.</li>
 </ul>
 <h5>Bug fixing</h5>
 <ul>

--- a/prj/vs2022/AmxBf16.vcxproj
+++ b/prj/vs2022/AmxBf16.vcxproj
@@ -110,6 +110,7 @@
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetMergedConvolution8iInput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetMergedConvolution8iOutput.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetQuantizedConvolution.cpp" />
+    <ClCompile Include="..\..\src\Simd\SimdAmxBf16iSynetQuantizedConvolutionNchwGemm.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetQuantizedConvolutionNhwcGemmV0.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetQuantizedConvolutionNhwcGemmV1.cpp" />
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetQuantizedConvolutionNhwcSpecV0.cpp" />

--- a/prj/vs2022/AmxBf16.vcxproj.filters
+++ b/prj/vs2022/AmxBf16.vcxproj.filters
@@ -293,6 +293,9 @@
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetQuantizedConvolution.cpp">
       <Filter>AmxBf16\Synet\Quantized</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Simd\SimdAmxBf16iSynetQuantizedConvolutionNchwGemm.cpp">
+      <Filter>AmxBf16\Synet\Quantized</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Simd\SimdAmxBf16SynetQuantizedConvolutionNhwcSpecV0.cpp">
       <Filter>AmxBf16\Synet\Quantized</Filter>
     </ClCompile>

--- a/src/Simd/SimdAmxBf16SynetQuantizedConvolution.cpp
+++ b/src/Simd/SimdAmxBf16SynetQuantizedConvolution.cpp
@@ -48,6 +48,8 @@ namespace Simd
                 return new SynetQuantizedConvolutionNhwcGemmV1(param);
             else if(SynetQuantizedConvolutionNhwcGemmV0::Preferable(param))
                 return new SynetQuantizedConvolutionNhwcGemmV0(param);
+            else if (SynetQuantizedConvolutionNchwGemm::Preferable(param))
+                return new SynetQuantizedConvolutionNchwGemm(param);
             else
                 return Avx512vnni::SynetQuantizedConvolutionInit(batch, conv);
         }

--- a/src/Simd/SimdAmxBf16iSynetQuantizedConvolutionNchwGemm.cpp
+++ b/src/Simd/SimdAmxBf16iSynetQuantizedConvolutionNchwGemm.cpp
@@ -1,0 +1,356 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2026 Yermalayeu Ihar.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdSynetQuantizedConvolution.h"
+#include "Simd/SimdSynetQuantizedActivation.h"
+#include "Simd/SimdSynetQuantizeLinear.h"
+#include "Simd/SimdSynetConvolution8iCommon.h"
+#include "Simd/SimdSynet.h"
+#include "Simd/SimdMath.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdCpu.h"
+#include "Simd/SimdLog.h"
+#include "Simd/SimdTile.h"
+#include "Simd/SimdCopy.h"
+#include "Simd/SimdSet.h"
+
+namespace Simd
+{
+#if defined(SIMD_AMXBF16_ENABLE) && defined(SIMD_SYNET_ENABLE) 
+    namespace AmxBf16
+    {
+        typedef Base::SynetQuantizedConvolutionNchwGemm::AlgParam AlgParam;
+        typedef Base::SynetQuantizedConvolutionNchwGemm::GemmPtr GemmPtr;
+
+        //-----------------------------------------------------------------------------------------
+
+        template<Term8iType term, SimdConvolutionActivationType type, int cfg> void QuantizedConvolutionNchwGemm_32x32(const int8_t* weight0, const ConvParam& p, const AlgParam& a,
+            size_t K, size_t dstC, size_t dstS, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m512i& iLo, const __m512i& iHi,
+            const __m512& iScale, const float* params, const __m512* _params, const __m512& dNorm, const __m512i& dZero, int32_t* buf, uint8_t* dst)
+        {
+            int dB = (int)a.bufN, dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
+            int stepW = 64, strideW = (int)K;
+            const int8_t* weight1 = weight0 + K * F;
+            const uint8_t* src1 = src0 + K * F;
+
+            if (cfg)
+                SetTileConf2x2(dstC, dstS);
+            if (update)
+            {
+                _tile_stream_loadd(0, buf + 0, strideB);
+                _tile_stream_loadd(1, buf + F, strideB);
+                _tile_stream_loadd(2, buf + 16 * dB + 0, strideB);
+                _tile_stream_loadd(3, buf + 16 * dB + F, strideB);
+            }
+            else
+            {
+                _tile_zero(0);
+                _tile_zero(1);
+                _tile_zero(2);
+                _tile_zero(3);
+            }
+
+            int K64 = (int)K - 64, k = 0;
+            _tile_stream_loadd(4, weight0, strideW);
+            _tile_loadd(6, src0 + k * 16, strideS);
+            for (; k < K64; weight1 += stepW)
+            {
+                _tile_loadd(7, src1 + k * 16, strideS);
+                _tile_stream_loadd(5, weight1, strideW);
+                _tile_dpbsud(0, 4, 6);
+                _tile_dpbsud(1, 4, 7);
+                weight0 += stepW;
+                _tile_stream_loadd(4, weight0, strideW);
+                _tile_dpbsud(2, 5, 6);
+                k += 64;
+                _tile_loadd(6, src0 + k * 16, strideS);
+                _tile_dpbsud(3, 5, 7);
+            }
+            _tile_loadd(7, src1 + k * 16, strideS);
+            _tile_stream_loadd(5, weight1, strideW);
+            _tile_dpbsud(0, 4, 6);
+            _tile_dpbsud(1, 4, 7);
+            _tile_dpbsud(2, 5, 6);
+            _tile_dpbsud(3, 5, 7);
+
+            _tile_stored(0, buf + 0, strideB);
+            _tile_stored(1, buf + F, strideB);
+            _tile_stored(2, buf + 16 * dB + 0, strideB);
+            _tile_stored(3, buf + 16 * dB + F, strideB);
+            if (term == Term8iLast8u)
+            {
+                __mmask16 tailD = TailMask16(dstS - F);
+                size_t dstC8 = AlignLo(dstC, 8), dc = 0;
+                for (; dc < dstC8; dc += 8)
+                    Apply2x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+                for (; dc < dstC; ++dc)
+                    Apply2<term, type>(dst + dc * dD, buf + dc * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+            }
+            else
+            {
+                TileMoveToMemory(buf + 0, dB);
+                TileMoveToMemory(buf + F, dB);
+                TileMoveToMemory(buf + 16 * dB + 0, dB);
+                TileMoveToMemory(buf + 16 * dB + F, dB);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type, int cfg> void QuantizedConvolutionNchwGemm_32x16(const int8_t* weight0, const ConvParam& p, const AlgParam& a,
+            size_t K, size_t dstC, size_t dstS, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m512i& iLo, const __m512i& iHi,
+            const __m512& iScale, const float* params, const __m512* _params, const __m512& dNorm, const __m512i& dZero, int32_t* buf, uint8_t* dst)
+        {
+            int dB = (int)a.bufN, dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
+            int stepW = 64, strideW = (int)K;
+            const int8_t* weight1 = weight0 + K * F;
+
+            if (cfg)
+                SetTileConf2x1(dstC, dstS);
+            if (update)
+            {
+                _tile_stream_loadd(0, buf + 0, strideB);
+                _tile_stream_loadd(2, buf + 16 * dB + 0, strideB);
+            }
+            else
+            {
+                _tile_zero(0);
+                _tile_zero(2);
+            }
+
+            int K64 = (int)K - 64, k = 0;
+            _tile_stream_loadd(4, weight0, strideW);
+            for (; k < K64; k += 64, weight1 += stepW)
+            {
+                _tile_loadd(6, src0 + k * 16, strideS);
+                _tile_stream_loadd(5, weight1, strideW);
+                _tile_dpbsud(0, 4, 6);
+                weight0 += stepW;
+                _tile_stream_loadd(4, weight0, strideW);
+                _tile_dpbsud(2, 5, 6);
+            }
+            _tile_loadd(6, src0 + k * 16, strideS);
+            _tile_stream_loadd(5, weight1, strideW);
+            _tile_dpbsud(0, 4, 6);
+            _tile_dpbsud(2, 5, 6);
+
+            _tile_stored(0, buf + 0, strideB);
+            _tile_stored(2, buf + 16 * dB + 0, strideB);
+            if (term == Term8iLast8u)
+            {
+                __mmask16 tailD = TailMask16(dstS);
+                size_t dstC8 = AlignLo(dstC, 8), dc = 0;
+                for (; dc < dstC8; dc += 8)
+                    Apply1x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+                for (; dc < dstC; ++dc)
+                    Apply1<term, type>(dst + dc * dD, buf + dc * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+            }
+            else
+            {
+                TileMoveToMemory(buf + 0, dB);
+                TileMoveToMemory(buf + 16 * dB + 0, dB);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type, int cfg> void QuantizedConvolutionNchwGemm_16x32(const int8_t* weight0, const ConvParam& p, const AlgParam& a,
+            size_t K, size_t dstC, size_t dstS, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m512i& iLo, const __m512i& iHi,
+            const __m512& iScale, const float* params, const __m512* _params, const __m512& dNorm, const __m512i& dZero, int32_t* buf, uint8_t* dst)
+        {
+            int dB = (int)a.bufN, dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
+            int stepW = 64, strideW = (int)K;
+            const uint8_t* src1 = src0 + K * F;
+
+            if (cfg)
+                SetTileConf1x2(dstC, dstS);
+            if (update)
+            {
+                _tile_stream_loadd(0, buf + 0, strideB);
+                _tile_stream_loadd(1, buf + F, strideB);
+            }
+            else
+            {
+                _tile_zero(0);
+                _tile_zero(1);
+            }
+
+            int K64 = (int)K - 64, k = 0;
+            _tile_loadd(6, src0 + k * 16, strideS);
+            for (; k < K64; weight0 += stepW)
+            {
+                _tile_stream_loadd(4, weight0, strideW);
+                _tile_loadd(7, src1 + k * 16, strideS);
+                _tile_dpbsud(0, 4, 6);
+                k += 64;
+                _tile_loadd(6, src0 + k * 16, strideS);
+                _tile_dpbsud(1, 4, 7);
+            }
+            _tile_stream_loadd(4, weight0, strideW);
+            _tile_loadd(7, src1 + k * 16, strideS);
+            _tile_dpbsud(0, 4, 6);
+            _tile_dpbsud(1, 4, 7);
+
+            _tile_stored(0, buf + 0, strideB);
+            _tile_stored(1, buf + F, strideB);
+            if (term == Term8iLast8u)
+            {
+                __mmask16 tailD = TailMask16(dstS - F);
+                size_t dstC8 = AlignLo(dstC, 8), dc = 0;
+                for (; dc < dstC8; dc += 8)
+                    Apply2x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+                for (; dc < dstC; ++dc)
+                    Apply2<term, type>(dst + dc * dD, buf + dc * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+            }
+            else
+            {
+                TileMoveToMemory(buf + 0, dB);
+                TileMoveToMemory(buf + F, dB);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type, int cfg> void QuantizedConvolutionNchwGemm_16x16(const int8_t* weight0, const ConvParam& p, const AlgParam& a,
+            size_t K, size_t dstC, size_t dstS, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m512i& iLo, const __m512i& iHi,
+            const __m512& iScale, const float* params, const __m512* _params, const __m512& dNorm, const __m512i& dZero, int32_t* buf, uint8_t* dst)
+        {
+            int dB = (int)a.bufN, dD = int(a.N * a.elem), strideB = dB * 4, strideS = 64;
+            int stepW = 64, strideW = (int)K;
+
+            if (cfg)
+                SetTileConf1x1(dstC, dstS);
+            if (update)
+            {
+                _tile_stream_loadd(0, buf + 0, strideB);
+            }
+            else
+            {
+                _tile_zero(0);
+            }
+            for (size_t k = 0; k < K; k += 64, weight0 += stepW)
+            {
+                _tile_stream_loadd(4, weight0, strideW);
+                _tile_loadd(6, src0 + k * 16, strideS);
+                _tile_dpbsud(0, 4, 6);
+            }
+            _tile_stored(0, buf + 0, strideB);
+            if (term == Term8iLast8u)
+            {
+                __mmask16 tailD = TailMask16(dstS);
+                size_t dstC8 = AlignLo(dstC, 8), dc = 0;
+                for (; dc < dstC8; dc += 8)
+                    Apply1x8<term, type>(dst + dc * dD, dD, buf + dc * dB, dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+                for (; dc < dstC; ++dc)
+                    Apply1<term, type>(dst + dc * dD, buf + dc * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, dc, dNorm, dZero, tailD);
+            }
+            else
+            {
+                TileMoveToMemory(buf + 0, dB);
+            }
+        }
+
+        typedef void (*QuantizedConvolutionNchwGemmPtr)(const int8_t* weight0, const ConvParam& p, const AlgParam& a,
+            size_t K, size_t dstC, size_t dstS, int update, const uint8_t* src0, const int32_t* sBias, const float* sNorm, const __m512i& iLo, const __m512i& iHi,
+            const __m512& iScale, const float* params, const __m512* _params, const __m512& dNorm, const __m512i& dZero, int32_t* buf, uint8_t* dst);
+
+        template<Term8iType term, SimdConvolutionActivationType type> void QuantizedConvolutionNchwGemm_2(const int8_t* weight, const ConvParam& p, const AlgParam& a,
+            size_t dstC, size_t dstH, size_t K, int update, const uint8_t* src, const int32_t* sBias, const float* sNorm, int32_t iZero, float iScale,
+            const float* params, float dNorm, int32_t dZero, int32_t* sum, int32_t* buf, uint8_t* dst)
+        {
+            size_t dstS = dstH * p.dstW, n1 = dstC, n = 32;
+            size_t nn = AlignLoAny(n1, n), m = n1 - nn;
+            size_t dB = a.bufN, dD = a.N * a.elem, dW = K, dp = type == ::SimdConvolutionActivationPrelu ? 1 : 0;
+            QuantizedConvolutionNchwGemmPtr body_2 = QuantizedConvolutionNchwGemm_32x32<term, type, 0>;
+            QuantizedConvolutionNchwGemmPtr tail_2 = m > 16 ? QuantizedConvolutionNchwGemm_32x32<term, type, 0> : QuantizedConvolutionNchwGemm_16x32<term, type, 0>;
+            QuantizedConvolutionNchwGemmPtr body_1 = QuantizedConvolutionNchwGemm_32x16<term, type, 0>;
+            QuantizedConvolutionNchwGemmPtr tail_1 = m > 16 ? QuantizedConvolutionNchwGemm_32x16<term, type, 0> : QuantizedConvolutionNchwGemm_16x16<term, type, 0>;
+
+            __m512 _iScale, _params[2], _dNorm;
+            __m512i _dZero = _mm512_set1_epi32(dZero), _iLo, _iHi;
+            if (type != SimdConvolutionActivationIdentity)
+            {
+                _iLo = _mm512_set1_epi32(-iZero);
+                _iHi = _mm512_set1_epi32(255 - iZero);
+                _iScale = _mm512_set1_ps(iScale);
+                _dNorm = _mm512_set1_ps(dNorm);
+                _params[0] = _mm512_set1_ps(params[0]);
+                _params[1] = _mm512_set1_ps(params[1]);
+            }
+
+            SetTileConfFull();
+            for (size_t ds = 0; ds < dstS; ds += DF)
+            {
+                size_t dS = Simd::Min(DF, dstS - ds);
+                const int8_t* w = weight;
+                int32_t* b = sum + ds;
+                uint8_t* d = dst + ds * a.elem;
+                size_t i = 0;
+                if (dS > F)
+                {
+                    for (; i < nn; i += n, w += n * dW, b += n * dB, d += n * dD)
+                        body_2(w, p, a, K, n, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _params, _dNorm, _dZero, b, d);
+                    if (m)
+                        tail_2(w, p, a, K, m, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _params, _dNorm, _dZero, b, d);
+                }
+                else
+                {
+                    for (; i < nn; i += n, w += n * dW, b += n * dB, d += n * dD)
+                        body_1(w, p, a, K, n, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _params, _dNorm, _dZero, b, d);
+                    if (m)
+                        tail_1(w, p, a, K, m, dS, update, src, sBias + i, sNorm + i, _iLo, _iHi, _iScale, params + i * dp, _params, _dNorm, _dZero, b, d);
+                }
+                src += K * DF;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SIMD_INLINE void SetGemm(const ConvParam& p, const AlgParam& a, GemmPtr* gemm)
+        {
+            gemm[0] = QuantizedConvolutionNchwGemm_2<Term8iInterim, SimdConvolutionActivationIdentity>;
+            switch (p.activation)
+            {
+            case SimdConvolutionActivationIdentity: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationIdentity>; break;
+            case SimdConvolutionActivationRelu: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationRelu>; break;
+            case SimdConvolutionActivationLeakyRelu: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationLeakyRelu>; break;
+            case SimdConvolutionActivationRestrictRange: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationRestrictRange>; break;
+            case SimdConvolutionActivationPrelu: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationPrelu>; break;
+            case SimdConvolutionActivationElu: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationElu>; break;
+            case SimdConvolutionActivationHswish: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationHswish>; break;
+            case SimdConvolutionActivationMish: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationMish>; break;
+            case SimdConvolutionActivationHardSigmoid: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationHardSigmoid>; break;
+            case SimdConvolutionActivationSwish: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationSwish>; break;
+            case SimdConvolutionActivationGelu: gemm[1] = QuantizedConvolutionNchwGemm_2<Term8iLast8u, SimdConvolutionActivationGelu>; break;
+            default:
+                gemm[1] = NULL;
+            }
+        }
+
+        //-----------------------------------------------------------------------------------------
+
+        SynetQuantizedConvolutionNchwGemm::SynetQuantizedConvolutionNchwGemm(const ConvParam& p)
+            : Avx512vnni::SynetQuantizedConvolutionNchwGemm(p)
+        {
+            if (_alg.K <= 32)
+                return;
+            SetAlgParam(F, F * 2, F * 2, 64);
+            SetGemm(p, _alg, _gemm);
+        }
+    }
+#endif
+}

--- a/src/Simd/SimdSynetQuantizedActivation.h
+++ b/src/Simd/SimdSynetQuantizedActivation.h
@@ -971,6 +971,64 @@ namespace Simd
             if (N > 6) ApplyMx1<term, type, flush, M>(ptr + 6 * dP, buf + 6 * DF, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
             if (N > 7) ApplyMx1<term, type, flush, M>(ptr + 7 * dP, buf + 7 * DF, sBias, sNorm, iLo, iHi, iScale, params, dNorm, dZero, tail);
         }
+
+        //--------------------------------------------------------------------------------------------------
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply1(uint8_t* dst, int32_t* buf, const int32_t* sBias, const float* sNorm,
+            const __m512i& iLo, const __m512i& iHi, const __m512& iScale, const __m512* _params, const float* params, size_t offset, const __m512& dNorm, const __m512i& dZero, __mmask16 mask = __mmask16(-1))
+        {
+            if (term == Term8iLast8u)
+            {
+                __m512i _sBias = _mm512_set1_epi32(sBias[offset]);
+                __m512 _sNorm = _mm512_set1_ps(sNorm[offset]);
+                __m512i d0 = Avx512bw::ToSave32i<type>(_mm512_maskz_loadu_epi32(mask, buf), _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
+                _mm_mask_storeu_epi8(dst, mask, _mm512_castsi512_si128(PackI16ToU8(PackI32ToI16(d0, K_ZERO), K_ZERO)));
+                _mm_prefetch((const char*)dst, _MM_HINT_NTA);
+                _mm_prefetch((const char*)buf, _MM_HINT_NTA);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply1x8(uint8_t* ptr, int dP, int32_t* buf, int dB, const int32_t* sBias, const float* sNorm,
+            const __m512i& iLo, const __m512i& iHi, const __m512& iScale, const __m512* _params, const float* params, size_t offset, const __m512& dNorm, const __m512i& dZero, __mmask16 tail = __mmask16(-1))
+        {
+            Apply1<term, type>(ptr + 0 * dP, buf + 0 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 0, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 1 * dP, buf + 1 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 1, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 2 * dP, buf + 2 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 2, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 3 * dP, buf + 3 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 3, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 4 * dP, buf + 4 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 4, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 5 * dP, buf + 5 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 5, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 6 * dP, buf + 6 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 6, dNorm, dZero, tail);
+            Apply1<term, type>(ptr + 7 * dP, buf + 7 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 7, dNorm, dZero, tail);
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply2(uint8_t* dst, int32_t* buf, const int32_t* sBias, const float* sNorm,
+            const __m512i& iLo, const __m512i& iHi, const __m512& iScale, const __m512* _params, const float* params, size_t offset, const __m512& dNorm, const __m512i& dZero, __mmask16 tail = __mmask16(-1))
+        {
+            if (term == Term8iLast8u)
+            {
+                __m512i _sBias = _mm512_set1_epi32(sBias[offset]);
+                __m512 _sNorm = _mm512_set1_ps(sNorm[offset]);
+                __m512i d0 = Avx512bw::ToSave32i<type>(_mm512_loadu_si512(buf + 0), _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
+                __m512i d1 = Avx512bw::ToSave32i<type>(_mm512_maskz_loadu_epi32(tail, buf + F), _sBias, _sNorm, iLo, iHi, iScale, _params, params, offset, dNorm, dZero);
+                _mm256_mask_storeu_epi8(dst, (__mmask32)0xFFFF | ((__mmask32)tail << 16), _mm512_castsi512_si256(PackI16ToU8(PackI32ToI16(d0, d1), K_ZERO)));
+                _mm_prefetch((const char*)dst, _MM_HINT_NTA);
+                _mm_prefetch((const char*)(buf + 0), _MM_HINT_NTA);
+                _mm_prefetch((const char*)(buf + F), _MM_HINT_NTA);
+            }
+        }
+
+        template<Term8iType term, SimdConvolutionActivationType type> SIMD_INLINE void Apply2x8(uint8_t* ptr, int dP, int32_t* buf, int dB, const int32_t* sBias, const float* sNorm,
+            const __m512i& iLo, const __m512i& iHi, const __m512& iScale, const __m512* _params, const float* params, size_t offset, const __m512& dNorm, const __m512i& dZero, __mmask16 tail = __mmask16(-1))
+        {
+            Apply2<term, type>(ptr + 0 * dP, buf + 0 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 0, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 1 * dP, buf + 1 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 1, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 2 * dP, buf + 2 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 2, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 3 * dP, buf + 3 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 3, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 4 * dP, buf + 4 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 4, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 5 * dP, buf + 5 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 5, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 6 * dP, buf + 6 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 6, dNorm, dZero, tail);
+            Apply2<term, type>(ptr + 7 * dP, buf + 7 * dB, sBias, sNorm, iLo, iHi, iScale, _params, params, offset + 7, dNorm, dZero, tail);
+        }
     }
 #endif
 

--- a/src/Simd/SimdSynetQuantizedConvolution.h
+++ b/src/Simd/SimdSynetQuantizedConvolution.h
@@ -790,6 +790,16 @@ namespace Simd
 
         //------------------------------------------------------------------------------------------------
 
+        class SynetQuantizedConvolutionNchwGemm : public Avx512vnni::SynetQuantizedConvolutionNchwGemm
+        {
+        public:
+            SynetQuantizedConvolutionNchwGemm(const ConvParam& p);
+
+            virtual String Ext() const { return _alg.microK == 64 ? "AmxBf16" : "Avx512vnni"; }
+        };
+
+        //------------------------------------------------------------------------------------------------
+
         void* SynetQuantizedConvolutionInit(size_t batch, const SimdConvolutionParameters* conv);
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds AMX-INT8 (TMUL) optimizations of `Base::SynetQuantizedConvolutionNchwGemm` for the X86 platform.

- New implementation in `src/Simd/SimdAmxBf16iSynetQuantizedConvolutionNchwGemm.cpp` (`AmxBf16` namespace).
- GEMM kernels follow the AMX-BF16 `SynetConvolution16bNchwGemm` 32x32 / 32x16 / 16x32 / 16x16 tile pattern, using `_tile_dpbsud` (signed weights × unsigned source) to match existing NCHW weight (A) and VNNI-packed source (B) layouts.
- AVX-512VNNI NCHW GEMM is kept as the parent/fallback (`K <= 32` stays on AVX-512VNNI).
- NCHW post-process helpers (`Apply1` / `Apply2` / `Apply1x8` / `Apply2x8`) added in `SimdSynetQuantizedActivation.h`.
- `AmxBf16::SynetQuantizedConvolutionInit` now selects the NCHW GEMM class when preferable.
- VS2022 `AmxBf16` project files updated.
- Release notes for 7.2.166 mention AMX-INT8 for this class.

## Test plan

- CMake Release build with `-DSIMD_AMXBF16=ON` (g++).
- `./Test "-r=.." -fi=SynetQuantizedConvolution -tt=1 -ts=1` from `build/` — **all tests passed** on a CPU with AMX-INT8.
- NCHW cases (odd 255 channels, 1x1 and 3x3, Identity and PReLU) exercised the new `AmxBf16::NchwGemm` path; object file contains `tdpbsud` TMUL instructions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73b2fc6d-7a6f-4e4c-a10b-98098d110e2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73b2fc6d-7a6f-4e4c-a10b-98098d110e2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

